### PR TITLE
Introduce pooled compressors for lz4 and zstd

### DIFF
--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -2,8 +2,10 @@
 package transfer
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"sync"
 
 	zstd "github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -14,45 +16,47 @@ const (
 	compressionZSTD = "zstd"
 )
 
-// No shared state is kept between decompression readers.
+// Compressor provides methods to create pooled writers and readers.
+type Compressor interface {
+	NewWriter(io.Writer, int) (io.WriteCloser, error)
+	NewReader(io.Reader) (io.ReadCloser, error)
+}
 
+var compressors = map[string]Compressor{
+	compressionLZ4:  newLZ4Compressor(),
+	compressionZSTD: newZstdCompressor(),
+}
+
+// NewCompressionWriter returns a writer for the given compression type. The
+// writer is pooled and must be closed to be returned to the pool.
 func NewCompressionWriter(w io.Writer, compress string, level int) (io.WriteCloser, error) {
 	if compress == "auto" {
 		compress = detectOptimalCompression()
 	}
 
-	switch compress {
-	case "none":
+	if compress == "none" {
 		return nopWriteCloser{w}, nil
-	case compressionLZ4:
-		return lz4.NewWriter(w), nil
-	case compressionZSTD:
-		// Ensure provided level is within the supported zstd range.
-		if level < 1 || level > 22 {
-			return nil, fmt.Errorf("invalid zstd compression level: %d", level)
-		}
-		encLevel := zstd.EncoderLevelFromZstd(level)
-		return zstd.NewWriter(w, zstd.WithEncoderLevel(encLevel))
-	default:
+	}
+
+	c, ok := compressors[compress]
+	if !ok {
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}
+	return c.NewWriter(w, level)
 }
 
+// NewDecompressionReader returns a reader for the given compression type. The
+// reader is pooled and must be closed to be returned to the pool.
 func NewDecompressionReader(r io.Reader, compress string) (io.ReadCloser, error) {
-	switch compress {
-	case "none":
+	if compress == "none" {
 		return io.NopCloser(r), nil
-	case compressionLZ4:
-		return io.NopCloser(lz4.NewReader(r)), nil
-	case compressionZSTD:
-		decoder, err := zstd.NewReader(r)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
-		}
-		return &zstdReadCloser{Decoder: decoder}, nil
-	default:
+	}
+
+	c, ok := compressors[compress]
+	if !ok {
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}
+	return c.NewReader(r)
 }
 
 type nopWriteCloser struct {
@@ -61,11 +65,121 @@ type nopWriteCloser struct {
 
 func (nopWriteCloser) Close() error { return nil }
 
-type zstdReadCloser struct {
-	*zstd.Decoder
+// LZ4 implementation -------------------------------------------------------
+
+type lz4Compressor struct {
+	writerPool sync.Pool
+	readerPool sync.Pool
 }
 
-func (z *zstdReadCloser) Close() error {
-	z.Decoder.Close()
+func newLZ4Compressor() *lz4Compressor {
+	return &lz4Compressor{
+		writerPool: sync.Pool{New: func() any { return lz4.NewWriter(io.Discard) }},
+		readerPool: sync.Pool{New: func() any { return lz4.NewReader(bytes.NewReader(nil)) }},
+	}
+}
+
+func (c *lz4Compressor) NewWriter(w io.Writer, _ int) (io.WriteCloser, error) {
+	lw := c.writerPool.Get().(*lz4.Writer)
+	lw.Reset(w)
+	return &lz4WriteCloser{Writer: lw, pool: &c.writerPool}, nil
+}
+
+func (c *lz4Compressor) NewReader(r io.Reader) (io.ReadCloser, error) {
+	lr := c.readerPool.Get().(*lz4.Reader)
+	lr.Reset(r)
+	return &lz4ReadCloser{Reader: lr, pool: &c.readerPool}, nil
+}
+
+type lz4WriteCloser struct {
+	*lz4.Writer
+	pool *sync.Pool
+}
+
+func (w *lz4WriteCloser) Close() error {
+	err := w.Writer.Close()
+	w.Writer.Reset(io.Discard)
+	w.pool.Put(w.Writer)
+	return err
+}
+
+type lz4ReadCloser struct {
+	*lz4.Reader
+	pool *sync.Pool
+}
+
+func (r *lz4ReadCloser) Close() error {
+	r.Reader.Reset(bytes.NewReader(nil))
+	r.pool.Put(r.Reader)
+	return nil
+}
+
+// Zstd implementation ------------------------------------------------------
+
+type zstdCompressor struct {
+	mu          sync.Mutex
+	writerPools map[int]*sync.Pool
+	readerPool  sync.Pool
+}
+
+func newZstdCompressor() *zstdCompressor {
+	return &zstdCompressor{
+		writerPools: make(map[int]*sync.Pool),
+		readerPool:  sync.Pool{New: func() any { dec, _ := zstd.NewReader(nil); return dec }},
+	}
+}
+
+func (c *zstdCompressor) poolForLevel(level int) *sync.Pool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	p := c.writerPools[level]
+	if p == nil {
+		encLevel := zstd.EncoderLevelFromZstd(level)
+		p = &sync.Pool{New: func() any { enc, _ := zstd.NewWriter(io.Discard, zstd.WithEncoderLevel(encLevel)); return enc }}
+		c.writerPools[level] = p
+	}
+	return p
+}
+
+func (c *zstdCompressor) NewWriter(w io.Writer, level int) (io.WriteCloser, error) {
+	if level < 1 || level > 22 {
+		return nil, fmt.Errorf("invalid zstd compression level: %d", level)
+	}
+	p := c.poolForLevel(level)
+	zw := p.Get().(*zstd.Encoder)
+	zw.Reset(w)
+	return &zstdWriteCloser{Encoder: zw, pool: p}, nil
+}
+
+func (c *zstdCompressor) NewReader(r io.Reader) (io.ReadCloser, error) {
+	zr := c.readerPool.Get().(*zstd.Decoder)
+	if err := zr.Reset(r); err != nil {
+		// decoder cannot be reused; discard from pool
+		zr.Close()
+		return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
+	}
+	return &zstdReadCloser{Decoder: zr, pool: &c.readerPool}, nil
+}
+
+type zstdWriteCloser struct {
+	*zstd.Encoder
+	pool *sync.Pool
+}
+
+func (w *zstdWriteCloser) Close() error {
+	err := w.Encoder.Close()
+	w.Encoder.Reset(nil)
+	w.pool.Put(w.Encoder)
+	return err
+}
+
+type zstdReadCloser struct {
+	*zstd.Decoder
+	pool *sync.Pool
+}
+
+func (r *zstdReadCloser) Close() error {
+	r.Decoder.Reset(nil)
+	r.pool.Put(r.Decoder)
 	return nil
 }

--- a/transfer/compression_auto_arm64_test.go
+++ b/transfer/compression_auto_arm64_test.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"testing"
 
-	zstd "github.com/klauspost/compress/zstd"
-	"github.com/pierrec/lz4/v4"
 	"golang.org/x/sys/cpu"
 )
 
@@ -20,7 +18,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCompressionWriter with ASIMD: %v", err)
 	}
-	if _, ok := w.(*zstd.Encoder); !ok {
+	if _, ok := w.(*zstdWriteCloser); !ok {
 		t.Fatalf("expected zstd writer when ASIMD is present")
 	}
 	w.Close()
@@ -30,7 +28,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCompressionWriter without ASIMD: %v", err)
 	}
-	if _, ok := w.(*lz4.Writer); !ok {
+	if _, ok := w.(*lz4WriteCloser); !ok {
 		t.Fatalf("expected lz4 writer when ASIMD is absent")
 	}
 	w.Close()

--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"testing"
 
-	zstd "github.com/klauspost/compress/zstd"
-	"github.com/pierrec/lz4/v4"
 	"golang.org/x/sys/cpu"
 )
 
@@ -20,7 +18,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCompressionWriter with AVX2: %v", err)
 	}
-	if _, ok := w.(*zstd.Encoder); !ok {
+	if _, ok := w.(*zstdWriteCloser); !ok {
 		t.Fatalf("expected zstd writer when AVX2 is present")
 	}
 	w.Close()
@@ -30,7 +28,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCompressionWriter without AVX2: %v", err)
 	}
-	if _, ok := w.(*lz4.Writer); !ok {
+	if _, ok := w.(*lz4WriteCloser); !ok {
 		t.Fatalf("expected lz4 writer when AVX2 is absent")
 	}
 	w.Close()

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -52,3 +52,67 @@ func TestNewCompressionWriterLevel(t *testing.T) {
 		}
 	})
 }
