### PR TITLE
Use unix splice in transfer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
     github.com/klauspost/compress/zstd v0.0.0
     github.com/pierrec/lz4/v4 v4.0.0
     golang.org/x/sys/cpu v0.0.0
+    golang.org/x/sys/unix v0.0.0
 )
 
 replace go.uber.org/zap => ./stubs/go.uber.org/zap
@@ -23,3 +24,4 @@ replace github.com/juju/ratelimit => ./stubs/github.com/juju/ratelimit
 replace github.com/klauspost/compress/zstd => ./stubs/github.com/klauspost/compress/zstd
 replace github.com/pierrec/lz4/v4 => ./stubs/github.com/pierrec/lz4/v4
 replace golang.org/x/sys/cpu => ./stubs/golang.org/x/sys/cpu
+replace golang.org/x/sys/unix => ./stubs/golang.org/x/sys/unix

--- a/stubs/golang.org/x/sys/unix/go.mod
+++ b/stubs/golang.org/x/sys/unix/go.mod
@@ -1,0 +1,4 @@
+module golang.org/x/sys/unix
+
+go 1.24
+

--- a/stubs/golang.org/x/sys/unix/unix.go
+++ b/stubs/golang.org/x/sys/unix/unix.go
@@ -1,0 +1,5 @@
+package unix
+
+func Splice(fdIn int, offIn *int64, fdOut int, offOut *int64, len int, flags int) (int, error) {
+	return 0, nil
+}

--- a/transfer/block.go
+++ b/transfer/block.go
@@ -12,6 +12,7 @@ import (
 	"lvmsync_go/config"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
 // PipeCreationCount tracks the number of pipes created by ReadBlockWithRetries
@@ -22,14 +23,14 @@ func ZeroCopyTransfer(src *os.File, dst *os.File, offset int64, length int64, pi
 	remaining := length
 	off := offset
 	for remaining > 0 {
-		n, err := syscall.Splice(int(src.Fd()), &off, pipeFds[1], nil, int(remaining), 0)
+		n, err := unix.Splice(int(src.Fd()), &off, pipeFds[1], nil, int(remaining), 0)
 		if err != nil {
 			return fmt.Errorf("splice read failed: %w", err)
 		}
 		if n == 0 {
 			break
 		}
-		_, err = syscall.Splice(pipeFds[0], nil, int(dst.Fd()), nil, int(n), 0)
+		_, err = unix.Splice(pipeFds[0], nil, int(dst.Fd()), nil, int(n), 0)
 		if err != nil {
 			return fmt.Errorf("splice write failed: %w", err)
 		}


### PR DESCRIPTION
## Summary
- use `golang.org/x/sys/unix` for `Splice` in block transfers
- add stub implementation of `unix.Splice`
- update module replacements for the new stub

## Testing
- `go mod tidy` *(fails: module golang.org/x/crypto/ssh: Forbidden)*
- `go test ./...` *(fails: no required module provides package golang.org/x/crypto/ssh)*

------
https://chatgpt.com/codex/tasks/task_e_688e1e69f9e08323a8934bbfc819ac90