### PR TITLE
Use native LVM library to execute commands

### DIFF
--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -1,13 +1,21 @@
 // lvm/lvm.go
 package lvm
 
+/*
+#cgo LDFLAGS: -llvm2cmd
+#include <stdlib.h>
+#include <lvm2cmd.h>
+
+extern void goLvmLog(int level, char *file, int line, int dm_errno, char *msg);
+static inline void setLvmLog() { lvm2_log_fn((lvm2_log_fn_t)goLvmLog); }
+*/
+import "C"
+
 import (
 	"bytes"
 	"container/list"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -63,19 +71,6 @@ func GetEscalationCommand() string {
 	return escalationCommand
 }
 
-func buildCommand(name string, args ...string) *exec.Cmd {
-	escalationCommandLock.RLock()
-	escCmd := escalationCommand
-	escalationCommandLock.RUnlock()
-
-	if escCmd != "" && os.Geteuid() != 0 {
-		cmdArgs := append([]string{name}, args...)
-		return exec.Command(escCmd, cmdArgs...)
-	}
-
-	return exec.Command(name, args...)
-}
-
 func checkRootPrivileges() error {
 	escalationCommandLock.RLock()
 	escCmd := escalationCommand
@@ -129,43 +124,53 @@ func (c *fdCache) Close() {
 	c.order.Init()
 }
 
-func captureOutput(r io.Reader, ch chan<- error, buf *bytes.Buffer) {
-	_, err := buf.ReadFrom(r)
-	ch <- err
+var (
+	lvmHandle     = C.lvm2_init()
+	cmdMutex      sync.Mutex
+	logBuffer     *bytes.Buffer
+	runLVMCommand = realRunLVMCommand
+)
+
+func init() {
+	C.setLvmLog()
+	C.lvm2_log_level(lvmHandle, C.LVM2_LOG_DEBUG)
 }
 
-func executeCommand(name string, args ...string) ([]byte, error) {
-	cmd := buildCommand(name, args...)
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
+//export goLvmLog
+func goLvmLog(level C.int, file *C.char, line C.int, dm_errno C.int, msg *C.char) {
+	cmdMutex.Lock()
+	if logBuffer != nil {
+		logBuffer.WriteString(C.GoString(msg))
+		logBuffer.WriteByte('\n')
 	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, err
+	cmdMutex.Unlock()
+}
+
+func realRunLVMCommand(name string, args ...string) ([]byte, error) {
+	cmdMutex.Lock()
+	defer cmdMutex.Unlock()
+
+	logBuffer = &bytes.Buffer{}
+	var b strings.Builder
+	b.WriteString(name)
+	for _, a := range args {
+		b.WriteByte(' ')
+		if strings.ContainsAny(a, " \t\n\"") {
+			b.WriteString(strconv.Quote(a))
+		} else {
+			b.WriteString(a)
+		}
 	}
+	ccmd := C.CString(b.String())
+	defer C.free(unsafe.Pointer(ccmd))
 
-	if err := cmd.Start(); err != nil {
-		return nil, err
+	ret := C.lvm2_run(lvmHandle, ccmd)
+	out := logBuffer.Bytes()
+	logBuffer = nil
+	if ret != C.LVM2_COMMAND_SUCCEEDED {
+		return out, fmt.Errorf("lvm command failed: %s", strings.TrimSpace(string(out)))
 	}
-
-	var outBuf, errBuf bytes.Buffer
-	outCh := make(chan error, 1)
-	errCh := make(chan error, 1)
-
-	go captureOutput(stdout, outCh, &outBuf)
-	go captureOutput(stderr, errCh, &errBuf)
-
-	<-outCh
-	<-errCh
-
-	err = cmd.Wait()
-	if err != nil {
-		return outBuf.Bytes(), fmt.Errorf("%w: %s", err, errBuf.String())
-	}
-
-	return outBuf.Bytes(), nil
+	return out, nil
 }
 
 func CreateSnapshot(lvPath, snapshotName, size string) error {
@@ -177,7 +182,7 @@ func CreateSnapshot(lvPath, snapshotName, size string) error {
 		return fmt.Errorf("invalid parameters: lvPath, snapshotName, and size must be non-empty")
 	}
 
-	output, err := executeCommand("lvcreate", "-s", "-n", snapshotName, "-L", size, lvPath)
+	output, err := runLVMCommand("lvcreate", "-s", "-n", snapshotName, "-L", size, lvPath)
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot [%s] for LV %s with size %s: %w",
 			snapshotName, lvPath, size, err)
@@ -201,7 +206,7 @@ func RemoveSnapshot(snapshotPath string) error {
 		return fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
 
-	output, err := executeCommand("lvremove", "-f", snapshotPath)
+	output, err := runLVMCommand("lvremove", "-f", snapshotPath)
 	if err != nil {
 		return fmt.Errorf("failed to remove snapshot [%s]: %w", snapshotPath, err)
 	}
@@ -222,7 +227,7 @@ func GetSnapshotUsage(snapshotPath string) (float64, error) {
 		return 0, fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
 
-	output, err := executeCommand("lvs", "--noheadings", "--units", "b",
+	output, err := runLVMCommand("lvs", "--noheadings", "--units", "b",
 		"--options", "data_percent", snapshotPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get snapshot usage for %s: %w", snapshotPath, err)
@@ -395,7 +400,7 @@ func GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
 		return 0, err
 	}
 
-	output, err := executeCommand("vgs", "--noheadings", "--units", "b",
+	output, err := runLVMCommand("vgs", "--noheadings", "--units", "b",
 		"--options", "vg_free", vgName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get free space for VG %s: %w", vgName, err)

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -2,8 +2,7 @@ package lvm
 
 import (
 	"errors"
-	"os"
-	"path/filepath"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -17,26 +16,13 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	tmpDir := t.TempDir()
-
-	// Create mock lvcreate script
-	lvcreateScript := filepath.Join(tmpDir, "lvcreate")
-	lvcreateContent := "#!/bin/sh\necho \"$@\" > \"" + filepath.Join(tmpDir, "lvcreate_args") + "\"\n"
-	if err := os.WriteFile(lvcreateScript, []byte(lvcreateContent), 0755); err != nil {
-		t.Fatalf("failed to write lvcreate script: %v", err)
+	var cmds []string
+	origRun := runLVMCommand
+	runLVMCommand = func(name string, args ...string) ([]byte, error) {
+		cmds = append(cmds, strings.Join(append([]string{name}, args...), " "))
+		return []byte(""), nil
 	}
-
-	// Create mock lvremove script
-	lvremoveScript := filepath.Join(tmpDir, "lvremove")
-	lvremoveContent := "#!/bin/sh\necho \"$@\" > \"" + filepath.Join(tmpDir, "lvremove_args") + "\"\n"
-	if err := os.WriteFile(lvremoveScript, []byte(lvremoveContent), 0755); err != nil {
-		t.Fatalf("failed to write lvremove script: %v", err)
-	}
-
-	// Prepend tmpDir to PATH so our scripts are used
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmpDir+":"+oldPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Cleanup(func() { runLVMCommand = origRun })
 
 	lvPath := "/dev/vg0/origin"
 	snapName := "snap"
@@ -45,30 +31,19 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 	if err := CreateSnapshot(lvPath, snapName, size); err != nil {
 		t.Fatalf("CreateSnapshot failed: %v", err)
 	}
-
-	argsData, err := os.ReadFile(filepath.Join(tmpDir, "lvcreate_args"))
-	if err != nil {
-		t.Fatalf("failed to read lvcreate args: %v", err)
-	}
-	got := strings.TrimSpace(string(argsData))
-	expected := "-s -n " + snapName + " -L " + size + " " + lvPath
-	if got != expected {
-		t.Fatalf("lvcreate args = %q, want %q", got, expected)
-	}
-
 	snapPath := "/dev/vg0/" + snapName
 	if err := RemoveSnapshot(snapPath); err != nil {
 		t.Fatalf("RemoveSnapshot failed: %v", err)
 	}
 
-	rmArgs, err := os.ReadFile(filepath.Join(tmpDir, "lvremove_args"))
-	if err != nil {
-		t.Fatalf("failed to read lvremove args: %v", err)
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(cmds))
 	}
-	got = strings.TrimSpace(string(rmArgs))
-	expected = "-f " + snapPath
-	if got != expected {
-		t.Fatalf("lvremove args = %q, want %q", got, expected)
+	if cmds[0] != fmt.Sprintf("lvcreate -s -n %s -L %s %s", snapName, size, lvPath) {
+		t.Fatalf("lvcreate args = %q", cmds[0])
+	}
+	if cmds[1] != fmt.Sprintf("lvremove -f %s", snapPath) {
+		t.Fatalf("lvremove args = %q", cmds[1])
 	}
 }
 

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -1,8 +1,6 @@
 package lvm
 
 import (
-	"os"
-	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
@@ -17,14 +15,11 @@ func TestGetSnapshotUsage(t *testing.T) {
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	tmpDir := t.TempDir()
-	script := filepath.Join(tmpDir, "lvs")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 75.5\n"), 0755); err != nil {
-		t.Fatalf("failed to write lvs script: %v", err)
+	origRun := runLVMCommand
+	runLVMCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("75.5\n"), nil
 	}
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmpDir+":"+oldPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Cleanup(func() { runLVMCommand = origRun })
 
 	usage, err := GetSnapshotUsage("/dev/vg0/snap")
 	if err != nil {
@@ -40,14 +35,11 @@ func TestMonitorSnapshot(t *testing.T) {
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	tmpDir := t.TempDir()
-	script := filepath.Join(tmpDir, "lvs")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 90\n"), 0755); err != nil {
-		t.Fatalf("failed to write lvs script: %v", err)
+	origRun := runLVMCommand
+	runLVMCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("90\n"), nil
 	}
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmpDir+":"+oldPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Cleanup(func() { runLVMCommand = origRun })
 
 	err := MonitorSnapshot("/dev/vg0/snap", 80, 10*time.Millisecond, make(chan struct{}))
 	if err == nil {


### PR DESCRIPTION
## Summary
- replace shell based LVM calls with direct liblvm2cmd execution and logging callback
- adjust snapshot related tests to stub native LVM invocation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68910b17dfc083239bff8e26314b9b3d