### PR TITLE
Fix dedup SaveState error handling and add tests

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -14,6 +14,10 @@ import (
 	"go.uber.org/zap"
 )
 
+var createStateFile = func(name string) (io.WriteCloser, error) {
+	return os.Create(name)
+}
+
 type DeduplicationStrategy interface {
 	ShouldTransfer(offset int64, data []byte) bool
 	RecordTransfer(offset int64, data []byte)
@@ -91,15 +95,19 @@ func (c *ChecksumDedup) SaveState() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	file, err := os.Create(c.stateFile)
+	file, err := createStateFile(c.stateFile)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
 	for offset, hash := range c.hashes {
-		binary.Write(file, binary.LittleEndian, offset)
-		file.Write(hash[:])
+		if err := binary.Write(file, binary.LittleEndian, offset); err != nil {
+			return err
+		}
+		if _, err := file.Write(hash[:]); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/transfer/dedup_save_state_test.go
+++ b/transfer/dedup_save_state_test.go
@@ -1,0 +1,49 @@
+package transfer
+
+import (
+	"crypto/sha256"
+	"errors"
+	"io"
+	"testing"
+)
+
+type failingWriter struct {
+	failAfter int
+	writes    int
+}
+
+func (fw *failingWriter) Write(p []byte) (int, error) {
+	if fw.writes == fw.failAfter {
+		return 0, errors.New("write failed")
+	}
+	fw.writes++
+	return len(p), nil
+}
+
+func (fw *failingWriter) Close() error { return nil }
+
+func TestChecksumDedupSaveStateWriteFailures(t *testing.T) {
+	hash := sha256.Sum256([]byte("data"))
+
+	t.Run("binary write failure", func(t *testing.T) {
+		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][32]byte{1: hash}}
+		fw := &failingWriter{failAfter: 0}
+		orig := createStateFile
+		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+		defer func() { createStateFile = orig }()
+		if err := c.SaveState(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("file write failure", func(t *testing.T) {
+		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][32]byte{1: hash}}
+		fw := &failingWriter{failAfter: 1}
+		orig := createStateFile
+		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+		defer func() { createStateFile = orig }()
+		if err := c.SaveState(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- handle errors from writing dedup state
- add tests for write failures during dedup state save

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68909bd57b8c83239392b95a5f8d0e40