### PR TITLE
Add syscall import for zero-copy transfer operations

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"lvmsync_go/common"


### PR DESCRIPTION
## Summary
- add missing `syscall` dependency to transfer package
- ensure zero-copy logic uses `syscall.Pipe` and `syscall.Close`

## Testing
- `go mod tidy` *(fails: module github.com/spf13/pflag: Forbidden)*
- `go test ./...` *(fails: no required module provides package github.com/spf13/pflag)*

------
https://chatgpt.com/codex/tasks/task_e_688e112df4b48323a70af5ebaeffcefb