### PR TITLE
Optimize pipe usage for zero-copy reads

### DIFF
--- a/transfer/block.go
+++ b/transfer/block.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -13,14 +14,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func ZeroCopyTransfer(src *os.File, dst *os.File, offset int64, length int64) error {
-	pipeFds := make([]int, 2)
-	if err := syscall.Pipe(pipeFds); err != nil {
-		return fmt.Errorf("pipe creation failed: %v", err)
-	}
-	defer syscall.Close(pipeFds[0])
-	defer syscall.Close(pipeFds[1])
+// PipeCreationCount tracks the number of pipes created by ReadBlockWithRetries
+// when no persistent pipe is supplied. It is mainly used for benchmarking.
+var PipeCreationCount int64
 
+func ZeroCopyTransfer(src *os.File, dst *os.File, offset int64, length int64, pipeFds [2]int) error {
 	remaining := length
 	off := offset
 	for remaining > 0 {
@@ -52,13 +50,22 @@ func ReadBlock(src *os.File, offset int64, size int) ([]byte, error) {
 	return buf, nil
 }
 
-func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool) ([]byte, error) {
+func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int) ([]byte, error) {
 	blockSize := cfg.BlockSize
 	maxRetries := cfg.MaxRetries
 	var data []byte
 	var err error
 
 	if useZeroCopy {
+		if pipeFds[0] == -1 && pipeFds[1] == -1 {
+			if err := syscall.Pipe(pipeFds[:]); err != nil {
+				return nil, err
+			}
+			atomic.AddInt64(&PipeCreationCount, 1)
+			defer syscall.Close(pipeFds[0])
+			defer syscall.Close(pipeFds[1])
+		}
+
 		r, w, err := os.Pipe()
 		if err != nil {
 			return nil, err
@@ -66,7 +73,7 @@ func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZer
 		defer r.Close()
 
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			err = ZeroCopyTransfer(src, w, offset, int64(blockSize))
+			err = ZeroCopyTransfer(src, w, offset, int64(blockSize), pipeFds)
 			if err == nil {
 				break
 			}

--- a/transfer/block_benchmark_test.go
+++ b/transfer/block_benchmark_test.go
@@ -1,0 +1,75 @@
+package transfer
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"lvmsync_go/config"
+	"syscall"
+)
+
+func prepareTestFile(size int) (*os.File, func(), error) {
+	f, err := os.CreateTemp("", "benchfile")
+	if err != nil {
+		return nil, nil, err
+	}
+	buf := make([]byte, size)
+	if _, err := f.Write(buf); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return nil, nil, err
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return nil, nil, err
+	}
+	cleanup := func() { os.Remove(f.Name()); f.Close() }
+	return f, cleanup, nil
+}
+
+func BenchmarkReadBlockWithRetriesEphemeral(b *testing.B) {
+	cfg := config.DefaultConfig()
+	cfg.ZeroCopy = true
+	fileSize := cfg.BlockSize * b.N
+	f, cleanup, err := prepareTestFile(fileSize)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	atomic.StoreInt64(&PipeCreationCount, 0)
+	for i := 0; i < b.N; i++ {
+		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, [2]int{-1, -1}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(atomic.LoadInt64(&PipeCreationCount)), "pipes")
+}
+
+func BenchmarkReadBlockWithRetriesPersistent(b *testing.B) {
+	cfg := config.DefaultConfig()
+	cfg.ZeroCopy = true
+	fileSize := cfg.BlockSize * b.N
+	f, cleanup, err := prepareTestFile(fileSize)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	var pipeFds [2]int
+	if err := syscall.Pipe(pipeFds[:]); err != nil {
+		b.Fatal(err)
+	}
+	defer syscall.Close(pipeFds[0])
+	defer syscall.Close(pipeFds[1])
+
+	atomic.StoreInt64(&PipeCreationCount, 0)
+	for i := 0; i < b.N; i++ {
+		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, pipeFds); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(atomic.LoadInt64(&PipeCreationCount)), "pipes")
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -100,12 +100,23 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	}
 	defer srcFile.Close()
 
+	var pipeFds [2]int
+	if cfg.ZeroCopy {
+		if err := syscall.Pipe(pipeFds[:]); err != nil {
+			return fmt.Errorf("failed to create pipe: %v", err)
+		}
+		defer syscall.Close(pipeFds[0])
+		defer syscall.Close(pipeFds[1])
+	} else {
+		pipeFds[0], pipeFds[1] = -1, -1
+	}
+
 	startTime := time.Now()
 	var totalBytesTransferred int64
 	skippedBlocks := 0
 
 	for _, r := range ranges {
-		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy)
+		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy, pipeFds)
 		if err != nil {
 			return fmt.Errorf("error reading block at offset %d: %v", r.Start, err)
 		}
@@ -230,7 +241,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 		go func() {
 			defer wg.Done()
 			for task := range tasks {
-				data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false)
+				data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
 				results <- &BlockResult{
 					Index:  task.Index,
 					Offset: uint64(task.R.Start),


### PR DESCRIPTION
## Summary
- reuse a pipe for kernel splicing instead of creating one for every block read
- expose `PipeCreationCount` for benchmarks
- wire persistent pipe through `dumpChangesCore`
- update parallel workers for new signature
- add benchmarks comparing persistent vs ephemeral pipe usage

## Testing
- `go test ./...` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_688d40422578832396e2eef04d4c7b13