### PR TITLE
Add configurable zstd compression concurrency

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,7 @@ remote_post_script: ""                 # Remote script to run after finishing tr
 
 compress: "lz4"                        # Compression method (options: "none", "lz4", "zstd", "auto")
 compress_level: 3                      # Compression level for zstd (ignored for lz4)
+compress_workers: 4                    # Maximum number of concurrent compression workers
 speed: "100MB"                         # Speed limit (e.g. "100MB")
 verify_checksum: false                 # Enable checksum verification for data integrity
 verbose: 0                             # Verbosity level (0 = silent, higher numbers = more verbose)

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -48,6 +49,7 @@ type Config struct {
 	RemotePostScript     string        `mapstructure:"remote_post_script"`
 	Compress             string        `mapstructure:"compress"`
 	CompressLevel        int           `mapstructure:"compress_level"`
+	CompressWorkers      int           `mapstructure:"compress_workers"`
 	Speed                string        `mapstructure:"speed"`
 	SpeedLimit           int           `mapstructure:"-"`
 	VerifyChecksum       bool          `mapstructure:"verify_checksum"`
@@ -102,6 +104,10 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 		return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
 	}
 
+	if conf.CompressWorkers <= 0 {
+		conf.CompressWorkers = runtime.NumCPU()
+	}
+
 	return &conf, nil
 }
 
@@ -149,6 +155,7 @@ func DefaultConfig() *Config {
 		RemotePostScript:     "",
 		Compress:             "lz4",
 		CompressLevel:        3,
+		CompressWorkers:      runtime.NumCPU(),
 		Speed:                "100MB",
 		VerifyChecksum:       false,
 		Verbose:              0,
@@ -219,6 +226,7 @@ func LoadConfig() (*Config, error) {
 	// Compression Options
 	compressionFlags.String("compress", defaultCfg.Compress, fmt.Sprintf("Compression type, options: %v", SupportedCompression))
 	compressionFlags.Int("compress_level", defaultCfg.CompressLevel, "Compression level for zstd (ignored for lz4)")
+	compressionFlags.Int("compress_workers", defaultCfg.CompressWorkers, "Maximum concurrency for compression")
 
 	// LVM Options
 	lvmFlags.Bool("skip_snapshot_creation", defaultCfg.SkipSnapshotCreation, "Skip automatic snapshot creation")

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -4,6 +4,7 @@ package transfer
 import (
 	"fmt"
 	"io"
+	"runtime"
 
 	zstd "github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -16,7 +17,7 @@ const (
 
 // No shared state is kept between decompression readers.
 
-func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteCloser, error) {
+func NewCompressionWriter(w io.Writer, compress string, level, workers int) (io.WriteCloser, error) {
 	if compress == "auto" {
 		compress = detectOptimalCompression()
 	}
@@ -31,8 +32,11 @@ func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteClos
 		if level < 1 || level > 22 {
 			return nil, fmt.Errorf("invalid zstd compression level: %d", level)
 		}
+		if workers <= 0 {
+			workers = runtime.NumCPU()
+		}
 		encLevel := zstd.EncoderLevelFromZstd(level)
-		return zstd.NewWriter(w, zstd.WithEncoderLevel(encLevel))
+		return zstd.NewWriter(w, zstd.WithEncoderLevel(encLevel), zstd.WithEncoderConcurrency(workers))
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}

--- a/transfer/compression_auto_arm64_test.go
+++ b/transfer/compression_auto_arm64_test.go
@@ -16,7 +16,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 	defer func() { cpu.ARM64.HasASIMD = original }()
 
 	cpu.ARM64.HasASIMD = true
-	w, err := NewCompressionWriter(io.Discard, "auto", 1)
+	w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
 	if err != nil {
 		t.Fatalf("NewCompressionWriter with ASIMD: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 	w.Close()
 
 	cpu.ARM64.HasASIMD = false
-	w, err = NewCompressionWriter(io.Discard, "auto", 1)
+	w, err = NewCompressionWriter(io.Discard, "auto", 1, 1)
 	if err != nil {
 		t.Fatalf("NewCompressionWriter without ASIMD: %v", err)
 	}

--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -16,7 +16,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 	defer func() { cpu.X86.HasAVX2 = original }()
 
 	cpu.X86.HasAVX2 = true
-	w, err := NewCompressionWriter(io.Discard, "auto", 1)
+	w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
 	if err != nil {
 		t.Fatalf("NewCompressionWriter with AVX2: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 	w.Close()
 
 	cpu.X86.HasAVX2 = false
-	w, err = NewCompressionWriter(io.Discard, "auto", 1)
+	w, err = NewCompressionWriter(io.Discard, "auto", 1, 1)
 	if err != nil {
 		t.Fatalf("NewCompressionWriter without AVX2: %v", err)
 	}

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -3,7 +3,10 @@ package transfer
 import (
 	"bytes"
 	"io"
+	"reflect"
 	"testing"
+
+	zstd "github.com/klauspost/compress/zstd"
 )
 
 func TestCompressionRoundTrip(t *testing.T) {
@@ -12,7 +15,7 @@ func TestCompressionRoundTrip(t *testing.T) {
 
 	for _, c := range types {
 		var buf bytes.Buffer
-		w, err := NewCompressionWriter(&buf, c, 1)
+		w, err := NewCompressionWriter(&buf, c, 1, 1)
 		if err != nil {
 			t.Fatalf("writer for %s: %v", c, err)
 		}
@@ -41,14 +44,28 @@ func TestCompressionRoundTrip(t *testing.T) {
 
 func TestNewCompressionWriterLevel(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 3); err != nil {
+		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 3, 1); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 100); err == nil {
+		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 100, 1); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
+}
+
+func TestNewCompressionWriterConcurrency(t *testing.T) {
+	var buf bytes.Buffer
+	w, err := NewCompressionWriter(&buf, compressionZSTD, 1, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer w.Close()
+	enc := w.(*zstd.Encoder)
+	conc := int(reflect.ValueOf(enc).Elem().FieldByName("o").FieldByName("concurrent").Int())
+	if conc != 2 {
+		t.Fatalf("expected concurrency 2, got %d", conc)
+	}
 }

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -64,7 +64,7 @@ func SaveChecksumState(filename string, state *ChecksumState) error {
 
 func prepareOutputWriter(out io.Writer, cfg *config.Config) (io.WriteCloser, *bufio.Writer, error) {
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
-	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel)
+	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel, cfg.CompressWorkers)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create compression writer: %w", err)
 	}
@@ -248,7 +248,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	fmt.Fprintln(out, handshake)
 
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
-	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel)
+	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel, cfg.CompressWorkers)
 	if err != nil {
 		return fmt.Errorf("failed to create compression writer: %w", err)
 	}


### PR DESCRIPTION
## Summary
- limit zstd compression with runtime-configurable worker count
- expose `compress_workers` configuration and CLI flag
- test that zstd writer honors configured concurrency

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689143c375808323af4a60b69ca8eb95