### PR TITLE
Refactor core logic for configurable execution and add tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,28 +17,88 @@ import (
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
 )
 
-var cfg *config.Config
-
-func runApplyMode() error {
-	args := pflag.Args()
-	if len(args) < 1 {
-		return fmt.Errorf("no destination device specified for apply mode")
-	}
-	destDevice := args[0]
-	applyFile := "-"
-
-	return transfer.RunApply(cfg, applyFile, destDevice)
+// Interfaces and helpers to allow injection of fake SSH clients in tests.
+type SSHClient interface {
+	NewSession() (SSHSession, error)
+	Close() error
 }
 
-func runClientMode(snapshotDevice, dest string) error {
+type SSHSession interface {
+	StdoutPipe() (io.Reader, error)
+	StderrPipe() (io.Reader, error)
+	StdinPipe() (io.WriteCloser, error)
+	Start(cmd string) error
+	Wait() error
+	Close() error
+}
+
+type realSSHClient struct{ *ssh.Client }
+
+func (c *realSSHClient) NewSession() (SSHSession, error) {
+	s, err := c.Client.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	return &realSSHSession{s}, nil
+}
+
+func (c *realSSHClient) Close() error { return c.Client.Close() }
+
+type realSSHSession struct{ *ssh.Session }
+
+func (s *realSSHSession) StdoutPipe() (io.Reader, error)     { return s.Session.StdoutPipe() }
+func (s *realSSHSession) StderrPipe() (io.Reader, error)     { return s.Session.StderrPipe() }
+func (s *realSSHSession) StdinPipe() (io.WriteCloser, error) { return s.Session.StdinPipe() }
+func (s *realSSHSession) Start(cmd string) error             { return s.Session.Start(cmd) }
+func (s *realSSHSession) Wait() error                        { return s.Session.Wait() }
+func (s *realSSHSession) Close() error                       { return s.Session.Close() }
+
+var (
+	newSSHClient = func(host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int) (SSHClient, error) {
+		c, err := remote.NewSSHClient(host, user, keyPath, port, knownHostsPath, verify, timeout, keepAliveInterval, retries)
+		if err != nil {
+			return nil, err
+		}
+		return &realSSHClient{c}, nil
+	}
+
+	validateRemoteCommand = func(client SSHClient, cmd string) error {
+		if rc, ok := client.(*realSSHClient); ok {
+			return remote.ValidateRemoteCommand(rc.Client, cmd)
+		}
+		return nil
+	}
+
+	runRemoteScript = func(client SSHClient, script string) error {
+		if rc, ok := client.(*realSSHClient); ok {
+			return remote.RunRemoteScript(rc.Client, script)
+		}
+		return nil
+	}
+
+	dumpChangesSequential = transfer.DumpChangesSequential
+	dumpChangesParallel   = transfer.DumpChangesParallel
+	dumpChangesWithDedup  = transfer.DumpChangesWithDeduplication
+	runApply              = transfer.RunApply
+)
+
+func runApplyMode(cfg *config.Config, applyFile, destDevice string) error {
+	if applyFile == "" {
+		applyFile = "-"
+	}
+	return runApply(cfg, applyFile, destDevice)
+}
+
+func runClientMode(cfg *config.Config, snapshotDevice, dest string) error {
 	originDevice := snapshotDevice
 	if strings.Contains(dest, ":") {
 		parts := strings.SplitN(dest, ":", 2)
 		destHost := parts[0]
 		destDevice := parts[1]
-		client, err := remote.NewSSHClient(destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries)
+		client, err := newSSHClient(destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries)
 		if err != nil {
 			return fmt.Errorf("failed to create SSH client: %w", err)
 		}
@@ -46,11 +106,11 @@ func runClientMode(snapshotDevice, dest string) error {
 		remote.SetLogger(zap.L())
 
 		if cfg.RemotePreScript != "" {
-			if err := remote.RunRemoteScript(client, cfg.RemotePreScript); err != nil {
+			if err := runRemoteScript(client, cfg.RemotePreScript); err != nil {
 				return fmt.Errorf("remote pre-script failed: %w", err)
 			}
 		}
-		if err := remote.ValidateRemoteCommand(client, cfg.LVMSyncPath); err != nil {
+		if err := validateRemoteCommand(client, cfg.LVMSyncPath); err != nil {
 			return fmt.Errorf("remote command validation failed: %w", err)
 		}
 
@@ -86,12 +146,12 @@ func runClientMode(snapshotDevice, dest string) error {
 		if cfg.Deduplication {
 			dedup := transfer.NewDeduplicationStrategy(cfg)
 			defer dedup.SaveState()
-			streamErr = transfer.DumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, remoteStdin, dedup)
+			streamErr = dumpChangesWithDedup(cfg, snapshotDevice, originDevice, remoteStdin, dedup)
 		} else {
 			if cfg.Parallel <= 1 {
-				streamErr = transfer.DumpChangesSequential(cfg, snapshotDevice, originDevice, remoteStdin)
+				streamErr = dumpChangesSequential(cfg, snapshotDevice, originDevice, remoteStdin)
 			} else {
-				streamErr = transfer.DumpChangesParallel(cfg, snapshotDevice, originDevice, remoteStdin)
+				streamErr = dumpChangesParallel(cfg, snapshotDevice, originDevice, remoteStdin)
 			}
 		}
 
@@ -105,7 +165,7 @@ func runClientMode(snapshotDevice, dest string) error {
 		}
 
 		if cfg.RemotePostScript != "" {
-			if err := remote.RunRemoteScript(client, cfg.RemotePostScript); err != nil {
+			if err := runRemoteScript(client, cfg.RemotePostScript); err != nil {
 				return fmt.Errorf("remote post-script failed: %w", err)
 			}
 		}
@@ -121,21 +181,20 @@ func runClientMode(snapshotDevice, dest string) error {
 		if cfg.Deduplication {
 			dedup := transfer.NewDeduplicationStrategy(cfg)
 			defer dedup.SaveState()
-			return transfer.DumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, limitedOut, dedup)
-		} else {
-			if cfg.Parallel <= 1 {
-				return transfer.DumpChangesSequential(cfg, snapshotDevice, originDevice, limitedOut)
-			}
-			return transfer.DumpChangesParallel(cfg, snapshotDevice, originDevice, limitedOut)
+			return dumpChangesWithDedup(cfg, snapshotDevice, originDevice, limitedOut, dedup)
 		}
+		if cfg.Parallel <= 1 {
+			return dumpChangesSequential(cfg, snapshotDevice, originDevice, limitedOut)
+		}
+		return dumpChangesParallel(cfg, snapshotDevice, originDevice, limitedOut)
 	}
 	return nil
 }
 
-func handleSignals(signals <-chan os.Signal, snapshotPath *string) {
+func handleSignals(cfg *config.Config, signals <-chan os.Signal, snapshotPath *string) {
 	sig := <-signals
 	zap.L().Info("Received signal, aborting", zap.String("signal", sig.String()))
-	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
+	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && len(pflag.Args()) > 0 && *snapshotPath != pflag.Arg(0) {
 		if err := lvm.RemoveSnapshot(*snapshotPath); err != nil {
 			zap.L().Warn("Failed to remove snapshot on shutdown", zap.Error(err))
 		} else {
@@ -145,25 +204,13 @@ func handleSignals(signals <-chan os.Signal, snapshotPath *string) {
 	os.Exit(1)
 }
 
-func main() {
-	var err error
-	cfg, err = config.LoadConfig()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Configuration error: %v\n", err)
-		os.Exit(1)
-	}
-
-	if err := cfg.Validate(); err != nil {
-		fmt.Fprintf(os.Stderr, "Configuration validation error: %v\n", err)
-		os.Exit(1)
-	}
-
+// Run executes the core logic given a configuration and arguments.
+func Run(cfg *config.Config, args []string) error {
 	lvm.SetEscalationCommand(cfg.LVMEscalation)
 
 	logger, err := zap.NewProduction()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Logger initialization error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("logger initialization error: %w", err)
 	}
 	zap.ReplaceGlobals(logger)
 	defer logger.Sync()
@@ -171,13 +218,17 @@ func main() {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	var snapshotPath string
+	go handleSignals(cfg, signals, &snapshotPath)
 
-	go handleSignals(signals, &snapshotPath)
+	if cfg.ApplyMode != "" {
+		if len(args) < 1 {
+			return fmt.Errorf("no destination device specified for apply mode")
+		}
+		return runApplyMode(cfg, cfg.ApplyMode, args[0])
+	}
 
-	args := pflag.Args()
 	if len(args) < 2 {
-		pflag.Usage()
-		os.Exit(1)
+		return fmt.Errorf("expected source and destination arguments")
 	}
 	originalVolume := args[0]
 	destPath := args[1]
@@ -185,29 +236,26 @@ func main() {
 	if !cfg.SkipDiskCheck {
 		freeSpace, err := lvm.CheckDiskSpace("/")
 		if err != nil {
-			logger.Fatal("Disk space check failed", zap.Error(err))
+			return fmt.Errorf("disk space check failed: %w", err)
 		}
 		requiredBytes, err := lvm.ParseSnapshotSize(cfg.SnapshotSize, originalVolume)
 		if err != nil {
-			logger.Fatal("Failed to parse snapshot size", zap.Error(err))
+			return fmt.Errorf("failed to parse snapshot size: %w", err)
 		}
 		if freeSpace < requiredBytes {
-			logger.Fatal("Insufficient disk space for snapshot",
-				zap.Uint64("free", freeSpace),
-				zap.Uint64("required", requiredBytes))
+			return fmt.Errorf("insufficient disk space for snapshot")
 		}
-		logger.Info("Disk space check passed", zap.Uint64("free", freeSpace))
+		zap.L().Info("Disk space check passed", zap.Uint64("free", freeSpace))
 	}
 
 	snapshotPath = originalVolume
 	if !cfg.SkipSnapshotCreation {
 		snapshotName := fmt.Sprintf("snap-%d", time.Now().Unix())
-		err = lvm.CreateSnapshot(originalVolume, snapshotName, cfg.SnapshotSize)
-		if err != nil {
-			logger.Fatal("Snapshot creation failed", zap.Error(err))
+		if err := lvm.CreateSnapshot(originalVolume, snapshotName, cfg.SnapshotSize); err != nil {
+			return fmt.Errorf("snapshot creation failed: %w", err)
 		}
 		snapshotPath = lvm.GetSnapshotDevicePath(snapshotName, cfg.VolumeGroup)
-		logger.Info("Snapshot created", zap.String("snapshot", snapshotPath))
+		zap.L().Info("Snapshot created", zap.String("snapshot", snapshotPath))
 
 		stopMonitor := make(chan struct{})
 		go func() {
@@ -219,16 +267,33 @@ func main() {
 		defer close(stopMonitor)
 	}
 
-	if err := runClientMode(snapshotPath, destPath); err != nil {
-		logger.Fatal("Copy operation failed", zap.Error(err))
+	if err := runClientMode(cfg, snapshotPath, destPath); err != nil {
+		return fmt.Errorf("copy operation failed: %w", err)
 	}
 
 	if !cfg.SkipSnapshotCreation {
-		err = lvm.RemoveSnapshot(snapshotPath)
-		if err != nil {
-			logger.Warn("Failed to remove snapshot", zap.Error(err))
+		if err := lvm.RemoveSnapshot(snapshotPath); err != nil {
+			zap.L().Warn("Failed to remove snapshot", zap.Error(err))
 		} else {
-			logger.Info("Snapshot removed", zap.String("snapshot", snapshotPath))
+			zap.L().Info("Snapshot removed", zap.String("snapshot", snapshotPath))
 		}
+	}
+	return nil
+}
+
+func main() {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Configuration error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Configuration validation error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := Run(cfg, pflag.Args()); err != nil {
+		zap.L().Fatal("Execution failed", zap.Error(err))
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"lvmsync_go/common"
+	"lvmsync_go/config"
+)
+
+// fakeSSHClient and fakeSSHSession implement the SSHClient/SSHSession
+// interfaces without performing any network operations.
+type fakeSSHClient struct{ session *fakeSSHSession }
+
+func (c *fakeSSHClient) NewSession() (SSHSession, error) { return c.session, nil }
+func (c *fakeSSHClient) Close() error                    { return nil }
+
+type fakeSSHSession struct {
+	stdin bytes.Buffer
+}
+
+func (s *fakeSSHSession) StdoutPipe() (io.Reader, error) { return strings.NewReader(""), nil }
+func (s *fakeSSHSession) StderrPipe() (io.Reader, error) { return strings.NewReader(""), nil }
+func (s *fakeSSHSession) StdinPipe() (io.WriteCloser, error) {
+	return nopWriteCloser{&s.stdin}, nil
+}
+func (s *fakeSSHSession) Start(cmd string) error { return nil }
+func (s *fakeSSHSession) Wait() error            { return nil }
+func (s *fakeSSHSession) Close() error           { return nil }
+
+type nopWriteCloser struct{ io.Writer }
+
+func (n nopWriteCloser) Close() error { return nil }
+
+// Test that runClientMode streams data to a remote session using a fake SSH client.
+func TestRunClientModeWithFakeSSH(t *testing.T) {
+	// Prepare a fake dump that runClientMode will stream.
+	data := []byte("12345678")
+	header := make([]byte, 12)
+	binary.BigEndian.PutUint64(header[0:8], 0)
+	binary.BigEndian.PutUint32(header[8:12], uint32(len(data)))
+	dump := append([]byte(common.ProtocolVersion+"\n"), append(header, data...)...)
+
+	// Override dumpChangesSequential to avoid disk operations.
+	origDump := dumpChangesSequential
+	dumpChangesSequential = func(cfg *config.Config, snapshot, source string, out io.Writer) error {
+		_, err := out.Write(dump)
+		return err
+	}
+	defer func() { dumpChangesSequential = origDump }()
+
+	// Use a fake SSH client to capture what is written.
+	session := &fakeSSHSession{}
+	fakeClient := &fakeSSHClient{session: session}
+	origNewClient := newSSHClient
+	newSSHClient = func(host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int) (SSHClient, error) {
+		return fakeClient, nil
+	}
+	defer func() { newSSHClient = origNewClient }()
+
+	cfg := &config.Config{Parallel: 1}
+	if err := runClientMode(cfg, "snapshot", "remote:/dev/null"); err != nil {
+		t.Fatalf("runClientMode returned error: %v", err)
+	}
+
+	if !bytes.Equal(session.stdin.Bytes(), dump) {
+		t.Fatalf("unexpected stream data: %x", session.stdin.Bytes())
+	}
+}
+
+// Test that runApplyMode applies a dump file to a destination using temporary files.
+func TestRunApplyMode(t *testing.T) {
+	data := []byte("abcdefgh")
+	header := make([]byte, 12)
+	binary.BigEndian.PutUint64(header[0:8], 0)
+	binary.BigEndian.PutUint32(header[8:12], uint32(len(data)))
+	dump := append([]byte(common.ProtocolVersion+"\n"), append(header, data...)...)
+
+	applyFile := t.TempDir() + "/dump"
+	if err := os.WriteFile(applyFile, dump, 0644); err != nil {
+		t.Fatalf("failed to write dump file: %v", err)
+	}
+	destFile := t.TempDir() + "/dest"
+	if err := os.WriteFile(destFile, make([]byte, len(data)), 0644); err != nil {
+		t.Fatalf("failed to create dest file: %v", err)
+	}
+
+	cfg := &config.Config{Deduplication: false}
+	if err := runApplyMode(cfg, applyFile, destFile); err != nil {
+		t.Fatalf("runApplyMode returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(destFile)
+	if err != nil {
+		t.Fatalf("failed to read dest file: %v", err)
+	}
+	if !bytes.Equal(got[:len(data)], data) {
+		t.Fatalf("destination content mismatch: %q", got[:len(data)])
+	}
+}


### PR DESCRIPTION
## Summary
- Extract main program flow into `Run` accepting configuration and args
- Introduce injectable SSH client interfaces for testing
- Add tests using fake SSH and temp files for client and apply modes

## Testing
- `go test ./...` *(fails: missing go.sum entries due to restricted module download)*

------
https://chatgpt.com/codex/tasks/task_e_688ea1b4936483239c62ab82745a26ec