### PR TITLE
Avoid root requirement in unit tests

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,7 +73,10 @@ func TestConfigValidate(t *testing.T) {
 			return []byte("100B\n"), nil
 		})
 		defer restore()
-		cfg := &Config{VolumeGroup: "vg0"}
+		prev := lvm.GetEscalationCommand()
+		lvm.SetEscalationCommand("sudo")
+		defer lvm.SetEscalationCommand(prev)
+		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo"}
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -84,7 +87,10 @@ func TestConfigValidate(t *testing.T) {
 			return nil, fmt.Errorf("command error")
 		})
 		defer restore()
-		cfg := &Config{VolumeGroup: "vg0"}
+		prev := lvm.GetEscalationCommand()
+		lvm.SetEscalationCommand("sudo")
+		defer lvm.SetEscalationCommand(prev)
+		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo"}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -6,6 +6,9 @@ import (
 )
 
 func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
 	restore := SetRunLVMCommand(func(name string, args ...string) ([]byte, error) {
 		if name != "vgs" {
 			return nil, fmt.Errorf("unexpected command %s", name)


### PR DESCRIPTION
## Summary
- ensure Config validation tests set a temporary escalation command so `checkRootPrivileges` doesn't fail
- stub `checkPrivs` in vg selection test to bypass root requirement

## Testing
- `su nobody -s /bin/bash -c "cd /workspace/lvmsync_go && HOME=/tmp GOROOT=/usr/local/go GOCACHE=/tmp/gocache GOPATH=/tmp/go GOMODCACHE=/tmp/gomodcache /usr/local/go/bin/go test ./..."`


------
https://chatgpt.com/codex/tasks/task_e_6891226190e4832396961bd67c1e01d3