### PR TITLE
Initialize remote logger to zap.NewNop

### DIFF
--- a/remote/keepalive.go
+++ b/remote/keepalive.go
@@ -23,7 +23,7 @@ func startKeepAlive(client *ssh.Client, host string, interval time.Duration) {
 func sendKeepAlive(client *ssh.Client, host string) error {
 	_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
 	if err != nil {
-		zap.L().Warn("SSH keepalive failed", zap.String("host", host), zap.Error(err))
+		Logger.Warn("SSH keepalive failed", zap.String("host", host), zap.Error(err))
 		return err
 	}
 	return nil

--- a/remote/logger_test.go
+++ b/remote/logger_test.go
@@ -1,0 +1,42 @@
+package remote
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestRunRemoteScriptNoLogger(t *testing.T) {
+	server := newMockSSHServer(t, func(cmd string) int { return 0 })
+	defer server.Close()
+
+	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: ssh.InsecureIgnoreHostKey()})
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer client.Close()
+
+	SetLogger(nil)
+
+	script := "echo hi"
+	if err := RunRemoteScript(client, script); err != nil {
+		t.Fatalf("RunRemoteScript error: %v", err)
+	}
+}
+
+func TestSendKeepAliveNoLogger(t *testing.T) {
+	server := newMockSSHServer(t, func(cmd string) int { return 0 })
+	defer server.Close()
+
+	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: ssh.InsecureIgnoreHostKey()})
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer client.Close()
+
+	SetLogger(nil)
+
+	if err := sendKeepAlive(client, "host"); err != nil {
+		t.Fatalf("sendKeepAlive error: %v", err)
+	}
+}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -15,11 +15,6 @@ import (
 )
 
 func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int) (*ssh.Client, error) {
-	logger := Logger
-	if logger == nil {
-		logger = zap.L()
-	}
-
 	var authMethods []ssh.AuthMethod
 	if keyPath != "" {
 		key, err := os.ReadFile(keyPath)
@@ -65,7 +60,7 @@ func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, v
 		if err == nil {
 			break
 		}
-		logger.Warn("SSH dial failed",
+		Logger.Warn("SSH dial failed",
 			zap.String("host", host),
 			zap.Int("port", port),
 			zap.Int("attempt", attempt+1),
@@ -76,7 +71,7 @@ func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, v
 		}
 	}
 	if err != nil {
-		logger.Error("Unable to establish SSH connection", zap.String("host", host), zap.Int("port", port), zap.Error(err))
+		Logger.Error("Unable to establish SSH connection", zap.String("host", host), zap.Int("port", port), zap.Error(err))
 		return nil, fmt.Errorf("failed to dial SSH after %d attempts: %w", retries+1, err)
 	}
 
@@ -112,8 +107,11 @@ func RunRemoteScript(client *ssh.Client, script string) error {
 	return session.Run(script)
 }
 
-var Logger *zap.Logger
+var Logger = zap.NewNop()
 
 func SetLogger(logger *zap.Logger) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	Logger = logger
 }

--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -96,18 +96,18 @@ func RunSSHCommand(host, user, keyPath string, port int, command string, timeout
 		return fmt.Errorf("SSH command failed: %w", err)
 	}
 
-	zap.L().Info("SSH command completed", zap.String("host", host), zap.String("command", command))
+	Logger.Info("SSH command completed", zap.String("host", host), zap.String("command", command))
 	return nil
 }
 
 func loadPrivateKeyMust(keyPath string) ssh.Signer {
 	key, err := os.ReadFile(keyPath)
 	if err != nil {
-		zap.L().Fatal("Failed to read SSH private key", zap.String("keyPath", keyPath), zap.Error(err))
+		Logger.Fatal("Failed to read SSH private key", zap.String("keyPath", keyPath), zap.Error(err))
 	}
 	signer, err := ssh.ParsePrivateKey(key)
 	if err != nil {
-		zap.L().Fatal("Failed to parse SSH private key", zap.String("keyPath", keyPath), zap.Error(err))
+		Logger.Fatal("Failed to parse SSH private key", zap.String("keyPath", keyPath), zap.Error(err))
 	}
 	return signer
 }


### PR DESCRIPTION
## Summary
- default remote logger to a no-op zap logger and allow overriding with SetLogger
- ensure remote functions use the shared logger
- test remote utilities with no logger set

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689083ea503483239e152f501b20c216