### PR TITLE
Configure bloom filter parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--deduplication`    | Enable deduplication to avoid re-transferring unchanged blocks                          | `false`          |
 | `--dedup_strategy`   | Deduplication strategy (`"checksum"`, `"rolling_hash"`, or `"bloom"`)                  | `"checksum"`    |
 | `--dedup_state_file` | Path to deduplication state file                                                        | `~/.lvmsync_dedup` |
+| `--bloom_entries`    | Estimated number of entries for bloom filter                                           | `1000000` |
+| `--bloom_fp_rate`    | False positive rate for bloom filter                                                   | `0.01` |
 
 #### Compression Options
 
@@ -219,6 +221,8 @@ progress: true                          # Show progress percentage during the tr
 deduplication: false                    # Enable deduplication to avoid re-transferring unchanged blocks
 dedup_strategy: "checksum"               # Strategy: "checksum", "rolling_hash", or "bloom"
 dedup_state_file: "~/.lvmsync_dedup"    # Path to deduplication state file
+bloom_entries: 1000000                  # Estimated number of entries for bloom filter
+bloom_fp_rate: 0.01                     # False positive rate for bloom filter
 
 # SSH Options:
 ssh_user: "root"                        # SSH username

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,13 @@ zerocopy: false                        # Enable zero-copy transfers (only in seq
 max_retries: 3                         # Maximum number of retries per block
 resume: ""                             # Path to resume state file
 
+# Deduplication Options
+deduplication: false                    # Enable deduplication to avoid re-transferring unchanged blocks
+dedup_strategy: "checksum"               # Strategy: "checksum", "rolling_hash", or "bloom"
+dedup_state_file: "~/.lvmsync_dedup"    # Path to deduplication state file
+bloom_entries: 1000000                  # Estimated number of entries for bloom filter
+bloom_fp_rate: 0.01                     # False positive rate for bloom filter
+
 ssh_user: "root"                       # SSH username
 ssh_key: ""                            # Path to SSH private key or use SSH agent
 ssh_port: 22                           # SSH port

--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,8 @@ type Config struct {
 	Deduplication        bool          `mapstructure:"deduplication"`
 	DedupStrategy        string        `mapstructure:"dedup_strategy"`
 	DedupStateFile       string        `mapstructure:"dedup_state_file"`
-	UseBloomFilter       bool          `mapstructure:"use_bloom_filter"`
+	BloomEntries         int           `mapstructure:"bloom_entries"`
+	BloomFpRate          float64       `mapstructure:"bloom_fp_rate"`
 }
 
 func (c *Config) HumanBlockSize() string {
@@ -160,7 +161,8 @@ func DefaultConfig() *Config {
 		Deduplication:        false,
 		DedupStrategy:        "checksum",
 		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
-		UseBloomFilter:       false,
+		BloomEntries:         1000000,
+		BloomFpRate:          0.01,
 	}
 }
 
@@ -206,7 +208,8 @@ func LoadConfig() (*Config, error) {
 	dedupFlags.Bool("deduplication", defaultCfg.Deduplication, "Enable deduplication to avoid re-transferring unchanged blocks")
 	dedupFlags.String("dedup_strategy", defaultCfg.DedupStrategy, fmt.Sprintf("Deduplication strategy: %v", SupportedDedupStrategies))
 	dedupFlags.String("dedup_state_file", defaultCfg.DedupStateFile, "Path to deduplication state file")
-	dedupFlags.Bool("use_bloom_filter", defaultCfg.UseBloomFilter, "Use bloom filter for quick duplicate detection")
+	dedupFlags.Int("bloom_entries", defaultCfg.BloomEntries, "Estimated number of entries for bloom filter")
+	dedupFlags.Float64("bloom_fp_rate", defaultCfg.BloomFpRate, "False positive rate for bloom filter")
 
 	// Compression Options
 	compressionFlags.String("compress", defaultCfg.Compress, fmt.Sprintf("Compression type, options: %v", SupportedCompression))

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -34,6 +34,8 @@ type BloomFilterDedup struct {
 	filter    *bloom.BloomFilter
 	stateFile string
 	mu        sync.RWMutex
+	entries   uint
+	fpRate    float64
 }
 
 type RollingHashDedup struct {
@@ -55,8 +57,10 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 		return d
 	case "bloom":
 		d := &BloomFilterDedup{
-			filter:    bloom.NewWithEstimates(1000000, 0.01),
+			filter:    bloom.NewWithEstimates(uint(cfg.BloomEntries), cfg.BloomFpRate),
 			stateFile: cfg.DedupStateFile,
+			entries:   uint(cfg.BloomEntries),
+			fpRate:    cfg.BloomFpRate,
 		}
 		if err := d.loadState(); err != nil {
 			zap.L().Warn("failed to load dedup state", zap.Error(err))
@@ -265,7 +269,7 @@ func (b *BloomFilterDedup) loadState() error {
 	defer b.mu.Unlock()
 
 	if b.filter == nil {
-		b.filter = bloom.NewWithEstimates(1000000, 0.01)
+		b.filter = bloom.NewWithEstimates(b.entries, b.fpRate)
 	}
 
 	_, err = b.filter.ReadFrom(file)

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -10,7 +10,7 @@ import (
 func TestBloomFilterDedupPersistence(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state")
 
-	d1 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile}
+	d1 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01}
 	data := []byte("hello")
 
 	if !d1.ShouldTransfer(0, data) {
@@ -21,7 +21,7 @@ func TestBloomFilterDedupPersistence(t *testing.T) {
 		t.Fatalf("failed to save state: %v", err)
 	}
 
-	d2 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile}
+	d2 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01}
 	if err := d2.loadState(); err != nil {
 		t.Fatalf("failed to load state: %v", err)
 	}

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/bits-and-blooms/bloom/v3"
 	"lvmsync_go/config"
 )
 
@@ -30,9 +31,15 @@ func TestWrapRateLimitedWriterEnabled(t *testing.T) {
 }
 
 func TestNewDeduplicationStrategy(t *testing.T) {
-	cfg := &config.Config{DedupStrategy: "bloom", DedupStateFile: "state"}
-	if _, ok := NewDeduplicationStrategy(cfg).(*BloomFilterDedup); !ok {
+	cfg := &config.Config{DedupStrategy: "bloom", DedupStateFile: "state", BloomEntries: 1000, BloomFpRate: 0.05}
+	d := NewDeduplicationStrategy(cfg)
+	bf, ok := d.(*BloomFilterDedup)
+	if !ok {
 		t.Fatal("expected bloom filter strategy")
+	}
+	m, k := bloom.EstimateParameters(uint(cfg.BloomEntries), cfg.BloomFpRate)
+	if bf.filter.Cap() != m || bf.filter.K() != k {
+		t.Fatalf("unexpected bloom filter parameters m=%d k=%d want m=%d k=%d", bf.filter.Cap(), bf.filter.K(), m, k)
 	}
 
 	cfg.DedupStrategy = "checksum"


### PR DESCRIPTION
## Summary
- allow configuring bloom filter capacity and false positive rate via `bloom_entries` and `bloom_fp_rate`
- use these settings when creating the BloomFilter-based deduplication strategy
- document new bloom filter options

## Testing
- `go test ./...` *(fails: fatal error: lvm2cmd.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68912881aa1c83239e685c91347eb6fb