+
+func TestCompressionPooling(t *testing.T) {
+	for _, c := range []string{compressionLZ4, compressionZSTD} {
+		// Writer reuse
+		w1, err := NewCompressionWriter(io.Discard, c, 1)
+		if err != nil {
+			t.Fatalf("writer1 for %s: %v", c, err)
+		}
+		var firstWriter any
+		switch w := w1.(type) {
+		case *lz4WriteCloser:
+			firstWriter = w.Writer
+		case *zstdWriteCloser:
+			firstWriter = w.Encoder
+		}
+		w1.Close()
+
+		w2, err := NewCompressionWriter(io.Discard, c, 1)
+		if err != nil {
+			t.Fatalf("writer2 for %s: %v", c, err)
+		}
+		var secondWriter any
+		switch w := w2.(type) {
+		case *lz4WriteCloser:
+			secondWriter = w.Writer
+		case *zstdWriteCloser:
+			secondWriter = w.Encoder
+		}
+		if firstWriter != secondWriter {
+			t.Fatalf("writer was not pooled for %s", c)
+		}
+		w2.Close()
+
+		// Reader reuse
+		r1, err := NewDecompressionReader(bytes.NewReader(nil), c)
+		if err != nil {
+			t.Fatalf("reader1 for %s: %v", c, err)
+		}
+		var firstReader any
+		switch r := r1.(type) {
+		case *lz4ReadCloser:
+			firstReader = r.Reader
+		case *zstdReadCloser:
+			firstReader = r.Decoder
+		}
+		r1.Close()
+
+		r2, err := NewDecompressionReader(bytes.NewReader(nil), c)
+		if err != nil {
+			t.Fatalf("reader2 for %s: %v", c, err)
+		}
+		var secondReader any
+		switch r := r2.(type) {
+		case *lz4ReadCloser:
+			secondReader = r.Reader
+		case *zstdReadCloser:
+			secondReader = r.Decoder
+		}
+		if firstReader != secondReader {
+			t.Fatalf("reader was not pooled for %s", c)
+		}
+		r2.Close()
+	}
+}


### PR DESCRIPTION
## Summary
- add generic Compressor interface and pooled implementations for LZ4 and Zstd
- refactor compression helpers to reuse writers/readers via sync.Pool
- extend tests to verify pooling and update auto-detection checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689144a5e6088323a54cb66fa79202d9