### PR TITLE
refactor: add pluggable volume group selection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -297,14 +297,14 @@ func LoadConfig() (*Config, error) {
 	}
 
 	if conf.VolumeGroup == "" {
-		vg, err := lvm.SelectVolumeGroupByFreeSpace(context.Background(), conf.SourceVGCandidates)
+		vg, err := lvm.SelectVolumeGroup(context.Background(), conf.SourceVGCandidates, lvm.ByFreeSpace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select source volume group: %w", err)
 		}
 		conf.VolumeGroup = vg.Name
 	}
 	if conf.TargetVolumeGroup == "" && len(conf.TargetVGCandidates) > 0 {
-		vg, err := lvm.SelectVolumeGroupByFreeSpace(context.Background(), conf.TargetVGCandidates)
+		vg, err := lvm.SelectVolumeGroup(context.Background(), conf.TargetVGCandidates, lvm.ByFreeSpace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select target volume group: %w", err)
 		}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -376,9 +376,20 @@ func ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
 	return vgs, nil
 }
 
-// SelectVolumeGroupByFreeSpace chooses the volume group with the most free space.
-// If candidates is non-empty, only those volume groups are considered.
-func SelectVolumeGroupByFreeSpace(ctx context.Context, candidates []string) (VolumeGroup, error) {
+// VolumeGroupSelector defines the strategy used to choose a volume group
+// from a list of candidates.
+type VolumeGroupSelector func([]VolumeGroup) (VolumeGroup, error)
+
+// SelectVolumeGroup chooses a volume group from the system using the provided
+// selector strategy. If candidates is non-empty, only those volume groups are
+// considered.
+func SelectVolumeGroup(ctx context.Context, candidates []string, selector VolumeGroupSelector) (VolumeGroup, error) {
+	if selector == nil {
+		return VolumeGroup{}, fmt.Errorf("selector must not be nil")
+	}
+	if err := checkPrivs(); err != nil {
+		return VolumeGroup{}, err
+	}
 	vgs, err := backend.ListVolumeGroups(ctx, candidates)
 	if err != nil {
 		return VolumeGroup{}, err
@@ -389,6 +400,11 @@ func SelectVolumeGroupByFreeSpace(ctx context.Context, candidates []string) (Vol
 		}
 		return VolumeGroup{}, fmt.Errorf("no volume groups found")
 	}
+	return selector(vgs)
+}
+
+// ByFreeSpace selects the volume group with the largest amount of free space.
+func ByFreeSpace(vgs []VolumeGroup) (VolumeGroup, error) {
 	chosen := vgs[0]
 	for _, vg := range vgs[1:] {
 		if vg.Free > chosen.Free {

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -40,7 +40,7 @@ func (f *vgBackend) ListVolumeGroups(_ context.Context, candidates []string) ([]
 	return res, nil
 }
 
-func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
+func TestSelectVolumeGroup(t *testing.T) {
 	orig := checkPrivs
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
@@ -48,7 +48,7 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 	restore := SetBackend(fb)
 	defer restore()
 
-	vg, err := SelectVolumeGroupByFreeSpace(context.Background(), nil)
+	vg, err := SelectVolumeGroup(context.Background(), nil, ByFreeSpace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 		t.Fatalf("expected vg1 with 200, got %s with %d", vg.Name, vg.Free)
 	}
 
-	vg, err = SelectVolumeGroupByFreeSpace(context.Background(), []string{"vg0"})
+	vg, err = SelectVolumeGroup(context.Background(), []string{"vg0"}, ByFreeSpace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -64,12 +64,12 @@ func TestSelectVolumeGroupByFreeSpace(t *testing.T) {
 		t.Fatalf("expected vg0 with 100, got %s with %d", vg.Name, vg.Free)
 	}
 
-	if _, err := SelectVolumeGroupByFreeSpace(context.Background(), []string{"vg2"}); err == nil {
+	if _, err := SelectVolumeGroup(context.Background(), []string{"vg2"}, ByFreeSpace); err == nil {
 		t.Fatalf("expected error for unknown vg")
 	}
 }
 
-func TestSelectVolumeGroupByFreeSpaceQueriesCandidates(t *testing.T) {
+func TestSelectVolumeGroupQueriesCandidates(t *testing.T) {
 	orig := checkPrivs
 	checkPrivs = func() error { return nil }
 	t.Cleanup(func() { checkPrivs = orig })
@@ -77,10 +77,36 @@ func TestSelectVolumeGroupByFreeSpaceQueriesCandidates(t *testing.T) {
 	restore := SetBackend(fb)
 	defer restore()
 
-	if _, err := SelectVolumeGroupByFreeSpace(context.Background(), []string{"vg0"}); err != nil {
+	if _, err := SelectVolumeGroup(context.Background(), []string{"vg0"}, ByFreeSpace); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !reflect.DeepEqual(fb.lastArgs, []string{"vg0"}) {
 		t.Fatalf("expected backend queried with [vg0], got %v", fb.lastArgs)
+	}
+}
+
+func TestSelectVolumeGroupCustomSelector(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
+	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
+	restore := SetBackend(fb)
+	defer restore()
+
+	selector := func(vgs []VolumeGroup) (VolumeGroup, error) {
+		for _, vg := range vgs {
+			if vg.Name == "vg0" {
+				return vg, nil
+			}
+		}
+		return VolumeGroup{}, fmt.Errorf("no suitable volume group")
+	}
+
+	vg, err := SelectVolumeGroup(context.Background(), nil, selector)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vg.Name != "vg0" {
+		t.Fatalf("expected vg0, got %s", vg.Name)
 	}
 }


### PR DESCRIPTION
## Summary
- introduce strategy-based volume group selection with `ByFreeSpace`
- use new selector in config auto-detection
- expand tests for selector behaviour and custom strategies

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68922ef95a8483239015cadd8804bd1e