### PR TITLE
Expose LZ4 compression levels and document valid values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,27 +47,28 @@ type Config struct {
 	RemotePreScript      string        `mapstructure:"remote_pre_script"`
 	RemotePostScript     string        `mapstructure:"remote_post_script"`
 	Compress             string        `mapstructure:"compress"`
-	CompressLevel        int           `mapstructure:"compress_level"`
-	Speed                string        `mapstructure:"speed"`
-	SpeedLimit           int           `mapstructure:"-"`
-	VerifyChecksum       bool          `mapstructure:"verify_checksum"`
-	Verbose              int           `mapstructure:"verbose"`
-	SkipSnapshotCreation bool          `mapstructure:"skip_snapshot_creation"`
-	SkipDiskCheck        bool          `mapstructure:"skip_disk_check"`
-	SnapshotSize         string        `mapstructure:"snapshot_size"`
-	VolumeGroup          string        `mapstructure:"volume_group"`
-	TargetVolumeGroup    string        `mapstructure:"target_volume_group"`
-	SourceVGCandidates   []string      `mapstructure:"source_vgs"`
-	TargetVGCandidates   []string      `mapstructure:"target_vgs"`
-	LVMEscalation        string        `mapstructure:"lvm_escalation"`
-	Progress             bool          `mapstructure:"progress"`
-	BlockSize            int           `mapstructure:"-"`
-	BlockSizeRaw         string        `mapstructure:"-"`
-	Deduplication        bool          `mapstructure:"deduplication"`
-	DedupStrategy        string        `mapstructure:"dedup_strategy"`
-	DedupStateFile       string        `mapstructure:"dedup_state_file"`
-	BloomEntries         int           `mapstructure:"bloom_entries"`
-	BloomFpRate          float64       `mapstructure:"bloom_fp_rate"`
+	// For LZ4 use lz4.Fast or lz4.Level1 through lz4.Level9; ZSTD accepts levels 1-22.
+	CompressLevel        int      `mapstructure:"compress_level"`
+	Speed                string   `mapstructure:"speed"`
+	SpeedLimit           int      `mapstructure:"-"`
+	VerifyChecksum       bool     `mapstructure:"verify_checksum"`
+	Verbose              int      `mapstructure:"verbose"`
+	SkipSnapshotCreation bool     `mapstructure:"skip_snapshot_creation"`
+	SkipDiskCheck        bool     `mapstructure:"skip_disk_check"`
+	SnapshotSize         string   `mapstructure:"snapshot_size"`
+	VolumeGroup          string   `mapstructure:"volume_group"`
+	TargetVolumeGroup    string   `mapstructure:"target_volume_group"`
+	SourceVGCandidates   []string `mapstructure:"source_vgs"`
+	TargetVGCandidates   []string `mapstructure:"target_vgs"`
+	LVMEscalation        string   `mapstructure:"lvm_escalation"`
+	Progress             bool     `mapstructure:"progress"`
+	BlockSize            int      `mapstructure:"-"`
+	BlockSizeRaw         string   `mapstructure:"-"`
+	Deduplication        bool     `mapstructure:"deduplication"`
+	DedupStrategy        string   `mapstructure:"dedup_strategy"`
+	DedupStateFile       string   `mapstructure:"dedup_state_file"`
+	BloomEntries         int      `mapstructure:"bloom_entries"`
+	BloomFpRate          float64  `mapstructure:"bloom_fp_rate"`
 }
 
 func (c *Config) HumanBlockSize() string {
@@ -98,8 +99,10 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 	conf.SpeedLimit = sl
 
 	// Validate compression level for zstd.
-	if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
-		return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+	if conf.Compress == "zstd" {
+		if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
+			return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+		}
 	}
 
 	return &conf, nil
