### PR TITLE
Add buffer pool for block transfers

### DIFF
--- a/transfer/block.go
+++ b/transfer/block.go
@@ -85,20 +85,20 @@ func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZer
 			return nil, err
 		}
 
-		data, err = io.ReadAll(r)
+		data = getBlockBuffer(blockSize)
+		_, err = io.ReadFull(r, data)
 		if err != nil {
+			putBlockBuffer(data)
 			return nil, err
-		}
-		if len(data) != blockSize {
-			return nil, fmt.Errorf("zero-copy short read: expected %d, got %d", blockSize, len(data))
 		}
 		return data, nil
 	}
 
+	buf := getBlockBuffer(blockSize)
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		data, err = ReadBlock(src, offset, blockSize)
-		if err == nil {
-			return data, nil
+		n, err := src.ReadAt(buf, offset)
+		if err == nil && n == blockSize {
+			return buf, nil
 		}
 
 		Logger.Warn("Failed to read block",
@@ -110,5 +110,6 @@ func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZer
 		time.Sleep(100 * time.Millisecond)
 	}
 
+	putBlockBuffer(buf)
 	return nil, fmt.Errorf("failed to read block at offset %d after %d attempts", offset, maxRetries)
 }

--- a/transfer/bufferpool.go
+++ b/transfer/bufferpool.go
@@ -1,0 +1,24 @@
+package transfer
+
+import "sync"
+
+var bufferPools sync.Map
+
+func getPool(size int) *sync.Pool {
+	if p, ok := bufferPools.Load(size); ok {
+		return p.(*sync.Pool)
+	}
+	p := &sync.Pool{New: func() interface{} {
+		return make([]byte, size)
+	}}
+	actual, _ := bufferPools.LoadOrStore(size, p)
+	return actual.(*sync.Pool)
+}
+
+func getBlockBuffer(size int) []byte {
+	return getPool(size).Get().([]byte)
+}
+
+func putBlockBuffer(buf []byte) {
+	getPool(len(buf)).Put(buf)
+}

--- a/transfer/pool_test.go
+++ b/transfer/pool_test.go
@@ -1,0 +1,66 @@
+package transfer
+
+import (
+	"os"
+	"testing"
+
+	"lvmsync_go/config"
+)
+
+func BenchmarkReadBlockWithPool(b *testing.B) {
+	cfg := &config.Config{BlockSize: 4096, MaxRetries: 1}
+	f, err := os.CreateTemp("", "poolbench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	data := make([]byte, cfg.BlockSize)
+	if _, err := f.Write(data); err != nil {
+		b.Fatal(err)
+	}
+	f.Close()
+	f, err = os.Open(f.Name())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf, err := ReadBlockWithRetries(cfg, f, 0, false)
+		if err != nil {
+			b.Fatal(err)
+		}
+		putBlockBuffer(buf)
+	}
+}
+
+func BenchmarkReadBlockWithMake(b *testing.B) {
+	cfg := &config.Config{BlockSize: 4096, MaxRetries: 1}
+	f, err := os.CreateTemp("", "poolbench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	data := make([]byte, cfg.BlockSize)
+	if _, err := f.Write(data); err != nil {
+		b.Fatal(err)
+	}
+	f.Close()
+	f, err = os.Open(f.Name())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	buf := make([]byte, cfg.BlockSize)
+	for i := 0; i < b.N; i++ {
+		if _, err := f.ReadAt(buf, 0); err != nil {
+			b.Fatal(err)
+		}
+		buf = make([]byte, cfg.BlockSize)
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -112,6 +112,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 		if cfg.Deduplication && dedup != nil {
 			if !dedup.ShouldTransfer(r.Start, data) {
 				skippedBlocks++
+				putBlockBuffer(data)
 				continue
 			}
 			dedup.RecordTransfer(r.Start, data)
@@ -124,8 +125,10 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 			return fmt.Errorf("failed to write header: %v", err)
 		}
 		if _, err := bufOut.Write(data); err != nil {
+			putBlockBuffer(data)
 			return fmt.Errorf("failed to write block data: %v", err)
 		}
+		putBlockBuffer(data)
 
 		totalBytesTransferred += int64(cfg.BlockSize)
 	}
@@ -272,8 +275,10 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 			return fmt.Errorf("failed to write header: %v", err)
 		}
 		if _, err := bufOut.Write(res.Data); err != nil {
+			putBlockBuffer(res.Data)
 			return fmt.Errorf("failed to write data: %v", err)
 		}
+		putBlockBuffer(res.Data)
 
 		totalBytesTransferred += int64(res.Size)
 
@@ -356,8 +361,9 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 			copy(transmittedSum[:], headerBuf[12:44])
 		}
 
-		data := make([]byte, chunkSize)
+		data := getBlockBuffer(int(chunkSize))
 		if _, err := io.ReadFull(reader, data); err != nil {
+			putBlockBuffer(data)
 			return fmt.Errorf("failed to read chunk data: %v", err)
 		}
 
@@ -370,6 +376,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 
 		if dedup != nil && cfg.Deduplication {
 			if !dedup.ShouldTransfer(int64(offset), data) {
+				putBlockBuffer(data)
 				continue
 			}
 			dedup.RecordTransfer(int64(offset), data)
@@ -380,8 +387,10 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 			continue
 		}
 		if _, err := destFile.Write(data); err != nil {
+			putBlockBuffer(data)
 			return fmt.Errorf("failed to write data at offset %d: %v", offset, err)
 		}
+		putBlockBuffer(data)
 
 		totalBytes += int64(chunkSize)
 	}


### PR DESCRIPTION
## Summary
- reuse buffers via `sync.Pool`
- use the pool in `ReadBlockWithRetries` and `processDumpDataCore`
- return buffers to the pool after writing
- add benchmarks for allocation reduction

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `GO111MODULE=off go test ./...` *(fails to find external packages)*

------
https://chatgpt.com/codex/tasks/task_e_688d4044da9083238f2ae0dfea5919d3