### PR TITLE
Add configurable compression concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 |--------|-------------|---------|
 | `--compress` | Compression type (options: `"none"`, `"lz4"`, `"zstd"`, `"auto"`) | `"lz4"` |
 | `--compress_level` | Compression level for Zstd (ignored for LZ4) | `3` |
+| `--compress_concurrency` | Number of goroutines used for compression (`0` to use all cores) | `0` |
 
 #### LVM Options
 
@@ -239,6 +240,7 @@ remote_post_script: ""                  # Remote script to run after finishing t
 # Compression Options:
 compress: "lz4"                         # Compression type (options: "none", "lz4", "zstd", "auto")
 compress_level: 3                       # Compression level for zstd (ignored for lz4)
+compress_concurrency: 0                # Number of goroutines for compression (0 to use all cores)
 
 # LVM Options:
 skip_snapshot_creation: false           # Skip automatic snapshot creation

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,7 @@ remote_post_script: ""                 # Remote script to run after finishing tr
 
 compress: "lz4"                        # Compression method (options: "none", "lz4", "zstd", "auto")
 compress_level: 3                      # Compression level for zstd (ignored for lz4)
+compress_concurrency: 0               # Number of goroutines for compression (0 to use all cores)
 speed: "100MB"                         # Speed limit (e.g. "100MB")
 verify_checksum: false                 # Enable checksum verification for data integrity
 verbose: 0                             # Verbosity level (0 = silent, higher numbers = more verbose)

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"lvmsync_go/lvm"
+	"runtime"
 )
 
 var SupportedCompression = []string{"none", "lz4", "zstd", "auto"}
@@ -55,6 +56,7 @@ type Config struct {
 	Compress             string        `mapstructure:"compress"`
 	// For LZ4 use lz4.Fast or lz4.Level1 through lz4.Level9; ZSTD accepts levels 1-22.
 	CompressLevel        int      `mapstructure:"compress_level"`
+	CompressConcurrency  int      `mapstructure:"compress_concurrency"`
 	Speed                string   `mapstructure:"speed"`
 	SpeedLimit           int      `mapstructure:"-"`
 	VerifyChecksum       bool     `mapstructure:"verify_checksum"`
@@ -103,6 +105,10 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 		return nil, err
 	}
 	conf.SpeedLimit = sl
+
+	if conf.CompressConcurrency <= 0 {
+		conf.CompressConcurrency = runtime.GOMAXPROCS(0)
+	}
 
 	// Validate compression levels based on the resolved compression algorithm.
 	resolved := conf.Compress
@@ -211,6 +217,7 @@ func DefaultConfig() *Config {
 		RemotePostScript:     "",
 		Compress:             "lz4",
 		CompressLevel:        3,
+		CompressConcurrency:  runtime.GOMAXPROCS(0),
 		Speed:                "100MB",
 		VerifyChecksum:       false,
 		Verbose:              0,
@@ -281,6 +288,7 @@ func LoadConfig() (*Config, error) {
 	// Compression Options
 	compressionFlags.String("compress", defaultCfg.Compress, fmt.Sprintf("Compression type, options: %v", SupportedCompression))
 	compressionFlags.Int("compress_level", defaultCfg.CompressLevel, "Compression level. LZ4 accepts lz4.Fast or lz4.Level1..lz4.Level9; ZSTD accepts 1-22")
+	compressionFlags.Int("compress_concurrency", defaultCfg.CompressConcurrency, "Compression concurrency (0 to use GOMAXPROCS)")
 
 	// LVM Options
 	lvmFlags.Bool("skip_snapshot_creation", defaultCfg.SkipSnapshotCreation, "Skip automatic snapshot creation")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -186,3 +186,30 @@ func TestCompressLevelValidation(t *testing.T) {
 		}
 	})
 }
