### PR TITLE
Add privileged escalation support for LVM backend

### DIFF
--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -3,6 +3,7 @@ package lvm
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -22,7 +23,39 @@ type lvm2Backend struct {
 }
 
 func newLVMBackend() lvmBackend {
-	return &lvm2Backend{client: lvm2.NewClient()}
+	esc := GetEscalationCommand()
+	if esc == "" {
+		return &lvm2Backend{client: lvm2.NewClient()}
+	}
+
+	parts := strings.Fields(esc)
+	if len(parts) == 0 {
+		return &lvm2Backend{client: lvm2.NewClient()}
+	}
+
+	tmp, err := os.CreateTemp("", "lvmsync_lvm_wrapper_*")
+	if err != nil {
+		return &lvm2Backend{client: lvm2.NewClient()}
+	}
+	wrapperPath := tmp.Name()
+
+	args := strings.Join(parts[1:], " ")
+	if args != "" {
+		args = " " + args
+	}
+	script := fmt.Sprintf("#!/bin/sh\nexec %s%s lvm \"$@\"\n", parts[0], args)
+	if _, err := tmp.WriteString(script); err != nil {
+		tmp.Close()
+		os.Remove(wrapperPath)
+		return &lvm2Backend{client: lvm2.NewClient()}
+	}
+	tmp.Close()
+	if err := os.Chmod(wrapperPath, 0700); err != nil {
+		os.Remove(wrapperPath)
+		return &lvm2Backend{client: lvm2.NewClient()}
+	}
+
+	return &lvm2Backend{client: lvm2.NewClient(lvm2.WithLVM(wrapperPath))}
 }
 
 func (b *lvm2Backend) CreateSnapshot(lvPath, snapshotName, size string) error {

--- a/lvm/backend_test.go
+++ b/lvm/backend_test.go
@@ -1,0 +1,47 @@
+package lvm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateSnapshotWithEscalationNonRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "args")
+	script := filepath.Join(tmpDir, "esc.sh")
+	content := fmt.Sprintf("#!/bin/sh\nprintf '%%s %%s' \"$1\" \"$2\" > %s\n", argsFile)
+	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
+		t.Fatalf("failed to create script: %v", err)
+	}
+
+	t.Cleanup(func() {
+		SetEscalationCommand("")
+	})
+
+	SetEscalationCommand(script)
+	restore := SetBackend(nil)
+	t.Cleanup(restore)
+
+	orig := checkPrivs
+	checkPrivs = func() error {
+		if GetEscalationCommand() == "" {
+			return fmt.Errorf("privileges required")
+		}
+		return nil
+	}
+	t.Cleanup(func() { checkPrivs = orig })
+
+	if err := CreateSnapshot("/dev/vg0/origin", "snap", "1G"); err != nil {
+		t.Fatalf("CreateSnapshot failed: %v", err)
+	}
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read args file: %v", err)
+	}
+	if string(data) != "lvm lvcreate" {
+		t.Fatalf("unexpected args %q", string(data))
+	}
+}


### PR DESCRIPTION
## Summary
- Allow specifying an escalation command for LVM operations by wrapping the command to invoke `lvm`
- Add test verifying snapshot creation works for non-root users with escalation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891d98b4d288323a08ef3e056d74ccc