### PR TITLE
Manual PATH lookup for LVMEscalation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -31,6 +30,8 @@ var (
 	compressionFlags *pflag.FlagSet
 	lvmFlags         *pflag.FlagSet
 )
+
+var getEuid = os.Geteuid
 
 type Config struct {
 	ConfigFile           string        `mapstructure:"config"`
@@ -322,16 +323,44 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("target volume group %q does not exist or is inaccessible: %w", c.TargetVolumeGroup, err)
 		}
 	}
-	if os.Geteuid() != 0 {
+	if getEuid() != 0 {
 		parts := strings.Fields(c.LVMEscalation)
 		if len(parts) == 0 {
 			return fmt.Errorf("lvm escalation command is empty")
 		}
-		if _, err := exec.LookPath(parts[0]); err != nil {
+		if _, err := findInPath(parts[0]); err != nil {
 			return fmt.Errorf("lvm escalation command %q not found: %w", parts[0], err)
 		}
 	}
 	return nil
+}
+
+func findInPath(name string) (string, error) {
+	if strings.ContainsRune(name, os.PathSeparator) {
+		info, err := os.Stat(name)
+		if err != nil {
+			return "", err
+		}
+		if info.IsDir() || info.Mode().Perm()&0111 == 0 {
+			return "", fmt.Errorf("%s is not executable", name)
+		}
+		return name, nil
+	}
+	pathEnv := os.Getenv("PATH")
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			continue
+		}
+		full := filepath.Join(dir, name)
+		info, err := os.Stat(full)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() && info.Mode().Perm()&0111 != 0 {
+			return full, nil
+		}
+	}
+	return "", fmt.Errorf("executable %q not found in $PATH", name)
 }
 
 func printUsage() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pierrec/lz4/v4"
@@ -131,6 +133,32 @@ func TestConfigValidate(t *testing.T) {
 			t.Fatalf("expected error")
 		}
 	})
+}
+
+func TestValidateEscalationCommandPath(t *testing.T) {
+	oldEuid := getEuid
+	getEuid = func() int { return 1000 }
+	defer func() { getEuid = oldEuid }()
+
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sudo")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("failed to create dummy executable: %v", err)
+	}
+	os.Setenv("PATH", dir)
+
+	cfg := &Config{LVMEscalation: "sudo"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	os.Setenv("PATH", "")
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected error when command missing")
+	}
 }
 
 func TestGetBlockSizeRaw(t *testing.T) {


### PR DESCRIPTION
## Summary
- avoid exec.LookPath by scanning $PATH manually
- add test covering PATH-based lookup of LVMEscalation command

## Testing
- `go test ./config`


------
https://chatgpt.com/codex/tasks/task_e_6891f0b5616883238e84ac28f69c421c