### PR TITLE
Use maphash for rolling hash dedup

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -4,9 +4,11 @@ package transfer
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"hash/maphash"
 	"io"
 	"os"
 	"sync"
+	"unsafe"
 
 	"lvmsync_go/config"
 
@@ -40,6 +42,11 @@ type RollingHashDedup struct {
 	stateFile string
 	hashes    map[int64]uint64
 	mu        sync.RWMutex
+	seed      maphash.Seed
+}
+
+var rollingHashPool = sync.Pool{
+	New: func() any { return new(maphash.Hash) },
 }
 
 func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
@@ -48,6 +55,7 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 		d := &RollingHashDedup{
 			stateFile: cfg.DedupStateFile,
 			hashes:    make(map[int64]uint64),
+			seed:      maphash.MakeSeed(),
 		}
 		if err := d.loadState(); err != nil {
 			zap.L().Warn("failed to load dedup state", zap.Error(err))
@@ -140,12 +148,13 @@ func (c *ChecksumDedup) loadState() error {
 }
 
 func (r *RollingHashDedup) computeHash(data []byte) uint64 {
-	const base uint64 = 257
-	var h uint64
-	for _, b := range data {
-		h = h*base + uint64(b)
-	}
-	return h
+	h := rollingHashPool.Get().(*maphash.Hash)
+	h.Reset()
+	h.SetSeed(r.seed)
+	h.Write(data)
+	sum := h.Sum64()
+	rollingHashPool.Put(h)
+	return sum
 }
 
 func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
@@ -176,6 +185,11 @@ func (r *RollingHashDedup) SaveState() error {
 	}
 	defer file.Close()
 
+	seedArr := *(*[2]uint64)(unsafe.Pointer(&r.seed))
+	if err := binary.Write(file, binary.LittleEndian, seedArr); err != nil {
+		return err
+	}
+
 	for offset, hash := range r.hashes {
 		if err := binary.Write(file, binary.LittleEndian, offset); err != nil {
 			return err
@@ -203,6 +217,15 @@ func (r *RollingHashDedup) loadState() error {
 	if r.hashes == nil {
 		r.hashes = make(map[int64]uint64)
 	}
+
+	var seedArr [2]uint64
+	if err := binary.Read(file, binary.LittleEndian, &seedArr); err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+	r.seed = *(*maphash.Seed)(unsafe.Pointer(&seedArr))
 
 	for {
 		var offset int64

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"hash/maphash"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestBloomFilterDedupPersistence(t *testing.T) {
 func TestRollingHashDedupPersistence(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state")
 
-	d1 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64)}
+	d1 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64), seed: maphash.MakeSeed()}
 	data := []byte("hello")
 
 	if !d1.ShouldTransfer(0, data) {
@@ -45,7 +46,7 @@ func TestRollingHashDedupPersistence(t *testing.T) {
 		t.Fatalf("failed to save state: %v", err)
 	}
 
-	d2 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64)}
+	d2 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64), seed: maphash.MakeSeed()}
 	if err := d2.loadState(); err != nil {
 		t.Fatalf("failed to load state: %v", err)
 	}


### PR DESCRIPTION
## Summary
- use `hash/maphash` for RollingHashDedup to avoid custom hash
- persist deterministic seed in dedup state
- adjust persistence test to provide seed

## Testing
- `go test ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_6891287ac7648323841279c3447d5c5c