### PR TITLE
Use 64-bit ioctl for volume size

### DIFF
--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -47,6 +48,8 @@ var deviceFDCache = &fdCache{
 var statfsFunc = unix.Statfs
 
 var checkPrivs = checkRootPrivileges
+
+var ioctlGetUint64Func = ioctlGetUint64
 
 func SetEscalationCommand(cmd string) {
 	escalationCommandLock.Lock()
@@ -229,14 +232,22 @@ func CheckDiskSpace(mountPoint string) (uint64, error) {
 	return available, nil
 }
 
+func ioctlGetUint64(fd int, req uint) (uint64, error) {
+	var value uint64
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(unsafe.Pointer(&value)))
+	if err != 0 {
+		return 0, err
+	}
+	return value, nil
+}
+
 func GetVolumeSize(volumePath string) (uint64, error) {
 	fd, err := deviceFDCache.getFD(volumePath)
 	if err != nil {
 		return 0, err
 	}
 
-	sizeInt, err := unix.IoctlGetInt(fd, BLKGETSIZE64)
-	size := uint64(sizeInt)
+	size, err := ioctlGetUint64Func(fd, BLKGETSIZE64)
 	if err != nil {
 		if err == unix.ENOTTY {
 			info, statErr := os.Stat(volumePath)

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -55,17 +55,64 @@ func TestParseSnapshotSize(t *testing.T) {
 }
 
 func TestGetVolumeSize(t *testing.T) {
+	t.Run("smallFile", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "vol")
+		if err := os.WriteFile(tmpFile, make([]byte, 2*1024*1024), 0644); err != nil {
+			t.Fatalf("failed to create temp volume: %v", err)
+		}
+
+		size, err := GetVolumeSize(tmpFile)
+		if err != nil {
+			t.Fatalf("GetVolumeSize failed: %v", err)
+		}
+		if size != 2*1024*1024 {
+			t.Fatalf("size = %d, want %d", size, 2*1024*1024)
+		}
+	})
+
+	t.Run("largeFile", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "vol")
+		f, err := os.Create(tmpFile)
+		if err != nil {
+			t.Fatalf("failed to create temp volume: %v", err)
+		}
+		defer f.Close()
+		if err := f.Truncate(int64(5 * 1024 * 1024 * 1024)); err != nil {
+			t.Fatalf("truncate failed: %v", err)
+		}
+
+		size, err := GetVolumeSize(tmpFile)
+		if err != nil {
+			t.Fatalf("GetVolumeSize failed: %v", err)
+		}
+		want := uint64(5) * 1024 * 1024 * 1024
+		if size != want {
+			t.Fatalf("size = %d, want %d", size, want)
+		}
+	})
+
+	Cleanup()
+}
+
+func TestGetVolumeSizeIoctlLarge(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "vol")
-	if err := os.WriteFile(tmpFile, make([]byte, 2*1024*1024), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, nil, 0644); err != nil {
 		t.Fatalf("failed to create temp volume: %v", err)
 	}
+
+	fiveGiB := uint64(5) * 1024 * 1024 * 1024
+	orig := ioctlGetUint64Func
+	ioctlGetUint64Func = func(fd int, req uint) (uint64, error) {
+		return fiveGiB, nil
+	}
+	defer func() { ioctlGetUint64Func = orig }()
 
 	size, err := GetVolumeSize(tmpFile)
 	if err != nil {
 		t.Fatalf("GetVolumeSize failed: %v", err)
 	}
-	if size != 2*1024*1024 {
-		t.Fatalf("size = %d, want %d", size, 2*1024*1024)
+	if size != fiveGiB {
+		t.Fatalf("size = %d, want %d", size, fiveGiB)
 	}
 
 	Cleanup()


### PR DESCRIPTION
## Summary
- add helper to read uint64 results from ioctl
- use 64-bit ioctl helper in `GetVolumeSize`
- test volume size retrieval for files and ioctl responses over 4GB

## Testing
- `go test ./lvm -run GetVolumeSize`


------
https://chatgpt.com/codex/tasks/task_e_6891ffa1dac883238e80ad05364d05fe