### PR TITLE
Handle stream and logger errors

### DIFF
--- a/error_handling_test.go
+++ b/error_handling_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type failingSyncCore struct {
+	zapcore.Core
+	err error
+}
+
+func (c *failingSyncCore) Sync() error {
+	return c.err
+}
+
+func TestCopyPipeAsyncError(t *testing.T) {
+	r, w := io.Pipe()
+	errCh := copyPipeAsync(io.Discard, r)
+	expected := errors.New("copy fail")
+	w.CloseWithError(expected)
+	if err := <-errCh; !errors.Is(err, expected) {
+		t.Fatalf("expected %v, got %v", expected, err)
+	}
+}
+
+func TestSyncLoggerLogsError(t *testing.T) {
+	syncErr := errors.New("sync fail")
+	core, observed := observer.New(zap.InfoLevel)
+	logger := zap.New(&failingSyncCore{Core: core, err: syncErr})
+	syncLogger(logger)
+	logs := observed.All()
+	if len(logs) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(logs))
+	}
+	if logs[0].Message != "Logger sync error" {
+		t.Fatalf("unexpected log message %q", logs[0].Message)
+	}
+	if logs[0].ContextMap()["error"].(string) != syncErr.Error() {
+		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), logs[0].ContextMap()["error"])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,24 @@ import (
 	"go.uber.org/zap"
 )
 
+// copyPipeAsync copies data from src to dst in a new goroutine and returns a channel that receives
+// the resulting error from io.Copy.
+func copyPipeAsync(dst io.Writer, src io.Reader) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(dst, src)
+		errCh <- err
+	}()
+	return errCh
+}
+
+// syncLogger flushes any buffered log entries and logs if the sync fails.
+func syncLogger(logger *zap.Logger) {
+	if err := logger.Sync(); err != nil {
+		logger.Error("Logger sync error", zap.Error(err))
+	}
+}
+
 var (
 	cfg                          *config.Config
 	applyFunc                    = transfer.RunApply
@@ -85,8 +103,8 @@ func runClientMode(snapshotDevice, dest string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get stderr pipe: %w", err)
 		}
-		go io.Copy(os.Stdout, stdoutPipe)
-		go io.Copy(os.Stderr, stderrPipe)
+		stdoutErrCh := copyPipeAsync(os.Stdout, stdoutPipe)
+		stderrErrCh := copyPipeAsync(os.Stderr, stderrPipe)
 
 		remoteCmd := fmt.Sprintf("%s --apply - %s", cfg.LVMSyncPath, destDevice)
 		zap.L().Info("Starting remote apply command", zap.String("command", remoteCmd))
@@ -119,6 +137,13 @@ func runClientMode(snapshotDevice, dest string) error {
 
 		if err := session.Wait(); err != nil {
 			return fmt.Errorf("remote command error: %w", err)
+		}
+
+		if err := <-stdoutErrCh; err != nil {
+			return fmt.Errorf("stdout copy error: %w", err)
+		}
+		if err := <-stderrErrCh; err != nil {
+			return fmt.Errorf("stderr copy error: %w", err)
 		}
 
 		if cfg.RemotePostScript != "" {
@@ -182,7 +207,7 @@ func main() {
 		os.Exit(1)
 	}
 	zap.ReplaceGlobals(logger)
-	defer logger.Sync()
+	defer syncLogger(logger)
 
 	logger.Info("Effective configuration",
 		zap.String("block_size", cfg.HumanBlockSize()),


### PR DESCRIPTION
## Summary
- capture errors from remote stream copies using goroutines
- log any zap logger sync errors on shutdown
- add tests for stream copy and logger sync error handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68909bc1853483239529022de4cb43cb