### PR TITLE
Add concurrency control to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure only one CI run per workflow/ref by adding concurrency group

## Testing
- `go test ./...` *(fails: missing go.sum entries)*
- `go mod tidy` *(fails: 403 fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_688e8f06c44483239c0ee725aa9d5a66