### PR TITLE
Use context for snapshot monitoring

### DIFF
--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -195,7 +195,7 @@ func GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error)
 	return usage, nil
 }
 
-func MonitorSnapshot(snapshotPath string, threshold float64, interval time.Duration, stopChan <-chan struct{}) error {
+func MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64, interval time.Duration) error {
 	if err := checkPrivs(); err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func MonitorSnapshot(snapshotPath string, threshold float64, interval time.Durat
 	for {
 		select {
 		case <-ticker.C:
-			usage, err := GetSnapshotUsage(context.Background(), snapshotPath)
+			usage, err := GetSnapshotUsage(ctx, snapshotPath)
 			if err != nil {
 				return err
 			}
@@ -218,9 +218,9 @@ func MonitorSnapshot(snapshotPath string, threshold float64, interval time.Durat
 			if usage >= threshold {
 				return fmt.Errorf("snapshot usage (%.2f%%) exceeds threshold (%.2f%%)", usage, threshold)
 			}
-		case <-stopChan:
+		case <-ctx.Done():
 			zap.L().Info("Snapshot monitoring stopped", zap.String("snapshot", snapshotPath))
-			return nil
+			return ctx.Err()
 		}
 	}
 }

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -55,7 +55,7 @@ func TestMonitorSnapshot(t *testing.T) {
 	restore := SetBackend(fb)
 	t.Cleanup(restore)
 
-	err := MonitorSnapshot("/dev/vg0/snap", 80, 10*time.Millisecond, make(chan struct{}))
+	err := MonitorSnapshot(context.Background(), "/dev/vg0/snap", 80, 10*time.Millisecond)
 	if err == nil {
 		t.Fatalf("MonitorSnapshot expected error, got nil")
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -268,14 +269,14 @@ func main() {
 		snapshotPath = lvm.GetSnapshotDevicePath(snapshotName, cfg.VolumeGroup)
 		logger.Info("Snapshot created", zap.String("snapshot", snapshotPath))
 
-		stopMonitor := make(chan struct{})
+		monitorCtx, cancel := context.WithCancel(context.Background())
 		go func() {
-			if err := lvm.MonitorSnapshot(snapshotPath, 80.0, 10*time.Second, stopMonitor); err != nil {
+			if err := lvm.MonitorSnapshot(monitorCtx, snapshotPath, 80.0, 10*time.Second); err != nil && !errors.Is(err, context.Canceled) {
 				zap.L().Error("Snapshot monitor error", zap.Error(err))
 				os.Exit(1)
 			}
 		}()
-		defer close(stopMonitor)
+		defer cancel()
 	}
 
 	if err := runClientMode(snapshotPath, destPath); err != nil {


### PR DESCRIPTION
## Summary
- replace stop channel with context cancellation in snapshot monitor
- propagate context to snapshot usage queries
- manage snapshot monitoring via context in `main.go`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ebd0c5c08323b5f7042b689be9ab