### PR TITLE
Check parsed bytes fit in int range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -80,22 +81,33 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 	}
 
 	conf.BlockSizeRaw = cb.getBlockSizeRaw()
-	conf.BlockSize = cb.parseBytesOrFallback("block_size", cb.defaults.BlockSizeRaw)
-	conf.SpeedLimit = cb.parseBytesOrFallback("speed", cb.defaults.Speed)
+	bs, err := cb.parseBytesOrFallback("block_size", cb.defaults.BlockSizeRaw)
+	if err != nil {
+		return nil, err
+	}
+	conf.BlockSize = bs
+	sl, err := cb.parseBytesOrFallback("speed", cb.defaults.Speed)
+	if err != nil {
+		return nil, err
+	}
+	conf.SpeedLimit = sl
 
 	return &conf, nil
 }
 
-func (cb *ConfigBuilder) parseBytesOrFallback(key, fallback string) int {
+func (cb *ConfigBuilder) parseBytesOrFallback(key, fallback string) (int, error) {
 	raw := strings.ReplaceAll(cb.v.GetString(key), " ", "")
 	if raw == "" {
 		raw = fallback
 	}
 	val, err := humanize.ParseBytes(raw)
 	if err != nil {
-		panic(fmt.Errorf("invalid %s value %q: %w", key, raw, err))
+		return 0, fmt.Errorf("invalid %s value %q: %w", key, raw, err)
 	}
-	return int(val)
+	if val > uint64(math.MaxInt) {
+		return 0, fmt.Errorf("%s value %q overflows int", key, raw)
+	}
+	return int(val), nil
 }
 
 func (cb *ConfigBuilder) getBlockSizeRaw() string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +15,11 @@ func TestParseBytesOrFallback(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", "1KB")
 		cb := &ConfigBuilder{v: v}
-		if got := cb.parseBytesOrFallback("block_size", "4KB"); got != 1000 {
+		got, err := cb.parseBytesOrFallback("block_size", "4KB")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 1000 {
 			t.Fatalf("expected 1000, got %d", got)
 		}
 	})
@@ -21,7 +27,11 @@ func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("fallback", func(t *testing.T) {
 		v := viper.New()
 		cb := &ConfigBuilder{v: v}
-		if got := cb.parseBytesOrFallback("block_size", "2KB"); got != 2000 {
+		got, err := cb.parseBytesOrFallback("block_size", "2KB")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 2000 {
 			t.Fatalf("expected 2000, got %d", got)
 		}
 	})
@@ -30,12 +40,31 @@ func TestParseBytesOrFallback(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", "notbytes")
 		cb := &ConfigBuilder{v: v}
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatalf("expected panic")
-			}
-		}()
-		cb.parseBytesOrFallback("block_size", "4KB")
+		if _, err := cb.parseBytesOrFallback("block_size", "4KB"); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("nearMaxInt", func(t *testing.T) {
+		v := viper.New()
+		v.Set("block_size", fmt.Sprintf("%d", uint64(math.MaxInt-1023)))
+		cb := &ConfigBuilder{v: v}
+		got, err := cb.parseBytesOrFallback("block_size", "4KB")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != math.MaxInt-1023 {
+			t.Fatalf("expected %d, got %d", math.MaxInt-1023, got)
+		}
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		v := viper.New()
+		v.Set("block_size", fmt.Sprintf("%d", uint64(math.MaxInt)+1))
+		cb := &ConfigBuilder{v: v}
+		if _, err := cb.parseBytesOrFallback("block_size", "4KB"); err == nil {
+			t.Fatalf("expected error")
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary
- ensure parsed sizes do not overflow the platform's `int` range
- surface errors when byte values exceed `math.MaxInt`
- cover edge cases near `int` overflow

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689083fa60f08323892502970fd1cbfd