### PR TITLE
Use constants for compression types

### DIFF
--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -10,13 +10,18 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
+const (
+	compressionLZ4  = "lz4"
+	compressionZSTD = "zstd"
+)
+
 // No shared state is kept between decompression readers.
 
 func detectOptimalCompression() string {
 	if cpu.X86.HasAVX2 {
-		return "zstd"
+		return compressionZSTD
 	}
-	return "lz4"
+	return compressionLZ4
 }
 
 func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteCloser, error) {
@@ -27,9 +32,9 @@ func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteClos
 	switch compress {
 	case "none":
 		return nopWriteCloser{w}, nil
-	case "lz4":
+	case compressionLZ4:
 		return lz4.NewWriter(w), nil
-	case "zstd":
+	case compressionZSTD:
 		return zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.EncoderLevel(level)))
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
@@ -40,9 +45,9 @@ func NewDecompressionReader(r io.Reader, compress string) (io.ReadCloser, error)
 	switch compress {
 	case "none":
 		return nopReadCloser{r}, nil
-	case "lz4":
+	case compressionLZ4:
 		return nopReadCloser{lz4.NewReader(r)}, nil
-	case "zstd":
+	case compressionZSTD:
 		decoder, err := zstd.NewReader(r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCompressionRoundTrip(t *testing.T) {
 	data := []byte("some test data for compression")
-	types := []string{"none", "lz4", "zstd"}
+	types := []string{"none", compressionLZ4, compressionZSTD}
 
 	for _, c := range types {
 		var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- centralize compression type strings into constants
- use constants across compression helpers and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68909bd6e6d88323886198459667d318