### PR TITLE
Add rolling hash dedup strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Parallel Execution**: Configurable concurrency for optimal performance.
 - **Rate-Limiting**: Control bandwidth usage during transfers.
 - **Compression**: Supports LZ4 and Zstd (with configurable compression levels and an auto mode based on CPU features).
-- **Checksum Verification**: Ensures data integrity.
-- **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
+ - **Checksum Verification**: Ensures data integrity.
+ - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or Bloom filter with persistent state.
+ - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers.
 - **LVM Snapshot Management**:
   - Automatic snapshot creation and removal.
@@ -88,6 +89,14 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--lvmsync_path`      | Remote command to run (e.g., `"lvmsync"`)               | `"lvmsync"`|
 | `--remote_pre_script` | Remote script to run before starting the transfer       | `""`      |
 | `--remote_post_script`| Remote script to run after finishing the transfer        | `""`      |
+
+#### Deduplication Options
+
+| Option               | Description                                                                             | Default          |
+|----------------------|-----------------------------------------------------------------------------------------|------------------|
+| `--deduplication`    | Enable deduplication to avoid re-transferring unchanged blocks                          | `false`          |
+| `--dedup_strategy`   | Deduplication strategy (`"checksum"`, `"rolling_hash"`, or `"bloom"`)                  | `"checksum"`    |
+| `--dedup_state_file` | Path to deduplication state file                                                        | `~/.lvmsync_dedup` |
 
 #### Compression Options
 
@@ -190,6 +199,11 @@ speed: "100MB"                          # Transfer speed limit (e.g., "100MB")
 verbose: 0                              # Verbosity level
 verify_checksum: false                  # Enable checksum verification
 progress: true                          # Show progress percentage during the transfer
+
+# Deduplication Options:
+deduplication: false                    # Enable deduplication to avoid re-transferring unchanged blocks
+dedup_strategy: "checksum"               # Strategy: "checksum", "rolling_hash", or "bloom"
+dedup_state_file: "~/.lvmsync_dedup"    # Path to deduplication state file
 
 # SSH Options:
 ssh_user: "root"                        # SSH username

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -32,8 +32,23 @@ type BloomFilterDedup struct {
 	mu        sync.RWMutex
 }
 
+type RollingHashDedup struct {
+	stateFile string
+	hashes    map[int64]uint64
+	mu        sync.RWMutex
+}
+
 func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 	switch cfg.DedupStrategy {
+	case "rolling_hash":
+		d := &RollingHashDedup{
+			stateFile: cfg.DedupStateFile,
+			hashes:    make(map[int64]uint64),
+		}
+		if err := d.loadState(); err != nil {
+			zap.L().Warn("failed to load dedup state", zap.Error(err))
+		}
+		return d
 	case "bloom":
 		d := &BloomFilterDedup{
 			filter:    bloom.NewWithEstimates(1000000, 0.01),
@@ -112,6 +127,88 @@ func (c *ChecksumDedup) loadState() error {
 			return err
 		}
 		c.hashes[offset] = hash
+	}
+	return nil
+}
+
+func (r *RollingHashDedup) computeHash(data []byte) uint64 {
+	const base uint64 = 257
+	var h uint64
+	for _, b := range data {
+		h = h*base + uint64(b)
+	}
+	return h
+}
+
+func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
+	h := r.computeHash(data)
+
+	r.mu.RLock()
+	prev, exists := r.hashes[offset]
+	r.mu.RUnlock()
+
+	return !exists || prev != h
+}
+
+func (r *RollingHashDedup) RecordTransfer(offset int64, data []byte) {
+	h := r.computeHash(data)
+
+	r.mu.Lock()
+	r.hashes[offset] = h
+	r.mu.Unlock()
+}
+
+func (r *RollingHashDedup) SaveState() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	file, err := os.Create(r.stateFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for offset, hash := range r.hashes {
+		if err := binary.Write(file, binary.LittleEndian, offset); err != nil {
+			return err
+		}
+		if err := binary.Write(file, binary.LittleEndian, hash); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *RollingHashDedup) loadState() error {
+	file, err := os.Open(r.stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.hashes == nil {
+		r.hashes = make(map[int64]uint64)
+	}
+
+	for {
+		var offset int64
+		if err := binary.Read(file, binary.LittleEndian, &offset); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		var hash uint64
+		if err := binary.Read(file, binary.LittleEndian, &hash); err != nil {
+			return err
+		}
+		r.hashes[offset] = hash
 	}
 	return nil
 }

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -30,3 +30,27 @@ func TestBloomFilterDedupPersistence(t *testing.T) {
 		t.Fatalf("expected bloom filter to persist state")
 	}
 }
+
+func TestRollingHashDedupPersistence(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state")
+
+	d1 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64)}
+	data := []byte("hello")
+
+	if !d1.ShouldTransfer(0, data) {
+		t.Fatalf("first transfer should be allowed")
+	}
+	d1.RecordTransfer(0, data)
+	if err := d1.SaveState(); err != nil {
+		t.Fatalf("failed to save state: %v", err)
+	}
+
+	d2 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64)}
+	if err := d2.loadState(); err != nil {
+		t.Fatalf("failed to load state: %v", err)
+	}
+
+	if d2.ShouldTransfer(0, data) {
+		t.Fatalf("expected rolling hash dedup to persist state")
+	}
+}


### PR DESCRIPTION
## Summary
- add RollingHashDedup implementing incremental hash based deduplication with persistent state
- wire up `rolling_hash` option and document dedup strategies and flags
- test persistence for the new strategy

## Testing
- `go test ./...` *(fails: no required module provides package golang.org/x/crypto/ssh)*
- `go get golang.org/x/crypto/ssh@latest` *(fails: Forbidden)*
- `go test ./transfer ./lvm`

------
https://chatgpt.com/codex/tasks/task_e_688e1b58249c83239b4120306b49eea8