### PR TITLE
Add decoder concurrency configuration

### DIFF
--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -32,10 +32,13 @@ func NewCompressionWriter(dst io.Writer, compress string, level int, concurrency
 	return strategy.NewWriter(dst, level, concurrency)
 }
 
-func NewDecompressionReader(r io.Reader, compress string) (io.ReadCloser, error) {
+func NewDecompressionReader(r io.Reader, compress string, concurrency int) (io.ReadCloser, error) {
+	if concurrency <= 0 {
+		concurrency = runtime.GOMAXPROCS(0)
+	}
 	strategy, ok := compressionStrategies[compress]
 	if !ok {
 		return nil, fmt.Errorf("unsupported compression type: %s", compress)
 	}
-	return strategy.NewReader(r)
+	return strategy.NewReader(r, concurrency)
 }

--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -11,7 +11,7 @@ import (
 
 type CompressionStrategy interface {
 	NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error)
-	NewReader(src io.Reader) (io.ReadCloser, error)
+	NewReader(src io.Reader, concurrency int) (io.ReadCloser, error)
 }
 
 type noneStrategy struct{}
@@ -20,7 +20,7 @@ func (noneStrategy) NewWriter(dst io.Writer, level int, concurrency int) (io.Wri
 	return nopWriteCloser{dst}, nil
 }
 
-func (noneStrategy) NewReader(src io.Reader) (io.ReadCloser, error) {
+func (noneStrategy) NewReader(src io.Reader, concurrency int) (io.ReadCloser, error) {
 	return io.NopCloser(src), nil
 }
 
@@ -41,7 +41,7 @@ func (lz4Strategy) NewWriter(dst io.Writer, level int, concurrency int) (io.Writ
 	return w, nil
 }
 
-func (lz4Strategy) NewReader(src io.Reader) (io.ReadCloser, error) {
+func (lz4Strategy) NewReader(src io.Reader, concurrency int) (io.ReadCloser, error) {
 	return io.NopCloser(lz4.NewReader(src)), nil
 }
 
@@ -101,23 +101,44 @@ func (zstdStrategy) NewWriter(dst io.Writer, level int, concurrency int) (io.Wri
 	return &pooledZstdWriter{Encoder: entry.enc, entry: entry}, nil
 }
 
-func (zstdStrategy) NewReader(src io.Reader) (io.ReadCloser, error) {
+type pooledZstdDecoder struct {
+	dec         *zstd.Decoder
+	concurrency int
+}
+
+type pooledZstdReader struct {
+	*zstd.Decoder
+	entry *pooledZstdDecoder
+}
+
+func (zstdStrategy) NewReader(src io.Reader, concurrency int) (io.ReadCloser, error) {
 	entryAny := zstdDecoderPool.Get()
-	var decoder *zstd.Decoder
+	var entry *pooledZstdDecoder
 	if entryAny == nil {
-		dec, err := zstd.NewReader(src)
+		entry = &pooledZstdDecoder{}
+	} else {
+		entry = entryAny.(*pooledZstdDecoder)
+	}
+
+	if entry.dec == nil || entry.concurrency != concurrency {
+		if entry.dec != nil {
+			entry.dec.Close()
+		}
+		dec, err := zstd.NewReader(src, zstd.WithDecoderConcurrency(concurrency))
 		if err != nil {
+			zstdDecoderPool.Put(entry)
 			return nil, fmt.Errorf("failed to initialize zstd decoder: %w", err)
 		}
-		decoder = dec
+		entry.dec = dec
+		entry.concurrency = concurrency
 	} else {
-		decoder = entryAny.(*zstd.Decoder)
-		if err := decoder.Reset(src); err != nil {
-			zstdDecoderPool.Put(decoder)
+		if err := entry.dec.Reset(src); err != nil {
+			zstdDecoderPool.Put(entry)
 			return nil, fmt.Errorf("failed to reset zstd decoder: %w", err)
 		}
 	}
-	return &zstdReadCloser{Decoder: decoder}, nil
+
+	return &pooledZstdReader{Decoder: entry.dec, entry: entry}, nil
 }
 
 var compressionStrategies = map[string]CompressionStrategy{
@@ -132,12 +153,8 @@ type nopWriteCloser struct {
 
 func (nopWriteCloser) Close() error { return nil }
 
-type zstdReadCloser struct {
-	*zstd.Decoder
-}
-
-func (z *zstdReadCloser) Close() error {
-	z.Decoder.Reset(nil)
-	zstdDecoderPool.Put(z.Decoder)
+func (r *pooledZstdReader) Close() error {
+	r.Decoder.Reset(nil)
+	zstdDecoderPool.Put(r.entry)
 	return nil
 }

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -32,7 +32,7 @@ func TestCompressionRoundTrip(t *testing.T) {
 			t.Fatalf("close %s: %v", tc.c, err)
 		}
 
-		r, err := NewDecompressionReader(&buf, tc.c)
+		r, err := NewDecompressionReader(&buf, tc.c, 1)
 		if err != nil {
 			t.Fatalf("reader for %s: %v", tc.c, err)
 		}
@@ -67,7 +67,7 @@ func TestLZ4CompressionLevels(t *testing.T) {
 			t.Fatalf("close level %d: %v", lvl, err)
 		}
 
-		r, err := NewDecompressionReader(&buf, compressionLZ4)
+		r, err := NewDecompressionReader(&buf, compressionLZ4, 1)
 		if err != nil {
 			t.Fatalf("reader for level %d: %v", lvl, err)
 		}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -400,7 +400,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
 	}
 
-	decReader, err := NewDecompressionReader(bufReader, compress)
+	decReader, err := NewDecompressionReader(bufReader, compress, cfg.CompressConcurrency)
 	if err != nil {
 		return fmt.Errorf("failed to create decompression reader: %w", err)
 	}


### PR DESCRIPTION
## Summary
- allow callers to pass a concurrency value when creating decompression readers
- configure zstd decoder with `zstd.WithDecoderConcurrency`
- update tests for new decompression API

## Testing
- `go test ./...` *(fails: lvm/lvm.go:7:10: fatal error: lvm2cmd.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68915a2c15d08323a3801d3dbd907539