### PR TITLE
Add Fatal method to zap Logger stub

### DIFF
--- a/stubs/go.uber.org/zap/zap.go
+++ b/stubs/go.uber.org/zap/zap.go
@@ -8,6 +8,7 @@ func (l *Logger) Info(msg string, fields ...Field)  {}
 func (l *Logger) Warn(msg string, fields ...Field)  {}
 func (l *Logger) Error(msg string, fields ...Field) {}
 func (l *Logger) Debug(msg string, fields ...Field) {}
+func (l *Logger) Fatal(msg string, fields ...Field) {}
 
 // Sugared Logger placeholder
 func (l *Logger) Sugar() *SugaredLogger { return &SugaredLogger{} }


### PR DESCRIPTION
## Summary
- stub zap Logger's Fatal method with zap's standard signature

## Testing
- `go test ./...` *(fails: no required module provides package golang.org/x/crypto/ssh)*
- `go get golang.org/x/crypto/ssh` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e1e5e52b88323b211bae6cda6a520