### PR TITLE
Use server-side VG filtering

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,21 @@ func (f *fakeBackend) GetSnapshotUsage(context.Context, string) (float64, error)
 func (f *fakeBackend) GetVolumeGroupFreeSpace(context.Context, string) (uint64, error) {
 	return f.free, f.err
 }
-func (f *fakeBackend) ListVolumeGroups(context.Context) ([]lvm.VolumeGroup, error) { return f.vgs, nil }
+func (f *fakeBackend) ListVolumeGroups(_ context.Context, candidates []string) ([]lvm.VolumeGroup, error) {
+	if len(candidates) == 0 {
+		return f.vgs, nil
+	}
+	res := []lvm.VolumeGroup{}
+	for _, name := range candidates {
+		for _, vg := range f.vgs {
+			if vg.Name == name {
+				res = append(res, vg)
+				break
+			}
+		}
+	}
+	return res, nil
+}
 
 func TestDefaultConfigCompress(t *testing.T) {
 	cfg := DefaultConfig()

--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -15,7 +15,7 @@ type lvmBackend interface {
 	RemoveSnapshot(ctx context.Context, snapshotPath string) error
 	GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error)
 	GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error)
-	ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error)
+	ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error)
 }
 
 type lvm2Backend struct {
@@ -125,8 +125,12 @@ func (b *lvm2Backend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string
 	return free, nil
 }
 
-func (b *lvm2Backend) ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
-	vgs, err := b.client.ListVolumeGroups(ctx, nil)
+func (b *lvm2Backend) ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error) {
+	var opts *lvm2.ListVGOptions
+	if len(candidates) > 0 {
+		opts = &lvm2.ListVGOptions{Names: candidates}
+	}
+	vgs, err := b.client.ListVolumeGroups(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -367,7 +367,7 @@ func ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
 		return nil, err
 	}
 
-	vgs, err := backend.ListVolumeGroups(ctx)
+	vgs, err := backend.ListVolumeGroups(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list volume groups: %w", err)
 	}
@@ -377,36 +377,23 @@ func ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
 // SelectVolumeGroupByFreeSpace chooses the volume group with the most free space.
 // If candidates is non-empty, only those volume groups are considered.
 func SelectVolumeGroupByFreeSpace(ctx context.Context, candidates []string) (VolumeGroup, error) {
-	vgs, err := ListVolumeGroups(ctx)
+	vgs, err := backend.ListVolumeGroups(ctx, candidates)
 	if err != nil {
 		return VolumeGroup{}, err
 	}
-
-	candidateSet := make(map[string]struct{}, len(candidates))
-	for _, c := range candidates {
-		candidateSet[c] = struct{}{}
-	}
-
-	var chosen *VolumeGroup
-	for _, vg := range vgs {
-		if len(candidateSet) > 0 {
-			if _, ok := candidateSet[vg.Name]; !ok {
-				continue
-			}
-		}
-		if chosen == nil || vg.Free > chosen.Free {
-			// create copy to avoid referencing loop variable
-			v := vg
-			chosen = &v
-		}
-	}
-	if chosen == nil {
-		if len(candidateSet) > 0 {
+	if len(vgs) == 0 {
+		if len(candidates) > 0 {
 			return VolumeGroup{}, fmt.Errorf("no matching volume group found")
 		}
 		return VolumeGroup{}, fmt.Errorf("no volume groups found")
 	}
-	return *chosen, nil
+	chosen := vgs[0]
+	for _, vg := range vgs[1:] {
+		if vg.Free > chosen.Free {
+			chosen = vg
+		}
+	}
+	return chosen, nil
 }
 
 func Cleanup() {

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -36,7 +36,7 @@ func (f *mockBackend) GetSnapshotUsage(context.Context, string) (float64, error)
 func (f *mockBackend) GetVolumeGroupFreeSpace(context.Context, string) (uint64, error) {
 	return 0, nil
 }
-func (f *mockBackend) ListVolumeGroups(context.Context) ([]VolumeGroup, error) {
+func (f *mockBackend) ListVolumeGroups(context.Context, []string) ([]VolumeGroup, error) {
 	return nil, nil
 }
 

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -20,7 +20,9 @@ func (f *usageBackend) GetSnapshotUsage(context.Context, string) (float64, error
 func (f *usageBackend) GetVolumeGroupFreeSpace(context.Context, string) (uint64, error) {
 	return 0, nil
 }
-func (f *usageBackend) ListVolumeGroups(context.Context) ([]VolumeGroup, error) { return nil, nil }
+func (f *usageBackend) ListVolumeGroups(context.Context, []string) ([]VolumeGroup, error) {
+	return nil, nil
+}
 
 func init() {
 	SetEscalationCommand("")

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -3,11 +3,13 @@ package lvm
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
 type vgBackend struct {
-	vgs []VolumeGroup
+	vgs      []VolumeGroup
+	lastArgs []string
 }
 
 func (f *vgBackend) CreateSnapshot(context.Context, string, string, string) error { return nil }
@@ -21,7 +23,22 @@ func (f *vgBackend) GetVolumeGroupFreeSpace(ctx context.Context, name string) (u
 	}
 	return 0, fmt.Errorf("unknown vg")
 }
-func (f *vgBackend) ListVolumeGroups(context.Context) ([]VolumeGroup, error) { return f.vgs, nil }
+func (f *vgBackend) ListVolumeGroups(_ context.Context, candidates []string) ([]VolumeGroup, error) {
+	f.lastArgs = candidates
+	if len(candidates) == 0 {
+		return f.vgs, nil
+	}
+	res := []VolumeGroup{}
+	for _, name := range candidates {
+		for _, vg := range f.vgs {
+			if vg.Name == name {
+				res = append(res, vg)
+				break
+			}
+		}
+	}
+	return res, nil
+}
 
 func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 	orig := checkPrivs
@@ -49,5 +66,21 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 
 	if _, err := SelectVolumeGroupByFreeSpace(context.Background(), []string{"vg2"}); err == nil {
 		t.Fatalf("expected error for unknown vg")
+	}
+}
+
+func TestSelectVolumeGroupByFreeSpaceQueriesCandidates(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
+	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
+	restore := SetBackend(fb)
+	defer restore()
+
+	if _, err := SelectVolumeGroupByFreeSpace(context.Background(), []string{"vg0"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(fb.lastArgs, []string{"vg0"}) {
+		t.Fatalf("expected backend queried with [vg0], got %v", fb.lastArgs)
 	}
 }


### PR DESCRIPTION
## Summary
- add candidate filtering to backend ListVolumeGroups and forward to lvm2 for server-side filtering
- pass volume group candidates directly in SelectVolumeGroupByFreeSpace
- test that SelectVolumeGroupByFreeSpace only queries specified candidates

## Testing
- `go test ./...` *(fails: TestNewCompressionWriterAutoX86/fallback in transfer)*
- `go test ./lvm`
- `go test ./config`


------
https://chatgpt.com/codex/tasks/task_e_6891e779f9188323a175440b6fc17994