### PR TITLE
Use createStateFile for all dedup strategies

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -170,7 +170,7 @@ func (r *RollingHashDedup) SaveState() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	file, err := os.Create(r.stateFile)
+	file, err := createStateFile(r.stateFile)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func (b *BloomFilterDedup) SaveState() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	file, err := os.Create(b.stateFile)
+	file, err := createStateFile(b.stateFile)
 	if err != nil {
 		return err
 	}

--- a/transfer/dedup_save_state_test.go
+++ b/transfer/dedup_save_state_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"testing"
+
+	"github.com/bits-and-blooms/bloom/v3"
 )
 
 type failingWriter struct {
@@ -46,4 +48,40 @@ func TestChecksumDedupSaveStateWriteFailures(t *testing.T) {
 			t.Fatalf("expected error")
 		}
 	})
+}
+
+func TestRollingHashDedupSaveStateWriteFailures(t *testing.T) {
+	t.Run("binary write failure", func(t *testing.T) {
+		r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
+		fw := &failingWriter{failAfter: 0}
+		orig := createStateFile
+		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+		defer func() { createStateFile = orig }()
+		if err := r.SaveState(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("file write failure", func(t *testing.T) {
+		r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
+		fw := &failingWriter{failAfter: 1}
+		orig := createStateFile
+		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+		defer func() { createStateFile = orig }()
+		if err := r.SaveState(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestBloomFilterDedupSaveStateWriteFailure(t *testing.T) {
+	b := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: "ignored"}
+	b.RecordTransfer(0, []byte("data"))
+	fw := &failingWriter{failAfter: 0}
+	orig := createStateFile
+	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+	defer func() { createStateFile = orig }()
+	if err := b.SaveState(); err == nil {
+		t.Fatalf("expected error")
+	}
 }


### PR DESCRIPTION
## Summary
- ensure RollingHash and Bloom filter dedup strategies use `createStateFile` for state persistence
- extend SaveState tests to simulate failures for RollingHash and Bloom filter dedup

## Testing
- `go test ./...`
- `go test ./transfer -run DedupPersistence -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6891287f117083238668534293df12f5