### PR TITLE
refactor fd cache

### DIFF
--- a/lvm/fd_cache.go
+++ b/lvm/fd_cache.go
@@ -1,0 +1,84 @@
+package lvm
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+const fdCacheSize = 16
+
+// fdCacheEntry represents a cached file descriptor.
+type fdCacheEntry struct {
+	path string
+	fd   int
+}
+
+// fdCache provides a simple LRU cache for file descriptors.
+type fdCache struct {
+	fds   map[string]*list.Element
+	order *list.List
+	mutex sync.Mutex
+	size  int
+}
+
+// NewFDCache returns an initialized file descriptor cache with the given capacity.
+func NewFDCache(size int) *fdCache {
+	if size <= 0 {
+		size = fdCacheSize
+	}
+	return &fdCache{
+		fds:   make(map[string]*list.Element, size),
+		order: list.New(),
+		size:  size,
+	}
+}
+
+// getFD retrieves an open file descriptor for the specified device path.
+// It reuses descriptors when possible and evicts the least recently used entry
+// when the cache reaches its capacity.
+func (c *fdCache) getFD(devicePath string) (int, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if elem, ok := c.fds[devicePath]; ok {
+		c.order.MoveToFront(elem)
+		return elem.Value.(*fdCacheEntry).fd, nil
+	}
+
+	fd, err := unix.Open(devicePath, unix.O_RDONLY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return -1, fmt.Errorf("failed to open device %s: %w", devicePath, err)
+	}
+
+	if c.order.Len() >= c.size {
+		if back := c.order.Back(); back != nil {
+			entry := back.Value.(*fdCacheEntry)
+			unix.Close(entry.fd)
+			delete(c.fds, entry.path)
+			c.order.Remove(back)
+		}
+	}
+
+	elem := c.order.PushFront(&fdCacheEntry{path: devicePath, fd: fd})
+	c.fds[devicePath] = elem
+	return fd, nil
+}
+
+// Close releases all cached file descriptors and resets the cache state.
+func (c *fdCache) Close() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for _, elem := range c.fds {
+		entry := elem.Value.(*fdCacheEntry)
+		unix.Close(entry.fd)
+	}
+	c.fds = make(map[string]*list.Element, c.size)
+	c.order.Init()
+}
+
+// deviceFDCache is the global cache used by volume operations.
+var deviceFDCache = NewFDCache(fdCacheSize)

--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -1,7 +1,6 @@
 package lvm
 
 import (
-	"container/list"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,10 +10,7 @@ import (
 )
 
 func TestFdCacheEvictionOrder(t *testing.T) {
-	cache := &fdCache{
-		fds:   make(map[string]*list.Element),
-		order: list.New(),
-	}
+	cache := NewFDCache(fdCacheSize)
 
 	tmpDir := t.TempDir()
 	var fd0, fd1 int
@@ -58,10 +54,7 @@ func TestFdCacheEvictionOrder(t *testing.T) {
 }
 
 func TestFdCacheCloseClosesAll(t *testing.T) {
-	cache := &fdCache{
-		fds:   make(map[string]*list.Element),
-		order: list.New(),
-	}
+	cache := NewFDCache(fdCacheSize)
 	tmpDir := t.TempDir()
 	var fds []int
 	for i := 0; i < 3; i++ {

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -2,7 +2,6 @@
 package lvm
 
 import (
-	"container/list"
 	"context"
 	"fmt"
 	"lvmsync_go/internal/sizeparse"
@@ -20,30 +19,12 @@ import (
 
 const (
 	BLKGETSIZE64 = 0x80081272
-
-	fdCacheSize = 16
 )
 
 var (
 	escalationCommand     string
 	escalationCommandLock sync.RWMutex
 )
-
-type fdCacheEntry struct {
-	path string
-	fd   int
-}
-
-type fdCache struct {
-	fds   map[string]*list.Element
-	order *list.List
-	mutex sync.Mutex
-}
-
-var deviceFDCache = &fdCache{
-	fds:   make(map[string]*list.Element),
-	order: list.New(),
-}
 
 var statfsFunc = unix.Statfs
 
@@ -68,48 +49,6 @@ func checkRootPrivileges() error {
 		return fmt.Errorf("insufficient privileges: LVM operations require root privileges")
 	}
 	return nil
-}
-
-func (c *fdCache) getFD(devicePath string) (int, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if elem, exists := c.fds[devicePath]; exists {
-		c.order.MoveToFront(elem)
-		return elem.Value.(*fdCacheEntry).fd, nil
-	}
-
-	fd, err := unix.Open(devicePath, unix.O_RDONLY|unix.O_NONBLOCK, 0)
-	if err != nil {
-		return -1, fmt.Errorf("failed to open device %s: %w", devicePath, err)
-	}
-
-	if c.order.Len() >= fdCacheSize {
-		back := c.order.Back()
-		if back != nil {
-			entry := back.Value.(*fdCacheEntry)
-			unix.Close(entry.fd)
-			delete(c.fds, entry.path)
-			c.order.Remove(back)
-		}
-	}
-
-	entry := &fdCacheEntry{path: devicePath, fd: fd}
-	elem := c.order.PushFront(entry)
-	c.fds[devicePath] = elem
-	return fd, nil
-}
-
-func (c *fdCache) Close() {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	for _, elem := range c.fds {
-		entry := elem.Value.(*fdCacheEntry)
-		unix.Close(entry.fd)
-	}
-	c.fds = make(map[string]*list.Element)
-	c.order.Init()
 }
 
 // backend is used to execute LVM operations. It can be overridden for tests.


### PR DESCRIPTION
## Summary
- factor file descriptor caching into dedicated module with constructor
- update fd cache tests for new API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68921309784883238286aa182f19165e