### PR TITLE
Implement LRU fd cache

### DIFF
--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -1,0 +1,86 @@
+package lvm
+
+import (
+	"container/list"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestFdCacheEvictionOrder(t *testing.T) {
+	cache := &fdCache{
+		fds:   make(map[string]*list.Element),
+		order: list.New(),
+	}
+
+	tmpDir := t.TempDir()
+	var fd0, fd1 int
+	for i := 0; i < fdCacheSize; i++ {
+		path := filepath.Join(tmpDir, fmt.Sprintf("file%d", i))
+		if err := os.WriteFile(path, nil, 0644); err != nil {
+			t.Fatalf("write file %d: %v", i, err)
+		}
+		fd, err := cache.getFD(path)
+		if err != nil {
+			t.Fatalf("getFD %d: %v", i, err)
+		}
+		if i == 0 {
+			fd0 = fd
+		}
+		if i == 1 {
+			fd1 = fd
+		}
+	}
+
+	if _, err := cache.getFD(filepath.Join(tmpDir, "file0")); err != nil {
+		t.Fatalf("reaccess file0: %v", err)
+	}
+
+	extra := filepath.Join(tmpDir, "extra")
+	if err := os.WriteFile(extra, nil, 0644); err != nil {
+		t.Fatalf("write extra: %v", err)
+	}
+	if _, err := cache.getFD(extra); err != nil {
+		t.Fatalf("getFD extra: %v", err)
+	}
+
+	if _, err := unix.FcntlInt(uintptr(fd1), unix.F_GETFD, 0); err == nil {
+		t.Fatalf("expected fd1 to be closed")
+	}
+	if _, err := unix.FcntlInt(uintptr(fd0), unix.F_GETFD, 0); err != nil {
+		t.Fatalf("expected fd0 to remain open: %v", err)
+	}
+
+	cache.Close()
+}
+
+func TestFdCacheCloseClosesAll(t *testing.T) {
+	cache := &fdCache{
+		fds:   make(map[string]*list.Element),
+		order: list.New(),
+	}
+	tmpDir := t.TempDir()
+	var fds []int
+	for i := 0; i < 3; i++ {
+		path := filepath.Join(tmpDir, fmt.Sprintf("file%d", i))
+		if err := os.WriteFile(path, nil, 0644); err != nil {
+			t.Fatalf("write file %d: %v", i, err)
+		}
+		fd, err := cache.getFD(path)
+		if err != nil {
+			t.Fatalf("getFD %d: %v", i, err)
+		}
+		fds = append(fds, fd)
+	}
+
+	cache.Close()
+
+	for i, fd := range fds {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); err == nil {
+			t.Fatalf("fd %d still open", i)
+		}
+	}
+}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -3,6 +3,7 @@ package lvm
 
 import (
 	"bytes"
+	"container/list"
 	"fmt"
 	"io"
 	"os"
@@ -30,13 +31,20 @@ var (
 	escalationCommandLock sync.RWMutex
 )
 
+type fdCacheEntry struct {
+	path string
+	fd   int
+}
+
 type fdCache struct {
-	fds   map[string]int
+	fds   map[string]*list.Element
+	order *list.List
 	mutex sync.Mutex
 }
 
 var deviceFDCache = &fdCache{
-	fds: make(map[string]int),
+	fds:   make(map[string]*list.Element),
+	order: list.New(),
 }
 
 var statfsFunc = syscall.Statfs
@@ -81,8 +89,9 @@ func (c *fdCache) getFD(devicePath string) (int, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if fd, exists := c.fds[devicePath]; exists {
-		return fd, nil
+	if elem, exists := c.fds[devicePath]; exists {
+		c.order.MoveToFront(elem)
+		return elem.Value.(*fdCacheEntry).fd, nil
 	}
 
 	fd, err := syscall.Open(devicePath, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
@@ -90,17 +99,19 @@ func (c *fdCache) getFD(devicePath string) (int, error) {
 		return -1, fmt.Errorf("failed to open device %s: %w", devicePath, err)
 	}
 
-	if len(c.fds) >= fdCacheSize {
-		var oldestPath string
-		for path := range c.fds {
-			oldestPath = path
-			break
+	if c.order.Len() >= fdCacheSize {
+		back := c.order.Back()
+		if back != nil {
+			entry := back.Value.(*fdCacheEntry)
+			syscall.Close(entry.fd)
+			delete(c.fds, entry.path)
+			c.order.Remove(back)
 		}
-		syscall.Close(c.fds[oldestPath])
-		delete(c.fds, oldestPath)
 	}
 
-	c.fds[devicePath] = fd
+	entry := &fdCacheEntry{path: devicePath, fd: fd}
+	elem := c.order.PushFront(entry)
+	c.fds[devicePath] = elem
 	return fd, nil
 }
 
@@ -108,10 +119,12 @@ func (c *fdCache) Close() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	for path, fd := range c.fds {
-		syscall.Close(fd)
-		delete(c.fds, path)
+	for _, elem := range c.fds {
+		entry := elem.Value.(*fdCacheEntry)
+		syscall.Close(entry.fd)
 	}
+	c.fds = make(map[string]*list.Element)
+	c.order.Init()
 }
 
 func captureOutput(r io.Reader, ch chan<- error, buf *bytes.Buffer) {


### PR DESCRIPTION
## Summary
- track file descriptor usage order in fdCache using list
- move accessed file descriptors to MRU and evict LRU when cache full
- add tests ensuring deterministic eviction and proper cleanup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689083e3de088323b21b9ba5c49aae40