### PR TITLE
refactor remote command validation

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -2,11 +2,12 @@
 package remote
 
 import (
-	"fmt"
-	"net"
-	"os"
-	"strings"
-	"time"
+        "fmt"
+        "io"
+        "net"
+        "os"
+        "strings"
+        "time"
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
@@ -84,20 +85,28 @@ func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, v
 }
 
 func ValidateRemoteCommand(client *ssh.Client, remoteCmd string) error {
-	tokens := strings.Fields(remoteCmd)
-	if len(tokens) == 0 {
-		return fmt.Errorf("remote command is empty")
-	}
-	cmd := tokens[0]
-	session, err := client.NewSession()
-	if err != nil {
-		return fmt.Errorf("failed to create SSH session for validation: %w", err)
-	}
-	defer session.Close()
-	if err := session.Run(fmt.Sprintf("command -v %s >/dev/null 2>&1", cmd)); err != nil {
-		return fmt.Errorf("remote command %s not found or not executable: %w", cmd, err)
-	}
-	return nil
+        tokens := strings.Fields(remoteCmd)
+        if len(tokens) == 0 {
+                return fmt.Errorf("remote command is empty")
+        }
+        cmd := tokens[0]
+        session, err := client.NewSession()
+        if err != nil {
+                return fmt.Errorf("failed to create SSH session for validation: %w", err)
+        }
+        defer session.Close()
+        session.Stdout = io.Discard
+        session.Stderr = io.Discard
+        if err := session.Run(fmt.Sprintf("%s --version", cmd)); err != nil {
+                if exitErr, ok := err.(*ssh.ExitError); ok {
+                        status := exitErr.ExitStatus()
+                        if status == 126 || status == 127 {
+                                return fmt.Errorf("remote command %s not found or not executable: %w", cmd, err)
+                        }
+                }
+                return fmt.Errorf("failed to run remote command %s: %w", cmd, err)
+        }
+        return nil
 }
 
 func RunRemoteScript(client *ssh.Client, script string) error {

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -1,12 +1,11 @@
 package remote
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"net"
-	"strings"
-	"sync"
-	"testing"
+        "crypto/rand"
+        "crypto/rsa"
+        "net"
+        "sync"
+        "testing"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -125,15 +124,16 @@ func (s *mockSSHServer) ConnectionCount() int {
 }
 
 func TestValidateRemoteCommand(t *testing.T) {
-	server := newMockSSHServer(t, func(cmd string) int {
-		if strings.Contains(cmd, "command -v echo") {
-			return 0
-		}
-		if strings.Contains(cmd, "command -v nonexistent") {
-			return 1
-		}
-		return 0
-	})
+        server := newMockSSHServer(t, func(cmd string) int {
+                switch cmd {
+                case "echo --version":
+                        return 0
+                case "nonexistent --version":
+                        return 127
+                default:
+                        return 0
+                }
+        })
 	defer server.Close()
 
 	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: ssh.InsecureIgnoreHostKey()})


### PR DESCRIPTION
## Summary
- avoid shell builtins when validating remote commands by executing `--version` and checking exit codes
- align unit tests with new validation strategy

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892201693fc8323ae1a7da06d20d362