### PR TITLE
Add adaptive block size detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `-v, --verbose` | Verbosity level (e.g., `-v`, `-vv`, `-vvv`) | `0` |
 | `--verify_checksum` | Enable checksum verification for data integrity | `false` |
 | `--progress` | Show progress percentage during the transfer | `true` |
-| `--block_size` | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`) | `"4K"` |
+| `--block_size` | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"` |
 
 #### SSH Options
 

--- a/config.yaml
+++ b/config.yaml
@@ -43,4 +43,4 @@ source_vgs: []                         # Candidate source VGs for auto-selection
 target_vgs: []                         # Candidate target VGs for auto-selection
 lvm_escalation: "sudo -n"              # Command used to re-execute the program with elevated privileges when required
 progress: true                         # Enable progress display during transfer
-block_size: "4K"                       # Block size for LVM operations
+block_size: "4K"                       # Block size for LVM operations (0 for auto)

--- a/config/config.go
+++ b/config/config.go
@@ -232,7 +232,7 @@ func LoadConfig() (*Config, error) {
 	generalFlags.Int("max_retries", defaultCfg.MaxRetries, "Maximum number of retries per block")
 	generalFlags.String("resume", defaultCfg.ResumeState, "Path to resume state file")
 	generalFlags.String("speed", defaultCfg.Speed, "Transfer speed limit")
-	generalFlags.String("block_size", defaultCfg.BlockSizeRaw, "Block size for data transfer")
+	generalFlags.String("block_size", defaultCfg.BlockSizeRaw, "Block size for data transfer; 0 for automatic detection")
 	generalFlags.CountP("verbose", "v", "Verbosity level")
 	generalFlags.Bool("verify_checksum", defaultCfg.VerifyChecksum, "Enable checksum verification")
 	generalFlags.String("checksum_algorithm", defaultCfg.ChecksumAlgorithm, fmt.Sprintf("Checksum algorithm: %v", SupportedChecksumAlgorithms))

--- a/internal/blocksize/blocksize.go
+++ b/internal/blocksize/blocksize.go
@@ -1,0 +1,50 @@
+package blocksize
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// Detect determines an optimal block size for the given block device.
+// It inspects sysfs queue attributes in the following order of preference:
+//  1. optimal_io_size
+//  2. minimum_io_size
+//  3. physical_block_size
+//  4. logical_block_size
+//
+// If none of these values are available or greater than zero, a default
+// of 4096 bytes is returned.
+func Detect(devicePath string) (int, error) {
+	fi, err := os.Stat(devicePath)
+	if err != nil {
+		return 0, fmt.Errorf("stat %s: %w", devicePath, err)
+	}
+	stat, ok := fi.Sys().(*unix.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("unsupported file info for %s", devicePath)
+	}
+	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(uint64(stat.Rdev)), unix.Minor(uint64(stat.Rdev))))
+	return readPreferredSize(queuePath)
+}
+
+var preference = []string{"optimal_io_size", "minimum_io_size", "physical_block_size", "logical_block_size"}
+
+func readPreferredSize(queuePath string) (int, error) {
+	for _, name := range preference {
+		data, err := os.ReadFile(filepath.Join(queuePath, name))
+		if err != nil {
+			continue
+		}
+		v, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || v <= 0 {
+			continue
+		}
+		return v, nil
+	}
+	return 4096, nil
+}

--- a/internal/blocksize/blocksize_test.go
+++ b/internal/blocksize/blocksize_test.go
@@ -1,0 +1,39 @@
+package blocksize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadPreferredSize(t *testing.T) {
+	dir := t.TempDir()
+	// write only physical_block_size
+	if err := os.WriteFile(filepath.Join(dir, "physical_block_size"), []byte("8192\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	size, err := readPreferredSize(dir)
+	if err != nil {
+		t.Fatalf("readPreferredSize error: %v", err)
+	}
+	if size != 8192 {
+		t.Fatalf("expected 8192, got %d", size)
+	}
+}
+
+func TestReadPreferredSizeOrder(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "physical_block_size"), []byte("4096\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "optimal_io_size"), []byte("32768\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	size, err := readPreferredSize(dir)
+	if err != nil {
+		t.Fatalf("readPreferredSize error: %v", err)
+	}
+	if size != 32768 {
+		t.Fatalf("expected 32768, got %d", size)
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -17,6 +17,7 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/config"
+	"lvmsync_go/internal/blocksize"
 
 	"go.uber.org/zap"
 )
@@ -93,6 +94,16 @@ func cleanupOutput(buf *bufio.Writer, w io.WriteCloser) {
 }
 
 func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) error {
+	if cfg.BlockSize == 0 {
+		bs, err := blocksize.Detect(source)
+		if err != nil {
+			return fmt.Errorf("auto-detect block size: %w", err)
+		}
+		cfg.BlockSize = bs
+		Logger.Info("Auto-detected block size", zap.Int("blockSize", cfg.BlockSize))
+	}
+	Logger.Info("Using block size", zap.Int("blockSize", cfg.BlockSize))
+
 	metadataDevice := GetMetadataDevice(snapshot)
 	if metadataDevice == "" {
 		return fmt.Errorf("failed to determine metadata device from snapshot %s", snapshot)
@@ -241,13 +252,22 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 		return DumpChangesSequential(cfg, snapshot, source, out)
 	}
 
+	if cfg.BlockSize == 0 {
+		bs, err := blocksize.Detect(source)
+		if err != nil {
+			return fmt.Errorf("auto-detect block size: %w", err)
+		}
+		cfg.BlockSize = bs
+		Logger.Info("Auto-detected block size", zap.Int("blockSize", cfg.BlockSize))
+	}
+
 	metadataDevice := GetMetadataDevice(snapshot)
 	if metadataDevice == "" {
 		return fmt.Errorf("failed to determine metadata device from snapshot %s", snapshot)
 	}
 	blockSize := int64(cfg.BlockSize)
 
-	Logger.Info("Using configured block size", zap.Int("blockSize", cfg.BlockSize))
+	Logger.Info("Using block size", zap.Int("blockSize", cfg.BlockSize))
 
 	ranges, err := GetDifferences(metadataDevice, blockSize)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add internal blocksize package to derive optimal block size from sysfs attributes
- autodetect block size during transfer when `--block_size` is set to 0
- document automatic block size support in configuration and README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68924cbd89188323b31aac0dcfc1ff27