### PR TITLE
Ensure vgdisplay success test sets LVMEscalation

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,7 +47,8 @@ func TestConfigValidate(t *testing.T) {
 			t.Fatalf("write script: %v", err)
 		}
 		t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
-		cfg := &Config{VolumeGroup: "vg0"}
+		cfg := DefaultConfig()
+		cfg.VolumeGroup = "vg0"
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}


### PR DESCRIPTION
## Summary
- use `DefaultConfig()` in TestConfigValidate's `vgdisplay success` subtest so LVMEscalation is configured

## Testing
- `go test ./config -run TestConfigValidate -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68907f705cac8323ae1d8362cf6922dd