### PR TITLE
Refactor anonymous closures

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,28 @@ func DefaultConfig() *Config {
 	}
 }
 
+func printUsage(generalFlags, sshFlags, remoteFlags, dedupFlags, compressionFlags, lvmFlags *pflag.FlagSet) {
+	fmt.Fprintf(os.Stderr, "Usage: %s [options] <snapshot|lvm device> <destination>\n\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "General Options:\n")
+	generalFlags.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nSSH Options:\n")
+	sshFlags.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nRemote Options:\n")
+	remoteFlags.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nDeduplication Options:\n")
+	dedupFlags.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nCompression Options:\n")
+	compressionFlags.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nLVM Options:\n")
+	lvmFlags.PrintDefaults()
+}
+
+func usageFunc(generalFlags, sshFlags, remoteFlags, dedupFlags, compressionFlags, lvmFlags *pflag.FlagSet) func() {
+	return func() {
+		printUsage(generalFlags, sshFlags, remoteFlags, dedupFlags, compressionFlags, lvmFlags)
+	}
+}
+
 func LoadConfig() (*Config, error) {
 	defaultCfg := DefaultConfig()
 
@@ -156,21 +178,7 @@ func LoadConfig() (*Config, error) {
 	pflag.CommandLine.AddFlagSet(compressionFlags)
 	pflag.CommandLine.AddFlagSet(lvmFlags)
 
-	pflag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options] <snapshot|lvm device> <destination>\n\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "General Options:\n")
-		generalFlags.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nSSH Options:\n")
-		sshFlags.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nRemote Options:\n")
-		remoteFlags.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nDeduplication Options:\n")
-		dedupFlags.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nCompression Options:\n")
-		compressionFlags.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nLVM Options:\n")
-		lvmFlags.PrintDefaults()
-	}
+	pflag.Usage = usageFunc(generalFlags, sshFlags, remoteFlags, dedupFlags, compressionFlags, lvmFlags)
 
 	v := viper.New()
 	v.SetConfigName("config")

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -4,6 +4,7 @@ package lvm
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,6 +112,11 @@ func (c *fdCache) Close() {
 	}
 }
 
