### PR TITLE
feat: add blake3 checksum algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Parallel Execution**: Configurable concurrency for optimal performance.
 - **Rate-Limiting**: Control bandwidth usage during transfers.
 - **Compression**: Supports LZ4 and Zstd (with configurable compression levels and an auto mode based on CPU features).
-- **Checksum Verification**: Ensures data integrity using SHA-256.
+- **Checksum Verification**: Ensures data integrity using SHA-256 or BLAKE3.
 - **Native LVM2 Integration**: Uses Go bindings to `liblvm` instead of shelling out.
 - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or Bloom filter with persistent state.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,7 @@ compress_level: 3                      # Compression level for zstd (ignored for
 compress_concurrency: 0               # Number of goroutines for compression (0 to use all cores)
 speed: "100MB"                         # Speed limit (e.g. "100MB")
 verify_checksum: false                 # Enable checksum verification for data integrity
+checksum_algorithm: sha256             # Checksum algorithm (options: sha256, blake3, blake3-512)
 verbose: 0                             # Verbosity level (0 = silent, higher numbers = more verbose)
 
 # LVM Options:

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ import (
 
 var SupportedCompression = []string{"none", "lz4", "zstd", "auto"}
 var SupportedDedupStrategies = []string{"auto", "checksum", "rolling_hash", "bloom"}
+var SupportedChecksumAlgorithms = []string{"sha256", "blake3", "blake3-512"}
 
 var (
 	generalFlags     *pflag.FlagSet
@@ -58,6 +59,7 @@ type Config struct {
 	Speed                string   `mapstructure:"speed"`
 	SpeedLimit           int      `mapstructure:"-"`
 	VerifyChecksum       bool     `mapstructure:"verify_checksum"`
+	ChecksumAlgorithm    string   `mapstructure:"checksum_algorithm"`
 	Verbose              int      `mapstructure:"verbose"`
 	SkipSnapshotCreation bool     `mapstructure:"skip_snapshot_creation"`
 	SkipDiskCheck        bool     `mapstructure:"skip_disk_check"`
@@ -98,11 +100,22 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 		return nil, err
 	}
 	conf.BlockSize = bs
+	if conf.ChecksumAlgorithm == "" {
+		conf.ChecksumAlgorithm = cb.defaults.ChecksumAlgorithm
+	}
 	sl, err := cb.parseBytesOrFallback("speed", cb.defaults.Speed)
 	if err != nil {
 		return nil, err
 	}
 	conf.SpeedLimit = sl
+
+	algo := strings.ToLower(conf.ChecksumAlgorithm)
+	switch algo {
+	case "sha256", "blake3", "blake3-512":
+		conf.ChecksumAlgorithm = algo
+	default:
+		return nil, fmt.Errorf("unsupported checksum algorithm: %s", conf.ChecksumAlgorithm)
+	}
 
 	if conf.CompressConcurrency <= 0 {
 		conf.CompressConcurrency = runtime.GOMAXPROCS(0)
@@ -179,6 +192,7 @@ func DefaultConfig() *Config {
 		CompressConcurrency:  runtime.GOMAXPROCS(0),
 		Speed:                "100MB",
 		VerifyChecksum:       false,
+		ChecksumAlgorithm:    "sha256",
 		Verbose:              0,
 		SkipSnapshotCreation: false,
 		SkipDiskCheck:        false,
@@ -221,6 +235,7 @@ func LoadConfig() (*Config, error) {
 	generalFlags.String("block_size", defaultCfg.BlockSizeRaw, "Block size for data transfer")
 	generalFlags.CountP("verbose", "v", "Verbosity level")
 	generalFlags.Bool("verify_checksum", defaultCfg.VerifyChecksum, "Enable checksum verification")
+	generalFlags.String("checksum_algorithm", defaultCfg.ChecksumAlgorithm, fmt.Sprintf("Checksum algorithm: %v", SupportedChecksumAlgorithms))
 	generalFlags.Bool("progress", defaultCfg.Progress, "Show progress during transfer")
 
 	// SSH Options

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/spf13/pflag v1.0.7
 	github.com/spf13/viper v1.20.1
+	github.com/zeebo/blake3 v0.2.4
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.40.0
 	golang.org/x/sys v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,12 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/transfer/checksum.go
+++ b/transfer/checksum.go
@@ -3,11 +3,17 @@ package transfer
 
 import (
 	"crypto/sha256"
+	"strings"
 	"sync"
+
+	"github.com/zeebo/blake3"
 )
 
+// ChecksumStrategy defines an interface for computing checksums with a
+// predictable output size.
 type ChecksumStrategy interface {
 	Compute(data []byte) []byte
+	Size() int
 }
 
 type SHA256Checksum struct{}
@@ -17,17 +23,42 @@ func (s *SHA256Checksum) Compute(data []byte) []byte {
 	return sum[:]
 }
 
+func (s *SHA256Checksum) Size() int { return sha256.Size }
+
+type BLAKE3Checksum struct{ size int }
+
+func (b *BLAKE3Checksum) Compute(data []byte) []byte {
+	if b.size > 32 {
+		sum := blake3.Sum512(data)
+		return sum[:]
+	}
+	sum := blake3.Sum256(data)
+	return sum[:]
+}
+
+func (b *BLAKE3Checksum) Size() int { return b.size }
+
 var (
-	sha256Instance ChecksumStrategy = &SHA256Checksum{}
-	initOnce       sync.Once
+	strategies map[string]ChecksumStrategy
+	initOnce   sync.Once
 )
 
 func initChecksumStrategies() {
-	sha256Instance = &SHA256Checksum{}
+	strategies = map[string]ChecksumStrategy{
+		"sha256":     &SHA256Checksum{},
+		"blake3":     &BLAKE3Checksum{size: 32},
+		"blake3-256": &BLAKE3Checksum{size: 32},
+		"blake3-512": &BLAKE3Checksum{size: 64},
+	}
 }
 
+// GetChecksumStrategy returns a checksum strategy for the requested algorithm.
+// An unknown algorithm defaults to SHA-256.
 func GetChecksumStrategy(algo string) ChecksumStrategy {
 	initOnce.Do(initChecksumStrategies)
-	// Only SHA-256 is supported; default to it for any request.
-	return sha256Instance
+	a := strings.ToLower(algo)
+	if s, ok := strategies[a]; ok {
+		return s
+	}
+	return strategies["sha256"]
 }

--- a/transfer/checksum_test.go
+++ b/transfer/checksum_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"testing"
+
+	"github.com/zeebo/blake3"
 )
 
 func TestSHA256Checksum(t *testing.T) {
@@ -12,6 +14,24 @@ func TestSHA256Checksum(t *testing.T) {
 	got := GetChecksumStrategy("sha256").Compute(data)
 	if !bytes.Equal(got, want[:]) {
 		t.Fatalf("sha256 checksum mismatch: got %x, want %x", got, want)
+	}
+}
+
+func TestBLAKE3Checksum(t *testing.T) {
+	data := []byte("verify blake3")
+	want := blake3.Sum256(data)
+	got := GetChecksumStrategy("blake3").Compute(data)
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("blake3 checksum mismatch: got %x, want %x", got, want)
+	}
+}
+
+func TestBLAKE3_512Checksum(t *testing.T) {
+	data := []byte("verify blake3 512")
+	want := blake3.Sum512(data)
+	got := GetChecksumStrategy("blake3-512").Compute(data)
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("blake3-512 checksum mismatch: got %x, want %x", got, want)
 	}
 }
 

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -2,7 +2,7 @@
 package transfer
 
 import (
-	"crypto/sha256"
+	"bytes"
 	"encoding/binary"
 	"hash/maphash"
 	"io"
@@ -30,8 +30,9 @@ type DeduplicationStrategy interface {
 
 type ChecksumDedup struct {
 	stateFile string
-	hashes    map[int64][32]byte
+	hashes    map[int64][]byte
 	mu        sync.RWMutex
+	strategy  ChecksumStrategy
 }
 
 type BloomFilterDedup struct {
@@ -40,6 +41,7 @@ type BloomFilterDedup struct {
 	mu        sync.RWMutex
 	entries   uint
 	fpRate    float64
+	strategy  ChecksumStrategy
 }
 
 type RollingHashDedup struct {
@@ -101,6 +103,7 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 			stateFile: cfg.DedupStateFile,
 			entries:   uint(cfg.BloomEntries),
 			fpRate:    cfg.BloomFpRate,
+			strategy:  GetChecksumStrategy(cfg.ChecksumAlgorithm),
 		}
 		if err := d.loadState(); err != nil {
 			zap.L().Warn("failed to load dedup state", zap.Error(err))
@@ -109,7 +112,8 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 	default:
 		d := &ChecksumDedup{
 			stateFile: cfg.DedupStateFile,
-			hashes:    make(map[int64][32]byte),
+			hashes:    make(map[int64][]byte),
+			strategy:  GetChecksumStrategy(cfg.ChecksumAlgorithm),
 		}
 		if err := d.loadState(); err != nil {
 			zap.L().Warn("failed to load dedup state", zap.Error(err))
@@ -123,12 +127,12 @@ func (c *ChecksumDedup) ShouldTransfer(offset int64, data []byte) bool {
 	prev, exists := c.hashes[offset]
 	c.mu.RUnlock()
 
-	sum := sha256.Sum256(data)
-	return !exists || prev != sum
+	sum := c.strategy.Compute(data)
+	return !exists || !bytes.Equal(prev, sum)
 }
 
 func (c *ChecksumDedup) RecordTransfer(offset int64, data []byte) {
-	sum := sha256.Sum256(data)
+	sum := c.strategy.Compute(data)
 
 	c.mu.Lock()
 	c.hashes[offset] = sum
@@ -145,11 +149,15 @@ func (c *ChecksumDedup) SaveState() error {
 	}
 	defer file.Close()
 
+	size := c.strategy.Size()
 	for offset, hash := range c.hashes {
 		if err := binary.Write(file, binary.LittleEndian, offset); err != nil {
 			return err
 		}
-		if _, err := file.Write(hash[:]); err != nil {
+		if len(hash) != size {
+			continue
+		}
+		if _, err := file.Write(hash); err != nil {
 			return err
 		}
 	}
@@ -166,6 +174,7 @@ func (c *ChecksumDedup) loadState() error {
 	}
 	defer file.Close()
 
+	size := c.strategy.Size()
 	for {
 		var offset int64
 		if err := binary.Read(file, binary.LittleEndian, &offset); err != nil {
@@ -174,8 +183,8 @@ func (c *ChecksumDedup) loadState() error {
 			}
 			return err
 		}
-		var hash [32]byte
-		if _, err := io.ReadFull(file, hash[:]); err != nil {
+		hash := make([]byte, size)
+		if _, err := io.ReadFull(file, hash); err != nil {
 			return err
 		}
 		c.hashes[offset] = hash
@@ -281,17 +290,16 @@ func (r *RollingHashDedup) loadState() error {
 }
 
 func (b *BloomFilterDedup) ShouldTransfer(offset int64, data []byte) bool {
-	h := sha256.Sum256(data)
+	sum := b.strategy.Compute(data)
 	b.mu.RLock()
-	ok := !b.filter.Test(h[:])
+	ok := !b.filter.Test(sum)
 	b.mu.RUnlock()
 	return ok
 }
 
 func (b *BloomFilterDedup) RecordTransfer(offset int64, data []byte) {
-	h := sha256.Sum256(data)
 	b.mu.Lock()
-	b.filter.Add(h[:])
+	b.filter.Add(b.strategy.Compute(data))
 	b.mu.Unlock()
 }
 

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -11,7 +11,7 @@ import (
 func TestBloomFilterDedupPersistence(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state")
 
-	d1 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01}
+	d1 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01, strategy: &SHA256Checksum{}}
 	data := []byte("hello")
 
 	if !d1.ShouldTransfer(0, data) {
@@ -22,7 +22,7 @@ func TestBloomFilterDedupPersistence(t *testing.T) {
 		t.Fatalf("failed to save state: %v", err)
 	}
 
-	d2 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01}
+	d2 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01, strategy: &SHA256Checksum{}}
 	if err := d2.loadState(); err != nil {
 		t.Fatalf("failed to load state: %v", err)
 	}

--- a/transfer/dedup_save_state_test.go
+++ b/transfer/dedup_save_state_test.go
@@ -28,7 +28,7 @@ func TestChecksumDedupSaveStateWriteFailures(t *testing.T) {
 	hash := sha256.Sum256([]byte("data"))
 
 	t.Run("binary write failure", func(t *testing.T) {
-		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][32]byte{1: hash}}
+		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
 		fw := &failingWriter{failAfter: 0}
 		orig := createStateFile
 		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
@@ -39,7 +39,7 @@ func TestChecksumDedupSaveStateWriteFailures(t *testing.T) {
 	})
 
 	t.Run("file write failure", func(t *testing.T) {
-		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][32]byte{1: hash}}
+		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
 		fw := &failingWriter{failAfter: 1}
 		orig := createStateFile
 		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
@@ -75,7 +75,7 @@ func TestRollingHashDedupSaveStateWriteFailures(t *testing.T) {
 }
 
 func TestBloomFilterDedupSaveStateWriteFailure(t *testing.T) {
-	b := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: "ignored"}
+	b := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: "ignored", strategy: &SHA256Checksum{}}
 	b.RecordTransfer(0, []byte("data"))
 	fw := &failingWriter{failAfter: 0}
 	orig := createStateFile

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -3,7 +3,7 @@ package transfer
 
 import (
 	"bufio"
-	"crypto/sha256"
+	"bytes"
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
@@ -29,14 +29,15 @@ func SetLogger(logger *zap.Logger) {
 }
 
 type ChecksumState struct {
-	Checksums map[uint64][32]byte
+	Checksums map[uint64][]byte
+	Strategy  string
 }
 
 func LoadChecksumState(filename string) (*ChecksumState, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &ChecksumState{Checksums: make(map[uint64][32]byte)}, nil
+			return &ChecksumState{Checksums: make(map[uint64][]byte), Strategy: "sha256"}, nil
 		}
 		return nil, err
 	}
@@ -48,6 +49,12 @@ func LoadChecksumState(filename string) (*ChecksumState, error) {
 		return nil, err
 	}
 
+	if state.Checksums == nil {
+		state.Checksums = make(map[uint64][]byte)
+	}
+	if state.Strategy == "" {
+		state.Strategy = "sha256"
+	}
 	return state, nil
 }
 
@@ -302,7 +309,12 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	startTime := time.Now()
 	var totalBytesTransferred int64
 
-	var header [12 + sha256.Size]byte
+	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
+	headerSize := 12
+	if cfg.VerifyChecksum {
+		headerSize += checksum.Size()
+	}
+	header := make([]byte, headerSize)
 	for res := range results {
 		if res.Err != nil {
 			return fmt.Errorf("error in block %d: %w", res.Index, res.Err)
@@ -312,9 +324,9 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 		binary.BigEndian.PutUint32(header[8:12], res.Size)
 		n := 12
 		if cfg.VerifyChecksum {
-			sum := sha256.Sum256(res.Data)
-			copy(header[12:], sum[:])
-			n += sha256.Size
+			sum := checksum.Compute(res.Data)
+			copy(header[12:], sum)
+			n += checksum.Size()
 		}
 
 		if _, err := bufOut.Write(header[:n]); err != nil {
@@ -422,9 +434,10 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 
 	startTime := time.Now()
 	var totalBytes int64
+	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	headerLen := 12
 	if verify {
-		headerLen += 32
+		headerLen += checksum.Size()
 	}
 	headerBuf := make([]byte, headerLen)
 
@@ -440,9 +453,10 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 		offset := binary.BigEndian.Uint64(headerBuf[0:8])
 		chunkSize := binary.BigEndian.Uint32(headerBuf[8:12])
 
-		var transmittedSum [32]byte
+		var transmittedSum []byte
 		if verify {
-			copy(transmittedSum[:], headerBuf[12:44])
+			transmittedSum = make([]byte, checksum.Size())
+			copy(transmittedSum, headerBuf[12:])
 		}
 
 		data := getBlockBuffer(int(chunkSize))
@@ -452,8 +466,8 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 		}
 
 		if verify {
-			computed := sha256.Sum256(data)
-			if transmittedSum != computed {
+			computed := checksum.Compute(data)
+			if !bytes.Equal(transmittedSum, computed) {
 				return fmt.Errorf("checksum mismatch at offset %d", offset)
 			}
 		}


### PR DESCRIPTION
## Summary
- add BLAKE3-256 and BLAKE3-512 checksum strategies
- make checksum algorithm configurable via CLI and config
- integrate pluggable checksum strategies into dedup and transfer paths

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68923b20486483239fce71878b4f0391