### PR TITLE
lvm: track and cleanup escalation wrapper

### DIFF
--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -19,7 +19,8 @@ type lvmBackend interface {
 }
 
 type lvm2Backend struct {
-	client *lvm2.Client
+	client      *lvm2.Client
+	wrapperPath string
 }
 
 func newLVMBackend() lvmBackend {
@@ -38,7 +39,7 @@ func newLVMBackend() lvmBackend {
 		return &lvm2Backend{client: lvm2.NewClient()}
 	}
 
-	return &lvm2Backend{client: lvm2.NewClient(lvm2.WithLVM(wrapperPath))}
+	return &lvm2Backend{client: lvm2.NewClient(lvm2.WithLVM(wrapperPath)), wrapperPath: wrapperPath}
 }
 
 func buildEscalationWrapper(bin string, args []string) (string, error) {

--- a/lvm/backend_test.go
+++ b/lvm/backend_test.go
@@ -45,3 +45,30 @@ func TestCreateSnapshotWithEscalationNonRoot(t *testing.T) {
 		t.Fatalf("unexpected args %q", string(data))
 	}
 }
+
+func TestCleanupRemovesWrapper(t *testing.T) {
+	t.Cleanup(func() { SetEscalationCommand("") })
+
+	SetEscalationCommand("/bin/true")
+	restore := SetBackend(nil)
+	t.Cleanup(restore)
+
+	b, ok := backend.(*lvm2Backend)
+	if !ok {
+		t.Fatalf("unexpected backend type %T", backend)
+	}
+	if b.wrapperPath == "" {
+		t.Fatal("wrapper path not set")
+	}
+
+	path := b.wrapperPath
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("wrapper file not created: %v", err)
+	}
+
+	Cleanup()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("wrapper file still exists after cleanup: %v", err)
+	}
+}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -410,4 +410,11 @@ func SelectVolumeGroupByFreeSpace(candidates []string) (VolumeGroup, error) {
 
 func Cleanup() {
 	deviceFDCache.Close()
+
+	if b, ok := backend.(*lvm2Backend); ok {
+		if b.wrapperPath != "" {
+			os.Remove(b.wrapperPath)
+			b.wrapperPath = ""
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- store escalation wrapper path in lvm backend and remove it during cleanup
- add tests ensuring wrapper file is deleted after cleanup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891e5176828832383df72b259f9dd2a