### PR TITLE
Handle missing SSH auth methods in client creation

### DIFF
--- a/main_remote_script_test.go
+++ b/main_remote_script_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -98,6 +101,23 @@ func (s *mockSSHServer) Commands() []string {
 	return append([]string(nil), s.commands...)
 }
 
+func createTempKey(t *testing.T) string {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	f, err := os.CreateTemp(t.TempDir(), "id_rsa")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if _, err := f.Write(keyPEM); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
 // Test that remote post script executes even when dumpChanges fails
 func TestRemotePostScriptRunsOnError(t *testing.T) {
 	server := newMockSSHServer(t, func(cmd string) int { return 0 })
@@ -111,6 +131,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	cfg.RemotePostScript = "post-script"
 	cfg.SSHUser = "test"
 	cfg.SSHPort = port
+	cfg.SSHKeyPath = createTempKey(t)
 	cfg.StrictHostKeyCheck = false
 	cfg.LVMSyncPath = "lvmsync"
 
@@ -153,6 +174,7 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	cfg.RemotePostScript = "post-script"
 	cfg.SSHUser = "test"
 	cfg.SSHPort = port
+	cfg.SSHKeyPath = createTempKey(t)
 	cfg.StrictHostKeyCheck = false
 	cfg.LVMSyncPath = "lvmsync"
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -36,6 +36,9 @@ func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, v
 			}
 		}
 	}
+	if len(authMethods) == 0 {
+		return nil, fmt.Errorf("no SSH authentication methods configured")
+	}
 	var hostKeyCallback ssh.HostKeyCallback
 	if verify {
 		var err error

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -18,5 +19,20 @@ func TestNewSSHManagerNoAgent(t *testing.T) {
 	_, err := NewSSHManager("root", "", time.Second, "", false)
 	if err == nil {
 		t.Fatal("expected error when SSH_AUTH_SOCK not set")
+	}
+}
+
+func TestNewSSHClientNoAuth(t *testing.T) {
+	oldSock := os.Getenv("SSH_AUTH_SOCK")
+	os.Unsetenv("SSH_AUTH_SOCK")
+	defer func() {
+		if oldSock != "" {
+			os.Setenv("SSH_AUTH_SOCK", oldSock)
+		}
+	}()
+
+	_, err := NewSSHClient("localhost", "root", "", 22, "", false, time.Second, time.Second, 0)
+	if err == nil || !strings.Contains(err.Error(), "no SSH authentication methods configured") {
+		t.Fatalf("expected error for missing auth methods, got %v", err)
 	}
 }

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -87,7 +87,8 @@ func TestNewSSHClient(t *testing.T) {
 	host, portStr, _ := net.SplitHostPort(server.addr)
 	port, _ := strconv.Atoi(portStr)
 
-	client, err := NewSSHClient(host, "test", "", port, "", false, time.Second, 10*time.Millisecond, 0)
+	keyPath := createTempKey(t)
+	client, err := NewSSHClient(host, "test", keyPath, port, "", false, time.Second, 10*time.Millisecond, 0)
 	if err != nil {
 		t.Fatalf("NewSSHClient error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- return explicit error when NewSSHClient has no auth methods
- add unit test for missing SSH auth
- adjust tests to use temporary key material

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ebd30eec83239f0b167c6228821a