### PR TITLE
Include compression in handshake and auto-select decompression

### DIFF
--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -116,7 +116,15 @@ func TestDumpChangesSequential(t *testing.T) {
 	if err := DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesSequential failed: %v", err)
 	}
-	offsets := parseOffsetsNoHandshake(t, bytes.NewReader(buf.Bytes()))
+	reader := bufio.NewReader(bytes.NewReader(buf.Bytes()))
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read handshake: %v", err)
+	}
+	if strings.TrimSpace(line) != common.ProtocolVersion+" compress:none" {
+		t.Fatalf("unexpected handshake %q", strings.TrimSpace(line))
+	}
+	offsets := parseOffsetsNoHandshake(t, reader)
 	expected := []int64{0, 2 * blockSize}
 	if !reflect.DeepEqual(offsets, expected) {
 		t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
@@ -146,12 +154,68 @@ func TestDumpChangesWithDeduplication(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read handshake: %v", err)
 	}
-	if strings.TrimSpace(line) != common.ProtocolVersion+" checksum-dedup" {
+	if strings.TrimSpace(line) != common.ProtocolVersion+" checksum-dedup compress:none" {
 		t.Fatalf("unexpected handshake %q", strings.TrimSpace(line))
 	}
 	offsets := parseOffsetsNoHandshake(t, reader)
 	expected := []int64{1 * blockSize}
 	if !reflect.DeepEqual(offsets, expected) {
 		t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
+	}
+}
+
+func TestProcessDumpDataAutoDecompression(t *testing.T) {
+	SetLogger(zap.NewNop())
+	blockSize := int64(1024)
+	changed := []int{0}
+	src, snapshot := createDumpTestFiles(t, blockSize, changed)
+
+	cfgDump := &config.Config{BlockSize: int(blockSize), Compress: "zstd", CompressLevel: 1, VerifyChecksum: true, Parallel: 1, MaxRetries: 1}
+	var buf bytes.Buffer
+	if err := DumpChangesParallel(cfgDump, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChangesParallel failed: %v", err)
+	}
+
+	data := buf.Bytes()
+	reader := bufio.NewReader(bytes.NewReader(data))
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read handshake: %v", err)
+	}
+	if strings.TrimSpace(line) != common.ProtocolVersion+" checksum compress:zstd" {
+		t.Fatalf("unexpected handshake %q", strings.TrimSpace(line))
+	}
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	info, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("stat source: %v", err)
+	}
+	destFile, err := os.Create(dest)
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	if err := destFile.Truncate(info.Size()); err != nil {
+		t.Fatalf("truncate dest: %v", err)
+	}
+	destFile.Close()
+
+	cfgProcess := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
+	if err := ProcessDumpData(cfgProcess, bytes.NewReader(data), dest); err != nil {
+		t.Fatalf("ProcessDumpData failed: %v", err)
+	}
+
+	outFile, err := os.Open(dest)
+	if err != nil {
+		t.Fatalf("open dest: %v", err)
+	}
+	got := make([]byte, blockSize)
+	if _, err := outFile.ReadAt(got, 0); err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	outFile.Close()
+	want := bytes.Repeat([]byte{1}, int(blockSize))
+	if !bytes.Equal(got, want) {
+		t.Fatalf("unexpected data %v, want %v", got[:4], want[:4])
 	}
 }

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"lvmsync_go/common"
 	"lvmsync_go/config"
 
 	"go.uber.org/zap"
