### PR TITLE
Use %w for error wrapping

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -188,25 +188,25 @@ func LoadConfig() (*Config, error) {
 	if configFile != "" {
 		v.SetConfigFile(configFile)
 		if err := v.ReadInConfig(); err != nil {
-			return nil, fmt.Errorf("error reading config file %q: %v", configFile, err)
+			return nil, fmt.Errorf("error reading config file %q: %w", configFile, err)
 		}
 	}
 	var conf Config
 	if err := v.Unmarshal(&conf); err != nil {
-		return nil, fmt.Errorf("error unmarshaling config: %v", err)
+		return nil, fmt.Errorf("error unmarshaling config: %w", err)
 	}
 
 	blockSizeStr := strings.ReplaceAll(v.GetString("block_size"), " ", "")
 	blockSize, err := humanize.ParseBytes(blockSizeStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid block size value %q: %v", blockSizeStr, err)
+		return nil, fmt.Errorf("invalid block size value %q: %w", blockSizeStr, err)
 	}
 	conf.BlockSize = int(blockSize)
 
 	speedStr := strings.ReplaceAll(v.GetString("speed"), " ", "")
 	speedVal, err := humanize.ParseBytes(speedStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid speed value %q: %v", speedStr, err)
+		return nil, fmt.Errorf("invalid speed value %q: %w", speedStr, err)
 	}
 	conf.SpeedLimit = int(speedVal)
 
@@ -216,7 +216,7 @@ func LoadConfig() (*Config, error) {
 func (c *Config) Validate() error {
 	out, err := exec.Command("vgdisplay", c.VolumeGroup).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("volume group %q does not exist or is inaccessible: %v, output: %s", c.VolumeGroup, err, string(out))
+		return fmt.Errorf("volume group %q does not exist or is inaccessible: %w, output: %s", c.VolumeGroup, err, string(out))
 	}
 	if os.Geteuid() != 0 {
 		parts := strings.Fields(c.LVMEscalation)
@@ -224,7 +224,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("lvm escalation command is empty")
 		}
 		if _, err := exec.LookPath(parts[0]); err != nil {
-			return fmt.Errorf("lvm escalation command %q not found: %v", parts[0], err)
+			return fmt.Errorf("lvm escalation command %q not found: %w", parts[0], err)
 		}
 	}
 	return nil

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -84,7 +84,7 @@ func (c *fdCache) getFD(devicePath string) (int, error) {
 
 	fd, err := syscall.Open(devicePath, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
 	if err != nil {
-		return -1, fmt.Errorf("failed to open device %s: %v", devicePath, err)
+		return -1, fmt.Errorf("failed to open device %s: %w", devicePath, err)
 	}
 
 	if len(c.fds) >= fdCacheSize {
@@ -146,7 +146,7 @@ func executeCommand(name string, args ...string) ([]byte, error) {
 
 	err = cmd.Wait()
 	if err != nil {
-		return outBuf.Bytes(), fmt.Errorf("%v: %s", err, errBuf.String())
+		return outBuf.Bytes(), fmt.Errorf("%w: %s", err, errBuf.String())
 	}
 
 	return outBuf.Bytes(), nil
@@ -163,7 +163,7 @@ func CreateSnapshot(lvPath, snapshotName, size string) error {
 
 	output, err := executeCommand("lvcreate", "-s", "-n", snapshotName, "-L", size, lvPath)
 	if err != nil {
-		return fmt.Errorf("failed to create snapshot [%s] for LV %s with size %s: %v",
+		return fmt.Errorf("failed to create snapshot [%s] for LV %s with size %s: %w",
 			snapshotName, lvPath, size, err)
 	}
 
@@ -187,7 +187,7 @@ func RemoveSnapshot(snapshotPath string) error {
 
 	output, err := executeCommand("lvremove", "-f", snapshotPath)
 	if err != nil {
-		return fmt.Errorf("failed to remove snapshot [%s]: %v", snapshotPath, err)
+		return fmt.Errorf("failed to remove snapshot [%s]: %w", snapshotPath, err)
 	}
 
 	zap.L().Info("Snapshot removed successfully",
@@ -209,13 +209,13 @@ func GetSnapshotUsage(snapshotPath string) (float64, error) {
 	output, err := executeCommand("lvs", "--noheadings", "--units", "b",
 		"--options", "data_percent", snapshotPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get snapshot usage for %s: %v", snapshotPath, err)
+		return 0, fmt.Errorf("failed to get snapshot usage for %s: %w", snapshotPath, err)
 	}
 
 	usageStr := strings.TrimSpace(string(output))
 	usage, err := strconv.ParseFloat(usageStr, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse snapshot usage %q: %v", usageStr, err)
+		return 0, fmt.Errorf("failed to parse snapshot usage %q: %w", usageStr, err)
 	}
 
 	zap.L().Info("Snapshot usage retrieved",
@@ -258,7 +258,7 @@ func MonitorSnapshot(snapshotPath string, threshold float64, interval time.Durat
 func CheckDiskSpace(mountPoint string) (uint64, error) {
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs(mountPoint, &stat); err != nil {
-		return 0, fmt.Errorf("failed to get disk stats for %q: %v", mountPoint, err)
+		return 0, fmt.Errorf("failed to get disk stats for %q: %w", mountPoint, err)
 	}
 
 	available := stat.Bavail * uint64(stat.Bsize)
@@ -278,7 +278,7 @@ func GetVolumeSize(volumePath string) (uint64, error) {
 	var size uint64
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(BLKGETSIZE64), uintptr(unsafe.Pointer(&size)))
 	if errno != 0 {
-		return 0, fmt.Errorf("ioctl BLKGETSIZE64 failed on %q: %v", volumePath, errno)
+		return 0, fmt.Errorf("ioctl BLKGETSIZE64 failed on %q: %w", volumePath, errno)
 	}
 
 	zap.L().Debug("Volume size retrieved",
@@ -293,7 +293,7 @@ func GetVolumeAttributes(volumePath string) (map[string]string, error) {
 	sysfsPath := filepath.Join("/sys/block", devName)
 
 	if _, err := os.Stat(sysfsPath); err != nil {
-		return nil, fmt.Errorf("device %s not found in sysfs: %v", devName, err)
+		return nil, fmt.Errorf("device %s not found in sysfs: %w", devName, err)
 	}
 
 	attributes := make(map[string]string)
@@ -321,7 +321,7 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 		percentStr := strings.TrimSuffix(sizeStr, "%")
 		percent, err := strconv.ParseFloat(percentStr, 64)
 		if err != nil {
-			return 0, fmt.Errorf("invalid percentage value %q: %v", sizeStr, err)
+			return 0, fmt.Errorf("invalid percentage value %q: %w", sizeStr, err)
 		}
 
 		if percent <= 0 || percent > 100 {
@@ -330,7 +330,7 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 
 		volSize, err := GetVolumeSize(volumePath)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get volume size for %q: %v", volumePath, err)
+			return 0, fmt.Errorf("failed to get volume size for %q: %w", volumePath, err)
 		}
 
 		parsedSize := uint64(float64(volSize) * (percent / 100.0))
@@ -344,7 +344,7 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 
 	parsedSize, err := humanize.ParseBytes(sizeStr)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse snapshot size %q: %v", sizeStr, err)
+		return 0, fmt.Errorf("failed to parse snapshot size %q: %w", sizeStr, err)
 	}
 
 	zap.L().Debug("Parsed snapshot size",
@@ -368,7 +368,7 @@ func GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
 	output, err := executeCommand("vgs", "--noheadings", "--units", "b",
 		"--options", "vg_free", vgName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get free space for VG %s: %v", vgName, err)
+		return 0, fmt.Errorf("failed to get free space for VG %s: %w", vgName, err)
 	}
 
 	sizeStr := strings.TrimSpace(string(output))
@@ -377,7 +377,7 @@ func GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
 
 	size, err := strconv.ParseUint(sizeStr, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse VG free space %q: %v", sizeStr, err)
+		return 0, fmt.Errorf("failed to parse VG free space %q: %w", sizeStr, err)
 	}
 
 	return size, nil

--- a/main.go
+++ b/main.go
@@ -40,33 +40,33 @@ func runClientMode(snapshotDevice, dest string) error {
 		destDevice := parts[1]
 		client, err := remote.NewSSHClient(destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval)
 		if err != nil {
-			return fmt.Errorf("failed to create SSH client: %v", err)
+			return fmt.Errorf("failed to create SSH client: %w", err)
 		}
 		defer client.Close()
 		remote.SetLogger(zap.L())
 
 		if cfg.RemotePreScript != "" {
 			if err := remote.RunRemoteScript(client, cfg.RemotePreScript); err != nil {
-				return fmt.Errorf("remote pre-script failed: %v", err)
+				return fmt.Errorf("remote pre-script failed: %w", err)
 			}
 		}
 		if err := remote.ValidateRemoteCommand(client, cfg.LVMSyncPath); err != nil {
-			return fmt.Errorf("remote command validation failed: %v", err)
+			return fmt.Errorf("remote command validation failed: %w", err)
 		}
 
 		session, err := client.NewSession()
 		if err != nil {
-			return fmt.Errorf("failed to create SSH session: %v", err)
+			return fmt.Errorf("failed to create SSH session: %w", err)
 		}
 		defer session.Close()
 
 		stdoutPipe, err := session.StdoutPipe()
 		if err != nil {
-			return fmt.Errorf("failed to get stdout pipe: %v", err)
+			return fmt.Errorf("failed to get stdout pipe: %w", err)
 		}
 		stderrPipe, err := session.StderrPipe()
 		if err != nil {
-			return fmt.Errorf("failed to get stderr pipe: %v", err)
+			return fmt.Errorf("failed to get stderr pipe: %w", err)
 		}
 		go io.Copy(os.Stdout, stdoutPipe)
 		go io.Copy(os.Stderr, stderrPipe)
@@ -76,10 +76,10 @@ func runClientMode(snapshotDevice, dest string) error {
 
 		remoteStdin, err := session.StdinPipe()
 		if err != nil {
-			return fmt.Errorf("failed to get remote stdin: %v", err)
+			return fmt.Errorf("failed to get remote stdin: %w", err)
 		}
 		if err := session.Start(remoteCmd); err != nil {
-			return fmt.Errorf("failed to start remote command: %v", err)
+			return fmt.Errorf("failed to start remote command: %w", err)
 		}
 
 		var streamErr error
@@ -97,22 +97,22 @@ func runClientMode(snapshotDevice, dest string) error {
 
 		remoteStdin.Close()
 		if streamErr != nil {
-			return fmt.Errorf("error during dumpChanges: %v", streamErr)
+			return fmt.Errorf("error during dumpChanges: %w", streamErr)
 		}
 
 		if err := session.Wait(); err != nil {
-			return fmt.Errorf("remote command error: %v", err)
+			return fmt.Errorf("remote command error: %w", err)
 		}
 
 		if cfg.RemotePostScript != "" {
 			if err := remote.RunRemoteScript(client, cfg.RemotePostScript); err != nil {
-				return fmt.Errorf("remote post-script failed: %v", err)
+				return fmt.Errorf("remote post-script failed: %w", err)
 			}
 		}
 	} else {
 		destFile, err := os.OpenFile(dest, os.O_RDWR, 0)
 		if err != nil {
-			return fmt.Errorf("failed to open destination device %s: %v", dest, err)
+			return fmt.Errorf("failed to open destination device %s: %w", dest, err)
 		}
 		defer destFile.Close()
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -19,11 +19,11 @@ func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, v
 	if keyPath != "" {
 		key, err := os.ReadFile(keyPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read SSH key file: %v", err)
+			return nil, fmt.Errorf("failed to read SSH key file: %w", err)
 		}
 		signer, err := ssh.ParsePrivateKey(key)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse SSH key: %v", err)
+			return nil, fmt.Errorf("failed to parse SSH key: %w", err)
 		}
 		authMethods = append(authMethods, ssh.PublicKeys(signer))
 	} else {
@@ -41,7 +41,7 @@ func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, v
 		var err error
 		hostKeyCallback, err = knownhosts.New(knownHostsPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create knownhosts callback: %v", err)
+			return nil, fmt.Errorf("failed to create knownhosts callback: %w", err)
 		}
 	} else {
 		hostKeyCallback = ssh.InsecureIgnoreHostKey()
@@ -71,11 +71,11 @@ func ValidateRemoteCommand(client *ssh.Client, remoteCmd string) error {
 	cmd := tokens[0]
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session for validation: %v", err)
+		return fmt.Errorf("failed to create SSH session for validation: %w", err)
 	}
 	defer session.Close()
 	if err := session.Run(fmt.Sprintf("command -v %s >/dev/null 2>&1", cmd)); err != nil {
-		return fmt.Errorf("remote command %s not found or not executable: %v", cmd, err)
+		return fmt.Errorf("remote command %s not found or not executable: %w", cmd, err)
 	}
 	return nil
 }
@@ -83,7 +83,7 @@ func ValidateRemoteCommand(client *ssh.Client, remoteCmd string) error {
 func RunRemoteScript(client *ssh.Client, script string) error {
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session for script: %v", err)
+		return fmt.Errorf("failed to create SSH session for script: %w", err)
 	}
 	defer session.Close()
 	Logger.Info("Running remote script", zap.String("script", script))

--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -23,12 +23,12 @@ type SSHManager struct {
 func NewSSHManager(user, keyPath string, timeout time.Duration, knownHostsPath string, verify bool) (*SSHManager, error) {
 	authMethods, err := getSSHAuthMethods(keyPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize authentication: %v", err)
+		return nil, fmt.Errorf("failed to initialize authentication: %w", err)
 	}
 
 	hostKeyCallback, err := getHostKeyCallback(knownHostsPath, verify)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set up host key verification: %v", err)
+		return nil, fmt.Errorf("failed to set up host key verification: %w", err)
 	}
 
 	sshConfig := &ssh.ClientConfig{
@@ -56,7 +56,7 @@ func (s *SSHManager) GetClient(host string, port int) (*ssh.Client, error) {
 
 	client, err := dialSSH(addr, s.sshConfig, s.timeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to establish SSH connection: %v", err)
+		return nil, fmt.Errorf("failed to establish SSH connection: %w", err)
 	}
 
 	s.clients[addr] = client
@@ -103,12 +103,12 @@ func getHostKeyCallback(knownHostsPath string, verify bool) (ssh.HostKeyCallback
 func dialSSH(addr string, sshConfig *ssh.ClientConfig, timeout time.Duration) (*ssh.Client, error) {
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to %s: %v", addr, err)
+		return nil, fmt.Errorf("failed to connect to %s: %w", addr, err)
 	}
 
 	clientConn, chans, reqs, err := ssh.NewClientConn(conn, addr, sshConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to establish SSH connection: %v", err)
+		return nil, fmt.Errorf("failed to establish SSH connection: %w", err)
 	}
 
 	return ssh.NewClient(clientConn, chans, reqs), nil
@@ -117,7 +117,7 @@ func dialSSH(addr string, sshConfig *ssh.ClientConfig, timeout time.Duration) (*
 func loadPrivateKey(keyPath string) (ssh.Signer, error) {
 	keyData, err := os.ReadFile(keyPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read private key: %v", err)
+		return nil, fmt.Errorf("failed to read private key: %w", err)
 	}
 	return ssh.ParsePrivateKey(keyData)
 }
@@ -130,7 +130,7 @@ func sshAgentAuth() (ssh.AuthMethod, error) {
 
 	conn, err := net.Dial("unix", agentSock)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to SSH agent: %v", err)
+		return nil, fmt.Errorf("failed to connect to SSH agent: %w", err)
 	}
 
 	return ssh.PublicKeysCallback(agent.NewClient(conn).Signers), nil

--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -46,7 +46,7 @@ func GetMultiplexedSession(client *ssh.Client, host string) (*SSHSession, error)
 func NewSSHSession(client *ssh.Client) (*SSHSession, error) {
 	session, err := client.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SSH session: %v", err)
+		return nil, fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	return &SSHSession{Client: client, Session: session}, nil
 }
@@ -75,25 +75,25 @@ func RunSSHCommand(host, user, keyPath string, port int, command string, timeout
 	}, timeout)
 
 	if err != nil {
-		return fmt.Errorf("failed to establish SSH connection: %v", err)
+		return fmt.Errorf("failed to establish SSH connection: %w", err)
 	}
 	defer client.Close()
 
 	session, err := NewSSHSession(client)
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %v", err)
+		return fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer session.Close()
 
 	var stdoutBuf, stderrBuf io.Writer
 	cmdErr := session.Start(command, nil, stdoutBuf, stderrBuf)
 	if cmdErr != nil {
-		return fmt.Errorf("failed to start command: %v", cmdErr)
+		return fmt.Errorf("failed to start command: %w", cmdErr)
 	}
 
 	err = session.Wait()
 	if err != nil {
-		return fmt.Errorf("SSH command failed: %v", err)
+		return fmt.Errorf("SSH command failed: %w", err)
 	}
 
 	zap.L().Info("SSH command completed", zap.String("host", host), zap.String("command", command))

--- a/transfer/block.go
+++ b/transfer/block.go
@@ -24,14 +24,14 @@ func ZeroCopyTransfer(src *os.File, dst *os.File, offset int64, length int64, pi
 	for remaining > 0 {
 		n, err := syscall.Splice(int(src.Fd()), &off, pipeFds[1], nil, int(remaining), 0)
 		if err != nil {
-			return fmt.Errorf("splice read failed: %v", err)
+			return fmt.Errorf("splice read failed: %w", err)
 		}
 		if n == 0 {
 			break
 		}
 		_, err = syscall.Splice(pipeFds[0], nil, int(dst.Fd()), nil, int(n), 0)
 		if err != nil {
-			return fmt.Errorf("splice write failed: %v", err)
+			return fmt.Errorf("splice write failed: %w", err)
 		}
 		remaining -= int64(n)
 	}

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -45,7 +45,7 @@ func NewDecompressionReader(r io.Reader, compress string) (io.ReadCloser, error)
 	case "zstd":
 		decoder, err := zstd.NewReader(r)
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize zstd decoder: %v", err)
+			return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
 		}
 		return &zstdReadCloser{Decoder: decoder}, nil
 	default:

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -64,7 +64,7 @@ func prepareOutputWriter(out io.Writer, cfg *config.Config) (io.WriteCloser, *bu
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
 	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create compression writer: %v", err)
+		return nil, nil, fmt.Errorf("failed to create compression writer: %w", err)
 	}
 	bufOut := bufio.NewWriter(compWriter)
 	return compWriter, bufOut, nil
@@ -78,7 +78,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	blockSize := int64(cfg.BlockSize)
 	ranges, err := GetDifferences(metadataDevice, blockSize)
 	if err != nil {
-		return fmt.Errorf("error getting differences: %v", err)
+		return fmt.Errorf("error getting differences: %w", err)
 	}
 	Logger.Info("Changed blocks determined", zap.Int("blockCount", len(ranges)))
 	if handshake != "" {
@@ -96,14 +96,14 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 
 	srcFile, err := os.Open(source)
 	if err != nil {
-		return fmt.Errorf("failed to open source device %s: %v", source, err)
+		return fmt.Errorf("failed to open source device %s: %w", source, err)
 	}
 	defer srcFile.Close()
 
 	var pipeFds [2]int
 	if cfg.ZeroCopy {
 		if err := syscall.Pipe(pipeFds[:]); err != nil {
-			return fmt.Errorf("failed to create pipe: %v", err)
+			return fmt.Errorf("failed to create pipe: %w", err)
 		}
 		defer syscall.Close(pipeFds[0])
 		defer syscall.Close(pipeFds[1])
@@ -118,7 +118,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	for _, r := range ranges {
 		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy, pipeFds)
 		if err != nil {
-			return fmt.Errorf("error reading block at offset %d: %v", r.Start, err)
+			return fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
 		}
 		if cfg.Deduplication && dedup != nil {
 			if !dedup.ShouldTransfer(r.Start, data) {
@@ -133,11 +133,11 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 		binary.BigEndian.PutUint64(header[0:8], uint64(r.Start))
 		binary.BigEndian.PutUint32(header[8:12], uint32(cfg.BlockSize))
 		if _, err := bufOut.Write(header); err != nil {
-			return fmt.Errorf("failed to write header: %v", err)
+			return fmt.Errorf("failed to write header: %w", err)
 		}
 		if _, err := bufOut.Write(data); err != nil {
 			putBlockBuffer(data)
-			return fmt.Errorf("failed to write block data: %v", err)
+			return fmt.Errorf("failed to write block data: %w", err)
 		}
 		putBlockBuffer(data)
 
@@ -195,7 +195,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 
 	ranges, err := GetDifferences(metadataDevice, blockSize)
 	if err != nil {
-		return fmt.Errorf("error getting differences: %v", err)
+		return fmt.Errorf("error getting differences: %w", err)
 	}
 	Logger.Info("Changed blocks determined", zap.Int("blockCount", len(ranges)))
 
@@ -213,13 +213,13 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
 	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel)
 	if err != nil {
-		return fmt.Errorf("failed to create compression writer: %v", err)
+		return fmt.Errorf("failed to create compression writer: %w", err)
 	}
 	bufOut := bufio.NewWriter(compWriter)
 
 	srcFile, err := os.Open(source)
 	if err != nil {
-		return fmt.Errorf("failed to open source device %s: %v", source, err)
+		return fmt.Errorf("failed to open source device %s: %w", source, err)
 	}
 	defer srcFile.Close()
 
@@ -277,7 +277,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 
 	for res := range results {
 		if res.Err != nil {
-			return fmt.Errorf("error in block %d: %v", res.Index, res.Err)
+			return fmt.Errorf("error in block %d: %w", res.Index, res.Err)
 		}
 
 		header := make([]byte, 12)
@@ -289,11 +289,11 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 		}
 
 		if _, err := bufOut.Write(header); err != nil {
-			return fmt.Errorf("failed to write header: %v", err)
+			return fmt.Errorf("failed to write header: %w", err)
 		}
 		if _, err := bufOut.Write(res.Data); err != nil {
 			putBlockBuffer(res.Data)
-			return fmt.Errorf("failed to write data: %v", err)
+			return fmt.Errorf("failed to write data: %w", err)
 		}
 		putBlockBuffer(res.Data)
 
@@ -336,20 +336,20 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) error {
 	decReader, err := NewDecompressionReader(in, cfg.Compress)
 	if err != nil {
-		return fmt.Errorf("failed to create decompression reader: %v", err)
+		return fmt.Errorf("failed to create decompression reader: %w", err)
 	}
 	defer decReader.Close()
 
 	reader := bufio.NewReader(decReader)
 	handshake, err := reader.ReadString('\n')
 	if err != nil {
-		return fmt.Errorf("failed to read protocol handshake: %v", err)
+		return fmt.Errorf("failed to read protocol handshake: %w", err)
 	}
 	handshake = strings.TrimSpace(handshake)
 
 	destFile, err := os.OpenFile(destPath, os.O_RDWR, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open destination device %s: %v", destPath, err)
+		return fmt.Errorf("failed to open destination device %s: %w", destPath, err)
 	}
 	defer destFile.Close()
 
@@ -367,7 +367,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("failed to read chunk header: %v", err)
+			return fmt.Errorf("failed to read chunk header: %w", err)
 		}
 
 		offset := binary.BigEndian.Uint64(headerBuf[0:8])
@@ -381,7 +381,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 		data := getBlockBuffer(int(chunkSize))
 		if _, err := io.ReadFull(reader, data); err != nil {
 			putBlockBuffer(data)
-			return fmt.Errorf("failed to read chunk data: %v", err)
+			return fmt.Errorf("failed to read chunk data: %w", err)
 		}
 
 		if verify {
@@ -405,7 +405,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 		}
 		if _, err := destFile.Write(data); err != nil {
 			putBlockBuffer(data)
-			return fmt.Errorf("failed to write data at offset %d: %v", offset, err)
+			return fmt.Errorf("failed to write data at offset %d: %w", offset, err)
 		}
 		putBlockBuffer(data)
 
@@ -435,7 +435,7 @@ func RunApply(cfg *config.Config, applyFile, destDevice string) error {
 	} else {
 		f, err := os.Open(applyFile)
 		if err != nil {
-			return fmt.Errorf("failed to open apply file %s: %v", applyFile, err)
+			return fmt.Errorf("failed to open apply file %s: %w", applyFile, err)
 		}
 		defer f.Close()
 		in = f


### PR DESCRIPTION
## Summary
- switch to `%w` in `fmt.Errorf` where errors are returned
- update all packages to wrap errors

## Testing
- `go vet ./...` *(fails: no required module provides packages)*

------
https://chatgpt.com/codex/tasks/task_e_688d4410d91883239f7c4af0aabf45f9