### PR TITLE
Fix snapshot cleanup on interrupts

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,14 +132,14 @@ func runClientMode(snapshotDevice, dest string) error {
 	return nil
 }
 
-func handleSignals(signals <-chan os.Signal, snapshotPath string) {
+func handleSignals(signals <-chan os.Signal, snapshotPath *string) {
 	sig := <-signals
 	zap.L().Info("Received signal, aborting", zap.String("signal", sig.String()))
-	if !cfg.SkipSnapshotCreation && snapshotPath != "" && snapshotPath != pflag.Arg(0) {
-		if err := lvm.RemoveSnapshot(snapshotPath); err != nil {
+	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
+		if err := lvm.RemoveSnapshot(*snapshotPath); err != nil {
 			zap.L().Warn("Failed to remove snapshot on shutdown", zap.Error(err))
 		} else {
-			zap.L().Info("Snapshot removed on shutdown", zap.String("snapshot", snapshotPath))
+			zap.L().Info("Snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))
 		}
 	}
 	os.Exit(1)
@@ -172,7 +172,7 @@ func main() {
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	var snapshotPath string
 
-	go handleSignals(signals, snapshotPath)
+	go handleSignals(signals, &snapshotPath)
 
 	args := pflag.Args()
 	if len(args) < 2 {


### PR DESCRIPTION
## Summary
- ensure `handleSignals` receives a pointer to the snapshot path so it always removes the correct snapshot

## Testing
- `go mod tidy` *(fails: module download forbidden)*
- `go test ./...` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688dc4c83b448323b03ce70395ac43f5