### PR TITLE
Add worker helper in parallel transfer

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -21,6 +21,7 @@ import (
 )
 
 var Logger *zap.Logger
+var workerWG *sync.WaitGroup
 
 func SetLogger(logger *zap.Logger) {
 	Logger = logger
@@ -179,6 +180,20 @@ func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) err
 	return DumpChangesSequential(cfg, snapshot, source, out)
 }
 
+func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
+	defer workerWG.Done()
+	for task := range tasks {
+		data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
+		results <- &BlockResult{
+			Index:  task.Index,
+			Offset: uint64(task.R.Start),
+			Size:   uint32(cfg.BlockSize),
+			Data:   data,
+			Err:    err,
+		}
+	}
+}
+
 func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) error {
 	if cfg.ZeroCopy {
 		Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
@@ -243,21 +258,10 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	}
 
 	var wg sync.WaitGroup
+	workerWG = &wg
 	for i := 0; i < cfg.Parallel; i++ {
 		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for task := range tasks {
-				data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
-				results <- &BlockResult{
-					Index:  task.Index,
-					Offset: uint64(task.R.Start),
-					Size:   uint32(cfg.BlockSize),
-					Data:   data,
-					Err:    err,
-				}
-			}
-		}()
+		go worker(cfg, srcFile, tasks, results)
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary
- add `workerWG` package variable for goroutine synchronization
- extract parallel block handling into new `worker` function
- spawn workers using `go worker(cfg, srcFile, tasks, results)`

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d43eb77848323a631df50d1ef63c2