### PR TITLE
Handle deduplication optionally

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -132,7 +132,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 		if err != nil {
 			return fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
 		}
-		if cfg.Deduplication && dedup != nil {
+		if dedup != nil {
 			if !dedup.ShouldTransfer(r.Start, data) {
 				skippedBlocks++
 				putBlockBuffer(data)
@@ -170,12 +170,15 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 }
 
 func DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.Writer) error {
-	dedup := NewDeduplicationStrategy(cfg)
-	defer func() {
-		if err := dedup.SaveState(); err != nil {
-			Logger.Error("Failed to save dedup state", zap.Error(err))
-		}
-	}()
+	var dedup DeduplicationStrategy
+	if cfg.Deduplication {
+		dedup = NewDeduplicationStrategy(cfg)
+		defer func() {
+			if err := dedup.SaveState(); err != nil {
+				Logger.Error("Failed to save dedup state", zap.Error(err))
+			}
+		}()
+	}
 	return dumpChangesCore(cfg, snapshot, source, out, dedup, "")
 }
 
@@ -185,13 +188,13 @@ func DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, o
 }
 
 func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
-	dedup := NewDeduplicationStrategy(cfg)
-	defer func() {
-		if err := dedup.SaveState(); err != nil {
-			Logger.Error("Failed to save dedup state", zap.Error(err))
-		}
-	}()
 	if cfg.Deduplication {
+		dedup := NewDeduplicationStrategy(cfg)
+		defer func() {
+			if err := dedup.SaveState(); err != nil {
+				Logger.Error("Failed to save dedup state", zap.Error(err))
+			}
+		}()
 		Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
 		return DumpChangesWithDeduplication(cfg, snapshot, source, out, dedup)
 	}


### PR DESCRIPTION
## Summary
- Only create and save deduplication strategy when enabled
- Skip dedup logic when deduplication strategy is nil

## Testing
- `go test ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_68912870c51c8323b0ce25a38e86c8ec