### PR TITLE
chore: allow stubbing privilege checks

### DIFF
--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -41,6 +41,8 @@ var deviceFDCache = &fdCache{
 
 var statfsFunc = syscall.Statfs
 
+var checkPrivs = checkRootPrivileges
+
 func SetEscalationCommand(cmd string) {
 	escalationCommandLock.Lock()
 	defer escalationCommandLock.Unlock()
@@ -154,7 +156,7 @@ func executeCommand(name string, args ...string) ([]byte, error) {
 }
 
 func CreateSnapshot(lvPath, snapshotName, size string) error {
-	if err := checkRootPrivileges(); err != nil {
+	if err := checkPrivs(); err != nil {
 		return err
 	}
 
@@ -178,7 +180,7 @@ func CreateSnapshot(lvPath, snapshotName, size string) error {
 }
 
 func RemoveSnapshot(snapshotPath string) error {
-	if err := checkRootPrivileges(); err != nil {
+	if err := checkPrivs(); err != nil {
 		return err
 	}
 
@@ -199,7 +201,7 @@ func RemoveSnapshot(snapshotPath string) error {
 }
 
 func GetSnapshotUsage(snapshotPath string) (float64, error) {
-	if err := checkRootPrivileges(); err != nil {
+	if err := checkPrivs(); err != nil {
 		return 0, err
 	}
 
@@ -227,7 +229,7 @@ func GetSnapshotUsage(snapshotPath string) (float64, error) {
 }
 
 func MonitorSnapshot(snapshotPath string, threshold float64, interval time.Duration, stopChan <-chan struct{}) error {
-	if err := checkRootPrivileges(); err != nil {
+	if err := checkPrivs(); err != nil {
 		return err
 	}
 
@@ -376,7 +378,7 @@ func GetSnapshotDevicePath(snapshotName, volumeGroup string) string {
 }
 
 func GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
-	if err := checkRootPrivileges(); err != nil {
+	if err := checkPrivs(); err != nil {
 		return 0, err
 	}
 

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -1,6 +1,7 @@
 package lvm
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,10 @@ func init() {
 }
 
 func TestCreateAndRemoveSnapshot(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
+
 	tmpDir := t.TempDir()
 
 	// Create mock lvcreate script
@@ -64,5 +69,17 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 	expected = "-f " + snapPath
 	if got != expected {
 		t.Fatalf("lvremove args = %q, want %q", got, expected)
+	}
+}
+
+func TestCreateSnapshotPrivilegeError(t *testing.T) {
+	orig := checkPrivs
+	errPriv := errors.New("privileges required")
+	checkPrivs = func() error { return errPriv }
+	t.Cleanup(func() { checkPrivs = orig })
+
+	err := CreateSnapshot("/dev/vg0/origin", "snap", "1G")
+	if !errors.Is(err, errPriv) {
+		t.Fatalf("expected privilege error, got %v", err)
 	}
 }

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -13,6 +13,10 @@ func init() {
 }
 
 func TestGetSnapshotUsage(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
+
 	tmpDir := t.TempDir()
 	script := filepath.Join(tmpDir, "lvs")
 	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 75.5\n"), 0755); err != nil {
@@ -32,6 +36,10 @@ func TestGetSnapshotUsage(t *testing.T) {
 }
 
 func TestMonitorSnapshot(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
+
 	tmpDir := t.TempDir()
 	script := filepath.Join(tmpDir, "lvs")
 	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 90\n"), 0755); err != nil {


### PR DESCRIPTION
## Summary
- allow stubbing of root privilege checks via a new `checkPrivs` package variable
- replace direct `checkRootPrivileges()` calls with `checkPrivs()`
- tests override `checkPrivs` and verify behavior when privilege checks fail

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689083d4aa148323b863de3caba293d7