### PR TITLE
Use structured volume group info

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -294,18 +294,18 @@ func LoadConfig() (*Config, error) {
 	}
 
 	if conf.VolumeGroup == "" {
-		vg, _, err := lvm.SelectVolumeGroupByFreeSpace(conf.SourceVGCandidates)
+		vg, err := lvm.SelectVolumeGroupByFreeSpace(conf.SourceVGCandidates)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select source volume group: %w", err)
 		}
-		conf.VolumeGroup = vg
+		conf.VolumeGroup = vg.Name
 	}
 	if conf.TargetVolumeGroup == "" && len(conf.TargetVGCandidates) > 0 {
-		vg, _, err := lvm.SelectVolumeGroupByFreeSpace(conf.TargetVGCandidates)
+		vg, err := lvm.SelectVolumeGroupByFreeSpace(conf.TargetVGCandidates)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select target volume group: %w", err)
 		}
-		conf.TargetVolumeGroup = vg
+		conf.TargetVolumeGroup = vg.Name
 	}
 
 	return conf, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,13 +14,14 @@ import (
 type fakeBackend struct {
 	free uint64
 	err  error
+	vgs  []lvm.VolumeGroup
 }
 
 func (f *fakeBackend) CreateSnapshot(string, string, string) error    { return nil }
 func (f *fakeBackend) RemoveSnapshot(string) error                    { return nil }
 func (f *fakeBackend) GetSnapshotUsage(string) (float64, error)       { return 0, nil }
 func (f *fakeBackend) GetVolumeGroupFreeSpace(string) (uint64, error) { return f.free, f.err }
-func (f *fakeBackend) ListVolumeGroups() ([]lvm.VolumeGroup, error)   { return nil, nil }
+func (f *fakeBackend) ListVolumeGroups() ([]lvm.VolumeGroup, error)   { return f.vgs, nil }
 
 func TestDefaultConfigCompress(t *testing.T) {
 	cfg := DefaultConfig()

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -371,10 +371,10 @@ func ListVolumeGroups() ([]VolumeGroup, error) {
 
 // SelectVolumeGroupByFreeSpace chooses the volume group with the most free space.
 // If candidates is non-empty, only those volume groups are considered.
-func SelectVolumeGroupByFreeSpace(candidates []string) (string, uint64, error) {
+func SelectVolumeGroupByFreeSpace(candidates []string) (VolumeGroup, error) {
 	vgs, err := ListVolumeGroups()
 	if err != nil {
-		return "", 0, err
+		return VolumeGroup{}, err
 	}
 
 	candidateSet := make(map[string]struct{}, len(candidates))
@@ -382,24 +382,26 @@ func SelectVolumeGroupByFreeSpace(candidates []string) (string, uint64, error) {
 		candidateSet[c] = struct{}{}
 	}
 
-	var chosen VolumeGroup
+	var chosen *VolumeGroup
 	for _, vg := range vgs {
 		if len(candidateSet) > 0 {
 			if _, ok := candidateSet[vg.Name]; !ok {
 				continue
 			}
 		}
-		if vg.Free > chosen.Free {
-			chosen = vg
+		if chosen == nil || vg.Free > chosen.Free {
+			// create copy to avoid referencing loop variable
+			v := vg
+			chosen = &v
 		}
 	}
-	if chosen.Name == "" {
+	if chosen == nil {
 		if len(candidateSet) > 0 {
-			return "", 0, fmt.Errorf("no matching volume group found")
+			return VolumeGroup{}, fmt.Errorf("no matching volume group found")
 		}
-		return "", 0, fmt.Errorf("no volume groups found")
+		return VolumeGroup{}, fmt.Errorf("no volume groups found")
 	}
-	return chosen.Name, chosen.Free, nil
+	return *chosen, nil
 }
 
 func Cleanup() {

--- a/lvm/lvm_arm64_stub.go
+++ b/lvm/lvm_arm64_stub.go
@@ -2,10 +2,10 @@
 
 package lvm
 
-func SelectVolumeGroupByFreeSpace(_ []string) (string, int, error) {
-	return "", 0, nil
+func SelectVolumeGroupByFreeSpace(_ []string) (VolumeGroup, error) {
+	return VolumeGroup{}, nil
 }
 
-func GetVolumeGroupFreeSpace(_ string) (int, error) {
+func GetVolumeGroupFreeSpace(_ string) (uint64, error) {
 	return 0, nil
 }

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -30,23 +30,23 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 	restore := SetBackend(fb)
 	defer restore()
 
-	vg, free, err := SelectVolumeGroupByFreeSpace(nil)
+	vg, err := SelectVolumeGroupByFreeSpace(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if vg != "vg1" || free != 200 {
-		t.Fatalf("expected vg1 with 200, got %s with %d", vg, free)
+	if vg.Name != "vg1" || vg.Free != 200 {
+		t.Fatalf("expected vg1 with 200, got %s with %d", vg.Name, vg.Free)
 	}
 
-	vg, free, err = SelectVolumeGroupByFreeSpace([]string{"vg0"})
+	vg, err = SelectVolumeGroupByFreeSpace([]string{"vg0"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if vg != "vg0" || free != 100 {
-		t.Fatalf("expected vg0 with 100, got %s with %d", vg, free)
+	if vg.Name != "vg0" || vg.Free != 100 {
+		t.Fatalf("expected vg0 with 100, got %s with %d", vg.Name, vg.Free)
 	}
 
-	if _, _, err := SelectVolumeGroupByFreeSpace([]string{"vg2"}); err == nil {
+	if _, err := SelectVolumeGroupByFreeSpace([]string{"vg2"}); err == nil {
 		t.Fatalf("expected error for unknown vg")
 	}
 }


### PR DESCRIPTION
## Summary
- Return strongly typed `VolumeGroup` from `SelectVolumeGroupByFreeSpace`
- Wire config selection to consume `VolumeGroup` structs
- Adjust tests and stubs for new volume group API usage

## Testing
- `go test ./... 2>&1 | tee /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6891ceaf60d48323aadf5cd42021cbe3