### PR TITLE
Validate LZ4 compression levels

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/klauspost/cpuid/v2"
+	"github.com/pierrec/lz4/v4"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"lvmsync_go/lvm"
@@ -98,14 +100,37 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 	}
 	conf.SpeedLimit = sl
 
-	// Validate compression level for zstd or auto.
-	if conf.Compress == "zstd" || conf.Compress == "auto" {
+	// Validate compression levels based on the resolved compression algorithm.
+	resolved := conf.Compress
+	if resolved == "auto" {
+		resolved = detectOptimalCompression()
+	}
+	switch resolved {
+	case "zstd":
 		if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
 			return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+		}
+	case "lz4":
+		lvl := lz4.CompressionLevel(conf.CompressLevel)
+		switch lvl {
+		case lz4.Fast, lz4.Level1, lz4.Level2, lz4.Level3, lz4.Level4, lz4.Level5, lz4.Level6, lz4.Level7, lz4.Level8, lz4.Level9:
+		// valid
+		default:
+			return nil, fmt.Errorf("invalid lz4 compression level: %d", conf.CompressLevel)
 		}
 	}
 
 	return &conf, nil
+}
+
+func detectOptimalCompression() string {
+	if cpuid.CPU.Has(cpuid.AVX512F) || cpuid.CPU.Has(cpuid.AVX2) || cpuid.CPU.Has(cpuid.BMI2) {
+		return "zstd"
+	}
+	if cpuid.CPU.Has(cpuid.ASIMD) {
+		return "zstd"
+	}
+	return "lz4"
 }
 
 func (cb *ConfigBuilder) parseBytesOrFallback(key, fallback string) (int, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/pierrec/lz4/v4"
 	"github.com/spf13/viper"
 	"lvmsync_go/lvm"
 )
@@ -140,7 +141,11 @@ func TestCompressLevelValidation(t *testing.T) {
 	t.Run("autoValid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "auto")
-		v.Set("compress_level", 3)
+		if detectOptimalCompression() == "zstd" {
+			v.Set("compress_level", 3)
+		} else {
+			v.Set("compress_level", int(lz4.Level3))
+		}
 		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
 		if _, err := cb.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -150,20 +155,34 @@ func TestCompressLevelValidation(t *testing.T) {
 	t.Run("autoInvalid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "auto")
-		v.Set("compress_level", 100)
+		if detectOptimalCompression() == "zstd" {
+			v.Set("compress_level", 100)
+		} else {
+			v.Set("compress_level", 3)
+		}
 		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
 		if _, err := cb.Build(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
-	t.Run("lz4NoValidation", func(t *testing.T) {
+	t.Run("lz4Valid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "lz4")
-		v.Set("compress_level", 100)
+		v.Set("compress_level", int(lz4.Level3))
 		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
 		if _, err := cb.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("lz4Invalid", func(t *testing.T) {
+		v := viper.New()
+		v.Set("compress", "lz4")
+		v.Set("compress_level", 3)
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		if _, err := cb.Build(); err == nil {
+			t.Fatalf("expected error")
 		}
 	})
 }

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -25,9 +25,18 @@ func NewCompressionWriter(dst io.Writer, compress string, level int) (io.WriteCl
 	case "none":
 		return nopWriteCloser{dst}, nil
 	case compressionLZ4:
-		// For LZ4, valid levels include lz4.Fast and lz4.Level1 through lz4.Level9.
+		// Validate level prior to constructing the writer to avoid applying an invalid option.
+		lvl := lz4.CompressionLevel(level)
+		switch lvl {
+		case lz4.Fast, lz4.Level1, lz4.Level2, lz4.Level3, lz4.Level4, lz4.Level5, lz4.Level6, lz4.Level7, lz4.Level8, lz4.Level9:
+		// valid
+		default:
+			return nil, fmt.Errorf("invalid lz4 compression level: %d", level)
+		}
 		w := lz4.NewWriter(dst)
-		w.Apply(lz4.CompressionLevelOption(lz4.CompressionLevel(level)))
+		if err := w.Apply(lz4.CompressionLevelOption(lvl)); err != nil {
+			return nil, fmt.Errorf("failed to apply lz4 compression level: %w", err)
+		}
 		return w, nil
 	case compressionZSTD:
 		// Ensure provided level is within the supported zstd range.

--- a/transfer/compression_auto_arm64_test.go
+++ b/transfer/compression_auto_arm64_test.go
@@ -30,7 +30,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 
 	t.Run("fallback", func(t *testing.T) {
 		cpuid.CPU = cpuid.CPUInfo{}
-		w, err := NewCompressionWriter(io.Discard, "auto", 1)
+		w, err := NewCompressionWriter(io.Discard, "auto", int(lz4.Level1))
 		if err != nil {
 			t.Fatalf("NewCompressionWriter without ASIMD: %v", err)
 		}

--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -33,7 +33,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 
 	t.Run("fallback", func(t *testing.T) {
 		cpuid.CPU = cpuid.CPUInfo{}
-		w, err := NewCompressionWriter(io.Discard, "auto", 1)
+		w, err := NewCompressionWriter(io.Discard, "auto", int(lz4.Level1))
 		if err != nil {
 			t.Fatalf("NewCompressionWriter without features: %v", err)
 		}

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -82,14 +82,26 @@ func TestLZ4CompressionLevels(t *testing.T) {
 }
 
 func TestNewCompressionWriterLevel(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
+	t.Run("zstdValid", func(t *testing.T) {
 		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 3); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("invalid", func(t *testing.T) {
+	t.Run("zstdInvalid", func(t *testing.T) {
 		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 100); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("lz4Valid", func(t *testing.T) {
+		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, int(lz4.Level3)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("lz4Invalid", func(t *testing.T) {
+		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, 3); err == nil {
 			t.Fatalf("expected error")
 		}
 	})


### PR DESCRIPTION
## Summary
- ensure `NewCompressionWriter` rejects out-of-range LZ4 compression levels before creating the writer
- validate LZ4 compression levels in config, including when `compress` is `auto` and CPU feature detection resolves to LZ4
- update tests for new validation rules

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68914aa5d9a4832389422e39f12e5e07