### PR TITLE
Implement bloom filter state persistence

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -135,16 +135,34 @@ func (b *BloomFilterDedup) RecordTransfer(offset int64, data []byte) {
 func (b *BloomFilterDedup) SaveState() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return nil
+
+	file, err := os.Create(b.stateFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = b.filter.WriteTo(file)
+	return err
 }
 
 func (b *BloomFilterDedup) loadState() error {
-	if _, err := os.Stat(b.stateFile); err != nil {
+	file, err := os.Open(b.stateFile)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
 	}
-	// Persistence for bloom filter is currently not implemented.
-	return nil
+	defer file.Close()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.filter == nil {
+		b.filter = bloom.NewWithEstimates(1000000, 0.01)
+	}
+
+	_, err = b.filter.ReadFrom(file)
+	return err
 }

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -1,0 +1,32 @@
+package transfer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bits-and-blooms/bloom/v3"
+)
+
+func TestBloomFilterDedupPersistence(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state")
+
+	d1 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile}
+	data := []byte("hello")
+
+	if !d1.ShouldTransfer(0, data) {
+		t.Fatalf("first transfer should be allowed")
+	}
+	d1.RecordTransfer(0, data)
+	if err := d1.SaveState(); err != nil {
+		t.Fatalf("failed to save state: %v", err)
+	}
+
+	d2 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile}
+	if err := d2.loadState(); err != nil {
+		t.Fatalf("failed to load state: %v", err)
+	}
+
+	if d2.ShouldTransfer(0, data) {
+		t.Fatalf("expected bloom filter to persist state")
+	}
+}


### PR DESCRIPTION
## Summary
- persist BloomFilterDedup via serialization to state file using WriteTo/ReadFrom
- add test ensuring bloom filter state is preserved across runs

## Testing
- `go test ./...` *(fails: no required module provides packages such as github.com/spf13/pflag, go.uber.org/zap, github.com/dustin/go-humanize, github.com/bits-and-blooms/bloom/v3, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688dc6a51ed08323a0b1bcb83cab0212