### PR TITLE
Validate zstd compression level handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,11 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 	}
 	conf.SpeedLimit = sl
 
+	// Validate compression level for zstd.
+	if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
+		return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+	}
+
 	return &conf, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,3 +115,25 @@ func TestGetBlockSizeRaw(t *testing.T) {
 		}
 	})
 }
+
+func TestCompressLevelValidation(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		v := viper.New()
+		v.Set("compress", "zstd")
+		v.Set("compress_level", 3)
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		if _, err := cb.Build(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		v := viper.New()
+		v.Set("compress", "zstd")
+		v.Set("compress_level", 100)
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		if _, err := cb.Build(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -35,7 +35,12 @@ func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteClos
 	case compressionLZ4:
 		return lz4.NewWriter(w), nil
 	case compressionZSTD:
-		return zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.EncoderLevel(level)))
+		// Ensure provided level is within the supported zstd range.
+		if level < 1 || level > 22 {
+			return nil, fmt.Errorf("invalid zstd compression level: %d", level)
+		}
+		encLevel := zstd.EncoderLevelFromZstd(level)
+		return zstd.NewWriter(w, zstd.WithEncoderLevel(encLevel))
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -38,3 +38,17 @@ func TestCompressionRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+func TestNewCompressionWriterLevel(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 3); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 100); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- validate `compress_level` against zstd range when building config
- use `EncoderLevelFromZstd` and reject invalid levels in compression writer
- test valid and invalid compression level scenarios

## Testing
- `go test ./config ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_68913d76f868832384ae51176e2f8f61