### PR TITLE
Add tests for block read retries and pipe handling

### DIFF
--- a/transfer/block_test.go
+++ b/transfer/block_test.go
@@ -1,0 +1,98 @@
+package transfer
+
+import (
+	"bytes"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"lvmsync_go/config"
+
+	"go.uber.org/zap"
+)
+
+func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
+	SetLogger(zap.NewNop())
+
+	blockSize := 4
+	data := []byte{1, 2, 3, 4}
+	cfg := &config.Config{BlockSize: blockSize, MaxRetries: 3}
+
+	tmp, err := os.CreateTemp(t.TempDir(), "block")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer tmp.Close()
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		if _, err := tmp.WriteAt(data, 0); err != nil {
+			t.Logf("write failed: %v", err)
+		}
+	}()
+
+	start := time.Now()
+	buf, err := ReadBlockWithRetries(cfg, tmp, 0, false, [2]int{-1, -1})
+	if err != nil {
+		t.Fatalf("ReadBlockWithRetries returned error: %v", err)
+	}
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("unexpected data: %v", buf)
+	}
+	if time.Since(start) < 100*time.Millisecond {
+		t.Fatalf("expected at least one retry, duration %v", time.Since(start))
+	}
+	putBlockBuffer(buf)
+}
+
+func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
+	SetLogger(zap.NewNop())
+
+	blockSize := 4
+	data := []byte{1, 2, 3, 4}
+	cfg := &config.Config{BlockSize: blockSize, MaxRetries: 1}
+
+	tmp, err := os.CreateTemp(t.TempDir(), "block")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer tmp.Close()
+	if _, err := tmp.WriteAt(data, 0); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	atomic.StoreInt64(&PipeCreationCount, 0)
+	buf, err := ReadBlockWithRetries(cfg, tmp, 0, true, [2]int{-1, -1})
+	if err != nil {
+		t.Fatalf("ReadBlockWithRetries error: %v", err)
+	}
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("unexpected data: %v", buf)
+	}
+	if c := atomic.LoadInt64(&PipeCreationCount); c != 1 {
+		t.Fatalf("expected PipeCreationCount 1, got %d", c)
+	}
+	putBlockBuffer(buf)
+
+	fds := [2]int{}
+	if err := syscall.Pipe(fds[:]); err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer syscall.Close(fds[0])
+	defer syscall.Close(fds[1])
+
+	atomic.StoreInt64(&PipeCreationCount, 0)
+	buf, err = ReadBlockWithRetries(cfg, tmp, 0, true, fds)
+	if err != nil {
+		t.Fatalf("ReadBlockWithRetries error: %v", err)
+	}
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("unexpected data: %v", buf)
+	}
+	if c := atomic.LoadInt64(&PipeCreationCount); c != 0 {
+		t.Fatalf("expected PipeCreationCount 0, got %d", c)
+	}
+	putBlockBuffer(buf)
+}


### PR DESCRIPTION
## Summary
- add transient read failure test for `ReadBlockWithRetries`
- verify pipe creation and reuse in zero-copy transfers

## Testing
- `go test ./...` *(fails: missing go.sum entry for module providing package github.com/spf13/pflag)*

------
https://chatgpt.com/codex/tasks/task_e_688eab3d74f483238b5c36004c439759