### PR TITLE
Replace MD5 checksum with SHA-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Parallel Execution**: Configurable concurrency for optimal performance.
 - **Rate-Limiting**: Control bandwidth usage during transfers.
 - **Compression**: Supports LZ4 and Zstd (with configurable compression levels and an auto mode based on CPU features).
- - **Checksum Verification**: Ensures data integrity.
+- **Checksum Verification**: Ensures data integrity using SHA-256.
  - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or Bloom filter with persistent state.
  - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers.

--- a/transfer/checksum.go
+++ b/transfer/checksum.go
@@ -2,7 +2,6 @@
 package transfer
 
 import (
-	"crypto/md5"
 	"crypto/sha256"
 	"sync"
 )
@@ -18,31 +17,17 @@ func (s *SHA256Checksum) Compute(data []byte) []byte {
 	return sum[:]
 }
 
-type MD5Checksum struct{}
-
-func (m *MD5Checksum) Compute(data []byte) []byte {
-	sum := md5.Sum(data)
-	return sum[:]
-}
-
 var (
 	sha256Instance ChecksumStrategy = &SHA256Checksum{}
-	md5Instance    ChecksumStrategy = &MD5Checksum{}
 	initOnce       sync.Once
 )
 
 func initChecksumStrategies() {
 	sha256Instance = &SHA256Checksum{}
-	md5Instance = &MD5Checksum{}
 }
 
 func GetChecksumStrategy(algo string) ChecksumStrategy {
 	initOnce.Do(initChecksumStrategies)
-
-	switch algo {
-	case "md5":
-		return md5Instance
-	default:
-		return sha256Instance
-	}
+	// Only SHA-256 is supported; default to it for any request.
+	return sha256Instance
 }

--- a/transfer/checksum_test.go
+++ b/transfer/checksum_test.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"bytes"
-	"crypto/md5"
 	"crypto/sha256"
 	"testing"
 )
@@ -16,11 +15,11 @@ func TestSHA256Checksum(t *testing.T) {
 	}
 }
 
-func TestMD5Checksum(t *testing.T) {
-	data := []byte("verify md5")
-	want := md5.Sum(data)
+func TestUnsupportedAlgorithmDefaultsToSHA256(t *testing.T) {
+	data := []byte("verify default")
+	want := sha256.Sum256(data)
 	got := GetChecksumStrategy("md5").Compute(data)
 	if !bytes.Equal(got, want[:]) {
-		t.Fatalf("md5 checksum mismatch: got %x, want %x", got, want)
+		t.Fatalf("default checksum mismatch: got %x, want %x", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- remove insecure MD5 checksum implementation and rely solely on SHA-256
- default checksum strategy to SHA-256 for all algorithms
- document SHA-256 as the checksum verification method

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68909bd84ef48323ba6569e99ef87f54