### PR TITLE
refactor: swap CLI strings for lvm2 backend

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,17 @@ import (
 	"lvmsync_go/lvm"
 )
 
+type fakeBackend struct {
+	free uint64
+	err  error
+}
+
+func (f *fakeBackend) CreateSnapshot(string, string, string) error    { return nil }
+func (f *fakeBackend) RemoveSnapshot(string) error                    { return nil }
+func (f *fakeBackend) GetSnapshotUsage(string) (float64, error)       { return 0, nil }
+func (f *fakeBackend) GetVolumeGroupFreeSpace(string) (uint64, error) { return f.free, f.err }
+func (f *fakeBackend) ListVolumeGroups() ([]lvm.VolumeGroup, error)   { return nil, nil }
+
 func TestDefaultConfigCompress(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg.Compress != "auto" {
@@ -78,9 +89,8 @@ func TestParseBytesOrFallback(t *testing.T) {
 
 func TestConfigValidate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		restore := lvm.SetRunLVMCommand(func(name string, args ...string) ([]byte, error) {
-			return []byte("100B\n"), nil
-		})
+		fb := &fakeBackend{free: 100}
+		restore := lvm.SetBackend(fb)
 		defer restore()
 		prev := lvm.GetEscalationCommand()
 		lvm.SetEscalationCommand("sudo")
@@ -92,9 +102,8 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		restore := lvm.SetRunLVMCommand(func(name string, args ...string) ([]byte, error) {
-			return nil, fmt.Errorf("command error")
-		})
+		fb := &fakeBackend{err: fmt.Errorf("command error")}
+		restore := lvm.SetBackend(fb)
 		defer restore()
 		prev := lvm.GetEscalationCommand()
 		lvm.SetEscalationCommand("sudo")

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.5
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
+	github.com/dpeckett/lvm2 v0.3.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/cpuid/v2 v2.2.7
@@ -18,6 +19,8 @@ require (
 
 require (
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
+	github.com/dpeckett/args v0.3.0 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,14 @@ github.com/bits-and-blooms/bloom/v3 v3.7.0 h1:VfknkqV4xI+PsaDIsoHueyxVDZrfvMn56j
 github.com/bits-and-blooms/bloom/v3 v3.7.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iHb1kOL2tfHTgyJBHg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dpeckett/args v0.3.0 h1:I3x1Fx/jou0QvApqvnqd5ZG2Z6Sw0W20t6bdJHgD93g=
+github.com/dpeckett/args v0.3.0/go.mod h1:lLJRsQR/vUhmhhFFn8LbsxaRNZTu/JaLwCvrEp9Gauw=
+github.com/dpeckett/lvm2 v0.3.1 h1:0LPHu1Yb+1oY7iDllJP0phxMg7sDXLvrzy9vDfEvU6w=
+github.com/dpeckett/lvm2 v0.3.1/go.mod h1:UReDUQm29dv1BdadQmph9dXCwtNV2L1AFJmtJ70htUU=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -1,0 +1,104 @@
+package lvm
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/dpeckett/lvm2"
+)
+
+type lvmBackend interface {
+	CreateSnapshot(lvPath, snapshotName, size string) error
+	RemoveSnapshot(snapshotPath string) error
+	GetSnapshotUsage(snapshotPath string) (float64, error)
+	GetVolumeGroupFreeSpace(vgName string) (uint64, error)
+	ListVolumeGroups() ([]VolumeGroup, error)
+}
+
+type lvm2Backend struct {
+	client *lvm2.Client
+}
+
+func newLVMBackend() lvmBackend {
+	return &lvm2Backend{client: lvm2.NewClient()}
+}
+
+func (b *lvm2Backend) CreateSnapshot(lvPath, snapshotName, size string) error {
+	ctx := context.Background()
+	opts := lvm2.CreateLVOptions{
+		Name:     snapshotName,
+		VGName:   lvPath,
+		Size:     size,
+		Snapshot: true,
+	}
+	return b.client.CreateLogicalVolume(ctx, opts)
+}
+
+func (b *lvm2Backend) RemoveSnapshot(snapshotPath string) error {
+	ctx := context.Background()
+	opts := lvm2.RemoveLVOptions{
+		Name:  snapshotPath,
+		Force: true,
+	}
+	return b.client.RemoveLogicalVolume(ctx, opts)
+}
+
+func (b *lvm2Backend) GetSnapshotUsage(snapshotPath string) (float64, error) {
+	ctx := context.Background()
+	lvs, err := b.client.ListLogicalVolumes(ctx, &lvm2.ListLVOptions{
+		Names: []string{snapshotPath},
+	})
+	if err != nil {
+		return 0, err
+	}
+	if len(lvs) == 0 {
+		return 0, fmt.Errorf("snapshot %s not found", snapshotPath)
+	}
+	usageStr := strings.TrimSpace(lvs[0].DataPercent)
+	usage, err := strconv.ParseFloat(usageStr, 64)
+	if err != nil {
+		return 0, err
+	}
+	return usage, nil
+}
+
+func (b *lvm2Backend) GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
+	ctx := context.Background()
+	vgs, err := b.client.ListVolumeGroups(ctx, &lvm2.ListVGOptions{
+		Names: []string{vgName},
+	})
+	if err != nil {
+		return 0, err
+	}
+	if len(vgs) == 0 {
+		return 0, fmt.Errorf("volume group %s not found", vgName)
+	}
+	freeStr := strings.TrimSpace(vgs[0].Free)
+	freeStr = strings.TrimSuffix(freeStr, "B")
+	free, err := strconv.ParseUint(freeStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return free, nil
+}
+
+func (b *lvm2Backend) ListVolumeGroups() ([]VolumeGroup, error) {
+	ctx := context.Background()
+	vgs, err := b.client.ListVolumeGroups(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	res := make([]VolumeGroup, 0, len(vgs))
+	for _, vg := range vgs {
+		freeStr := strings.TrimSpace(vg.Free)
+		freeStr = strings.TrimSuffix(freeStr, "B")
+		free, err := strconv.ParseUint(freeStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, VolumeGroup{Name: vg.Name, Free: free})
+	}
+	return res, nil
+}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -1,18 +1,7 @@
 // lvm/lvm.go
 package lvm
 
-/*
-#cgo LDFLAGS: -llvm2cmd
-#include <stdlib.h>
-#include <lvm2cmd.h>
-
-extern void goLvmLog(int level, char *file, int line, int dm_errno, char *msg);
-static inline void setLvmLog() { lvm2_log_fn((lvm2_log_fn_t)goLvmLog); }
-*/
-import "C"
-
 import (
-	"bytes"
 	"container/list"
 	"fmt"
 	"os"
@@ -124,65 +113,18 @@ func (c *fdCache) Close() {
 	c.order.Init()
 }
 
-var (
-	lvmHandle     = C.lvm2_init()
-	cmdMutex      sync.Mutex
-	logBuffer     *bytes.Buffer
-	runLVMCommand = realRunLVMCommand
-)
+// backend is used to execute LVM operations. It can be overridden for tests.
+var backend lvmBackend = newLVMBackend()
 
-// SetRunLVMCommand overrides the function used to execute LVM commands.
-// It returns a restore function to reset the original behavior.
-func SetRunLVMCommand(f func(string, ...string) ([]byte, error)) func() {
-	orig := runLVMCommand
-	if f == nil {
-		runLVMCommand = realRunLVMCommand
+// SetBackend overrides the LVM backend. It returns a restore function to reset the original behavior.
+func SetBackend(b lvmBackend) func() {
+	orig := backend
+	if b == nil {
+		backend = newLVMBackend()
 	} else {
-		runLVMCommand = f
+		backend = b
 	}
-	return func() { runLVMCommand = orig }
-}
-
-func init() {
-	C.setLvmLog()
-	C.lvm2_log_level(lvmHandle, C.LVM2_LOG_DEBUG)
-}
-
-//export goLvmLog
-func goLvmLog(level C.int, file *C.char, line C.int, dm_errno C.int, msg *C.char) {
-	cmdMutex.Lock()
-	if logBuffer != nil {
-		logBuffer.WriteString(C.GoString(msg))
-		logBuffer.WriteByte('\n')
-	}
-	cmdMutex.Unlock()
-}
-
-func realRunLVMCommand(name string, args ...string) ([]byte, error) {
-	cmdMutex.Lock()
-	defer cmdMutex.Unlock()
-
-	logBuffer = &bytes.Buffer{}
-	var b strings.Builder
-	b.WriteString(name)
-	for _, a := range args {
-		b.WriteByte(' ')
-		if strings.ContainsAny(a, " \t\n\"") {
-			b.WriteString(strconv.Quote(a))
-		} else {
-			b.WriteString(a)
-		}
-	}
-	ccmd := C.CString(b.String())
-	defer C.free(unsafe.Pointer(ccmd))
-
-	ret := C.lvm2_run(lvmHandle, ccmd)
-	out := logBuffer.Bytes()
-	logBuffer = nil
-	if ret != C.LVM2_COMMAND_SUCCEEDED {
-		return out, fmt.Errorf("lvm command failed: %s", strings.TrimSpace(string(out)))
-	}
-	return out, nil
+	return func() { backend = orig }
 }
 
 func CreateSnapshot(lvPath, snapshotName, size string) error {
@@ -194,8 +136,7 @@ func CreateSnapshot(lvPath, snapshotName, size string) error {
 		return fmt.Errorf("invalid parameters: lvPath, snapshotName, and size must be non-empty")
 	}
 
-	output, err := runLVMCommand("lvcreate", "-s", "-n", snapshotName, "-L", size, lvPath)
-	if err != nil {
+	if err := backend.CreateSnapshot(lvPath, snapshotName, size); err != nil {
 		return fmt.Errorf("failed to create snapshot [%s] for LV %s with size %s: %w",
 			snapshotName, lvPath, size, err)
 	}
@@ -203,8 +144,7 @@ func CreateSnapshot(lvPath, snapshotName, size string) error {
 	zap.L().Info("Snapshot created successfully",
 		zap.String("lv_path", lvPath),
 		zap.String("snapshot_name", snapshotName),
-		zap.String("size", size),
-		zap.String("output", string(output)))
+		zap.String("size", size))
 
 	return nil
 }
@@ -218,14 +158,12 @@ func RemoveSnapshot(snapshotPath string) error {
 		return fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
 
-	output, err := runLVMCommand("lvremove", "-f", snapshotPath)
-	if err != nil {
+	if err := backend.RemoveSnapshot(snapshotPath); err != nil {
 		return fmt.Errorf("failed to remove snapshot [%s]: %w", snapshotPath, err)
 	}
 
 	zap.L().Info("Snapshot removed successfully",
-		zap.String("snapshot_path", snapshotPath),
-		zap.String("output", string(output)))
+		zap.String("snapshot_path", snapshotPath))
 
 	return nil
 }
@@ -239,16 +177,9 @@ func GetSnapshotUsage(snapshotPath string) (float64, error) {
 		return 0, fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
 
-	output, err := runLVMCommand("lvs", "--noheadings", "--units", "b",
-		"--options", "data_percent", snapshotPath)
+	usage, err := backend.GetSnapshotUsage(snapshotPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get snapshot usage for %s: %w", snapshotPath, err)
-	}
-
-	usageStr := strings.TrimSpace(string(output))
-	usage, err := strconv.ParseFloat(usageStr, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse snapshot usage %q: %w", usageStr, err)
 	}
 
 	zap.L().Info("Snapshot usage retrieved",
@@ -412,21 +343,10 @@ func GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
 		return 0, err
 	}
 
-	output, err := runLVMCommand("vgs", "--noheadings", "--units", "b",
-		"--options", "vg_free", vgName)
+	size, err := backend.GetVolumeGroupFreeSpace(vgName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get free space for VG %s: %w", vgName, err)
 	}
-
-	sizeStr := strings.TrimSpace(string(output))
-	sizeStr = strings.TrimSuffix(sizeStr, "B")
-	sizeStr = strings.TrimSpace(sizeStr)
-
-	size, err := strconv.ParseUint(sizeStr, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse VG free space %q: %w", sizeStr, err)
-	}
-
 	return size, nil
 }
 
@@ -442,29 +362,9 @@ func ListVolumeGroups() ([]VolumeGroup, error) {
 		return nil, err
 	}
 
-	output, err := runLVMCommand("vgs", "--noheadings", "--units", "b",
-		"--options", "vg_name,vg_free", "--separator", ":")
+	vgs, err := backend.ListVolumeGroups()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list volume groups: %w", err)
-	}
-
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	vgs := make([]VolumeGroup, 0, len(lines))
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		parts := strings.Split(line, ":")
-		if len(parts) != 2 {
-			continue
-		}
-		name := strings.TrimSpace(parts[0])
-		freeStr := strings.TrimSuffix(strings.TrimSpace(parts[1]), "B")
-		free, err := strconv.ParseUint(freeStr, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse VG free space %q: %w", freeStr, err)
-		}
-		vgs = append(vgs, VolumeGroup{Name: name, Free: free})
 	}
 	return vgs, nil
 }

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -3,9 +3,24 @@ package lvm
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 )
+
+type mockBackend struct{ calls []string }
+
+func (f *mockBackend) CreateSnapshot(lvPath, snapName, size string) error {
+	f.calls = append(f.calls, fmt.Sprintf("create:%s:%s:%s", lvPath, snapName, size))
+	return nil
+}
+
+func (f *mockBackend) RemoveSnapshot(path string) error {
+	f.calls = append(f.calls, fmt.Sprintf("remove:%s", path))
+	return nil
+}
+
+func (f *mockBackend) GetSnapshotUsage(string) (float64, error)       { return 0, nil }
+func (f *mockBackend) GetVolumeGroupFreeSpace(string) (uint64, error) { return 0, nil }
+func (f *mockBackend) ListVolumeGroups() ([]VolumeGroup, error)       { return nil, nil }
 
 func init() {
 	SetEscalationCommand("")
@@ -16,13 +31,9 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	var cmds []string
-	origRun := runLVMCommand
-	runLVMCommand = func(name string, args ...string) ([]byte, error) {
-		cmds = append(cmds, strings.Join(append([]string{name}, args...), " "))
-		return []byte(""), nil
-	}
-	t.Cleanup(func() { runLVMCommand = origRun })
+	fb := &mockBackend{}
+	restore := SetBackend(fb)
+	t.Cleanup(restore)
 
 	lvPath := "/dev/vg0/origin"
 	snapName := "snap"
@@ -36,14 +47,14 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 		t.Fatalf("RemoveSnapshot failed: %v", err)
 	}
 
-	if len(cmds) != 2 {
-		t.Fatalf("expected 2 commands, got %d", len(cmds))
+	if len(fb.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(fb.calls))
 	}
-	if cmds[0] != fmt.Sprintf("lvcreate -s -n %s -L %s %s", snapName, size, lvPath) {
-		t.Fatalf("lvcreate args = %q", cmds[0])
+	if fb.calls[0] != fmt.Sprintf("create:%s:%s:%s", lvPath, snapName, size) {
+		t.Fatalf("unexpected create call %q", fb.calls[0])
 	}
-	if cmds[1] != fmt.Sprintf("lvremove -f %s", snapPath) {
-		t.Fatalf("lvremove args = %q", cmds[1])
+	if fb.calls[1] != fmt.Sprintf("remove:%s", snapPath) {
+		t.Fatalf("unexpected remove call %q", fb.calls[1])
 	}
 }
 

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -6,6 +6,16 @@ import (
 	"time"
 )
 
+type usageBackend struct {
+	usage float64
+}
+
+func (f *usageBackend) CreateSnapshot(string, string, string) error    { return nil }
+func (f *usageBackend) RemoveSnapshot(string) error                    { return nil }
+func (f *usageBackend) GetSnapshotUsage(string) (float64, error)       { return f.usage, nil }
+func (f *usageBackend) GetVolumeGroupFreeSpace(string) (uint64, error) { return 0, nil }
+func (f *usageBackend) ListVolumeGroups() ([]VolumeGroup, error)       { return nil, nil }
+
 func init() {
 	SetEscalationCommand("")
 }
@@ -15,11 +25,9 @@ func TestGetSnapshotUsage(t *testing.T) {
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	origRun := runLVMCommand
-	runLVMCommand = func(name string, args ...string) ([]byte, error) {
-		return []byte("75.5\n"), nil
-	}
-	t.Cleanup(func() { runLVMCommand = origRun })
+	fb := &usageBackend{usage: 75.5}
+	restore := SetBackend(fb)
+	t.Cleanup(restore)
 
 	usage, err := GetSnapshotUsage("/dev/vg0/snap")
 	if err != nil {
@@ -35,11 +43,9 @@ func TestMonitorSnapshot(t *testing.T) {
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	origRun := runLVMCommand
-	runLVMCommand = func(name string, args ...string) ([]byte, error) {
-		return []byte("90\n"), nil
-	}
-	t.Cleanup(func() { runLVMCommand = origRun })
+	fb := &usageBackend{usage: 90}
+	restore := SetBackend(fb)
+	t.Cleanup(restore)
 
 	err := MonitorSnapshot("/dev/vg0/snap", 80, 10*time.Millisecond, make(chan struct{}))
 	if err == nil {

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -5,16 +5,29 @@ import (
 	"testing"
 )
 
+type vgBackend struct {
+	vgs []VolumeGroup
+}
+
+func (f *vgBackend) CreateSnapshot(string, string, string) error { return nil }
+func (f *vgBackend) RemoveSnapshot(string) error                 { return nil }
+func (f *vgBackend) GetSnapshotUsage(string) (float64, error)    { return 0, nil }
+func (f *vgBackend) GetVolumeGroupFreeSpace(name string) (uint64, error) {
+	for _, vg := range f.vgs {
+		if vg.Name == name {
+			return vg.Free, nil
+		}
+	}
+	return 0, fmt.Errorf("unknown vg")
+}
+func (f *vgBackend) ListVolumeGroups() ([]VolumeGroup, error) { return f.vgs, nil }
+
 func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 	orig := checkPrivs
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
-	restore := SetRunLVMCommand(func(name string, args ...string) ([]byte, error) {
-		if name != "vgs" {
-			return nil, fmt.Errorf("unexpected command %s", name)
-		}
-		return []byte("vg0:100B\nvg1:200B\n"), nil
-	})
+	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
+	restore := SetBackend(fb)
 	defer restore()
 
 	vg, free, err := SelectVolumeGroupByFreeSpace(nil)


### PR DESCRIPTION
## Summary
- replace low-level cgo use with github.com/dpeckett/lvm2 client
- implement backend with helpers for snapshots and volume groups
- adapt tests to mock the new backend

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891cb75a67c8323891c8d0d3b32bd26