### PR TITLE
Optimize bloom dedup locking

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -222,19 +222,18 @@ func (r *RollingHashDedup) loadState() error {
 }
 
 func (b *BloomFilterDedup) ShouldTransfer(offset int64, data []byte) bool {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
 	h := sha256.Sum256(data)
-	return !b.filter.Test(h[:])
+	b.mu.RLock()
+	ok := !b.filter.Test(h[:])
+	b.mu.RUnlock()
+	return ok
 }
 
 func (b *BloomFilterDedup) RecordTransfer(offset int64, data []byte) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	h := sha256.Sum256(data)
+	b.mu.Lock()
 	b.filter.Add(h[:])
+	b.mu.Unlock()
 }
 
 func (b *BloomFilterDedup) SaveState() error {

--- a/transfer/dedup_benchmark_test.go
+++ b/transfer/dedup_benchmark_test.go
@@ -1,0 +1,33 @@
+package transfer
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/bits-and-blooms/bloom/v3"
+)
+
+func BenchmarkBloomFilterShouldTransfer(b *testing.B) {
+	d := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000000, 0.01)}
+	data := []byte("benchmark data")
+	d.RecordTransfer(0, data)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			d.ShouldTransfer(0, data)
+		}
+	})
+}
+
+func BenchmarkBloomFilterRecordTransfer(b *testing.B) {
+	d := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000000, 0.01)}
+	data := []byte("benchmark data")
+	var offset int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			o := atomic.AddInt64(&offset, 1)
+			d.RecordTransfer(o, data)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- compute SHA256 sums before acquiring locks in Bloom filter dedup
- add benchmarks for Bloom filter dedup operations

## Testing
- `go test ./...`
- `go test -bench=Bloom -run=^$ ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_68912873269483239a181c32e4ee9b18