### PR TITLE
refactor ioctl use and test volume size caching

### DIFF
--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -84,3 +84,41 @@ func TestFdCacheCloseClosesAll(t *testing.T) {
 		}
 	}
 }
+
+func TestGetVolumeSizeCachesFD(t *testing.T) {
+	deviceFDCache.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "vol")
+	if err := os.WriteFile(tmpFile, make([]byte, 1024), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	size, err := GetVolumeSize(tmpFile)
+	if err != nil {
+		t.Fatalf("GetVolumeSize failed: %v", err)
+	}
+	if size != 1024 {
+		t.Fatalf("size = %d, want 1024", size)
+	}
+
+	elem, ok := deviceFDCache.fds[tmpFile]
+	if !ok {
+		t.Fatalf("file descriptor not cached")
+	}
+	fd := elem.Value.(*fdCacheEntry).fd
+
+	size, err = GetVolumeSize(tmpFile)
+	if err != nil {
+		t.Fatalf("second GetVolumeSize failed: %v", err)
+	}
+	if size != 1024 {
+		t.Fatalf("size = %d, want 1024", size)
+	}
+
+	elem2, ok := deviceFDCache.fds[tmpFile]
+	if !ok || elem2.Value.(*fdCacheEntry).fd != fd {
+		t.Fatalf("file descriptor not reused")
+	}
+
+	Cleanup()
+}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/dustin/go-humanize"
 	"go.uber.org/zap"
@@ -48,15 +47,6 @@ var deviceFDCache = &fdCache{
 var statfsFunc = unix.Statfs
 
 var checkPrivs = checkRootPrivileges
-
-func ioctlGetUint64(fd int, req uint) (uint64, error) {
-	var value uint64
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(unsafe.Pointer(&value)))
-	if errno != 0 {
-		return 0, errno
-	}
-	return value, nil
-}
 
 func SetEscalationCommand(cmd string) {
 	escalationCommandLock.Lock()
@@ -245,7 +235,8 @@ func GetVolumeSize(volumePath string) (uint64, error) {
 		return 0, err
 	}
 
-	size, err := ioctlGetUint64(fd, BLKGETSIZE64)
+	sizeInt, err := unix.IoctlGetInt(fd, BLKGETSIZE64)
+	size := uint64(sizeInt)
 	if err != nil {
 		if err == unix.ENOTTY {
 			info, statErr := os.Stat(volumePath)


### PR DESCRIPTION
## Summary
- call `unix.IoctlGetInt` for `BLKGETSIZE64` instead of custom syscall
- drop direct `unix.Syscall`/`unsafe` usage
- add test ensuring `GetVolumeSize` caches file descriptors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891f0a843008323b82c6183a4ab7151