@@ -85,8 +86,12 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int) (srcPath, sn
 func parseOffsets(t *testing.T, data []byte, blockSize int64) []int64 {
 	t.Helper()
 	reader := bufio.NewReader(bytes.NewReader(data))
-	if _, err := reader.ReadString('\n'); err != nil {
+	line, err := reader.ReadString('\n')
+	if err != nil {
 		t.Fatalf("failed to read handshake: %v", err)
+	}
+	if strings.TrimSpace(line) != common.ProtocolVersion+" compress:none" {
+		t.Fatalf("unexpected handshake %q", strings.TrimSpace(line))
 	}
 	var offsets []int64
 	for {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -96,9 +96,13 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 		return fmt.Errorf("error getting differences: %w", err)
 	}
 	Logger.Info("Changed blocks determined", zap.Int("blockCount", len(ranges)))
+
+	tokens := []string{common.ProtocolVersion}
 	if handshake != "" {
-		fmt.Fprintln(out, handshake)
+		tokens = append(tokens, handshake)
 	}
+	tokens = append(tokens, "compress:"+cfg.Compress)
+	fmt.Fprintln(out, strings.Join(tokens, " "))
 
 	compWriter, bufOut, err := prepareOutputWriter(out, cfg)
 	if err != nil {
@@ -183,8 +187,7 @@ func DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.W
 }
 
 func DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy) error {
-	handshake := common.ProtocolVersion + " checksum-dedup"
-	return dumpChangesCore(cfg, snapshot, source, out, dedup, handshake)
+	return dumpChangesCore(cfg, snapshot, source, out, dedup, "checksum-dedup")
 }
 
 func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
@@ -241,11 +244,12 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 		totalDataSize += (r.End - r.Start + 1)
 	}
 
-	handshake := common.ProtocolVersion
+	htokens := []string{common.ProtocolVersion}
 	if cfg.VerifyChecksum {
-		handshake += " checksum"
+		htokens = append(htokens, "checksum")
 	}
-	fmt.Fprintln(out, handshake)
+	htokens = append(htokens, "compress:"+cfg.Compress)
+	fmt.Fprintln(out, strings.Join(htokens, " "))
 
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
 	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel)
@@ -362,33 +366,47 @@ func finalizeResults(wg *sync.WaitGroup, results chan<- *BlockResult) {
 }
 
 func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) error {
-	decReader, err := NewDecompressionReader(in, cfg.Compress)
+	bufReader := bufio.NewReader(in)
+	handshake, err := bufReader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read protocol handshake: %w", err)
+	}
+	handshake = strings.TrimSpace(handshake)
+	if !strings.HasPrefix(handshake, common.ProtocolVersion) {
+		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(handshake, common.ProtocolVersion))
+	tokens := strings.Fields(rest)
+	compress := "none"
+	hasChecksum := false
+	hasDedup := false
+	for _, t := range tokens {
+		if strings.HasPrefix(t, "compress:") {
+			compress = strings.TrimPrefix(t, "compress:")
+		} else if t == "checksum" {
+			hasChecksum = true
+		} else if t == "checksum-dedup" {
+			hasChecksum = true
+			hasDedup = true
+		} else {
+			return fmt.Errorf("unexpected protocol handshake: %s", handshake)
+		}
+	}
+
+	if verify && !hasChecksum {
+		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
+	}
+	if dedup != nil && !hasDedup {
+		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
+	}
+
+	decReader, err := NewDecompressionReader(bufReader, compress)
 	if err != nil {
 		return fmt.Errorf("failed to create decompression reader: %w", err)
 	}
 	defer decReader.Close()
 
 	reader := bufio.NewReader(decReader)
-	handshake, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("failed to read protocol handshake: %w", err)
-	}
-	handshake = strings.TrimSpace(handshake)
-	allowedHandshakes := []string{
-		common.ProtocolVersion,
-		common.ProtocolVersion + " checksum",
-		common.ProtocolVersion + " checksum-dedup",
-	}
-	valid := false
-	for _, h := range allowedHandshakes {
-		if handshake == h {
-			valid = true
-			break
-		}
-	}
-	if !valid {
-		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
-	}
 
 	destFile, err := os.OpenFile(destPath, os.O_RDWR, 0)
 	if err != nil {


### PR DESCRIPTION
## Summary
- advertise selected compression in dump handshake
- parse handshake to choose decompression algorithm
- test handshake parsing and automatic decompression

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689143a0636c832396d99bd08e8dc133