### PR TITLE
Allow stdout output without destination argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,12 @@ import (
 
 var cfg *config.Config
 
+var (
+	dumpChangesSequential        = transfer.DumpChangesSequential
+	dumpChangesParallel          = transfer.DumpChangesParallel
+	dumpChangesWithDeduplication = transfer.DumpChangesWithDeduplication
+)
+
 func runApplyMode() error {
 	args := pflag.Args()
 	if len(args) < 1 {
@@ -34,6 +40,18 @@ func runApplyMode() error {
 
 func runClientMode(snapshotDevice, dest string) error {
 	originDevice := snapshotDevice
+	if cfg.StdoutMode {
+		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)
+		if cfg.Deduplication {
+			dedup := transfer.NewDeduplicationStrategy(cfg)
+			defer dedup.SaveState()
+			return dumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, limitedOut, dedup)
+		}
+		if cfg.Parallel <= 1 {
+			return dumpChangesSequential(cfg, snapshotDevice, originDevice, limitedOut)
+		}
+		return dumpChangesParallel(cfg, snapshotDevice, originDevice, limitedOut)
+	}
 	if strings.Contains(dest, ":") {
 		parts := strings.SplitN(dest, ":", 2)
 		destHost := parts[0]
@@ -86,12 +104,12 @@ func runClientMode(snapshotDevice, dest string) error {
 		if cfg.Deduplication {
 			dedup := transfer.NewDeduplicationStrategy(cfg)
 			defer dedup.SaveState()
-			streamErr = transfer.DumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, remoteStdin, dedup)
+			streamErr = dumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, remoteStdin, dedup)
 		} else {
 			if cfg.Parallel <= 1 {
-				streamErr = transfer.DumpChangesSequential(cfg, snapshotDevice, originDevice, remoteStdin)
+				streamErr = dumpChangesSequential(cfg, snapshotDevice, originDevice, remoteStdin)
 			} else {
-				streamErr = transfer.DumpChangesParallel(cfg, snapshotDevice, originDevice, remoteStdin)
+				streamErr = dumpChangesParallel(cfg, snapshotDevice, originDevice, remoteStdin)
 			}
 		}
 
@@ -121,13 +139,12 @@ func runClientMode(snapshotDevice, dest string) error {
 		if cfg.Deduplication {
 			dedup := transfer.NewDeduplicationStrategy(cfg)
 			defer dedup.SaveState()
-			return transfer.DumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, limitedOut, dedup)
-		} else {
-			if cfg.Parallel <= 1 {
-				return transfer.DumpChangesSequential(cfg, snapshotDevice, originDevice, limitedOut)
-			}
-			return transfer.DumpChangesParallel(cfg, snapshotDevice, originDevice, limitedOut)
+			return dumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, limitedOut, dedup)
 		}
+		if cfg.Parallel <= 1 {
+			return dumpChangesSequential(cfg, snapshotDevice, originDevice, limitedOut)
+		}
+		return dumpChangesParallel(cfg, snapshotDevice, originDevice, limitedOut)
 	}
 	return nil
 }
@@ -175,12 +192,15 @@ func main() {
 	go handleSignals(signals, &snapshotPath)
 
 	args := pflag.Args()
-	if len(args) < 2 {
+	if (cfg.StdoutMode && len(args) < 1) || (!cfg.StdoutMode && len(args) < 2) {
 		pflag.Usage()
 		os.Exit(1)
 	}
 	originalVolume := args[0]
-	destPath := args[1]
+	destPath := ""
+	if !cfg.StdoutMode {
+		destPath = args[1]
+	}
 
 	if !cfg.SkipDiskCheck {
 		freeSpace, err := lvm.CheckDiskSpace("/")

--- a/main_stdout_test.go
+++ b/main_stdout_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"lvmsync_go/config"
+)
+
+func TestRunClientModeStdout(t *testing.T) {
+	cfg = config.DefaultConfig()
+	cfg.StdoutMode = true
+	cfg.Deduplication = false
+	cfg.Parallel = 1
+	cfg.SpeedLimit = 0
+
+	expected := "test output"
+
+	originalFunc := dumpChangesSequential
+	dumpChangesSequential = func(c *config.Config, snapshot, source string, out io.Writer) error {
+		_, err := out.Write([]byte(expected))
+		return err
+	}
+	defer func() { dumpChangesSequential = originalFunc }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = w
+
+	if err := runClientMode("/dev/snap", ""); err != nil {
+		t.Fatalf("runClientMode returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+	output, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+
+	if string(output) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(output))
+	}
+}


### PR DESCRIPTION
## Summary
- allow using `--stdout` with only a source argument
- send client output to STDOUT when `--stdout` is supplied
- add test verifying stdout mode produces output without a destination file

## Testing
- `go test ./...` *(fails: missing go.sum entries; modules could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_688ea1a4db988323962852b423fb55d1