### PR TITLE
Default to automatic compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--compress` | Compression type (options: `"none"`, `"lz4"`, `"zstd"`, `"auto"`) | `"lz4"` |
+| `--compress` | Compression type (options: `"none"`, `"lz4"`, `"zstd"`, `"auto"`) | `"auto"` |
 | `--compress_level` | Compression level for Zstd (ignored for LZ4) | `3` |
 | `--compress_concurrency` | Number of goroutines used for compression (`0` to use all cores) | `0` |
 
@@ -238,7 +238,7 @@ remote_pre_script: ""                   # Remote script to run before starting t
 remote_post_script: ""                  # Remote script to run after finishing transfer
 
 # Compression Options:
-compress: "lz4"                         # Compression type (options: "none", "lz4", "zstd", "auto")
+compress: "auto"                        # Compression type (options: "none", "lz4", "zstd", "auto")
 compress_level: 3                       # Compression level for zstd (ignored for lz4)
 compress_concurrency: 0                # Number of goroutines for compression (0 to use all cores)
 

--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ lvmsync_path: "lvmsync"                  # Remote command to run (e.g. "lvmsync"
 remote_pre_script: ""                  # Remote script to run before starting transfer
 remote_post_script: ""                 # Remote script to run after finishing transfer
 
-compress: "lz4"                        # Compression method (options: "none", "lz4", "zstd", "auto")
+compress: "auto"                       # Compression method (options: "none", "lz4", "zstd", "auto")
 compress_level: 3                      # Compression level for zstd (ignored for lz4)
 compress_concurrency: 0               # Number of goroutines for compression (0 to use all cores)
 speed: "100MB"                         # Speed limit (e.g. "100MB")

--- a/config/config.go
+++ b/config/config.go
@@ -171,7 +171,7 @@ func DefaultConfig() *Config {
 		LVMSyncPath:          "lvmsync",
 		RemotePreScript:      "",
 		RemotePostScript:     "",
-		Compress:             "lz4",
+		Compress:             "auto",
 		CompressLevel:        3,
 		CompressConcurrency:  runtime.GOMAXPROCS(0),
 		Speed:                "100MB",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,13 @@ import (
 	"lvmsync_go/lvm"
 )
 
+func TestDefaultConfigCompress(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Compress != "auto" {
+		t.Fatalf("expected default Compress to be 'auto', got %q", cfg.Compress)
+	}
+}
+
 func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		v := viper.New()


### PR DESCRIPTION
## Summary
- default to `compress: auto` so runtime chooses optimal algorithm
- test the new default and refresh docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915cde43948323b217b0d1f0606f69