### PR TITLE
Reuse transfer header buffers and add benchmarks

### DIFF
--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -63,7 +63,7 @@ func TestNewCompressionWriterAutoX86(t *testing.T) {
 		}
 		switch algo {
 		case compressionLZ4:
-			if _, ok := w.(*lz4.Writer); !ok {
+			if _, ok := w.(*pooledLz4Writer); !ok {
 				t.Fatalf("expected lz4 writer when benchmark prefers lz4")
 			}
 		case compressionZSTD:

--- a/transfer/dumpchanges_benchmark_test.go
+++ b/transfer/dumpchanges_benchmark_test.go
@@ -1,0 +1,42 @@
+package transfer
+
+import (
+	"bytes"
+	"testing"
+
+	"lvmsync_go/config"
+
+	"go.uber.org/zap"
+)
+
+func BenchmarkDumpChangesSequential(b *testing.B) {
+	SetLogger(zap.NewNop())
+	blockSize := int64(4096)
+	changed := []int{0, 1, 2, 3}
+	src, snapshot := createDumpTestFiles(b, blockSize, changed)
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
+	var buf bytes.Buffer
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+			b.Fatalf("DumpChangesSequential failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkDumpChangesParallel(b *testing.B) {
+	SetLogger(zap.NewNop())
+	blockSize := int64(4096)
+	changed := []int{0, 1, 2, 3}
+	src, snapshot := createDumpTestFiles(b, blockSize, changed)
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, VerifyChecksum: true, MaxRetries: 1}
+	var buf bytes.Buffer
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+			b.Fatalf("DumpChangesParallel failed: %v", err)
+		}
+	}
+}

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // helper to create source and metadata files with deterministic ranges
-func createDumpTestFiles(t *testing.T, blockSize int64, changedBlocks []int) (src, snapshot string) {
+func createDumpTestFiles(t testing.TB, blockSize int64, changedBlocks []int) (src, snapshot string) {
 	t.Helper()
 	dir := t.TempDir()
 

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -131,6 +131,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	var totalBytesTransferred int64
 	skippedBlocks := 0
 
+	var header [12]byte
 	for _, r := range ranges {
 		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy, pipeFds)
 		if err != nil {
@@ -145,10 +146,9 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 			dedup.RecordTransfer(r.Start, data)
 		}
 
-		header := make([]byte, 12)
 		binary.BigEndian.PutUint64(header[0:8], uint64(r.Start))
 		binary.BigEndian.PutUint32(header[8:12], uint32(cfg.BlockSize))
-		if _, err := bufOut.Write(header); err != nil {
+		if _, err := bufOut.Write(header[:]); err != nil {
 			return fmt.Errorf("failed to write header: %w", err)
 		}
 		if _, err := bufOut.Write(data); err != nil {
@@ -302,20 +302,22 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	startTime := time.Now()
 	var totalBytesTransferred int64
 
+	var header [12 + sha256.Size]byte
 	for res := range results {
 		if res.Err != nil {
 			return fmt.Errorf("error in block %d: %w", res.Index, res.Err)
 		}
 
-		header := make([]byte, 12)
 		binary.BigEndian.PutUint64(header[0:8], res.Offset)
 		binary.BigEndian.PutUint32(header[8:12], res.Size)
+		n := 12
 		if cfg.VerifyChecksum {
 			sum := sha256.Sum256(res.Data)
-			header = append(header, sum[:]...)
+			copy(header[12:], sum[:])
+			n += sha256.Size
 		}
 
-		if _, err := bufOut.Write(header); err != nil {
+		if _, err := bufOut.Write(header[:n]); err != nil {
 			return fmt.Errorf("failed to write header: %w", err)
 		}
 		if _, err := bufOut.Write(res.Data); err != nil {


### PR DESCRIPTION
## Summary
- reuse a single header buffer in dumpChanges and parallel results processing to avoid per-block allocations
- add benchmarks for sequential and parallel dump to track allocations
- adjust x86 compression fallback test for pooled LZ4 writer

## Testing
- `go test ./...`
- `go test -run ^$ -bench DumpChanges -benchmem ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_6891ebd4622c832398c81bbe00ee0b8f