### PR TITLE
Use runtime CPU count for zstd concurrency

### DIFF
--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -8,6 +8,7 @@ import (
 	zstd "github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 	"golang.org/x/sys/cpu"
+	"runtime"
 )
 
 const (
@@ -35,7 +36,9 @@ func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteClos
 	case compressionLZ4:
 		return lz4.NewWriter(w), nil
 	case compressionZSTD:
-		return zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.EncoderLevel(level)))
+		return zstd.NewWriter(w,
+			zstd.WithEncoderLevel(zstd.EncoderLevel(level)),
+			zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}
@@ -48,7 +51,7 @@ func NewDecompressionReader(r io.Reader, compress string) (io.ReadCloser, error)
 	case compressionLZ4:
 		return nopReadCloser{lz4.NewReader(r)}, nil
 	case compressionZSTD:
-		decoder, err := zstd.NewReader(r)
+		decoder, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(runtime.GOMAXPROCS(0)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
 		}

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bytes"
 	"io"
+	"runtime"
 	"testing"
 )
 
@@ -37,4 +38,31 @@ func TestCompressionRoundTrip(t *testing.T) {
 			t.Fatalf("roundtrip mismatch for %s", c)
 		}
 	}
+}
+
+func TestZstdConcurrencyInstantiation(t *testing.T) {
+	orig := runtime.GOMAXPROCS(0)
+	runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(orig)
+
+	var buf bytes.Buffer
+	w, err := NewCompressionWriter(&buf, compressionZSTD, 1)
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	if _, err := w.Write([]byte("test")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	r, err := NewDecompressionReader(&buf, compressionZSTD)
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	if _, err := io.ReadAll(r); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	r.Close()
 }


### PR DESCRIPTION
## Summary
- configure zstd writer and decoder to use `runtime.GOMAXPROCS(0)` for concurrency
- add test ensuring zstd writer/reader instantiate successfully with runtime-based concurrency

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68913d7239888323923c1525aedd10a0