### PR TITLE
Guard compression level validation for Zstd or auto modes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,9 +97,11 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 	}
 	conf.SpeedLimit = sl
 
-	// Validate compression level for zstd.
-	if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
-		return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+	// Validate compression level for zstd or auto.
+	if conf.Compress == "zstd" || conf.Compress == "auto" {
+		if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
+			return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+		}
 	}
 
 	return &conf, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -117,7 +117,7 @@ func TestGetBlockSizeRaw(t *testing.T) {
 }
 
 func TestCompressLevelValidation(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
+	t.Run("zstdValid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "zstd")
 		v.Set("compress_level", 3)
@@ -127,13 +127,43 @@ func TestCompressLevelValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid", func(t *testing.T) {
+	t.Run("zstdInvalid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "zstd")
 		v.Set("compress_level", 100)
 		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
 		if _, err := cb.Build(); err == nil {
 			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("autoValid", func(t *testing.T) {
+		v := viper.New()
+		v.Set("compress", "auto")
+		v.Set("compress_level", 3)
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		if _, err := cb.Build(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("autoInvalid", func(t *testing.T) {
+		v := viper.New()
+		v.Set("compress", "auto")
+		v.Set("compress_level", 100)
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		if _, err := cb.Build(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("lz4NoValidation", func(t *testing.T) {
+		v := viper.New()
+		v.Set("compress", "lz4")
+		v.Set("compress_level", 100)
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		if _, err := cb.Build(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- validate Zstd compression levels only when compression mode is `zstd` or `auto`
- add tests verifying validation for `zstd` and `auto` and bypass for other modes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689143b050bc83239dcad47bd132d7fc