### PR TITLE
Add automatic VG selection and target VG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,16 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 
 #### LVM Options
 
-| Option                     | Description                                                                                                          | Default      |
-|----------------------------|----------------------------------------------------------------------------------------------------------------------|--------------|
-| `--skip_snapshot_creation` | Skip automatic snapshot creation                                                                                     | `false`      |
-| `--skip_disk_check`        | Skip disk space check before snapshot creation                                                                       | `false`      |
-| `--snapshot_size`          | Snapshot size as an absolute value (e.g., `"20G"`) or as a percentage (e.g., `"20%"`)                                  | `"20%"`      |
-| `--volume_group`           | Volume group name of the source LVM volume                                                                            | `"vg0"`      |
-| `--lvm_escalation`         | Command used to escalate privileges for LVM commands (e.g., `"sudo -n"`)                                               | `"sudo -n"`  |
+| Option                     | Description                                                            | Default      |
+|----------------------------|------------------------------------------------------------------------|--------------|
+| `--skip_snapshot_creation` | Skip automatic snapshot creation                                       | `false`      |
+| `--skip_disk_check`        | Skip disk space check before snapshot creation                        | `false`      |
+| `--snapshot_size`          | Snapshot size as an absolute value (e.g., `"20G"`) or as a percentage (e.g., `"20%"`) | `"20%"`      |
+| `--volume_group`           | Source volume group. If empty, the group with the most free space is selected automatically. | `"vg0"`      |
+| `--target_volume_group`    | Volume group name of the target LVM volume                             | `""`       |
+| `--source_vgs`             | Candidate source volume groups for auto-selection                      | `[]`       |
+| `--target_vgs`             | Candidate target volume groups for auto-selection                      | `[]`       |
+| `--lvm_escalation`         | Command used to escalate privileges for LVM commands (e.g., `"sudo -n"`) | `"sudo -n"`  |
 
 ### Examples
 
@@ -237,19 +240,20 @@ compress_level: 3                       # Compression level for zstd (ignored fo
 skip_snapshot_creation: false           # Skip automatic snapshot creation
 skip_disk_check: false                  # Skip disk space check before snapshot creation
 snapshot_size: "20%"                    # Snapshot size as an absolute value (e.g., "20G") or as a percentage (e.g., "20%")
