### PR TITLE
Expand compression detection benchmarks

### DIFF
--- a/internal/compressiondetect/compressiondetect.go
+++ b/internal/compressiondetect/compressiondetect.go
@@ -2,8 +2,10 @@ package compressiondetect
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand"
+	"runtime"
 	"sync"
 	"time"
 
@@ -15,15 +17,30 @@ import (
 var (
 	detectOnce sync.Once
 	detected   string
+
+	benchMu    sync.Mutex
+	benchCache = make(map[string]string)
 )
 
 // DetectOptimalCompression determines the fastest compression algorithm for the current CPU.
 func DetectOptimalCompression() string {
 	detectOnce.Do(func() {
-		if cpuid.CPU.Has(cpuid.AVX512F) || cpuid.CPU.Has(cpuid.AVX2) || cpuid.CPU.Has(cpuid.BMI2) || cpuid.CPU.Has(cpuid.SSE42) || cpuid.CPU.Has(cpuid.ASIMD) || cpuid.CPU.Has(cpuid.SVE) {
+		cores := cpuid.CPU.PhysicalCores
+		if cores == 0 {
+			cores = runtime.NumCPU()
+		}
+		cacheSize := 0
+		if cpuid.CPU.Cache.L3 > 0 {
+			cacheSize += cpuid.CPU.Cache.L3
+		}
+		if cpuid.CPU.Cache.L2 > 0 {
+			cacheSize += cpuid.CPU.Cache.L2
+		}
+
+		if cpuid.CPU.Has(cpuid.AVX512F) || cpuid.CPU.Has(cpuid.AVX2) || cpuid.CPU.Has(cpuid.BMI2) || cpuid.CPU.Has(cpuid.SSE42) || cpuid.CPU.Has(cpuid.ASIMD) || cpuid.CPU.Has(cpuid.SVE) || (cores >= 4 && cacheSize >= 2<<20) {
 			detected = "zstd"
 		} else {
-			detected = BenchmarkCompression()
+			detected = benchmarkCached(cores, cacheSize)
 		}
 	})
 	return detected
@@ -38,29 +55,8 @@ func BenchmarkCompression() string {
 		return "lz4"
 	}
 
-	lz4Start := time.Now()
-	lw := lz4.NewWriter(io.Discard)
-	if _, err := lw.Write(sample); err != nil {
-		return "lz4"
-	}
-	if err := lw.Close(); err != nil {
-		return "lz4"
-	}
-	lz4Dur := time.Since(lz4Start)
-
-	zw, err := zstd.NewWriter(io.Discard)
-	if err != nil {
-		return "lz4"
-	}
-	zstdStart := time.Now()
-	if _, err := zw.Write(sample); err != nil {
-		zw.Close()
-		return "lz4"
-	}
-	if err := zw.Close(); err != nil {
-		return "lz4"
-	}
-	zstdDur := time.Since(zstdStart)
+	lz4Dur := benchLZ4(sample)
+	zstdDur := benchZSTD(sample)
 
 	if zstdDur < lz4Dur {
 		return "zstd"
@@ -68,8 +64,82 @@ func BenchmarkCompression() string {
 	return "lz4"
 }
 
+func benchLZ4(sample []byte) time.Duration {
+	var buf bytes.Buffer
+
+	start := time.Now()
+	lw := lz4.NewWriter(&buf)
+	if _, err := lw.Write(sample); err != nil {
+		return time.Hour
+	}
+	if err := lw.Close(); err != nil {
+		return time.Hour
+	}
+	compDur := time.Since(start)
+
+	r := lz4.NewReader(bytes.NewReader(buf.Bytes()))
+	decStart := time.Now()
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		return time.Hour
+	}
+	decDur := time.Since(decStart)
+
+	return compDur + decDur
+}
+
+func benchZSTD(sample []byte) time.Duration {
+	var buf bytes.Buffer
+
+	zw, err := zstd.NewWriter(&buf)
+	if err != nil {
+		return time.Hour
+	}
+	start := time.Now()
+	if _, err := zw.Write(sample); err != nil {
+		zw.Close()
+		return time.Hour
+	}
+	if err := zw.Close(); err != nil {
+		return time.Hour
+	}
+	compDur := time.Since(start)
+
+	zr, err := zstd.NewReader(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		return time.Hour
+	}
+	decStart := time.Now()
+	if _, err := io.Copy(io.Discard, zr); err != nil {
+		zr.Close()
+		return time.Hour
+	}
+	zr.Close()
+	decDur := time.Since(decStart)
+
+	return compDur + decDur
+}
+
+func benchmarkCached(cores, cache int) string {
+	key := fmt.Sprintf("%d-%d", cores, cache)
+	benchMu.Lock()
+	if res, ok := benchCache[key]; ok {
+		benchMu.Unlock()
+		return res
+	}
+	benchMu.Unlock()
+
+	res := BenchmarkCompression()
+	benchMu.Lock()
+	benchCache[key] = res
+	benchMu.Unlock()
+	return res
+}
+
 // ResetForTest clears cached detection results; intended for use in tests.
 func ResetForTest() {
 	detectOnce = sync.Once{}
 	detected = ""
+	benchMu.Lock()
+	benchCache = make(map[string]string)
+	benchMu.Unlock()
 }

--- a/transfer/compression_auto_arm64_test.go
+++ b/transfer/compression_auto_arm64_test.go
@@ -29,8 +29,25 @@ func TestNewCompressionWriterAutoARM64(t *testing.T) {
 		w.Close()
 	})
 
+	t.Run("cpu-metrics", func(t *testing.T) {
+		cpuid.CPU = cpuid.CPUInfo{}
+		cpuid.CPU.PhysicalCores = 8
+		cpuid.CPU.Cache.L3 = 8 << 20
+		compressiondetect.ResetForTest()
+		w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
+		if err != nil {
+			t.Fatalf("NewCompressionWriter with cpu metrics: %v", err)
+		}
+		if _, ok := w.(*pooledZstdWriter); !ok {
+			t.Fatalf("expected zstd writer when cores and cache are large")
+		}
+		w.Close()
+	})
+
 	t.Run("fallback", func(t *testing.T) {
 		cpuid.CPU = cpuid.CPUInfo{}
+		cpuid.CPU.PhysicalCores = 1
+		cpuid.CPU.Cache.L3 = 0
 		compressiondetect.ResetForTest()
 		algo := compressiondetect.DetectOptimalCompression()
 		lvl := 1

--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -32,8 +32,25 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 		})
 	}
 
+	t.Run("cpu-metrics", func(t *testing.T) {
+		cpuid.CPU = cpuid.CPUInfo{}
+		cpuid.CPU.PhysicalCores = 8
+		cpuid.CPU.Cache.L3 = 8 << 20
+		compressiondetect.ResetForTest()
+		w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
+		if err != nil {
+			t.Fatalf("NewCompressionWriter with cpu metrics: %v", err)
+		}
+		if _, ok := w.(*pooledZstdWriter); !ok {
+			t.Fatalf("expected zstd writer when cores and cache are large")
+		}
+		w.Close()
+	})
+
 	t.Run("fallback", func(t *testing.T) {
 		cpuid.CPU = cpuid.CPUInfo{}
+		cpuid.CPU.PhysicalCores = 1
+		cpuid.CPU.Cache.L3 = 0
 		compressiondetect.ResetForTest()
 		algo := compressiondetect.DetectOptimalCompression()
 		lvl := 1


### PR DESCRIPTION
## Summary
- gather CPU core and cache metrics when choosing compression
- run both compression and decompression benchmarks and cache results
- extend auto-compression tests to cover new heuristics

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915e8ce0e483239ef8411d57a7e42d