### PR TITLE
Pool LZ4 compression objects

### DIFF
--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -26,6 +26,29 @@ func (noneStrategy) NewReader(src io.Reader, concurrency int) (io.ReadCloser, er
 
 type lz4Strategy struct{}
 
+var (
+	lz4WriterPool sync.Pool
+	lz4ReaderPool sync.Pool
+)
+
+type pooledLz4WriterEntry struct {
+	w           *lz4.Writer
+	level       int
+	concurrency int
+}
+
+type pooledLz4Writer struct {
+	*lz4.Writer
+	entry *pooledLz4WriterEntry
+}
+
+func (w *pooledLz4Writer) Close() error {
+	err := w.Writer.Close()
+	w.Writer.Reset(nil)
+	lz4WriterPool.Put(w.entry)
+	return err
+}
+
 func (lz4Strategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
 	lvl := lz4.CompressionLevel(level)
 	switch lvl {
@@ -34,15 +57,82 @@ func (lz4Strategy) NewWriter(dst io.Writer, level int, concurrency int) (io.Writ
 	default:
 		return nil, fmt.Errorf("invalid lz4 compression level: %d", level)
 	}
-	w := lz4.NewWriter(dst)
-	if err := w.Apply(lz4.CompressionLevelOption(lvl)); err != nil {
-		return nil, fmt.Errorf("failed to apply lz4 compression level: %w", err)
+
+	entryAny := lz4WriterPool.Get()
+	var entry *pooledLz4WriterEntry
+	if entryAny == nil {
+		entry = &pooledLz4WriterEntry{}
+	} else {
+		entry = entryAny.(*pooledLz4WriterEntry)
 	}
-	return w, nil
+
+	if entry.w == nil {
+		entry.w = lz4.NewWriter(dst)
+		if err := entry.w.Apply(lz4.CompressionLevelOption(lvl), lz4.ConcurrencyOption(concurrency)); err != nil {
+			lz4WriterPool.Put(entry)
+			return nil, fmt.Errorf("failed to apply lz4 options: %w", err)
+		}
+		entry.level = level
+		entry.concurrency = concurrency
+	} else {
+		entry.w.Reset(dst)
+		if entry.level != level || entry.concurrency != concurrency {
+			if err := entry.w.Apply(lz4.CompressionLevelOption(lvl), lz4.ConcurrencyOption(concurrency)); err != nil {
+				lz4WriterPool.Put(entry)
+				return nil, fmt.Errorf("failed to apply lz4 options: %w", err)
+			}
+			entry.level = level
+			entry.concurrency = concurrency
+		}
+	}
+
+	return &pooledLz4Writer{Writer: entry.w, entry: entry}, nil
+}
+
+type pooledLz4ReaderEntry struct {
+	r           *lz4.Reader
+	concurrency int
+}
+
+type pooledLz4Reader struct {
+	*lz4.Reader
+	entry *pooledLz4ReaderEntry
+}
+
+func (r *pooledLz4Reader) Close() error {
+	r.Reader.Reset(nil)
+	lz4ReaderPool.Put(r.entry)
+	return nil
 }
 
 func (lz4Strategy) NewReader(src io.Reader, concurrency int) (io.ReadCloser, error) {
-	return io.NopCloser(lz4.NewReader(src)), nil
+	entryAny := lz4ReaderPool.Get()
+	var entry *pooledLz4ReaderEntry
+	if entryAny == nil {
+		entry = &pooledLz4ReaderEntry{}
+	} else {
+		entry = entryAny.(*pooledLz4ReaderEntry)
+	}
+
+	if entry.r == nil {
+		entry.r = lz4.NewReader(src)
+		if err := entry.r.Apply(lz4.ConcurrencyOption(concurrency)); err != nil {
+			lz4ReaderPool.Put(entry)
+			return nil, fmt.Errorf("failed to apply lz4 options: %w", err)
+		}
+		entry.concurrency = concurrency
+	} else {
+		entry.r.Reset(src)
+		if entry.concurrency != concurrency {
+			if err := entry.r.Apply(lz4.ConcurrencyOption(concurrency)); err != nil {
+				lz4ReaderPool.Put(entry)
+				return nil, fmt.Errorf("failed to apply lz4 options: %w", err)
+			}
+			entry.concurrency = concurrency
+		}
+	}
+
+	return &pooledLz4Reader{Reader: entry.r, entry: entry}, nil
 }
 
 type zstdStrategy struct{}

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -110,3 +110,128 @@ func TestNewCompressionWriterLevel(t *testing.T) {
 		}
 	})
 }
