### PR TITLE
Add rolling hash deduplication strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Checksum Verification**: Ensures data integrity.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers.
+- **Deduplication Strategies**: Skip unchanged blocks using checksum, rolling hash or bloom filter methods.
 - **LVM Snapshot Management**:
   - Automatic snapshot creation and removal.
   - Configurable snapshot size (absolute or percentage-based).
@@ -88,6 +89,14 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--lvmsync_path`      | Remote command to run (e.g., `"lvmsync"`)               | `"lvmsync"`|
 | `--remote_pre_script` | Remote script to run before starting the transfer       | `""`      |
 | `--remote_post_script`| Remote script to run after finishing the transfer        | `""`      |
+
+#### Deduplication Options
+
+| Option              | Description                                                          | Default            |
+|---------------------|----------------------------------------------------------------------|--------------------|
+| `--deduplication`   | Enable deduplication to avoid re-transferring unchanged blocks       | `false`            |
+| `--dedup_strategy`  | Deduplication strategy (`checksum`, `rolling_hash`, `bloom`)         | `"checksum"`      |
+| `--dedup_state_file`| Path to deduplication state file                                      | `~/.lvmsync_dedup` |
 
 #### Compression Options
 
@@ -202,6 +211,11 @@ stricthostkeychecking: true             # Enable SSH StrictHostKeyChecking
 lvmsync_path: "lvmsync"                 # Remote command to run
 remote_pre_script: ""                   # Remote script to run before starting transfer
 remote_post_script: ""                  # Remote script to run after finishing transfer
+
+# Deduplication Options:
+deduplication: false                    # Enable deduplication to skip unchanged blocks
+dedup_strategy: "checksum"               # Strategy: checksum, rolling_hash, or bloom
+dedup_state_file: "~/.lvmsync_dedup"     # Path to deduplication state file
 
 # Compression Options:
 compress: "lz4"                         # Compression type (options: "none", "lz4", "zstd", "auto")

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	BlockSize            int           `mapstructure:"block_size"`
 	BlockSizeRaw         string        `mapstructure:"-"`
 	Deduplication        bool          `mapstructure:"deduplication"`
-	DedupStrategy        string        `mapstructure:"dedup_strategy"`
+	DedupStrategy        string        `mapstructure:"dedup_strategy"` // checksum, rolling_hash or bloom
 	DedupStateFile       string        `mapstructure:"dedup_state_file"`
 	UseBloomFilter       bool          `mapstructure:"use_bloom_filter"`
 }

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -30,13 +30,37 @@ type BloomFilterDedup struct {
 	mu        sync.RWMutex
 }
 
+type RollingHashDedup struct {
+	stateFile string
+	hashes    map[int64]uint64
+	mu        sync.RWMutex
+}
+
+const rollingBase uint64 = 257
+const rollingMod uint64 = 2305843009213693951 // 2^61 - 1 prime
+
+func rollingHash(data []byte) uint64 {
+	var h uint64
+	for _, b := range data {
+		h = (h*rollingBase + uint64(b)) % rollingMod
+	}
+	return h
+}
+
 func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 	switch cfg.DedupStrategy {
+	case "rolling_hash":
+		return &RollingHashDedup{
+			stateFile: cfg.DedupStateFile,
+			hashes:    make(map[int64]uint64),
+		}
 	case "bloom":
 		return &BloomFilterDedup{
 			filter:    bloom.NewWithEstimates(1000000, 0.01),
 			stateFile: cfg.DedupStateFile,
 		}
+	case "checksum":
+		fallthrough
 	default:
 		return &ChecksumDedup{
 			stateFile: cfg.DedupStateFile,
@@ -98,5 +122,42 @@ func (b *BloomFilterDedup) RecordTransfer(offset int64, data []byte) {
 func (b *BloomFilterDedup) SaveState() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return nil
+}
+
+func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
+	r.mu.RLock()
+	prev, exists := r.hashes[offset]
+	r.mu.RUnlock()
+
+	h := rollingHash(data)
+	return !exists || prev != h
+}
+
+func (r *RollingHashDedup) RecordTransfer(offset int64, data []byte) {
+	h := rollingHash(data)
+	r.mu.Lock()
+	r.hashes[offset] = h
+	r.mu.Unlock()
+}
+
+func (r *RollingHashDedup) SaveState() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	file, err := os.Create(r.stateFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for offset, hash := range r.hashes {
+		if err := binary.Write(file, binary.LittleEndian, offset); err != nil {
+			return err
+		}
+		if err := binary.Write(file, binary.LittleEndian, hash); err != nil {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- implement a Rabin-Karp style rolling hash deduplication
- allow selecting it through `NewDeduplicationStrategy`
- document deduplication strategies and options in README
- clarify supported dedup strategies in config comments

## Testing
- `go vet ./...` *(fails: no required module provides package)*
- `go test ./...` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_688d4427595c83238ec1dfde7a1047be