+func readFromPipe(r io.Reader, buf *bytes.Buffer, ch chan<- error) {
+	_, err := buf.ReadFrom(r)
+	ch <- err
+}
+
 func executeCommand(name string, args ...string) ([]byte, error) {
 	cmd := buildCommand(name, args...)
 
@@ -131,15 +137,8 @@ func executeCommand(name string, args ...string) ([]byte, error) {
 	outCh := make(chan error, 1)
 	errCh := make(chan error, 1)
 
-	go func() {
-		_, err := outBuf.ReadFrom(stdout)
-		outCh <- err
-	}()
-
-	go func() {
-		_, err := errBuf.ReadFrom(stderr)
-		errCh <- err
-	}()
+	go readFromPipe(stdout, &outBuf, outCh)
+	go readFromPipe(stderr, &errBuf, errCh)
 
 	<-outCh
 	<-errCh

--- a/main.go
+++ b/main.go
@@ -132,6 +132,26 @@ func runClientMode(snapshotDevice, dest string) error {
 	return nil
 }
 
+func handleSignal(signals chan os.Signal, snapshotPath *string) {
+	sig := <-signals
+	zap.L().Info("Received signal, aborting", zap.String("signal", sig.String()))
+	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
+		if err := lvm.RemoveSnapshot(*snapshotPath); err != nil {
+			zap.L().Warn("Failed to remove snapshot on shutdown", zap.Error(err))
+		} else {
+			zap.L().Info("Snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))
+		}
+	}
+	os.Exit(1)
+}
+
+func monitorSnapshotRoutine(snapshotPath string, stopMonitor chan struct{}) {
+	if err := lvm.MonitorSnapshot(snapshotPath, 80.0, 10*time.Second, stopMonitor); err != nil {
+		zap.L().Error("Snapshot monitor error", zap.Error(err))
+		os.Exit(1)
+	}
+}
+
 func main() {
 	var err error
 	cfg, err = config.LoadConfig()
@@ -159,18 +179,7 @@ func main() {
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	var snapshotPath string
 
-	go func() {
-		sig := <-signals
-		zap.L().Info("Received signal, aborting", zap.String("signal", sig.String()))
-		if !cfg.SkipSnapshotCreation && snapshotPath != "" && snapshotPath != pflag.Arg(0) {
-			if err := lvm.RemoveSnapshot(snapshotPath); err != nil {
-				zap.L().Warn("Failed to remove snapshot on shutdown", zap.Error(err))
-			} else {
-				zap.L().Info("Snapshot removed on shutdown", zap.String("snapshot", snapshotPath))
-			}
-		}
-		os.Exit(1)
-	}()
+	go handleSignal(signals, &snapshotPath)
 
 	args := pflag.Args()
 	if len(args) < 2 {
@@ -208,12 +217,7 @@ func main() {
 		logger.Info("Snapshot created", zap.String("snapshot", snapshotPath))
 
 		stopMonitor := make(chan struct{})
-		go func() {
-			if err := lvm.MonitorSnapshot(snapshotPath, 80.0, 10*time.Second, stopMonitor); err != nil {
-				zap.L().Error("Snapshot monitor error", zap.Error(err))
-				os.Exit(1)
-			}
-		}()
+		go monitorSnapshotRoutine(snapshotPath, stopMonitor)
 		defer close(stopMonitor)
 	}
 

--- a/transfer/block_benchmark_test.go
+++ b/transfer/block_benchmark_test.go
@@ -9,6 +9,10 @@ import (
 	"syscall"
 )
 
+func makeCleanupFunc(f *os.File) func() {
+	return func() { os.Remove(f.Name()); f.Close() }
+}
+
 func prepareTestFile(size int) (*os.File, func(), error) {
 	f, err := os.CreateTemp("", "benchfile")
 	if err != nil {
@@ -25,8 +29,7 @@ func prepareTestFile(size int) (*os.File, func(), error) {
 		os.Remove(f.Name())
 		return nil, nil, err
 	}
-	cleanup := func() { os.Remove(f.Name()); f.Close() }
-	return f, cleanup, nil
+	return f, makeCleanupFunc(f), nil
 }
 
 func BenchmarkReadBlockWithRetriesEphemeral(b *testing.B) {

--- a/transfer/bufferpool.go
+++ b/transfer/bufferpool.go
@@ -8,11 +8,15 @@ func getPool(size int) *sync.Pool {
 	if p, ok := bufferPools.Load(size); ok {
 		return p.(*sync.Pool)
 	}
-	p := &sync.Pool{New: func() interface{} {
-		return make([]byte, size)
-	}}
+	p := &sync.Pool{New: newBufferFunc(size)}
 	actual, _ := bufferPools.LoadOrStore(size, p)
 	return actual.(*sync.Pool)
+}
+
+func newBufferFunc(size int) func() interface{} {
+	return func() interface{} {
+		return make([]byte, size)
+	}
 }
 
 func getBlockBuffer(size int) []byte {

--- a/transfer/checksum.go
+++ b/transfer/checksum.go
@@ -31,11 +31,13 @@ var (
 	initOnce       sync.Once
 )
 
+func initChecksumInstances() {
+	sha256Instance = &SHA256Checksum{}
+	md5Instance = &MD5Checksum{}
+}
+
 func GetChecksumStrategy(algo string) ChecksumStrategy {
-	initOnce.Do(func() {
-		sha256Instance = &SHA256Checksum{}
-		md5Instance = &MD5Checksum{}
-	})
+	initOnce.Do(initChecksumInstances)
 
 	switch algo {
 	case "md5":

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -70,6 +70,37 @@ func prepareOutputWriter(out io.Writer, cfg *config.Config) (io.WriteCloser, *bu
 	return compWriter, bufOut, nil
 }
 
+func flushAndClose(bufOut *bufio.Writer, w io.WriteCloser) {
+	bufOut.Flush()
+	w.Close()
+}
+
+func dumpWorker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for task := range tasks {
+		data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
+		results <- &BlockResult{
+			Index:  task.Index,
+			Offset: uint64(task.R.Start),
+			Size:   uint32(cfg.BlockSize),
+			Data:   data,
+			Err:    err,
+		}
+	}
+}
+
+func enqueueTasks(resumeStart, numBlocks int, ranges []BlockRange, tasks chan<- BlockTask) {
+	for i := resumeStart; i < numBlocks; i++ {
+		tasks <- BlockTask{Index: i, R: ranges[i]}
+	}
+	close(tasks)
+}
+
+func closeResultsWhenDone(wg *sync.WaitGroup, results chan<- *BlockResult) {
+	wg.Wait()
+	close(results)
+}
+
 func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) error {
 	metadataDevice := GetMetadataDevice(snapshot)
 	if metadataDevice == "" {
@@ -89,10 +120,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	if err != nil {
 		return err
 	}
-	defer func() {
-		bufOut.Flush()
-		compWriter.Close()
-	}()
+	defer flushAndClose(bufOut, compWriter)
 
 	srcFile, err := os.Open(source)
 	if err != nil {
@@ -245,32 +273,12 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	var wg sync.WaitGroup
 	for i := 0; i < cfg.Parallel; i++ {
 		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for task := range tasks {
-				data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
-				results <- &BlockResult{
-					Index:  task.Index,
-					Offset: uint64(task.R.Start),
-					Size:   uint32(cfg.BlockSize),
-					Data:   data,
-					Err:    err,
-				}
-			}
-		}()
+		go dumpWorker(cfg, srcFile, tasks, results, &wg)
 	}
 
-	go func() {
-		for i := resumeStart; i < numBlocks; i++ {
-			tasks <- BlockTask{Index: i, R: ranges[i]}
-		}
-		close(tasks)
-	}()
+	go enqueueTasks(resumeStart, numBlocks, ranges, tasks)
 
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
+	go closeResultsWhenDone(&wg, results)
 
 	startTime := time.Now()
 	var totalBytesTransferred int64


### PR DESCRIPTION
## Summary
- extract anonymous goroutines in `lvm.go` into `readFromPipe`
- add `handleSignal` and `monitorSnapshotRoutine` helpers
- replace inline goroutines in the transfer package with named helpers
- expose `newBufferFunc` and `flushAndClose` utilities
- extract usage printing logic and cleanup helper

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d440e11c0832390f7957b40004ac7