### PR TITLE
refactor: add compression strategy

### DIFF
--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"io"
 	"runtime"
-
-	zstd "github.com/klauspost/compress/zstd"
-	"github.com/pierrec/lz4/v4"
 )
 
 const (
@@ -26,64 +23,17 @@ func NewCompressionWriter(dst io.Writer, compress string, level int, concurrency
 		concurrency = runtime.GOMAXPROCS(0)
 	}
 
-	switch compress {
-	case "none":
-		return nopWriteCloser{dst}, nil
-	case compressionLZ4:
-		// Validate level prior to constructing the writer to avoid applying an invalid option.
-		lvl := lz4.CompressionLevel(level)
-		switch lvl {
-		case lz4.Fast, lz4.Level1, lz4.Level2, lz4.Level3, lz4.Level4, lz4.Level5, lz4.Level6, lz4.Level7, lz4.Level8, lz4.Level9:
-		// valid
-		default:
-			return nil, fmt.Errorf("invalid lz4 compression level: %d", level)
-		}
-		w := lz4.NewWriter(dst)
-		if err := w.Apply(lz4.CompressionLevelOption(lvl)); err != nil {
-			return nil, fmt.Errorf("failed to apply lz4 compression level: %w", err)
-		}
-		return w, nil
-	case compressionZSTD:
-		// Ensure provided level is within the supported zstd range.
-		if level < 1 || level > 22 {
-			return nil, fmt.Errorf("invalid zstd compression level: %d", level)
-		}
-		encLevel := zstd.EncoderLevelFromZstd(level)
-		opts := []zstd.EOption{zstd.WithEncoderLevel(encLevel), zstd.WithEncoderConcurrency(concurrency)}
-		return zstd.NewWriter(dst, opts...)
-	default:
+	strategy, ok := compressionStrategies[compress]
+	if !ok {
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}
+	return strategy.NewWriter(dst, level, concurrency)
 }
 
 func NewDecompressionReader(r io.Reader, compress string) (io.ReadCloser, error) {
-	switch compress {
-	case "none":
-		return io.NopCloser(r), nil
-	case compressionLZ4:
-		return io.NopCloser(lz4.NewReader(r)), nil
-	case compressionZSTD:
-		decoder, err := zstd.NewReader(r)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
-		}
-		return &zstdReadCloser{Decoder: decoder}, nil
-	default:
+	strategy, ok := compressionStrategies[compress]
+	if !ok {
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}
-}
-
-type nopWriteCloser struct {
-	io.Writer
-}
-
-func (nopWriteCloser) Close() error { return nil }
-
-type zstdReadCloser struct {
-	*zstd.Decoder
-}
-
-func (z *zstdReadCloser) Close() error {
-	z.Decoder.Close()
-	return nil
+	return strategy.NewReader(r)
 }

--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -1,0 +1,85 @@
+package transfer
+
+import (
+	"fmt"
+	"io"
+
+	zstd "github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+)
+
+type CompressionStrategy interface {
+	NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error)
+	NewReader(src io.Reader) (io.ReadCloser, error)
+}
+
+type noneStrategy struct{}
+
+func (noneStrategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
+	return nopWriteCloser{dst}, nil
+}
+
+func (noneStrategy) NewReader(src io.Reader) (io.ReadCloser, error) {
+	return io.NopCloser(src), nil
+}
+
+type lz4Strategy struct{}
+
+func (lz4Strategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
+	lvl := lz4.CompressionLevel(level)
+	switch lvl {
+	case lz4.Fast, lz4.Level1, lz4.Level2, lz4.Level3, lz4.Level4, lz4.Level5, lz4.Level6, lz4.Level7, lz4.Level8, lz4.Level9:
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid lz4 compression level: %d", level)
+	}
+	w := lz4.NewWriter(dst)
+	if err := w.Apply(lz4.CompressionLevelOption(lvl)); err != nil {
+		return nil, fmt.Errorf("failed to apply lz4 compression level: %w", err)
+	}
+	return w, nil
+}
+
+func (lz4Strategy) NewReader(src io.Reader) (io.ReadCloser, error) {
+	return io.NopCloser(lz4.NewReader(src)), nil
+}
+
+type zstdStrategy struct{}
+
+func (zstdStrategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
+	if level < 1 || level > 22 {
+		return nil, fmt.Errorf("invalid zstd compression level: %d", level)
+	}
+	encLevel := zstd.EncoderLevelFromZstd(level)
+	opts := []zstd.EOption{zstd.WithEncoderLevel(encLevel), zstd.WithEncoderConcurrency(concurrency)}
+	return zstd.NewWriter(dst, opts...)
+}
+
+func (zstdStrategy) NewReader(src io.Reader) (io.ReadCloser, error) {
+	decoder, err := zstd.NewReader(src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
+	}
+	return &zstdReadCloser{Decoder: decoder}, nil
+}
+
+var compressionStrategies = map[string]CompressionStrategy{
+	"none":          noneStrategy{},
+	compressionLZ4:  lz4Strategy{},
+	compressionZSTD: zstdStrategy{},
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (nopWriteCloser) Close() error { return nil }
+
+type zstdReadCloser struct {
+	*zstd.Decoder
+}
+
+func (z *zstdReadCloser) Close() error {
+	z.Decoder.Close()
+	return nil
+}


### PR DESCRIPTION
## Summary
- add CompressionStrategy interface and implementations for none, lz4 and zstd
- use strategy lookup in NewCompressionWriter and NewDecompressionReader

## Testing
- `go test ./...` *(fails: lvm2cmd.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689150d0801c8323a415f38405b7c0ed