### PR TITLE
Reset escalation command in LVM tests

### DIFF
--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -14,6 +14,7 @@ func TestGetSnapshotDevicePath(t *testing.T) {
 }
 
 func TestSetGetEscalationCommand(t *testing.T) {
+	t.Cleanup(func() { SetEscalationCommand("") })
 	SetEscalationCommand("sudo")
 	if GetEscalationCommand() != "sudo" {
 		t.Fatalf("expected sudo, got %s", GetEscalationCommand())

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+func init() {
+	SetEscalationCommand("")
+}
+
 func TestCreateAndRemoveSnapshot(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+func init() {
+	SetEscalationCommand("")
+}
+
 func TestGetSnapshotUsage(t *testing.T) {
 	tmpDir := t.TempDir()
 	script := filepath.Join(tmpDir, "lvs")


### PR DESCRIPTION
## Summary
- ensure `TestSetGetEscalationCommand` restores the global escalation command
- reset escalation command before snapshot tests so they use mock LVM binaries

## Testing
- `go test ./lvm -run Snapshot -v`
- `go test ./... -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68907f71eb088323a1c69ba6cfa60623