-volume_group: "vg0"                     # Volume group name of the source LVM volume
+volume_group: "vg0"                     # Source volume group. Auto-selected by free space when empty
+target_volume_group: ""                 # Volume group name of the target LVM volume
+source_vgs: []                          # Candidate source VGs for auto-selection
+target_vgs: []                          # Candidate target VGs for auto-selection
 lvm_escalation: "sudo -n"               # Command used to escalate privileges for LVM commands
 ```
-
-## Graceful Shutdown
 
 LVMSync installs signal handlers for SIGINT and SIGTERM. If an interruption occurs, the tool will attempt to remove any created snapshot before exiting, ensuring no orphaned snapshots remain.
 
 ## Configuration Validation
 
 Before starting, LVMSync validates key configuration parameters:
-- Checks that the specified volume group exists (via `vgdisplay`).
-- Verifies that the escalation command is available if not running as root.
+- Verifies that the specified volume groups exist.
+- Ensures the escalation command is available if not running as root.
 
 Invalid configurations will cause the tool to abort with a clear error message.
 

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,10 @@ verbose: 0                             # Verbosity level (0 = silent, higher num
 skip_snapshot_creation: false          # Skip automatic snapshot creation
 skip_disk_check: false                 # Skip disk space check before snapshot creation
 snapshot_size: "20%"                   # Snapshot size as an absolute value (e.g. "20G") or as a percentage (e.g. "20%")
-volume_group: "vg0"                    # Volume group name of the source LVM volume
+volume_group: "vg0"                    # Source volume group. Auto-selected by free space when empty
+target_volume_group: ""                # Volume group name of the target LVM volume
+source_vgs: []                         # Candidate source VGs for auto-selection
+target_vgs: []                         # Candidate target VGs for auto-selection
 lvm_escalation: "sudo -n"              # Command used to escalate privileges for LVM commands
 progress: true                         # Enable progress display during transfer
 block_size: "4K"                       # Block size for LVM operations

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"lvmsync_go/lvm"
 )
 
 var SupportedCompression = []string{"none", "lz4", "zstd", "auto"}
@@ -55,6 +56,9 @@ type Config struct {
 	SkipDiskCheck        bool          `mapstructure:"skip_disk_check"`
 	SnapshotSize         string        `mapstructure:"snapshot_size"`
 	VolumeGroup          string        `mapstructure:"volume_group"`
+	TargetVolumeGroup    string        `mapstructure:"target_volume_group"`
+	SourceVGCandidates   []string      `mapstructure:"source_vgs"`
+	TargetVGCandidates   []string      `mapstructure:"target_vgs"`
 	LVMEscalation        string        `mapstructure:"lvm_escalation"`
 	Progress             bool          `mapstructure:"progress"`
 	BlockSize            int           `mapstructure:"-"`
@@ -146,6 +150,9 @@ func DefaultConfig() *Config {
 		SkipDiskCheck:        false,
 		SnapshotSize:         "20%",
 		VolumeGroup:          "vg0",
+		TargetVolumeGroup:    "",
+		SourceVGCandidates:   []string{},
+		TargetVGCandidates:   []string{},
 		LVMEscalation:        "sudo -n",
 		Progress:             true,
 		BlockSize:            4096,
@@ -211,6 +218,9 @@ func LoadConfig() (*Config, error) {
 	lvmFlags.String("snapshot_size", defaultCfg.SnapshotSize, "Snapshot size (e.g., '20G' or '20%')")
 	lvmFlags.String("lvm_escalation", defaultCfg.LVMEscalation, "Command used to escalate privileges for LVM commands")
 	lvmFlags.String("volume_group", defaultCfg.VolumeGroup, "Volume group name of the source LVM volume")
+	lvmFlags.String("target_volume_group", defaultCfg.TargetVolumeGroup, "Volume group name of the target LVM volume")
+	lvmFlags.StringSlice("source_vgs", defaultCfg.SourceVGCandidates, "Candidate source volume groups for auto-selection")
+	lvmFlags.StringSlice("target_vgs", defaultCfg.TargetVGCandidates, "Candidate target volume groups for auto-selection")
 
 	// Register flags and set usage
 	pflag.CommandLine.AddFlagSet(generalFlags)
@@ -244,12 +254,38 @@ func LoadConfig() (*Config, error) {
 		v:        v,
 		defaults: defaultCfg,
 	}
-	return builder.Build()
+	conf, err := builder.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	if conf.VolumeGroup == "" {
+		vg, _, err := lvm.SelectVolumeGroupByFreeSpace(conf.SourceVGCandidates)
+		if err != nil {
+			return nil, fmt.Errorf("failed to select source volume group: %w", err)
+		}
+		conf.VolumeGroup = vg
+	}
+	if conf.TargetVolumeGroup == "" && len(conf.TargetVGCandidates) > 0 {
+		vg, _, err := lvm.SelectVolumeGroupByFreeSpace(conf.TargetVGCandidates)
+		if err != nil {
+			return nil, fmt.Errorf("failed to select target volume group: %w", err)
+		}
+		conf.TargetVolumeGroup = vg
+	}
+
+	return conf, nil
 }
 func (c *Config) Validate() error {
-	out, err := exec.Command("vgdisplay", c.VolumeGroup).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("volume group %q does not exist or is inaccessible: %w, output: %s", c.VolumeGroup, err, string(out))
+	if c.VolumeGroup != "" {
+		if _, err := lvm.GetVolumeGroupFreeSpace(c.VolumeGroup); err != nil {
+			return fmt.Errorf("volume group %q does not exist or is inaccessible: %w", c.VolumeGroup, err)
+		}
+	}
+	if c.TargetVolumeGroup != "" {
+		if _, err := lvm.GetVolumeGroupFreeSpace(c.TargetVolumeGroup); err != nil {
+			return fmt.Errorf("target volume group %q does not exist or is inaccessible: %w", c.TargetVolumeGroup, err)
+		}
 	}
 	if os.Geteuid() != 0 {
 		parts := strings.Fields(c.LVMEscalation)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,11 +3,10 @@ package config
 import (
 	"fmt"
 	"math"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
+	"lvmsync_go/lvm"
 )
 
 func TestParseBytesOrFallback(t *testing.T) {
@@ -69,27 +68,22 @@ func TestParseBytesOrFallback(t *testing.T) {
 }
 
 func TestConfigValidate(t *testing.T) {
-	t.Run("vgdisplay success", func(t *testing.T) {
-		dir := t.TempDir()
-		script := filepath.Join(dir, "vgdisplay")
-		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-			t.Fatalf("write script: %v", err)
-		}
-		t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
-		cfg := DefaultConfig()
-		cfg.VolumeGroup = "vg0"
+	t.Run("success", func(t *testing.T) {
+		restore := lvm.SetRunLVMCommand(func(name string, args ...string) ([]byte, error) {
+			return []byte("100B\n"), nil
+		})
+		defer restore()
+		cfg := &Config{VolumeGroup: "vg0"}
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 
-	t.Run("vgdisplay failure", func(t *testing.T) {
-		dir := t.TempDir()
-		script := filepath.Join(dir, "vgdisplay")
-		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
-			t.Fatalf("write script: %v", err)
-		}
-		t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+	t.Run("failure", func(t *testing.T) {
+		restore := lvm.SetRunLVMCommand(func(name string, args ...string) ([]byte, error) {
+			return nil, fmt.Errorf("command error")
+		})
+		defer restore()
 		cfg := &Config{VolumeGroup: "vg0"}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -131,6 +131,18 @@ var (
 	runLVMCommand = realRunLVMCommand
 )
 
+// SetRunLVMCommand overrides the function used to execute LVM commands.
+// It returns a restore function to reset the original behavior.
+func SetRunLVMCommand(f func(string, ...string) ([]byte, error)) func() {
+	orig := runLVMCommand
+	if f == nil {
+		runLVMCommand = realRunLVMCommand
+	} else {
+		runLVMCommand = f
+	}
+	return func() { runLVMCommand = orig }
+}
+
 func init() {
 	C.setLvmLog()
 	C.lvm2_log_level(lvmHandle, C.LVM2_LOG_DEBUG)
@@ -416,6 +428,78 @@ func GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
 	}
 
 	return size, nil
+}
+
+// VolumeGroup represents basic information about a volume group.
+type VolumeGroup struct {
+	Name string
+	Free uint64
+}
+
+// ListVolumeGroups returns information about all available volume groups.
+func ListVolumeGroups() ([]VolumeGroup, error) {
+	if err := checkPrivs(); err != nil {
+		return nil, err
+	}
+
+	output, err := runLVMCommand("vgs", "--noheadings", "--units", "b",
+		"--options", "vg_name,vg_free", "--separator", ":")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list volume groups: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	vgs := make([]VolumeGroup, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.Split(line, ":")
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		freeStr := strings.TrimSuffix(strings.TrimSpace(parts[1]), "B")
+		free, err := strconv.ParseUint(freeStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse VG free space %q: %w", freeStr, err)
+		}
+		vgs = append(vgs, VolumeGroup{Name: name, Free: free})
+	}
+	return vgs, nil
+}
+
+// SelectVolumeGroupByFreeSpace chooses the volume group with the most free space.
+// If candidates is non-empty, only those volume groups are considered.
+func SelectVolumeGroupByFreeSpace(candidates []string) (string, uint64, error) {
+	vgs, err := ListVolumeGroups()
+	if err != nil {
+		return "", 0, err
+	}
+
+	candidateSet := make(map[string]struct{}, len(candidates))
+	for _, c := range candidates {
+		candidateSet[c] = struct{}{}
+	}
+
+	var chosen VolumeGroup
+	for _, vg := range vgs {
+		if len(candidateSet) > 0 {
+			if _, ok := candidateSet[vg.Name]; !ok {
+				continue
+			}
+		}
+		if vg.Free > chosen.Free {
+			chosen = vg
+		}
+	}
+	if chosen.Name == "" {
+		if len(candidateSet) > 0 {
+			return "", 0, fmt.Errorf("no matching volume group found")
+		}
+		return "", 0, fmt.Errorf("no volume groups found")
+	}
+	return chosen.Name, chosen.Free, nil
 }
 
 func Cleanup() {

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -1,0 +1,36 @@
+package lvm
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
+	restore := SetRunLVMCommand(func(name string, args ...string) ([]byte, error) {
+		if name != "vgs" {
+			return nil, fmt.Errorf("unexpected command %s", name)
+		}
+		return []byte("vg0:100B\nvg1:200B\n"), nil
+	})
+	defer restore()
+
+	vg, free, err := SelectVolumeGroupByFreeSpace(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vg != "vg1" || free != 200 {
+		t.Fatalf("expected vg1 with 200, got %s with %d", vg, free)
+	}
+
+	vg, free, err = SelectVolumeGroupByFreeSpace([]string{"vg0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vg != "vg0" || free != 100 {
+		t.Fatalf("expected vg0 with 100, got %s with %d", vg, free)
+	}
+
+	if _, _, err := SelectVolumeGroupByFreeSpace([]string{"vg2"}); err == nil {
+		t.Fatalf("expected error for unknown vg")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -210,6 +210,7 @@ func main() {
 		zap.Int("compress_level", cfg.CompressLevel),
 		zap.String("snapshot_size", cfg.SnapshotSize),
 		zap.String("volume_group", cfg.VolumeGroup),
+		zap.String("target_volume_group", cfg.TargetVolumeGroup),
 		zap.Bool("stdout_mode", cfg.StdoutMode),
 		zap.String("lvmsync_path", cfg.LVMSyncPath),
 	)


### PR DESCRIPTION
## Summary
- add volume-group utility functions to list groups and choose by free space
- allow config to auto-select source/target volume groups with candidate lists
- document VG selection options in README and default config

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68910f4874988323b2eb86a428ab2cac