### PR TITLE
feat: add reusable transfer handshake

### DIFF
--- a/common/handshake.go
+++ b/common/handshake.go
@@ -1,0 +1,93 @@
+package common
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Handshake describes protocol negotiation parameters exchanged at the start
+// of a transfer. The format is a single line of space separated tokens:
+//
+//	lvmsync PROTO[3] compress:<algo> [checksum|checksum-dedup]
+//
+// Additional tokens may be added in the future while preserving backward
+// compatibility. The receiver must ignore unknown tokens to allow for
+// extension.
+//
+// Compress specifies the compression algorithm in use. Checksum indicates
+// whether chunk checksums are included. When ChecksumDedup is true the
+// checksum list also doubles as a deduplication map.
+//
+// Version will always be set to ProtocolVersion on successful parsing.
+//
+// Handshake is deliberately simple to mirror rsync's textual negotiation
+// while remaining easy to extend and debug.
+//
+// This package aims to centralize handshake formatting and parsing to keep
+// transfer/ code focused on business logic and improve maintainability.
+type Handshake struct {
+	Version       string
+	Compress      string
+	Checksum      bool
+	ChecksumDedup bool
+}
+
+// String reconstructs the textual representation of the handshake. It is
+// primarily intended for diagnostics and mirrors the line emitted by
+// WriteHandshake without the trailing newline.
+func (h Handshake) String() string {
+	var sb strings.Builder
+	_ = WriteHandshake(&sb, h) // Writing to strings.Builder never fails.
+	return strings.TrimSpace(sb.String())
+}
+
+// WriteHandshake serializes h to w using the protocol line format. A trailing
+// newline is always written.
+func WriteHandshake(w io.Writer, h Handshake) error {
+	tokens := []string{ProtocolVersion}
+	if h.ChecksumDedup {
+		tokens = append(tokens, "checksum-dedup")
+	} else if h.Checksum {
+		tokens = append(tokens, "checksum")
+	}
+	if h.Compress == "" {
+		h.Compress = "none"
+	}
+	tokens = append(tokens, "compress:"+h.Compress)
+	if _, err := fmt.Fprintln(w, strings.Join(tokens, " ")); err != nil {
+		return fmt.Errorf("write handshake: %w", err)
+	}
+	return nil
+}
+
+// ReadHandshake parses a handshake from r. r must be a bufio.Reader so that
+// the caller can continue reading the remaining stream after the handshake
+// has been consumed.
+func ReadHandshake(r *bufio.Reader) (Handshake, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return Handshake{}, fmt.Errorf("read handshake: %w", err)
+	}
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, ProtocolVersion) {
+		return Handshake{}, fmt.Errorf("unexpected protocol handshake: %s", line)
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(line, ProtocolVersion))
+	h := Handshake{Version: ProtocolVersion, Compress: "none"}
+	for _, t := range strings.Fields(rest) {
+		switch {
+		case strings.HasPrefix(t, "compress:"):
+			h.Compress = strings.TrimPrefix(t, "compress:")
+		case t == "checksum":
+			h.Checksum = true
+		case t == "checksum-dedup":
+			h.Checksum = true
+			h.ChecksumDedup = true
+		default:
+			return Handshake{}, fmt.Errorf("unexpected token in handshake: %s", t)
+		}
+	}
+	return h, nil
+}

--- a/common/handshake_test.go
+++ b/common/handshake_test.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"bufio"
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestHandshakeRoundTrip(t *testing.T) {
+	original := Handshake{Version: ProtocolVersion, Compress: "gzip", Checksum: true}
+	var buf bytes.Buffer
+	if err := WriteHandshake(&buf, original); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+	parsed, err := ReadHandshake(bufio.NewReader(&buf))
+	if err != nil {
+		t.Fatalf("read handshake: %v", err)
+	}
+	if !reflect.DeepEqual(original, parsed) {
+		t.Fatalf("handshake mismatch: %+v != %+v", original, parsed)
+	}
+}
+
+func TestHandshakeString(t *testing.T) {
+	h := Handshake{Compress: "none", Checksum: true, ChecksumDedup: true}
+	expected := "lvmsync PROTO[3] checksum-dedup compress:none"
+	if h.String() != expected {
+		t.Fatalf("unexpected string: %s", h.String())
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -104,12 +104,21 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	}
 	Logger.Info("Changed blocks determined", zap.Int("blockCount", len(ranges)))
 
-	tokens := []string{common.ProtocolVersion}
-	if handshake != "" {
-		tokens = append(tokens, handshake)
+	// Compose protocol handshake using the shared helper to ensure
+	// consistent formatting between sender and receiver. This mirrors the
+	// textual negotiation style employed by rsync while remaining easy to
+	// extend with additional capability tokens.
+	hs := common.Handshake{Compress: cfg.Compress}
+	switch handshake {
+	case "checksum":
+		hs.Checksum = true
+	case "checksum-dedup":
+		hs.Checksum = true
+		hs.ChecksumDedup = true
 	}
-	tokens = append(tokens, "compress:"+cfg.Compress)
-	fmt.Fprintln(out, strings.Join(tokens, " "))
+	if err := common.WriteHandshake(out, hs); err != nil {
+		return err
+	}
 
 	compWriter, bufOut, err := prepareOutputWriter(out, cfg)
 	if err != nil {
@@ -381,40 +390,19 @@ func finalizeResults(wg *sync.WaitGroup, results chan<- *BlockResult) {
 
 func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) error {
 	bufReader := bufio.NewReader(in)
-	handshake, err := bufReader.ReadString('\n')
+	hs, err := common.ReadHandshake(bufReader)
 	if err != nil {
 		return fmt.Errorf("failed to read protocol handshake: %w", err)
 	}
-	handshake = strings.TrimSpace(handshake)
-	if !strings.HasPrefix(handshake, common.ProtocolVersion) {
-		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
+
+	if verify && !hs.Checksum {
+		return fmt.Errorf("unexpected protocol handshake: %s", hs.String())
 	}
-	rest := strings.TrimSpace(strings.TrimPrefix(handshake, common.ProtocolVersion))
-	tokens := strings.Fields(rest)
-	compress := "none"
-	hasChecksum := false
-	hasDedup := false
-	for _, t := range tokens {
-		if strings.HasPrefix(t, "compress:") {
-			compress = strings.TrimPrefix(t, "compress:")
-		} else if t == "checksum" {
-			hasChecksum = true
-		} else if t == "checksum-dedup" {
-			hasChecksum = true
-			hasDedup = true
-		} else {
-			return fmt.Errorf("unexpected protocol handshake: %s", handshake)
-		}
+	if dedup != nil && !hs.ChecksumDedup {
+		return fmt.Errorf("unexpected protocol handshake: %s", hs.String())
 	}
 
-	if verify && !hasChecksum {
-		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
-	}
-	if dedup != nil && !hasDedup {
-		return fmt.Errorf("unexpected protocol handshake: %s", handshake)
-	}
-
-	decReader, err := NewDecompressionReader(bufReader, compress, cfg.CompressConcurrency)
+	decReader, err := NewDecompressionReader(bufReader, hs.Compress, cfg.CompressConcurrency)
 	if err != nil {
 		return fmt.Errorf("failed to create decompression reader: %w", err)
 	}


### PR DESCRIPTION
## Summary
- centralize protocol handshake logic into common.Handshake
- reuse handshake helper in transfer sender and receiver

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689248ad6f6c832393d3b2311e7fb1e8