### PR TITLE
Handle zstd decoder close errors

### DIFF
--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -80,6 +80,5 @@ type zstdReadCloser struct {
 }
 
 func (z *zstdReadCloser) Close() error {
-	z.Decoder.Close()
-	return nil
+	return z.Decoder.Close()
 }

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -40,7 +40,9 @@ func TestCompressionRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", tc.c, err)
 		}
-		r.Close()
+		if err := r.Close(); err != nil {
+			t.Fatalf("close %s: %v", tc.c, err)
+		}
 
 		if !bytes.Equal(out, data) {
 			t.Fatalf("roundtrip mismatch for %s", tc.c)
@@ -73,7 +75,9 @@ func TestLZ4CompressionLevels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read level %d: %v", lvl, err)
 		}
-		r.Close()
+		if err := r.Close(); err != nil {
+			t.Fatalf("close level %d: %v", lvl, err)
+		}
 
 		if !bytes.Equal(out, data) {
 			t.Fatalf("roundtrip mismatch for level %d", lvl)

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -404,7 +404,11 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 	if err != nil {
 		return fmt.Errorf("failed to create decompression reader: %w", err)
 	}
-	defer decReader.Close()
+	defer func() {
+		if err := decReader.Close(); err != nil && Logger != nil {
+			Logger.Warn("Failed to close decompression reader", zap.Error(err))
+		}
+	}()
 
 	reader := bufio.NewReader(decReader)
 


### PR DESCRIPTION
## Summary
- propagate errors from the zstd decoder's Close
- log decompression reader close failures
- verify Close errors in compression tests

## Testing
- `go test ./...` *(fails: lvm/lvm.go:7:10: fatal error: lvm2cmd.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891530c94c08323bc94da3cd82ff33b