### PR TITLE
Refactor checksum initialization

### DIFF
--- a/transfer/checksum.go
+++ b/transfer/checksum.go
@@ -31,11 +31,13 @@ var (
 	initOnce       sync.Once
 )
 
+func initChecksumStrategies() {
+	sha256Instance = &SHA256Checksum{}
+	md5Instance = &MD5Checksum{}
+}
+
 func GetChecksumStrategy(algo string) ChecksumStrategy {
-	initOnce.Do(func() {
-		sha256Instance = &SHA256Checksum{}
-		md5Instance = &MD5Checksum{}
-	})
+	initOnce.Do(initChecksumStrategies)
 
 	switch algo {
 	case "md5":


### PR DESCRIPTION
## Summary
- refactor checksum strategies initialization into `initChecksumStrategies`
- call `initOnce.Do(initChecksumStrategies)` in `GetChecksumStrategy`

## Testing
- `go vet ./...` *(fails: no required module provides packages)*

------
https://chatgpt.com/codex/tasks/task_e_688d43f429988323b3d338134fc5e89e