+
+func TestCompressConcurrency(t *testing.T) {
+	t.Run("defaultPositive", func(t *testing.T) {
+		v := viper.New()
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		cfg, err := cb.Build()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.CompressConcurrency <= 0 {
+			t.Fatalf("expected positive concurrency, got %d", cfg.CompressConcurrency)
+		}
+	})
+
+	t.Run("override", func(t *testing.T) {
+		v := viper.New()
+		v.Set("compress_concurrency", 8)
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		cfg, err := cb.Build()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.CompressConcurrency != 8 {
+			t.Fatalf("expected 8, got %d", cfg.CompressConcurrency)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func main() {
 		zap.String("dedup_strategy", cfg.DedupStrategy),
 		zap.String("compress", cfg.Compress),
 		zap.Int("compress_level", cfg.CompressLevel),
+		zap.Int("compress_concurrency", cfg.CompressConcurrency),
 		zap.String("snapshot_size", cfg.SnapshotSize),
 		zap.String("volume_group", cfg.VolumeGroup),
 		zap.String("target_volume_group", cfg.TargetVolumeGroup),

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -4,6 +4,7 @@ package transfer
 import (
 	"fmt"
 	"io"
+	"runtime"
 
 	zstd "github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -16,9 +17,13 @@ const (
 
 // No shared state is kept between decompression readers.
 
-func NewCompressionWriter(dst io.Writer, compress string, level int) (io.WriteCloser, error) {
+func NewCompressionWriter(dst io.Writer, compress string, level int, concurrency int) (io.WriteCloser, error) {
 	if compress == "auto" {
 		compress = detectOptimalCompression()
+	}
+
+	if concurrency <= 0 {
+		concurrency = runtime.GOMAXPROCS(0)
 	}
 
 	switch compress {
@@ -44,7 +49,8 @@ func NewCompressionWriter(dst io.Writer, compress string, level int) (io.WriteCl
 			return nil, fmt.Errorf("invalid zstd compression level: %d", level)
 		}
 		encLevel := zstd.EncoderLevelFromZstd(level)
-		return zstd.NewWriter(dst, zstd.WithEncoderLevel(encLevel))
+		opts := []zstd.EOption{zstd.WithEncoderLevel(encLevel), zstd.WithEncoderConcurrency(concurrency)}
+		return zstd.NewWriter(dst, opts...)
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}

--- a/transfer/compression_auto_arm64_test.go
+++ b/transfer/compression_auto_arm64_test.go
@@ -21,7 +21,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 		cpuid.CPU.Enable(cpuid.ASIMD)
 		detectOnce = sync.Once{}
 		detected = ""
-		w, err := NewCompressionWriter(io.Discard, "auto", 1)
+		w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
 		if err != nil {
 			t.Fatalf("NewCompressionWriter with ASIMD: %v", err)
 		}
@@ -40,7 +40,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 		if algo == compressionLZ4 {
 			lvl = int(lz4.Level1)
 		}
-		w, err := NewCompressionWriter(io.Discard, "auto", lvl)
+		w, err := NewCompressionWriter(io.Discard, "auto", lvl, 1)
 		if err != nil {
 			t.Fatalf("NewCompressionWriter without ASIMD: %v", err)
 		}

--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -23,7 +23,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 			cpuid.CPU.Enable(feat)
 			detectOnce = sync.Once{}
 			detected = ""
-			w, err := NewCompressionWriter(io.Discard, "auto", 1)
+			w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
 			if err != nil {
 				t.Fatalf("NewCompressionWriter with %s: %v", feat.String(), err)
 			}
@@ -43,7 +43,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 		if algo == compressionLZ4 {
 			lvl = int(lz4.Level1)
 		}
-		w, err := NewCompressionWriter(io.Discard, "auto", lvl)
+		w, err := NewCompressionWriter(io.Discard, "auto", lvl, 1)
 		if err != nil {
 			t.Fatalf("NewCompressionWriter without features: %v", err)
 		}

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -21,7 +21,7 @@ func TestCompressionRoundTrip(t *testing.T) {
 
 	for _, tc := range cases {
 		var buf bytes.Buffer
-		w, err := NewCompressionWriter(&buf, tc.c, tc.level)
+		w, err := NewCompressionWriter(&buf, tc.c, tc.level, 1)
 		if err != nil {
 			t.Fatalf("writer for %s: %v", tc.c, err)
 		}
@@ -54,7 +54,7 @@ func TestLZ4CompressionLevels(t *testing.T) {
 
 	for _, lvl := range levels {
 		var buf bytes.Buffer
-		w, err := NewCompressionWriter(&buf, compressionLZ4, lvl)
+		w, err := NewCompressionWriter(&buf, compressionLZ4, lvl, 1)
 		if err != nil {
 			t.Fatalf("writer for level %d: %v", lvl, err)
 		}
@@ -83,25 +83,25 @@ func TestLZ4CompressionLevels(t *testing.T) {
 
 func TestNewCompressionWriterLevel(t *testing.T) {
 	t.Run("zstdValid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 3); err != nil {
+		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 3, 1); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("zstdInvalid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 100); err == nil {
+		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 100, 1); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("lz4Valid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, int(lz4.Level3)); err != nil {
+		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, int(lz4.Level3), 1); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("lz4Invalid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, 3); err == nil {
+		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, 3, 1); err == nil {
 			t.Fatalf("expected error")
 		}
 	})

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -64,7 +64,7 @@ func SaveChecksumState(filename string, state *ChecksumState) error {
 
 func prepareOutputWriter(out io.Writer, cfg *config.Config) (io.WriteCloser, *bufio.Writer, error) {
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
-	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel)
+	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel, cfg.CompressConcurrency)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create compression writer: %w", err)
 	}
@@ -252,7 +252,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	fmt.Fprintln(out, strings.Join(htokens, " "))
 
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
-	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel)
+	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel, cfg.CompressConcurrency)
 	if err != nil {
 		return fmt.Errorf("failed to create compression writer: %w", err)
 	}


### PR DESCRIPTION
## Summary
- allow specifying zstd compression concurrency
- expose new `compress_concurrency` option in configuration and docs

## Testing
- `go test ./config ./transfer` *(fails: `fatal error: lvm2cmd.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68914f11d17083239be0a62fcb8ffa30