### PR TITLE
Reuse zstd codecs via sync.Pool

### DIFF
--- a/transfer/compression_auto_arm64_test.go
+++ b/transfer/compression_auto_arm64_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"testing"
 
-	zstd "github.com/klauspost/compress/zstd"
 	"github.com/klauspost/cpuid/v2"
 	"github.com/pierrec/lz4/v4"
 	compressiondetect "lvmsync_go/internal/compressiondetect"
@@ -24,7 +23,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewCompressionWriter with ASIMD: %v", err)
 		}
-		if _, ok := w.(*zstd.Encoder); !ok {
+		if _, ok := w.(*pooledZstdWriter); !ok {
 			t.Fatalf("expected zstd writer when ASIMD is present")
 		}
 		w.Close()
@@ -48,7 +47,7 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 				t.Fatalf("expected lz4 writer when benchmark prefers lz4")
 			}
 		case compressionZSTD:
-			if _, ok := w.(*zstd.Encoder); !ok {
+			if _, ok := w.(*pooledZstdWriter); !ok {
 				t.Fatalf("expected zstd writer when benchmark prefers zstd")
 			}
 		}

--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"testing"
 
-	zstd "github.com/klauspost/compress/zstd"
 	"github.com/klauspost/cpuid/v2"
 	"github.com/pierrec/lz4/v4"
 	compressiondetect "lvmsync_go/internal/compressiondetect"
@@ -26,7 +25,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewCompressionWriter with %s: %v", feat.String(), err)
 			}
-			if _, ok := w.(*zstd.Encoder); !ok {
+			if _, ok := w.(*pooledZstdWriter); !ok {
 				t.Fatalf("expected zstd writer when %s is present", feat.String())
 			}
 			w.Close()
@@ -51,7 +50,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 				t.Fatalf("expected lz4 writer when benchmark prefers lz4")
 			}
 		case compressionZSTD:
-			if _, ok := w.(*zstd.Encoder); !ok {
+			if _, ok := w.(*pooledZstdWriter); !ok {
 				t.Fatalf("expected zstd writer when benchmark prefers zstd")
 			}
 		}

--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"fmt"
 	"io"
+	"sync"
 
 	zstd "github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -46,19 +47,75 @@ func (lz4Strategy) NewReader(src io.Reader) (io.ReadCloser, error) {
 
 type zstdStrategy struct{}
 
+var (
+	zstdEncoderPool sync.Pool
+	zstdDecoderPool sync.Pool
+)
+
+type pooledZstdEncoder struct {
+	enc         *zstd.Encoder
+	level       int
+	concurrency int
+}
+
+type pooledZstdWriter struct {
+	*zstd.Encoder
+	entry *pooledZstdEncoder
+}
+
+func (w *pooledZstdWriter) Close() error {
+	err := w.Encoder.Close()
+	w.Encoder.Reset(nil)
+	zstdEncoderPool.Put(w.entry)
+	return err
+}
+
 func (zstdStrategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
 	if level < 1 || level > 22 {
 		return nil, fmt.Errorf("invalid zstd compression level: %d", level)
 	}
-	encLevel := zstd.EncoderLevelFromZstd(level)
-	opts := []zstd.EOption{zstd.WithEncoderLevel(encLevel), zstd.WithEncoderConcurrency(concurrency)}
-	return zstd.NewWriter(dst, opts...)
+
+	entryAny := zstdEncoderPool.Get()
+	var entry *pooledZstdEncoder
+	if entryAny == nil {
+		entry = &pooledZstdEncoder{}
+	} else {
+		entry = entryAny.(*pooledZstdEncoder)
+	}
+
+	if entry.enc == nil || entry.level != level || entry.concurrency != concurrency {
+		encLevel := zstd.EncoderLevelFromZstd(level)
+		opts := []zstd.EOption{zstd.WithEncoderLevel(encLevel), zstd.WithEncoderConcurrency(concurrency)}
+		enc, err := zstd.NewWriter(dst, opts...)
+		if err != nil {
+			zstdEncoderPool.Put(entry)
+			return nil, err
+		}
+		entry.enc = enc
+		entry.level = level
+		entry.concurrency = concurrency
+	} else {
+		entry.enc.Reset(dst)
+	}
+
+	return &pooledZstdWriter{Encoder: entry.enc, entry: entry}, nil
 }
 
 func (zstdStrategy) NewReader(src io.Reader) (io.ReadCloser, error) {
-	decoder, err := zstd.NewReader(src)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
+	entryAny := zstdDecoderPool.Get()
+	var decoder *zstd.Decoder
+	if entryAny == nil {
+		dec, err := zstd.NewReader(src)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
+		}
+		decoder = dec
+	} else {
+		decoder = entryAny.(*zstd.Decoder)
+		if err := decoder.Reset(src); err != nil {
+			zstdDecoderPool.Put(decoder)
+			return nil, fmt.Errorf("failed to reset zstd decoder: %w", err)
+		}
 	}
 	return &zstdReadCloser{Decoder: decoder}, nil
 }
@@ -80,5 +137,7 @@ type zstdReadCloser struct {
 }
 
 func (z *zstdReadCloser) Close() error {
-	return z.Decoder.Close()
+	z.Decoder.Reset(nil)
+	zstdDecoderPool.Put(z.Decoder)
+	return nil
 }


### PR DESCRIPTION
## Summary
- reuse zstd encoders and decoders with sync.Pool to avoid allocations
- reset pooled codecs for new streams and return them on close
- adjust tests to match new pooled writer type

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891581d1fec832387799ab73bce32a2