### PR TITLE
Introduce context-aware LVM operations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -294,14 +295,14 @@ func LoadConfig() (*Config, error) {
 	}
 
 	if conf.VolumeGroup == "" {
-		vg, err := lvm.SelectVolumeGroupByFreeSpace(conf.SourceVGCandidates)
+		vg, err := lvm.SelectVolumeGroupByFreeSpace(context.Background(), conf.SourceVGCandidates)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select source volume group: %w", err)
 		}
 		conf.VolumeGroup = vg.Name
 	}
 	if conf.TargetVolumeGroup == "" && len(conf.TargetVGCandidates) > 0 {
-		vg, err := lvm.SelectVolumeGroupByFreeSpace(conf.TargetVGCandidates)
+		vg, err := lvm.SelectVolumeGroupByFreeSpace(context.Background(), conf.TargetVGCandidates)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select target volume group: %w", err)
 		}
@@ -312,12 +313,12 @@ func LoadConfig() (*Config, error) {
 }
 func (c *Config) Validate() error {
 	if c.VolumeGroup != "" {
-		if _, err := lvm.GetVolumeGroupFreeSpace(c.VolumeGroup); err != nil {
+		if _, err := lvm.GetVolumeGroupFreeSpace(context.Background(), c.VolumeGroup); err != nil {
 			return fmt.Errorf("volume group %q does not exist or is inaccessible: %w", c.VolumeGroup, err)
 		}
 	}
 	if c.TargetVolumeGroup != "" {
-		if _, err := lvm.GetVolumeGroupFreeSpace(c.TargetVolumeGroup); err != nil {
+		if _, err := lvm.GetVolumeGroupFreeSpace(context.Background(), c.TargetVolumeGroup); err != nil {
 			return fmt.Errorf("target volume group %q does not exist or is inaccessible: %w", c.TargetVolumeGroup, err)
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -17,11 +18,13 @@ type fakeBackend struct {
 	vgs  []lvm.VolumeGroup
 }
 
-func (f *fakeBackend) CreateSnapshot(string, string, string) error    { return nil }
-func (f *fakeBackend) RemoveSnapshot(string) error                    { return nil }
-func (f *fakeBackend) GetSnapshotUsage(string) (float64, error)       { return 0, nil }
-func (f *fakeBackend) GetVolumeGroupFreeSpace(string) (uint64, error) { return f.free, f.err }
-func (f *fakeBackend) ListVolumeGroups() ([]lvm.VolumeGroup, error)   { return f.vgs, nil }
+func (f *fakeBackend) CreateSnapshot(context.Context, string, string, string) error { return nil }
+func (f *fakeBackend) RemoveSnapshot(context.Context, string) error                 { return nil }
+func (f *fakeBackend) GetSnapshotUsage(context.Context, string) (float64, error)    { return 0, nil }
+func (f *fakeBackend) GetVolumeGroupFreeSpace(context.Context, string) (uint64, error) {
+	return f.free, f.err
+}
+func (f *fakeBackend) ListVolumeGroups(context.Context) ([]lvm.VolumeGroup, error) { return f.vgs, nil }
 
 func TestDefaultConfigCompress(t *testing.T) {
 	cfg := DefaultConfig()

--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -11,11 +11,11 @@ import (
 )
 
 type lvmBackend interface {
-	CreateSnapshot(lvPath, snapshotName, size string) error
-	RemoveSnapshot(snapshotPath string) error
-	GetSnapshotUsage(snapshotPath string) (float64, error)
-	GetVolumeGroupFreeSpace(vgName string) (uint64, error)
-	ListVolumeGroups() ([]VolumeGroup, error)
+	CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error
+	RemoveSnapshot(ctx context.Context, snapshotPath string) error
+	GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error)
+	GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error)
+	ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error)
 }
 
 type lvm2Backend struct {
@@ -69,8 +69,7 @@ func buildEscalationWrapper(bin string, args []string) (string, error) {
 	return wrapperPath, nil
 }
 
-func (b *lvm2Backend) CreateSnapshot(lvPath, snapshotName, size string) error {
-	ctx := context.Background()
+func (b *lvm2Backend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
 	opts := lvm2.CreateLVOptions{
 		Name:     snapshotName,
 		VGName:   lvPath,
@@ -80,8 +79,7 @@ func (b *lvm2Backend) CreateSnapshot(lvPath, snapshotName, size string) error {
 	return b.client.CreateLogicalVolume(ctx, opts)
 }
 
-func (b *lvm2Backend) RemoveSnapshot(snapshotPath string) error {
-	ctx := context.Background()
+func (b *lvm2Backend) RemoveSnapshot(ctx context.Context, snapshotPath string) error {
 	opts := lvm2.RemoveLVOptions{
 		Name:  snapshotPath,
 		Force: true,
@@ -89,8 +87,7 @@ func (b *lvm2Backend) RemoveSnapshot(snapshotPath string) error {
 	return b.client.RemoveLogicalVolume(ctx, opts)
 }
 
-func (b *lvm2Backend) GetSnapshotUsage(snapshotPath string) (float64, error) {
-	ctx := context.Background()
+func (b *lvm2Backend) GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
 	lvs, err := b.client.ListLogicalVolumes(ctx, &lvm2.ListLVOptions{
 		Names: []string{snapshotPath},
 	})
@@ -108,8 +105,7 @@ func (b *lvm2Backend) GetSnapshotUsage(snapshotPath string) (float64, error) {
 	return usage, nil
 }
 
-func (b *lvm2Backend) GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
-	ctx := context.Background()
+func (b *lvm2Backend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
 	vgs, err := b.client.ListVolumeGroups(ctx, &lvm2.ListVGOptions{
 		Names: []string{vgName},
 	})
@@ -128,8 +124,7 @@ func (b *lvm2Backend) GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
 	return free, nil
 }
 
-func (b *lvm2Backend) ListVolumeGroups() ([]VolumeGroup, error) {
-	ctx := context.Background()
+func (b *lvm2Backend) ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
 	vgs, err := b.client.ListVolumeGroups(ctx, nil)
 	if err != nil {
 		return nil, err

--- a/lvm/backend_test.go
+++ b/lvm/backend_test.go
@@ -1,6 +1,7 @@
 package lvm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ func TestCreateSnapshotWithEscalationNonRoot(t *testing.T) {
 	}
 	t.Cleanup(func() { checkPrivs = orig })
 
-	if err := CreateSnapshot("/dev/vg0/origin", "snap", "1G"); err != nil {
+	if err := CreateSnapshot(context.Background(), "/dev/vg0/origin", "snap", "1G"); err != nil {
 		t.Fatalf("CreateSnapshot failed: %v", err)
 	}
 

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -3,6 +3,7 @@ package lvm
 
 import (
 	"container/list"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -132,7 +133,7 @@ func SetBackend(b lvmBackend) func() {
 	return func() { backend = orig }
 }
 
-func CreateSnapshot(lvPath, snapshotName, size string) error {
+func CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
 	if err := checkPrivs(); err != nil {
 		return err
 	}
@@ -141,7 +142,7 @@ func CreateSnapshot(lvPath, snapshotName, size string) error {
 		return fmt.Errorf("invalid parameters: lvPath, snapshotName, and size must be non-empty")
 	}
 
-	if err := backend.CreateSnapshot(lvPath, snapshotName, size); err != nil {
+	if err := backend.CreateSnapshot(ctx, lvPath, snapshotName, size); err != nil {
 		return fmt.Errorf("failed to create snapshot [%s] for LV %s with size %s: %w",
 			snapshotName, lvPath, size, err)
 	}
@@ -154,7 +155,7 @@ func CreateSnapshot(lvPath, snapshotName, size string) error {
 	return nil
 }
 
-func RemoveSnapshot(snapshotPath string) error {
+func RemoveSnapshot(ctx context.Context, snapshotPath string) error {
 	if err := checkPrivs(); err != nil {
 		return err
 	}
@@ -163,7 +164,7 @@ func RemoveSnapshot(snapshotPath string) error {
 		return fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
 
-	if err := backend.RemoveSnapshot(snapshotPath); err != nil {
+	if err := backend.RemoveSnapshot(ctx, snapshotPath); err != nil {
 		return fmt.Errorf("failed to remove snapshot [%s]: %w", snapshotPath, err)
 	}
 
@@ -173,7 +174,7 @@ func RemoveSnapshot(snapshotPath string) error {
 	return nil
 }
 
-func GetSnapshotUsage(snapshotPath string) (float64, error) {
+func GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
 	if err := checkPrivs(); err != nil {
 		return 0, err
 	}
@@ -182,7 +183,7 @@ func GetSnapshotUsage(snapshotPath string) (float64, error) {
 		return 0, fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
 
-	usage, err := backend.GetSnapshotUsage(snapshotPath)
+	usage, err := backend.GetSnapshotUsage(ctx, snapshotPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get snapshot usage for %s: %w", snapshotPath, err)
 	}
@@ -209,7 +210,7 @@ func MonitorSnapshot(snapshotPath string, threshold float64, interval time.Durat
 	for {
 		select {
 		case <-ticker.C:
-			usage, err := GetSnapshotUsage(snapshotPath)
+			usage, err := GetSnapshotUsage(context.Background(), snapshotPath)
 			if err != nil {
 				return err
 			}
@@ -342,12 +343,12 @@ func GetSnapshotDevicePath(snapshotName, volumeGroup string) string {
 	return path
 }
 
-func GetVolumeGroupFreeSpace(vgName string) (uint64, error) {
+func GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
 	if err := checkPrivs(); err != nil {
 		return 0, err
 	}
 
-	size, err := backend.GetVolumeGroupFreeSpace(vgName)
+	size, err := backend.GetVolumeGroupFreeSpace(ctx, vgName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get free space for VG %s: %w", vgName, err)
 	}
@@ -361,12 +362,12 @@ type VolumeGroup struct {
 }
 
 // ListVolumeGroups returns information about all available volume groups.
-func ListVolumeGroups() ([]VolumeGroup, error) {
+func ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
 	if err := checkPrivs(); err != nil {
 		return nil, err
 	}
 
-	vgs, err := backend.ListVolumeGroups()
+	vgs, err := backend.ListVolumeGroups(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list volume groups: %w", err)
 	}
@@ -375,8 +376,8 @@ func ListVolumeGroups() ([]VolumeGroup, error) {
 
 // SelectVolumeGroupByFreeSpace chooses the volume group with the most free space.
 // If candidates is non-empty, only those volume groups are considered.
-func SelectVolumeGroupByFreeSpace(candidates []string) (VolumeGroup, error) {
-	vgs, err := ListVolumeGroups()
+func SelectVolumeGroupByFreeSpace(ctx context.Context, candidates []string) (VolumeGroup, error) {
+	vgs, err := ListVolumeGroups(ctx)
 	if err != nil {
 		return VolumeGroup{}, err
 	}

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -1,26 +1,44 @@
 package lvm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 )
 
 type mockBackend struct{ calls []string }
 
-func (f *mockBackend) CreateSnapshot(lvPath, snapName, size string) error {
+func (f *mockBackend) CreateSnapshot(ctx context.Context, lvPath, snapName, size string) error {
 	f.calls = append(f.calls, fmt.Sprintf("create:%s:%s:%s", lvPath, snapName, size))
-	return nil
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(50 * time.Millisecond):
+		return nil
+	}
 }
 
-func (f *mockBackend) RemoveSnapshot(path string) error {
+func (f *mockBackend) RemoveSnapshot(ctx context.Context, path string) error {
 	f.calls = append(f.calls, fmt.Sprintf("remove:%s", path))
-	return nil
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(50 * time.Millisecond):
+		return nil
+	}
 }
 
-func (f *mockBackend) GetSnapshotUsage(string) (float64, error)       { return 0, nil }
-func (f *mockBackend) GetVolumeGroupFreeSpace(string) (uint64, error) { return 0, nil }
-func (f *mockBackend) ListVolumeGroups() ([]VolumeGroup, error)       { return nil, nil }
+func (f *mockBackend) GetSnapshotUsage(context.Context, string) (float64, error) {
+	return 0, nil
+}
+func (f *mockBackend) GetVolumeGroupFreeSpace(context.Context, string) (uint64, error) {
+	return 0, nil
+}
+func (f *mockBackend) ListVolumeGroups(context.Context) ([]VolumeGroup, error) {
+	return nil, nil
+}
 
 func init() {
 	SetEscalationCommand("")
@@ -39,11 +57,11 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 	snapName := "snap"
 	size := "1G"
 
-	if err := CreateSnapshot(lvPath, snapName, size); err != nil {
+	if err := CreateSnapshot(context.Background(), lvPath, snapName, size); err != nil {
 		t.Fatalf("CreateSnapshot failed: %v", err)
 	}
 	snapPath := "/dev/vg0/" + snapName
-	if err := RemoveSnapshot(snapPath); err != nil {
+	if err := RemoveSnapshot(context.Background(), snapPath); err != nil {
 		t.Fatalf("RemoveSnapshot failed: %v", err)
 	}
 
@@ -64,8 +82,35 @@ func TestCreateSnapshotPrivilegeError(t *testing.T) {
 	checkPrivs = func() error { return errPriv }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	err := CreateSnapshot("/dev/vg0/origin", "snap", "1G")
+	err := CreateSnapshot(context.Background(), "/dev/vg0/origin", "snap", "1G")
 	if !errors.Is(err, errPriv) {
 		t.Fatalf("expected privilege error, got %v", err)
+	}
+}
+
+func TestCreateSnapshotContextCancel(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
+
+	fb := &mockBackend{}
+	restore := SetBackend(fb)
+	t.Cleanup(restore)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	lvPath := "/dev/vg0/origin"
+	snapName := "snap"
+	size := "1G"
+
+	err := CreateSnapshot(ctx, lvPath, snapName, size)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+
+	// backend should have recorded attempt before ctx cancelled
+	if len(fb.calls) == 0 || fb.calls[0] != fmt.Sprintf("create:%s:%s:%s", lvPath, snapName, size) {
+		t.Fatalf("backend call not recorded")
 	}
 }

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -1,6 +1,7 @@
 package lvm
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,11 +12,15 @@ type usageBackend struct {
 	usage float64
 }
 
-func (f *usageBackend) CreateSnapshot(string, string, string) error    { return nil }
-func (f *usageBackend) RemoveSnapshot(string) error                    { return nil }
-func (f *usageBackend) GetSnapshotUsage(string) (float64, error)       { return f.usage, nil }
-func (f *usageBackend) GetVolumeGroupFreeSpace(string) (uint64, error) { return 0, nil }
-func (f *usageBackend) ListVolumeGroups() ([]VolumeGroup, error)       { return nil, nil }
+func (f *usageBackend) CreateSnapshot(context.Context, string, string, string) error { return nil }
+func (f *usageBackend) RemoveSnapshot(context.Context, string) error                 { return nil }
+func (f *usageBackend) GetSnapshotUsage(context.Context, string) (float64, error) {
+	return f.usage, nil
+}
+func (f *usageBackend) GetVolumeGroupFreeSpace(context.Context, string) (uint64, error) {
+	return 0, nil
+}
+func (f *usageBackend) ListVolumeGroups(context.Context) ([]VolumeGroup, error) { return nil, nil }
 
 func init() {
 	SetEscalationCommand("")
@@ -30,7 +35,7 @@ func TestGetSnapshotUsage(t *testing.T) {
 	restore := SetBackend(fb)
 	t.Cleanup(restore)
 
-	usage, err := GetSnapshotUsage("/dev/vg0/snap")
+	usage, err := GetSnapshotUsage(context.Background(), "/dev/vg0/snap")
 	if err != nil {
 		t.Fatalf("GetSnapshotUsage failed: %v", err)
 	}

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -1,6 +1,7 @@
 package lvm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -9,10 +10,10 @@ type vgBackend struct {
 	vgs []VolumeGroup
 }
 
-func (f *vgBackend) CreateSnapshot(string, string, string) error { return nil }
-func (f *vgBackend) RemoveSnapshot(string) error                 { return nil }
-func (f *vgBackend) GetSnapshotUsage(string) (float64, error)    { return 0, nil }
-func (f *vgBackend) GetVolumeGroupFreeSpace(name string) (uint64, error) {
+func (f *vgBackend) CreateSnapshot(context.Context, string, string, string) error { return nil }
+func (f *vgBackend) RemoveSnapshot(context.Context, string) error                 { return nil }
+func (f *vgBackend) GetSnapshotUsage(context.Context, string) (float64, error)    { return 0, nil }
+func (f *vgBackend) GetVolumeGroupFreeSpace(ctx context.Context, name string) (uint64, error) {
 	for _, vg := range f.vgs {
 		if vg.Name == name {
 			return vg.Free, nil
@@ -20,7 +21,7 @@ func (f *vgBackend) GetVolumeGroupFreeSpace(name string) (uint64, error) {
 	}
 	return 0, fmt.Errorf("unknown vg")
 }
-func (f *vgBackend) ListVolumeGroups() ([]VolumeGroup, error) { return f.vgs, nil }
+func (f *vgBackend) ListVolumeGroups(context.Context) ([]VolumeGroup, error) { return f.vgs, nil }
 
 func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 	orig := checkPrivs
@@ -30,7 +31,7 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 	restore := SetBackend(fb)
 	defer restore()
 
-	vg, err := SelectVolumeGroupByFreeSpace(nil)
+	vg, err := SelectVolumeGroupByFreeSpace(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -38,7 +39,7 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 		t.Fatalf("expected vg1 with 200, got %s with %d", vg.Name, vg.Free)
 	}
 
-	vg, err = SelectVolumeGroupByFreeSpace([]string{"vg0"})
+	vg, err = SelectVolumeGroupByFreeSpace(context.Background(), []string{"vg0"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +47,7 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 		t.Fatalf("expected vg0 with 100, got %s with %d", vg.Name, vg.Free)
 	}
 
-	if _, err := SelectVolumeGroupByFreeSpace([]string{"vg2"}); err == nil {
+	if _, err := SelectVolumeGroupByFreeSpace(context.Background(), []string{"vg2"}); err == nil {
 		t.Fatalf("expected error for unknown vg")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -169,7 +170,7 @@ func handleSignals(signals <-chan os.Signal, snapshotPath *string) {
 	sig := <-signals
 	zap.L().Info("Received signal, aborting", zap.String("signal", sig.String()))
 	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
-		if err := lvm.RemoveSnapshot(*snapshotPath); err != nil {
+		if err := lvm.RemoveSnapshot(context.Background(), *snapshotPath); err != nil {
 			zap.L().Warn("Failed to remove snapshot on shutdown", zap.Error(err))
 		} else {
 			zap.L().Info("Snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))
@@ -260,7 +261,7 @@ func main() {
 	snapshotPath = originalVolume
 	if !cfg.SkipSnapshotCreation {
 		snapshotName := fmt.Sprintf("snap-%d", time.Now().Unix())
-		err = lvm.CreateSnapshot(originalVolume, snapshotName, cfg.SnapshotSize)
+		err = lvm.CreateSnapshot(context.Background(), originalVolume, snapshotName, cfg.SnapshotSize)
 		if err != nil {
 			logger.Fatal("Snapshot creation failed", zap.Error(err))
 		}
@@ -282,7 +283,7 @@ func main() {
 	}
 
 	if !cfg.SkipSnapshotCreation {
-		err = lvm.RemoveSnapshot(snapshotPath)
+		err = lvm.RemoveSnapshot(context.Background(), snapshotPath)
 		if err != nil {
 			logger.Warn("Failed to remove snapshot", zap.Error(err))
 		} else {


### PR DESCRIPTION
## Summary
- accept `context.Context` in lvm backend interface and lvm2 client wrappers
- propagate context through high-level LVM helpers (snapshot creation, VG queries, etc.)
- extend tests with context parameters and add timeout test for cancellation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891e50ef9e88323a0c8bd736d70194c