### PR TITLE
Parse LV path and pass origin LV

### DIFF
--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -71,12 +72,29 @@ func buildEscalationWrapper(bin string, args []string) (string, error) {
 }
 
 func (b *lvm2Backend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
+	trimmed := strings.TrimPrefix(lvPath, "/dev/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid LV path: %s", lvPath)
+	}
+	vgName, lvName := parts[0], parts[1]
+
 	opts := lvm2.CreateLVOptions{
 		Name:     snapshotName,
-		VGName:   lvPath,
+		VGName:   vgName,
 		Size:     size,
 		Snapshot: true,
 	}
+
+	val := reflect.ValueOf(&opts).Elem()
+	field := val.FieldByName("LVName")
+	if !field.IsValid() {
+		return fmt.Errorf("lvm2.CreateLVOptions missing LVName field")
+	}
+	if field.CanSet() {
+		field.SetString(lvName)
+	}
+
 	return b.client.CreateLogicalVolume(ctx, opts)
 }
 

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/dpeckett/lvm2"
 )
 
 type mockBackend struct{ calls []string }
@@ -112,5 +117,34 @@ func TestCreateSnapshotContextCancel(t *testing.T) {
 	// backend should have recorded attempt before ctx cancelled
 	if len(fb.calls) == 0 || fb.calls[0] != fmt.Sprintf("create:%s:%s:%s", lvPath, snapName, size) {
 		t.Fatalf("backend call not recorded")
+	}
+}
+
+func TestLVM2BackendCreateSnapshotUsesVGAndLV(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "args")
+	script := filepath.Join(tmpDir, "lvm.sh")
+	content := fmt.Sprintf("#!/bin/sh\nprintf '%%s ' \"$@\" > %s\n", argsFile)
+	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
+		t.Fatalf("failed to create script: %v", err)
+	}
+
+	b := &lvm2Backend{client: lvm2.NewClient(lvm2.WithLVM(script))}
+
+	if err := b.CreateSnapshot(context.Background(), "/dev/vg0/origin", "snap", "1G"); err != nil {
+		t.Fatalf("CreateSnapshot failed: %v", err)
+	}
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read args file: %v", err)
+	}
+	args := strings.Fields(string(data))
+	if len(args) < 2 {
+		t.Fatalf("insufficient arguments: %v", args)
+	}
+	vg, lv := args[len(args)-2], args[len(args)-1]
+	if vg != "vg0" || lv != "origin" {
+		t.Fatalf("unexpected VG/LV args: %v", args[len(args)-2:])
 	}
 }


### PR DESCRIPTION
## Summary
- parse logical volume path to extract volume group and LV names
- populate LV name in LVM snapshot creation
- add test verifying VG and LV parameters are passed to lvcreate

## Testing
- `go test ./lvm -run TestLVM2BackendCreateSnapshotUsesVGAndLV -count=1 -v` *(fails: lvm2.CreateLVOptions missing LVName field)*
- `go test ./... -count=1` *(fails: lvm2.CreateLVOptions missing LVName field)*

------
https://chatgpt.com/codex/tasks/task_e_6891f0a3a5f8832395aba86a31090c02