### PR TITLE
refactor: centralize escalation wrapper

### DIFF
--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -23,39 +23,50 @@ type lvm2Backend struct {
 }
 
 func newLVMBackend() lvmBackend {
-	esc := GetEscalationCommand()
-	if esc == "" {
+	escCmd := GetEscalationCommand()
+	if escCmd == "" {
 		return &lvm2Backend{client: lvm2.NewClient()}
 	}
 
-	parts := strings.Fields(esc)
+	parts := strings.Fields(escCmd)
 	if len(parts) == 0 {
 		return &lvm2Backend{client: lvm2.NewClient()}
 	}
 
-	tmp, err := os.CreateTemp("", "lvmsync_lvm_wrapper_*")
+	wrapperPath, err := buildEscalationWrapper(parts[0], parts[1:])
 	if err != nil {
-		return &lvm2Backend{client: lvm2.NewClient()}
-	}
-	wrapperPath := tmp.Name()
-
-	args := strings.Join(parts[1:], " ")
-	if args != "" {
-		args = " " + args
-	}
-	script := fmt.Sprintf("#!/bin/sh\nexec %s%s lvm \"$@\"\n", parts[0], args)
-	if _, err := tmp.WriteString(script); err != nil {
-		tmp.Close()
-		os.Remove(wrapperPath)
-		return &lvm2Backend{client: lvm2.NewClient()}
-	}
-	tmp.Close()
-	if err := os.Chmod(wrapperPath, 0700); err != nil {
-		os.Remove(wrapperPath)
 		return &lvm2Backend{client: lvm2.NewClient()}
 	}
 
 	return &lvm2Backend{client: lvm2.NewClient(lvm2.WithLVM(wrapperPath))}
+}
+
+func buildEscalationWrapper(bin string, args []string) (string, error) {
+	tmp, err := os.CreateTemp("", "lvmsync_lvm_wrapper_*")
+	if err != nil {
+		return "", err
+	}
+	wrapperPath := tmp.Name()
+
+	argStr := strings.Join(args, " ")
+	if argStr != "" {
+		argStr = " " + argStr
+	}
+	script := fmt.Sprintf("#!/bin/sh\nexec %s%s lvm \"$@\"\n", bin, argStr)
+	if _, err := tmp.WriteString(script); err != nil {
+		tmp.Close()
+		os.Remove(wrapperPath)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(wrapperPath)
+		return "", err
+	}
+	if err := os.Chmod(wrapperPath, 0700); err != nil {
+		os.Remove(wrapperPath)
+		return "", err
+	}
+	return wrapperPath, nil
 }
 
 func (b *lvm2Backend) CreateSnapshot(lvPath, snapshotName, size string) error {

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -61,11 +61,7 @@ func GetEscalationCommand() string {
 }
 
 func checkRootPrivileges() error {
-	escalationCommandLock.RLock()
-	escCmd := escalationCommand
-	escalationCommandLock.RUnlock()
-
-	if os.Geteuid() != 0 && escCmd == "" {
+	if os.Geteuid() != 0 && GetEscalationCommand() == "" {
 		return fmt.Errorf("insufficient privileges: LVM operations require root privileges")
 	}
 	return nil


### PR DESCRIPTION
## Summary
- create helper to build escalation wrapper for `lvm` and use it when an escalation command is configured
- simplify root privilege check to rely on `GetEscalationCommand`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891dcf9631883239ed593c3c7b58105