### PR TITLE
Potential fix for code scanning alert no. 3: Use of insecure HostKeyCallback implementation

### DIFF
--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -66,11 +66,15 @@ func (s *SSHSession) Close() {
 	s.Session.Close()
 }
 
-func RunSSHCommand(host, user, keyPath string, port int, command string, timeout time.Duration) error {
+func RunSSHCommand(host, user, keyPath, hostKeyPath string, port int, command string, timeout time.Duration) error {
+	publicKey, err := loadHostPublicKeyMust(hostKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load host public key: %w", err)
+	}
 	client, err := dialSSH(fmt.Sprintf("%s:%d", host, port), &ssh.ClientConfig{
 		User:            user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(loadPrivateKeyMust(keyPath))},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.FixedHostKey(publicKey),
 		Timeout:         timeout,
 	}, timeout)
 
@@ -110,4 +114,19 @@ func loadPrivateKeyMust(keyPath string) ssh.Signer {
 		zap.L().Fatal("Failed to parse SSH private key", zap.String("keyPath", keyPath), zap.Error(err))
 	}
 	return signer
+}
+
+// loadHostPublicKeyMust loads the allowed host public key from the given path and parses it.
+func loadHostPublicKeyMust(keyPath string) (ssh.PublicKey, error) {
+	key, err := os.ReadFile(keyPath)
+	if err != nil {
+		zap.L().Fatal("Failed to read SSH host public key", zap.String("keyPath", keyPath), zap.Error(err))
+		return nil, err
+	}
+	publicKey, err := ssh.ParsePublicKey(key)
+	if err != nil {
+		zap.L().Fatal("Failed to parse SSH host public key", zap.String("keyPath", keyPath), zap.Error(err))
+		return nil, err
+	}
+	return publicKey, nil
 }


### PR DESCRIPTION
Potential fix for [https://github.com/oferchen/lvmsync_go/security/code-scanning/3](https://github.com/oferchen/lvmsync_go/security/code-scanning/3)

To fix this problem, the code should verify the SSH server's host key against a known, trusted value. The best way to do this is to load the expected public key for the server from a file (or another secure source), parse it, and use `ssh.FixedHostKey(publicKey)` as the `HostKeyCallback`. This ensures that the client will only connect if the server presents the expected host key, preventing MitM attacks.

Specifically, in `remote/ssh_session.go`, the code in `RunSSHCommand` should be changed so that instead of using `ssh.InsecureIgnoreHostKey()`, it loads the allowed host public key (e.g., from a file path provided as an argument or a constant), parses it, and uses `ssh.FixedHostKey(publicKey)` for the `HostKeyCallback`. This will require:
- Adding a function to load and parse the allowed host public key.
- Modifying the `RunSSHCommand` function to accept a path to the allowed host public key (or otherwise obtain it).
- Replacing the insecure callback with the secure one.

If the code is only meant to connect to a single host, a single public key file is sufficient. If it must support multiple hosts, a more complex allow-list may be needed, but for now, we will implement the single-key approach as per the example.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