+
+func TestLZ4WriterPoolReuse(t *testing.T) {
+	data1 := []byte("first payload")
+	data2 := []byte("second payload")
+
+	var buf bytes.Buffer
+	w1, err := NewCompressionWriter(&buf, compressionLZ4, int(lz4.Level3), 1)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	if _, err := w1.Write(data1); err != nil {
+		t.Fatalf("write1: %v", err)
+	}
+	if err := w1.Close(); err != nil {
+		t.Fatalf("close1: %v", err)
+	}
+
+	pw1 := w1.(*pooledLz4Writer)
+	writerPtr := pw1.Writer
+
+	r1, err := NewDecompressionReader(&buf, compressionLZ4, 1)
+	if err != nil {
+		t.Fatalf("reader1: %v", err)
+	}
+	out1, err := io.ReadAll(r1)
+	if err != nil {
+		t.Fatalf("read1: %v", err)
+	}
+	if err := r1.Close(); err != nil {
+		t.Fatalf("close reader1: %v", err)
+	}
+	if !bytes.Equal(out1, data1) {
+		t.Fatalf("mismatch1")
+	}
+
+	buf.Reset()
+	w2, err := NewCompressionWriter(&buf, compressionLZ4, int(lz4.Level3), 1)
+	if err != nil {
+		t.Fatalf("new writer2: %v", err)
+	}
+	if _, err := w2.Write(data2); err != nil {
+		t.Fatalf("write2: %v", err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatalf("close2: %v", err)
+	}
+
+	pw2 := w2.(*pooledLz4Writer)
+	if pw2.Writer != writerPtr {
+		t.Fatalf("writer was not reused")
+	}
+
+	r2, err := NewDecompressionReader(&buf, compressionLZ4, 1)
+	if err != nil {
+		t.Fatalf("reader2: %v", err)
+	}
+	out2, err := io.ReadAll(r2)
+	if err != nil {
+		t.Fatalf("read2: %v", err)
+	}
+	if err := r2.Close(); err != nil {
+		t.Fatalf("close reader2: %v", err)
+	}
+	if !bytes.Equal(out2, data2) {
+		t.Fatalf("mismatch2")
+	}
+}
+
+func TestLZ4ReaderPoolReuse(t *testing.T) {
+	data1 := []byte("alpha")
+	data2 := []byte("beta")
+
+	compress := func(data []byte) []byte {
+		var b bytes.Buffer
+		w, err := NewCompressionWriter(&b, compressionLZ4, int(lz4.Level3), 1)
+		if err != nil {
+			t.Fatalf("compress writer: %v", err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("compress write: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("compress close: %v", err)
+		}
+		return b.Bytes()
+	}
+
+	buf1 := bytes.NewBuffer(compress(data1))
+	r1, err := NewDecompressionReader(buf1, compressionLZ4, 1)
+	if err != nil {
+		t.Fatalf("new reader1: %v", err)
+	}
+	out1, err := io.ReadAll(r1)
+	if err != nil {
+		t.Fatalf("read1: %v", err)
+	}
+	if err := r1.Close(); err != nil {
+		t.Fatalf("close1: %v", err)
+	}
+	if !bytes.Equal(out1, data1) {
+		t.Fatalf("mismatch1")
+	}
+
+	pr1 := r1.(*pooledLz4Reader)
+	readerPtr := pr1.Reader
+
+	buf2 := bytes.NewBuffer(compress(data2))
+	r2, err := NewDecompressionReader(buf2, compressionLZ4, 1)
+	if err != nil {
+		t.Fatalf("new reader2: %v", err)
+	}
+	if r2.(*pooledLz4Reader).Reader != readerPtr {
+		t.Fatalf("reader was not reused")
+	}
+	out2, err := io.ReadAll(r2)
+	if err != nil {
+		t.Fatalf("read2: %v", err)
+	}
+	if err := r2.Close(); err != nil {
+		t.Fatalf("close2: %v", err)
+	}
+	if !bytes.Equal(out2, data2) {
+		t.Fatalf("mismatch2")
+	}
+}


### PR DESCRIPTION
## Summary
- pool LZ4 writers and readers with sync.Pool
- ensure pooled LZ4 objects reset on close
- add tests verifying LZ4 pooling correctness

## Testing
- `go test ./transfer -run LZ4 -count=1 -v`
- `go test ./transfer -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6891605731e88323aaa82e4c558ea8a2