### PR TITLE
Add Go version matrix to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: almalinux:8
+    strategy:
+      matrix:
+        go-version: ['1.21', '1.22']
 
     steps:
       - name: Install system dependencies
@@ -20,6 +23,11 @@ jobs:
 
       - name: Checkout source
         uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
 
       - name: Setup Go module cache
         uses: actions/cache@v3


### PR DESCRIPTION
## Summary
- test against Go 1.21 and 1.22 in CI
- setup Go using matrix versions

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_688e8efeb9888323a803dae40c653809