### PR TITLE
check restore handshake

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -346,6 +346,21 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 		return fmt.Errorf("failed to read protocol handshake: %v", err)
 	}
 	handshake = strings.TrimSpace(handshake)
+	allowedHandshakes := []string{
+		common.ProtocolVersion,
+		common.ProtocolVersion + " checksum",
+		common.ProtocolVersion + " checksum-dedup",
+	}
+	valid := false
+	for _, h := range allowedHandshakes {
+		if handshake == h {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
+	}
 
 	destFile, err := os.OpenFile(destPath, os.O_RDWR, 0)
 	if err != nil {


### PR DESCRIPTION
## Summary
- check handshake string when restoring a dump

## Testing
- `go vet ./...` *(fails: no required module provides packages)*

------
https://chatgpt.com/codex/tasks/task_e_688d442698e083238fbc56177de9309c