### PR TITLE
Ensure LVM cleanup on exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,7 @@ func main() {
 	}
 	zap.ReplaceGlobals(logger)
 	defer syncLogger(logger)
+	defer lvm.Cleanup()
 
 	logger.Info("Effective configuration",
 		zap.String("block_size", cfg.HumanBlockSize()),


### PR DESCRIPTION
## Summary
- Defer `lvm.Cleanup()` in `main.go` so cleanup always runs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ebce8474832383ee31e4bf4a99e7