@@ -218,7 +221,7 @@ func LoadConfig() (*Config, error) {
 
 	// Compression Options
 	compressionFlags.String("compress", defaultCfg.Compress, fmt.Sprintf("Compression type, options: %v", SupportedCompression))
-	compressionFlags.Int("compress_level", defaultCfg.CompressLevel, "Compression level for zstd (ignored for lz4)")
+	compressionFlags.Int("compress_level", defaultCfg.CompressLevel, "Compression level. LZ4 accepts lz4.Fast or lz4.Level1..lz4.Level9; ZSTD accepts 1-22")
 
 	// LVM Options
 	lvmFlags.Bool("skip_snapshot_creation", defaultCfg.SkipSnapshotCreation, "Skip automatic snapshot creation")

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -16,23 +16,26 @@ const (
 
 // No shared state is kept between decompression readers.
 
-func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteCloser, error) {
+func NewCompressionWriter(dst io.Writer, compress string, level int) (io.WriteCloser, error) {
 	if compress == "auto" {
 		compress = detectOptimalCompression()
 	}
 
 	switch compress {
 	case "none":
-		return nopWriteCloser{w}, nil
+		return nopWriteCloser{dst}, nil
 	case compressionLZ4:
-		return lz4.NewWriter(w), nil
+		// For LZ4, valid levels include lz4.Fast and lz4.Level1 through lz4.Level9.
+		w := lz4.NewWriter(dst)
+		w.Apply(lz4.CompressionLevelOption(lz4.CompressionLevel(level)))
+		return w, nil
 	case compressionZSTD:
 		// Ensure provided level is within the supported zstd range.
 		if level < 1 || level > 22 {
 			return nil, fmt.Errorf("invalid zstd compression level: %d", level)
 		}
 		encLevel := zstd.EncoderLevelFromZstd(level)
-		return zstd.NewWriter(w, zstd.WithEncoderLevel(encLevel))
+		return zstd.NewWriter(dst, zstd.WithEncoderLevel(encLevel))
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -4,37 +4,79 @@ import (
 	"bytes"
 	"io"
 	"testing"
+
+	"github.com/pierrec/lz4/v4"
 )
 
 func TestCompressionRoundTrip(t *testing.T) {
 	data := []byte("some test data for compression")
-	types := []string{"none", compressionLZ4, compressionZSTD}
+	cases := []struct {
+		c     string
+		level int
+	}{
+		{"none", 0},
+		{compressionLZ4, int(lz4.Level1)},
+		{compressionZSTD, 1},
+	}
 
-	for _, c := range types {
+	for _, tc := range cases {
 		var buf bytes.Buffer
-		w, err := NewCompressionWriter(&buf, c, 1)
+		w, err := NewCompressionWriter(&buf, tc.c, tc.level)
 		if err != nil {
-			t.Fatalf("writer for %s: %v", c, err)
+			t.Fatalf("writer for %s: %v", tc.c, err)
 		}
 		if _, err := w.Write(data); err != nil {
-			t.Fatalf("write %s: %v", c, err)
+			t.Fatalf("write %s: %v", tc.c, err)
 		}
 		if err := w.Close(); err != nil {
-			t.Fatalf("close %s: %v", c, err)
+			t.Fatalf("close %s: %v", tc.c, err)
 		}
 
-		r, err := NewDecompressionReader(&buf, c)
+		r, err := NewDecompressionReader(&buf, tc.c)
 		if err != nil {
-			t.Fatalf("reader for %s: %v", c, err)
+			t.Fatalf("reader for %s: %v", tc.c, err)
 		}
 		out, err := io.ReadAll(r)
 		if err != nil {
-			t.Fatalf("read %s: %v", c, err)
+			t.Fatalf("read %s: %v", tc.c, err)
 		}
 		r.Close()
 
 		if !bytes.Equal(out, data) {
-			t.Fatalf("roundtrip mismatch for %s", c)
+			t.Fatalf("roundtrip mismatch for %s", tc.c)
+		}
+	}
+}
+
+func TestLZ4CompressionLevels(t *testing.T) {
+	data := []byte("some test data for compression")
+	levels := []int{int(lz4.Fast), int(lz4.Level5), int(lz4.Level9)}
+
+	for _, lvl := range levels {
+		var buf bytes.Buffer
+		w, err := NewCompressionWriter(&buf, compressionLZ4, lvl)
+		if err != nil {
+			t.Fatalf("writer for level %d: %v", lvl, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("write level %d: %v", lvl, err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("close level %d: %v", lvl, err)
+		}
+
+		r, err := NewDecompressionReader(&buf, compressionLZ4)
+		if err != nil {
+			t.Fatalf("reader for level %d: %v", lvl, err)
+		}
+		out, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("read level %d: %v", lvl, err)
+		}
+		r.Close()
+
+		if !bytes.Equal(out, data) {
+			t.Fatalf("roundtrip mismatch for level %d", lvl)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- allow passing explicit LZ4 compression level in `NewCompressionWriter`
- document valid LZ4 compression constants and update CLI help
- add tests exercising multiple LZ4 compression levels

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689143bdec8c832398798cedd247326a