### PR TITLE
Make metadata mapper directory configurable

### DIFF
--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -67,16 +67,18 @@ func createDumpTestFiles(t *testing.T, blockSize int64, changedBlocks []int) (sr
 	}
 	metaFile.Close()
 
-	// create symlink for GetMetadataDevice
-	if err := os.MkdirAll("/dev/mapper", 0755); err != nil {
-		t.Fatalf("failed to create /dev/mapper: %v", err)
-	}
+	// create symlink for GetMetadataDevice in a temporary mapper directory
+	mapper := t.TempDir()
+	SetMapperDir(mapper)
 	snapshot = "testvg-testlv"
-	link := "/dev/mapper/testvg-testlv-cow"
+	link := filepath.Join(mapper, "testvg-testlv-cow")
 	if err := os.Symlink(meta, link); err != nil {
 		t.Fatalf("failed to create metadata symlink: %v", err)
 	}
-	t.Cleanup(func() { os.Remove(link) })
+	t.Cleanup(func() {
+		os.Remove(link)
+		SetMapperDir("/dev/mapper")
+	})
 
 	return src, snapshot
 }

--- a/transfer/metadata.go
+++ b/transfer/metadata.go
@@ -10,6 +10,13 @@ import (
 	"strings"
 )
 
+var mapperDir = "/dev/mapper"
+
+// SetMapperDir overrides the directory used to look up mapper devices.
+func SetMapperDir(dir string) {
+	mapperDir = dir
+}
+
 func ReadMetadataHeader(metadataPath string) (int64, error) {
 	file, err := os.Open(metadataPath)
 	if err != nil {
@@ -90,5 +97,5 @@ func GetMetadataDevice(snapshot string) string {
 	vg := replacer.Replace(parts[0])
 	lv := replacer.Replace(parts[1])
 
-	return fmt.Sprintf("/dev/mapper/%s-%s-cow", vg, lv)
+	return filepath.Join(mapperDir, fmt.Sprintf("%s-%s-cow", vg, lv))
 }

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -59,15 +59,17 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int) (srcPath, sn
 	}
 	metaFile.Close()
 
-	// create symlink for GetMetadataDevice
-	if err := os.MkdirAll("/dev/mapper", 0755); err != nil {
-		t.Fatalf("failed to create /dev/mapper: %v", err)
-	}
-	linkPath := "/dev/mapper/vg-lv-cow"
+	// create symlink for GetMetadataDevice in a temporary mapper directory
+	mapper := t.TempDir()
+	SetMapperDir(mapper)
+	linkPath := filepath.Join(mapper, "vg-lv-cow")
 	if err := os.Symlink(metaPath, linkPath); err != nil {
 		t.Fatalf("failed to create metadata symlink: %v", err)
 	}
-	t.Cleanup(func() { os.Remove(linkPath) })
+	t.Cleanup(func() {
+		os.Remove(linkPath)
+		SetMapperDir("/dev/mapper")
+	})
 
 	snapshot = "vg-lv"
 


### PR DESCRIPTION
## Summary
- add `mapperDir` package variable and `SetMapperDir` setter
- build metadata path using configurable mapper directory
- use temp mapper directory in transfer tests

## Testing
- `go test ./transfer -run .`


------
https://chatgpt.com/codex/tasks/task_e_68907f73b0e08323afabd929cd715e22