### PR TITLE
Implement automatic privilege escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
   - Automatic snapshot creation and removal.
   - Configurable snapshot size (absolute or percentage-based).
   - Configurable volume group for constructing the snapshot device path.
-  - Configurable privilege escalation (defaulting to `sudo -n`).
+  - Automatic privilege escalation (defaulting to `sudo -n`).
   - Snapshot health monitoring that fails fast if usage exceeds a threshold.
 - **Graceful Shutdown**: Signal handling ensures snapshots are cleaned up on interruption.
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.
@@ -131,7 +131,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--target_volume_group` | Volume group name of the target LVM volume | `""` |
 | `--source_vgs` | Candidate source volume groups for auto-selection | `[]` |
 | `--target_vgs` | Candidate target volume groups for auto-selection | `[]` |
-| `--lvm_escalation` | Command used to escalate privileges for LVM commands (e.g., `"sudo -n"`) | `"sudo -n"` |
+| `--lvm_escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., `"sudo -n"`) | `"sudo -n"` |
 
 ### Examples
 
@@ -192,7 +192,7 @@ lvmsync --skip_disk_check=false --snapshot_size "25%" --volume_group "vg_data" -
 In this example, LVMSync will:
 - Validate that the volume group `vg_data` exists.
 - Create a snapshot of `/dev/vg_data/original` sized at 25% of the original volume.
-- Use the escalation command `sudo -n` if not running as root.
+        - Automatically re-exec with `sudo -n` if not running as root.
 - Monitor snapshot usage (failing fast if usage exceeds 80%).
 - Perform the block-level transfer.
 - Remove the snapshot upon completion.
@@ -250,7 +250,7 @@ volume_group: "vg0"                     # Source volume group. Auto-selected by 
 target_volume_group: ""                 # Volume group name of the target LVM volume
 source_vgs: []                          # Candidate source VGs for auto-selection
 target_vgs: []                          # Candidate target VGs for auto-selection
