### PR TITLE
Stabilize SSH manager connection tests

### DIFF
--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -124,9 +124,7 @@ func TestSSHManager(t *testing.T) {
 	if client1 != client2 {
 		t.Fatalf("expected cached client")
 	}
-	if server.ConnectionCount() != 1 {
-		t.Fatalf("expected one connection, got %d", server.ConnectionCount())
-	}
+	waitForConnectionCount(t, server, 1)
 
 	mgr.CloseAll()
 
@@ -137,9 +135,19 @@ func TestSSHManager(t *testing.T) {
 	if client3 == client1 {
 		t.Fatalf("expected new client after CloseAll")
 	}
-	if server.ConnectionCount() != 2 {
-		t.Fatalf("expected two connections, got %d", server.ConnectionCount())
-	}
+	waitForConnectionCount(t, server, 2)
 
 	mgr.CloseAll()
+}
+
+func waitForConnectionCount(t *testing.T, server *mockSSHServer, expected int) {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if server.ConnectionCount() == expected {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected %d connections, got %d", expected, server.ConnectionCount())
 }


### PR DESCRIPTION
## Summary
- prevent SSHManager test flakiness by waiting for expected connection counts

## Testing
- `go test ./...`
- `for i in {1..5}; do go test ./remote -run TestSSHManager -v; done`


------
https://chatgpt.com/codex/tasks/task_e_688f9d8955848323a9761e94f7d6a78f