### PR TITLE
Add Codecov upload to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,7 @@ jobs:
         with:
           name: coverage
           path: coverage.out
+
+      - uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out


### PR DESCRIPTION
## Summary
- ensure tests generate `coverage.out`
- upload coverage to Codecov in CI

## Testing
- `go test -v -coverprofile=coverage.out -covermode=atomic ./...` *(fails: missing module entries and unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688e8f157a48832384cfc67e90012ec0