### PR TITLE
Use x/time rate limiter for throttled writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.5
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/juju/ratelimit v1.0.2
 	github.com/klauspost/compress v1.18.0
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/spf13/pflag v1.0.7
@@ -13,6 +12,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.40.0
 	golang.org/x/sys v0.34.0
+	golang.org/x/time v0.12.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIx
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=
-github.com/juju/ratelimit v1.0.2/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -62,6 +60,8 @@ golang.org/x/term v0.33.0 h1:NuFncQrRcaRvVmgRkvM3j/F00gWIAlcmlB8ACEKmGIg=
 golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=
 golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
+golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
+golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -14,6 +14,21 @@ func TestWrapRateLimitedWriterDisabled(t *testing.T) {
 	}
 }
 
+func TestWrapRateLimitedWriterEnabled(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := WrapRateLimitedWriter(buf, 1024)
+	if w == buf {
+		t.Fatal("writer should be wrapped when limit is positive")
+	}
+	data := []byte("test data")
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if got := buf.String(); got != string(data) {
+		t.Fatalf("unexpected buffer content %q", got)
+	}
+}
+
 func TestNewDeduplicationStrategy(t *testing.T) {
 	cfg := &config.Config{DedupStrategy: "bloom", DedupStateFile: "state"}
 	if _, ok := NewDeduplicationStrategy(cfg).(*BloomFilterDedup); !ok {

--- a/transfer/utils.go
+++ b/transfer/utils.go
@@ -2,18 +2,49 @@
 package transfer
 
 import (
+	"context"
 	"io"
 	"sync"
 
-	"github.com/juju/ratelimit"
+	"golang.org/x/time/rate"
 )
 
+// rateLimitedWriter wraps an io.Writer and throttles write throughput to a
+// specified number of bytes per second using a shared rate limiter.
+type rateLimitedWriter struct {
+	w       io.Writer
+	limiter *rate.Limiter
+}
+
+func (rlw *rateLimitedWriter) Write(p []byte) (int, error) {
+	written := 0
+	for len(p) > 0 {
+		chunk := len(p)
+		if burst := rlw.limiter.Burst(); chunk > burst {
+			chunk = burst
+		}
+		if err := rlw.limiter.WaitN(context.Background(), chunk); err != nil {
+			return written, err
+		}
+		n, err := rlw.w.Write(p[:chunk])
+		written += n
+		if err != nil {
+			return written, err
+		}
+		p = p[n:]
+	}
+	return written, nil
+}
+
 var (
-	rateLimiterCache     *ratelimit.Bucket
+	rateLimiterCache     *rate.Limiter
 	lastSpeedLimit       int
 	rateLimiterCacheLock sync.Mutex
 )
 
+// WrapRateLimitedWriter returns an io.Writer that limits the write throughput
+// to the specified speedLimit in bytes per second. The limiter instance is
+// cached to avoid unnecessary allocations when the limit remains unchanged.
 func WrapRateLimitedWriter(w io.Writer, speedLimit int) io.Writer {
 	if speedLimit <= 0 {
 		return w
@@ -22,12 +53,10 @@ func WrapRateLimitedWriter(w io.Writer, speedLimit int) io.Writer {
 	rateLimiterCacheLock.Lock()
 	defer rateLimiterCacheLock.Unlock()
 
-	if rateLimiterCache != nil && lastSpeedLimit == speedLimit {
-		return ratelimit.Writer(w, rateLimiterCache)
+	if rateLimiterCache == nil || lastSpeedLimit != speedLimit {
+		rateLimiterCache = rate.NewLimiter(rate.Limit(speedLimit), speedLimit)
+		lastSpeedLimit = speedLimit
 	}
 
-	rateLimiterCache = ratelimit.NewBucketWithRate(float64(speedLimit), int64(speedLimit))
-	lastSpeedLimit = speedLimit
-
-	return ratelimit.Writer(w, rateLimiterCache)
+	return &rateLimitedWriter{w: w, limiter: rateLimiterCache}
 }


### PR DESCRIPTION
## Summary
- replace juju/ratelimit with golang.org/x/time rate limiter
- add custom rateLimitedWriter and corresponding unit test
- drop unused juju dependency

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890ee604fa883239fb70f035dcb2ad8