### PR TITLE
Add tests for SSH keepalive and client manager

### DIFF
--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 type mockSSHServer struct {
-	addr     string
-	listener net.Listener
-	handler  func(string) int
-	mu       sync.Mutex
-	commands []string
+	addr       string
+	listener   net.Listener
+	handler    func(string) int
+	mu         sync.Mutex
+	commands   []string
+	globalReqs []string
+	connCount  int
 }
 
 func newMockSSHServer(t *testing.T, handler func(string) int) *mockSSHServer {
@@ -52,7 +54,10 @@ func (s *mockSSHServer) serve(config *ssh.ServerConfig) {
 			if err != nil {
 				return
 			}
-			go ssh.DiscardRequests(reqs)
+			s.mu.Lock()
+			s.connCount++
+			s.mu.Unlock()
+			go s.handleRequests(reqs)
 			for newCh := range chans {
 				if newCh.ChannelType() != "session" {
 					newCh.Reject(ssh.UnknownChannelType, "unknown channel type")
@@ -88,6 +93,15 @@ func (s *mockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
 	}
 }
 
+func (s *mockSSHServer) handleRequests(in <-chan *ssh.Request) {
+	for req := range in {
+		s.mu.Lock()
+		s.globalReqs = append(s.globalReqs, req.Type)
+		s.mu.Unlock()
+		req.Reply(true, nil)
+	}
+}
+
 func (s *mockSSHServer) Close() {
 	s.listener.Close()
 }
@@ -96,6 +110,18 @@ func (s *mockSSHServer) Commands() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.commands...)
+}
+
+func (s *mockSSHServer) GlobalRequests() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.globalReqs...)
+}
+
+func (s *mockSSHServer) ConnectionCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.connCount
 }
 
 func TestValidateRemoteCommand(t *testing.T) {

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -1,0 +1,145 @@
+package remote
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestSendKeepAlive(t *testing.T) {
+	server := newMockSSHServer(t, func(cmd string) int { return 0 })
+	defer server.Close()
+
+	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: ssh.InsecureIgnoreHostKey()})
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer client.Close()
+
+	if err := sendKeepAlive(client, "host"); err != nil {
+		t.Fatalf("sendKeepAlive error: %v", err)
+	}
+
+	reqs := server.GlobalRequests()
+	if len(reqs) != 1 || reqs[0] != "keepalive@openssh.com" {
+		t.Fatalf("expected one keepalive request, got %v", reqs)
+	}
+}
+
+func TestStartKeepAlive(t *testing.T) {
+	server := newMockSSHServer(t, func(cmd string) int { return 0 })
+	defer server.Close()
+
+	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: ssh.InsecureIgnoreHostKey()})
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		startKeepAlive(client, "host", 10*time.Millisecond)
+		close(done)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	client.Close()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("startKeepAlive did not exit")
+	}
+
+	if len(server.GlobalRequests()) == 0 {
+		t.Fatalf("expected keepalive requests, got none")
+	}
+}
+
+func createTempKey(t *testing.T) string {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	f, err := os.CreateTemp(t.TempDir(), "id_rsa")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if _, err := f.Write(keyPEM); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestNewSSHClient(t *testing.T) {
+	server := newMockSSHServer(t, func(cmd string) int { return 0 })
+	defer server.Close()
+
+	host, portStr, _ := net.SplitHostPort(server.addr)
+	port, _ := strconv.Atoi(portStr)
+
+	client, err := NewSSHClient(host, "test", "", port, "", false, time.Second, 10*time.Millisecond, 0)
+	if err != nil {
+		t.Fatalf("NewSSHClient error: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	client.Close()
+
+	if len(server.GlobalRequests()) == 0 {
+		t.Fatalf("expected keepalive requests, got none")
+	}
+}
+
+func TestSSHManager(t *testing.T) {
+	server := newMockSSHServer(t, func(cmd string) int { return 0 })
+	defer server.Close()
+
+	keyPath := createTempKey(t)
+	mgr, err := NewSSHManager("test", keyPath, time.Second, "", false)
+	if err != nil {
+		t.Fatalf("NewSSHManager error: %v", err)
+	}
+
+	host, portStr, _ := net.SplitHostPort(server.addr)
+	port, _ := strconv.Atoi(portStr)
+
+	client1, err := mgr.GetClient(host, port)
+	if err != nil {
+		t.Fatalf("GetClient error: %v", err)
+	}
+
+	client2, err := mgr.GetClient(host, port)
+	if err != nil {
+		t.Fatalf("GetClient second error: %v", err)
+	}
+	if client1 != client2 {
+		t.Fatalf("expected cached client")
+	}
+	if server.ConnectionCount() != 1 {
+		t.Fatalf("expected one connection, got %d", server.ConnectionCount())
+	}
+
+	mgr.CloseAll()
+
+	client3, err := mgr.GetClient(host, port)
+	if err != nil {
+		t.Fatalf("GetClient after CloseAll error: %v", err)
+	}
+	if client3 == client1 {
+		t.Fatalf("expected new client after CloseAll")
+	}
+	if server.ConnectionCount() != 2 {
+		t.Fatalf("expected two connections, got %d", server.ConnectionCount())
+	}
+
+	mgr.CloseAll()
+}


### PR DESCRIPTION
## Summary
- extend mock SSH server to capture global requests and connection counts
- add tests for sendKeepAlive, startKeepAlive, NewSSHClient, and SSHManager using the mock server

## Testing
- `go test ./remote -run TestSendKeepAlive -v` *(fails: missing go.sum entry)*
- `go mod tidy` *(fails: module downloads forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688eab49813c83238e031c05857d7857