### PR TITLE
Add CPU-aware auto deduplication strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,14 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | Option               | Description                                                                             | Default          |
 |----------------------|-----------------------------------------------------------------------------------------|------------------|
 | `--deduplication`    | Enable deduplication to avoid re-transferring unchanged blocks                          | `false`          |
-| `--dedup_strategy`   | Deduplication strategy (`"checksum"`, `"rolling_hash"`, or `"bloom"`)                  | `"checksum"`    |
+| `--dedup_strategy`   | Deduplication strategy (`"auto"`, `"checksum"`, `"rolling_hash"`, or `"bloom"`)        | `"auto"`        |
 | `--dedup_state_file` | Path to deduplication state file                                                        | `~/.lvmsync_dedup` |
+
+By default, `--dedup_strategy auto` inspects CPU capabilities via
+`golang.org/x/sys/cpu`. If hardware SHA support is detected, the checksum
+strategy is selected; otherwise a rolling hash is used. Experts can override
+this behaviour with `--dedup_strategy checksum`, `--dedup_strategy rolling_hash`,
+or `--dedup_strategy bloom`.
 
 #### Compression Options
 
@@ -217,7 +223,7 @@ progress: true                          # Show progress percentage during the tr
 
 # Deduplication Options:
 deduplication: false                    # Enable deduplication to avoid re-transferring unchanged blocks
-dedup_strategy: "checksum"               # Strategy: "checksum", "rolling_hash", or "bloom"
+dedup_strategy: "auto"                   # Strategy: "auto", "checksum", "rolling_hash", or "bloom"
 dedup_state_file: "~/.lvmsync_dedup"    # Path to deduplication state file
 
 # SSH Options:

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 var SupportedCompression = []string{"none", "lz4", "zstd", "auto"}
-var SupportedDedupStrategies = []string{"checksum", "rolling_hash", "bloom"}
+var SupportedDedupStrategies = []string{"auto", "checksum", "rolling_hash", "bloom"}
 
 var (
 	generalFlags     *pflag.FlagSet
@@ -158,7 +158,7 @@ func DefaultConfig() *Config {
 		BlockSize:            4096,
 		BlockSizeRaw:         "4KB",
 		Deduplication:        false,
-		DedupStrategy:        "checksum",
+		DedupStrategy:        "auto",
 		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
 		UseBloomFilter:       false,
 	}

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -6,12 +6,14 @@ import (
 	"encoding/binary"
 	"io"
 	"os"
+	"runtime"
 	"sync"
 
 	"lvmsync_go/config"
 
 	"github.com/bits-and-blooms/bloom/v3"
 	"go.uber.org/zap"
+	"golang.org/x/sys/cpu"
 )
 
 var createStateFile = func(name string) (io.WriteCloser, error) {
@@ -42,8 +44,38 @@ type RollingHashDedup struct {
 	mu        sync.RWMutex
 }
 
+// detectBestStrategy selects the fastest deduplication strategy for the current
+// CPU. Checksum-based deduplication is preferred when hardware SHA
+// acceleration is available; otherwise a rolling hash is used.
+var detectBestStrategy = func() string {
+	if hasHardwareSHA() {
+		return "checksum"
+	}
+	return "rolling_hash"
+}
+
+func hasHardwareSHA() bool {
+	switch runtime.GOARCH {
+	case "amd64":
+		return true
+	case "arm64":
+		return cpu.ARM64.HasSHA2
+	case "arm":
+		return cpu.ARM.HasSHA2
+	case "s390x":
+		return cpu.S390X.HasSHA256
+	default:
+		return false
+	}
+}
+
 func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
-	switch cfg.DedupStrategy {
+	strategy := cfg.DedupStrategy
+	if strategy == "auto" {
+		strategy = detectBestStrategy()
+		cfg.DedupStrategy = strategy
+	}
+	switch strategy {
 	case "rolling_hash":
 		d := &RollingHashDedup{
 			stateFile: cfg.DedupStateFile,

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -482,8 +482,8 @@ func RunApply(cfg *config.Config, applyFile, destDevice string) error {
 	}
 
 	if cfg.Deduplication {
-		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
 		dedup := NewDeduplicationStrategy(cfg)
+		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
 				Logger.Error("Failed to save dedup state", zap.Error(err))

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -39,4 +39,19 @@ func TestNewDeduplicationStrategy(t *testing.T) {
 	if _, ok := NewDeduplicationStrategy(cfg).(*ChecksumDedup); !ok {
 		t.Fatal("expected checksum strategy")
 	}
+
+	origDetect := detectBestStrategy
+	defer func() { detectBestStrategy = origDetect }()
+
+	cfg.DedupStrategy = "auto"
+	detectBestStrategy = func() string { return "rolling_hash" }
+	if _, ok := NewDeduplicationStrategy(cfg).(*RollingHashDedup); !ok {
+		t.Fatal("expected rolling hash strategy for auto")
+	}
+
+	cfg.DedupStrategy = "auto"
+	detectBestStrategy = func() string { return "checksum" }
+	if _, ok := NewDeduplicationStrategy(cfg).(*ChecksumDedup); !ok {
+		t.Fatal("expected checksum strategy for auto")
+	}
 }


### PR DESCRIPTION
## Summary
- add `auto` deduplication strategy and default to hardware-aware selection
- detect CPU SHA capabilities to choose checksum or rolling hash
- document auto detection and how to override with flags
- test auto strategy selection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689128903d948323a7d505f59f7191e9