### PR TITLE
Implement deduplication state loading

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -4,18 +4,21 @@ package transfer
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"io"
 	"os"
 	"sync"
 
 	"lvmsync_go/config"
 
 	"github.com/bits-and-blooms/bloom/v3"
+	"go.uber.org/zap"
 )
 
 type DeduplicationStrategy interface {
 	ShouldTransfer(offset int64, data []byte) bool
 	RecordTransfer(offset int64, data []byte)
 	SaveState() error
+	LoadState() error
 }
 
 type ChecksumDedup struct {
@@ -31,18 +34,27 @@ type BloomFilterDedup struct {
 }
 
 func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
+	var dedup DeduplicationStrategy
 	switch cfg.DedupStrategy {
 	case "bloom":
-		return &BloomFilterDedup{
+		dedup = &BloomFilterDedup{
 			filter:    bloom.NewWithEstimates(1000000, 0.01),
 			stateFile: cfg.DedupStateFile,
 		}
 	default:
-		return &ChecksumDedup{
+		dedup = &ChecksumDedup{
 			stateFile: cfg.DedupStateFile,
 			hashes:    make(map[int64][32]byte),
 		}
 	}
+
+	if _, err := os.Stat(cfg.DedupStateFile); err == nil {
+		if err := dedup.LoadState(); err != nil {
+			Logger.Warn("Failed to load dedup state", zap.Error(err))
+		}
+	}
+
+	return dedup
 }
 
 func (c *ChecksumDedup) ShouldTransfer(offset int64, data []byte) bool {
@@ -79,6 +91,36 @@ func (c *ChecksumDedup) SaveState() error {
 	return nil
 }
 
+func (c *ChecksumDedup) LoadState() error {
+	file, err := os.Open(c.stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for {
+		var offset int64
+		if err := binary.Read(file, binary.LittleEndian, &offset); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		var hash [32]byte
+		if _, err := io.ReadFull(file, hash[:]); err != nil {
+			return err
+		}
+		c.hashes[offset] = hash
+	}
+	return nil
+}
+
 func (b *BloomFilterDedup) ShouldTransfer(offset int64, data []byte) bool {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -98,5 +140,29 @@ func (b *BloomFilterDedup) RecordTransfer(offset int64, data []byte) {
 func (b *BloomFilterDedup) SaveState() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return nil
+
+	file, err := os.Create(b.stateFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = b.filter.WriteTo(file)
+	return err
+}
+
+func (b *BloomFilterDedup) LoadState() error {
+	file, err := os.Open(b.stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, err = b.filter.ReadFrom(file)
+	return err
 }

--- a/transfer/dedup_test.go
+++ b/transfer/dedup_test.go
@@ -1,0 +1,56 @@
+package transfer
+
+import (
+	"os"
+	"testing"
+
+	"lvmsync_go/config"
+)
+
+func TestChecksumDedupPersistence(t *testing.T) {
+	f, err := os.CreateTemp("", "checksum_state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	cfg := &config.Config{DedupStrategy: "checksum", DedupStateFile: f.Name()}
+	d := NewDeduplicationStrategy(cfg)
+	data := []byte("block")
+	if !d.ShouldTransfer(0, data) {
+		t.Fatalf("expected transfer on first check")
+	}
+	d.RecordTransfer(0, data)
+	if err := d.SaveState(); err != nil {
+		t.Fatal(err)
+	}
+
+	d2 := NewDeduplicationStrategy(cfg)
+	if d2.ShouldTransfer(0, data) {
+		t.Fatalf("expected block to be skipped after reload")
+	}
+}
+
+func TestBloomFilterDedupPersistence(t *testing.T) {
+	f, err := os.CreateTemp("", "bloom_state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	cfg := &config.Config{DedupStrategy: "bloom", DedupStateFile: f.Name()}
+	d := NewDeduplicationStrategy(cfg)
+	data := []byte("block")
+	if !d.ShouldTransfer(0, data) {
+		t.Fatalf("expected transfer on first check")
+	}
+	d.RecordTransfer(0, data)
+	if err := d.SaveState(); err != nil {
+		t.Fatal(err)
+	}
+
+	d2 := NewDeduplicationStrategy(cfg)
+	if d2.ShouldTransfer(0, data) {
+		t.Fatalf("expected block to be skipped after reload")
+	}
+}


### PR DESCRIPTION
## Summary
- load deduplication state for checksum and bloom filters
- persist bloom filter state to disk
- auto-load dedup state in `NewDeduplicationStrategy`
- add unit tests verifying dedup persistence

## Testing
- `go test ./...` *(fails: no required module provides packages)*

------
https://chatgpt.com/codex/tasks/task_e_688d440cb324832382e8a3be3d790481