### PR TITLE
support apply mode flag and add tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,17 +19,19 @@ import (
 	"go.uber.org/zap"
 )
 
-var cfg *config.Config
+var (
+	cfg       *config.Config
+	applyFunc = transfer.RunApply
+)
 
-func runApplyMode() error {
+func runApplyMode(applyFile string) error {
 	args := pflag.Args()
 	if len(args) < 1 {
 		return fmt.Errorf("no destination device specified for apply mode")
 	}
 	destDevice := args[0]
-	applyFile := "-"
 
-	return transfer.RunApply(cfg, applyFile, destDevice)
+	return applyFunc(cfg, applyFile, destDevice)
 }
 
 func runClientMode(snapshotDevice, dest string) error {
@@ -173,6 +175,13 @@ func main() {
 	var snapshotPath string
 
 	go handleSignals(signals, &snapshotPath)
+
+	if cfg.ApplyMode != "" {
+		if err := runApplyMode(cfg.ApplyMode); err != nil {
+			logger.Fatal("Apply operation failed", zap.Error(err))
+		}
+		return
+	}
 
 	args := pflag.Args()
 	if len(args) < 2 {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/spf13/pflag"
+	"lvmsync_go/config"
+	"testing"
+)
+
+func TestApplyFlagTriggersApplyMode(t *testing.T) {
+	// Setup configuration with apply file
+	cfg = config.DefaultConfig()
+	cfg.ApplyMode = "dumpfile"
+	dest := "/dev/null"
+
+	// Prepare flag set with destination argument
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	pflag.CommandLine = fs
+	if err := fs.Parse([]string{dest}); err != nil {
+		t.Fatalf("failed to parse args: %v", err)
+	}
+
+	called := false
+	original := applyFunc
+	applyFunc = func(c *config.Config, applyFile, destDevice string) error {
+		called = true
+		if applyFile != cfg.ApplyMode {
+			t.Fatalf("expected applyFile %s, got %s", cfg.ApplyMode, applyFile)
+		}
+		if destDevice != dest {
+			t.Fatalf("expected dest %s, got %s", dest, destDevice)
+		}
+		return nil
+	}
+	defer func() { applyFunc = original }()
+
+	if err := runApplyMode(cfg.ApplyMode); err != nil {
+		t.Fatalf("runApplyMode returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("applyFunc was not called")
+	}
+}


### PR DESCRIPTION
## Summary
- honor `--apply` flag before positional args
- use provided apply file when running apply mode
- test apply mode trigger

## Testing
- `go test ./...` *(fails: missing go.sum entries for multiple modules)*

------
https://chatgpt.com/codex/tasks/task_e_688ea1a2a27483238772cf36e0f1c43f