### PR TITLE
Handle dedup state save errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,11 @@ func runClientMode(snapshotDevice, dest string) error {
 		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)
 		if cfg.Deduplication {
 			dedup := transfer.NewDeduplicationStrategy(cfg)
-			defer dedup.SaveState()
+			defer func() {
+				if err := dedup.SaveState(); err != nil {
+					zap.L().Error("Failed to save dedup state", zap.Error(err))
+				}
+			}()
 			return dumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, limitedOut, dedup)
 		}
 		if cfg.Parallel <= 1 {
@@ -102,7 +106,11 @@ func runClientMode(snapshotDevice, dest string) error {
 		var streamErr error
 		if cfg.Deduplication {
 			dedup := transfer.NewDeduplicationStrategy(cfg)
-			defer dedup.SaveState()
+			defer func() {
+				if err := dedup.SaveState(); err != nil {
+					zap.L().Error("Failed to save dedup state", zap.Error(err))
+				}
+			}()
 			streamErr = dumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, remoteStdin, dedup)
 		} else {
 			if cfg.Parallel <= 1 {
@@ -137,7 +145,11 @@ func runClientMode(snapshotDevice, dest string) error {
 
 		if cfg.Deduplication {
 			dedup := transfer.NewDeduplicationStrategy(cfg)
-			defer dedup.SaveState()
+			defer func() {
+				if err := dedup.SaveState(); err != nil {
+					zap.L().Error("Failed to save dedup state", zap.Error(err))
+				}
+			}()
 			return dumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, limitedOut, dedup)
 		}
 		if cfg.Parallel <= 1 {

--- a/main_save_state_error_test.go
+++ b/main_save_state_error_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"lvmsync_go/config"
+	"lvmsync_go/transfer"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestRunClientModeLogsSaveStateError(t *testing.T) {
+	cfg = config.DefaultConfig()
+	cfg.StdoutMode = true
+	cfg.Deduplication = true
+	cfg.DedupStrategy = "checksum"
+	cfg.DedupStateFile = filepath.Join(t.TempDir(), "missing", "state")
+	cfg.BlockSize = 1024
+	cfg.MaxRetries = 1
+
+	original := dumpChangesWithDeduplication
+	dumpChangesWithDeduplication = func(c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
+		return nil
+	}
+	defer func() { dumpChangesWithDeduplication = original }()
+
+	core, observed := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+	zap.ReplaceGlobals(logger)
+	defer zap.ReplaceGlobals(zap.NewNop())
+
+	if err := runClientMode("/dev/snap", ""); err != nil {
+		t.Fatalf("runClientMode returned error: %v", err)
+	}
+
+	logs := observed.FilterMessage("Failed to save dedup state").All()
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logs))
+	}
+}

--- a/transfer/save_state_error_test.go
+++ b/transfer/save_state_error_test.go
@@ -1,0 +1,33 @@
+package transfer
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"lvmsync_go/config"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestDumpChangesLogsSaveStateError(t *testing.T) {
+	core, observed := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+	SetLogger(logger)
+	defer SetLogger(nil)
+
+	blockSize := int64(1024)
+	changed := []int{0}
+	src, snapshot := createDumpTestFiles(t, blockSize, changed)
+
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Deduplication: true, DedupStrategy: "checksum", DedupStateFile: filepath.Join(t.TempDir(), "missing", "state"), MaxRetries: 1}
+	var buf bytes.Buffer
+	if err := DumpChanges(cfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChanges failed: %v", err)
+	}
+	logs := observed.FilterMessage("Failed to save dedup state").All()
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logs))
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -171,7 +171,11 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 
 func DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.Writer) error {
 	dedup := NewDeduplicationStrategy(cfg)
-	defer dedup.SaveState()
+	defer func() {
+		if err := dedup.SaveState(); err != nil {
+			Logger.Error("Failed to save dedup state", zap.Error(err))
+		}
+	}()
 	return dumpChangesCore(cfg, snapshot, source, out, dedup, "")
 }
 
@@ -182,7 +186,11 @@ func DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, o
 
 func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
 	dedup := NewDeduplicationStrategy(cfg)
-	defer dedup.SaveState()
+	defer func() {
+		if err := dedup.SaveState(); err != nil {
+			Logger.Error("Failed to save dedup state", zap.Error(err))
+		}
+	}()
 	if cfg.Deduplication {
 		Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
 		return DumpChangesWithDeduplication(cfg, snapshot, source, out, dedup)
@@ -476,7 +484,11 @@ func RunApply(cfg *config.Config, applyFile, destDevice string) error {
 	if cfg.Deduplication {
 		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
 		dedup := NewDeduplicationStrategy(cfg)
-		defer dedup.SaveState()
+		defer func() {
+			if err := dedup.SaveState(); err != nil {
+				Logger.Error("Failed to save dedup state", zap.Error(err))
+			}
+		}()
 		return ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)
 	}
 


### PR DESCRIPTION
## Summary
- log and continue when dedup SaveState fails in transfer and client mode
- add tests to ensure SaveState errors are logged

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68909bd3ea98832397ed603b235ce92f