-lvm_escalation: "sudo -n"               # Command used to escalate privileges for LVM commands
+lvm_escalation: "sudo -n"               # Command used to re-execute the program with elevated privileges when needed
 ```
 
 LVMSync installs signal handlers for SIGINT and SIGTERM. If an interruption occurs, the tool will attempt to remove any created snapshot before exiting, ensuring no orphaned snapshots remain.

--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,6 @@ volume_group: "vg0"                    # Source volume group. Auto-selected by f
 target_volume_group: ""                # Volume group name of the target LVM volume
 source_vgs: []                         # Candidate source VGs for auto-selection
 target_vgs: []                         # Candidate target VGs for auto-selection
-lvm_escalation: "sudo -n"              # Command used to escalate privileges for LVM commands
+lvm_escalation: "sudo -n"              # Command used to re-execute the program with elevated privileges when required
 progress: true                         # Enable progress display during transfer
 block_size: "4K"                       # Block size for LVM operations

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,9 +112,8 @@ func TestConfigValidate(t *testing.T) {
 		fb := &fakeBackend{free: 100}
 		restore := lvm.SetBackend(fb)
 		defer restore()
-		prev := lvm.GetEscalationCommand()
-		lvm.SetEscalationCommand("sudo")
-		defer lvm.SetEscalationCommand(prev)
+		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
+		defer restorePriv()
 		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo"}
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -125,9 +124,8 @@ func TestConfigValidate(t *testing.T) {
 		fb := &fakeBackend{err: fmt.Errorf("command error")}
 		restore := lvm.SetBackend(fb)
 		defer restore()
-		prev := lvm.GetEscalationCommand()
-		lvm.SetEscalationCommand("sudo")
-		defer lvm.SetEscalationCommand(prev)
+		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
+		defer restorePriv()
 		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo"}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")

--- a/internal/privesc/privesc.go
+++ b/internal/privesc/privesc.go
@@ -1,0 +1,28 @@
+package privesc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// EnsureRoot verifies that the current process has root privileges.
+// If not, it attempts to re-exec the process using the provided
+// escalation command (e.g. "sudo -n"). The current process will be
+// replaced on success.
+func EnsureRoot(escalationCmd string) error {
+	if os.Geteuid() == 0 {
+		return nil
+	}
+	if strings.TrimSpace(escalationCmd) == "" {
+		return fmt.Errorf("root privileges required")
+	}
+	parts := strings.Fields(escalationCmd)
+	argv := append(parts, os.Args...)
+	if err := unix.Exec(parts[0], argv, os.Environ()); err != nil {
+		return fmt.Errorf("failed to exec %s: %w", parts[0], err)
+	}
+	return nil
+}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -21,34 +20,29 @@ const (
 	BLKGETSIZE64 = 0x80081272
 )
 
-var (
-	escalationCommand     string
-	escalationCommandLock sync.RWMutex
-)
-
 var statfsFunc = unix.Statfs
 
 var checkPrivs = checkRootPrivileges
 
 var ioctlGetUint64Func = ioctlGetUint64
 
-func SetEscalationCommand(cmd string) {
-	escalationCommandLock.Lock()
-	defer escalationCommandLock.Unlock()
-	escalationCommand = cmd
-}
-
-func GetEscalationCommand() string {
-	escalationCommandLock.RLock()
-	defer escalationCommandLock.RUnlock()
-	return escalationCommand
-}
-
 func checkRootPrivileges() error {
-	if os.Geteuid() != 0 && GetEscalationCommand() == "" {
+	if os.Geteuid() != 0 {
 		return fmt.Errorf("insufficient privileges: LVM operations require root privileges")
 	}
 	return nil
+}
+
+// SetPrivilegeChecker overrides the default privilege check function. It
+// returns a restore function to reset the original behavior.
+func SetPrivilegeChecker(fn func() error) func() {
+	orig := checkPrivs
+	if fn == nil {
+		checkPrivs = checkRootPrivileges
+	} else {
+		checkPrivs = fn
+	}
+	return func() { checkPrivs = orig }
 }
 
 // backend is used to execute LVM operations. It can be overridden for tests.

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -13,14 +13,6 @@ func TestGetSnapshotDevicePath(t *testing.T) {
 	}
 }
 
-func TestSetGetEscalationCommand(t *testing.T) {
-	t.Cleanup(func() { SetEscalationCommand("") })
-	SetEscalationCommand("sudo")
-	if GetEscalationCommand() != "sudo" {
-		t.Fatalf("expected sudo, got %s", GetEscalationCommand())
-	}
-}
-
 func TestParseSnapshotSize(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "vol")
 	if err := os.WriteFile(tmpFile, make([]byte, 1024*1024), 0644); err != nil {

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -40,10 +40,6 @@ func (f *mockBackend) ListVolumeGroups(context.Context, []string) ([]VolumeGroup
 	return nil, nil
 }
 
-func init() {
-	SetEscalationCommand("")
-}
-
 func TestCreateAndRemoveSnapshot(t *testing.T) {
 	orig := checkPrivs
 	checkPrivs = func() error { return nil }

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -24,10 +24,6 @@ func (f *usageBackend) ListVolumeGroups(context.Context, []string) ([]VolumeGrou
 	return nil, nil
 }
 
-func init() {
-	SetEscalationCommand("")
-}
-
 func TestGetSnapshotUsage(t *testing.T) {
 	orig := checkPrivs
 	checkPrivs = func() error { return nil }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"lvmsync_go/config"
+	"lvmsync_go/internal/privesc"
 	"lvmsync_go/lvm"
 	"lvmsync_go/remote"
 	"lvmsync_go/transfer"
@@ -189,12 +190,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := privesc.EnsureRoot(cfg.LVMEscalation); err != nil {
+		fmt.Fprintf(os.Stderr, "Privilege escalation error: %v\n", err)
+		os.Exit(1)
+	}
+
 	if err := cfg.Validate(); err != nil {
 		fmt.Fprintf(os.Stderr, "Configuration validation error: %v\n", err)
 		os.Exit(1)
 	}
-
-	lvm.SetEscalationCommand(cfg.LVMEscalation)
 
 	logger, err := zap.NewProduction()
 	if err != nil {


### PR DESCRIPTION
## Summary
- add internal privilege escalation helper and re-exec when not root
- streamline LVM privilege checks via exported checker override
- document automatic privilege escalation workflow

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: unsupported version of the configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68922254ebe083238207c1e783bc99bf