### PR TITLE
Default block size to auto-detection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,4 +43,4 @@ source_vgs: []                         # Candidate source VGs for auto-selection
 target_vgs: []                         # Candidate target VGs for auto-selection
 lvm_escalation: "sudo -n"              # Command used to re-execute the program with elevated privileges when required
 progress: true                         # Enable progress display during transfer
-block_size: "4K"                       # Block size for LVM operations (0 for auto)
+block_size: "auto"                     # Block size for LVM operations ('auto' or 0 for automatic detection)

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,9 @@ type Config struct {
 }
 
 func (c *Config) HumanBlockSize() string {
+	if c.BlockSize == 0 {
+		return "auto"
+	}
 	return sizeparse.FormatBytes(uint64(c.BlockSize))
 }
 
@@ -94,12 +97,12 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
 	}
 
-	conf.BlockSizeRaw = cb.getBlockSizeRaw()
-	bs, err := cb.parseBytesOrFallback("block_size", cb.defaults.BlockSizeRaw)
+	bs, raw, err := cb.parseBlockSize()
 	if err != nil {
 		return nil, err
 	}
 	conf.BlockSize = bs
+	conf.BlockSizeRaw = raw
 	if conf.ChecksumAlgorithm == "" {
 		conf.ChecksumAlgorithm = cb.defaults.ChecksumAlgorithm
 	}
@@ -160,12 +163,23 @@ func (cb *ConfigBuilder) parseBytesOrFallback(key, fallback string) (int, error)
 	return int(u), nil
 }
 
-func (cb *ConfigBuilder) getBlockSizeRaw() string {
-	raw := strings.TrimSpace(cb.v.GetString("block_size"))
-	if raw != "" {
-		return raw
+func (cb *ConfigBuilder) parseBlockSize() (int, string, error) {
+	raw := strings.ReplaceAll(strings.TrimSpace(cb.v.GetString("block_size")), " ", "")
+	if raw == "" {
+		raw = cb.defaults.BlockSizeRaw
 	}
-	return cb.defaults.BlockSizeRaw
+	if strings.EqualFold(raw, "auto") {
+		return 0, raw, nil
+	}
+	val, isPercent, err := sizeparse.Parse(raw)
+	if err != nil || isPercent {
+		return 0, "", fmt.Errorf("invalid block_size value %q: %w", raw, err)
+	}
+	u := uint64(val)
+	if float64(u) != val || u > uint64(math.MaxInt) {
+		return 0, "", fmt.Errorf("block_size value %q overflows int", raw)
+	}
+	return int(u), raw, nil
 }
 
 func DefaultConfig() *Config {
@@ -203,8 +217,8 @@ func DefaultConfig() *Config {
 		TargetVGCandidates:   []string{},
 		LVMEscalation:        "sudo -n",
 		Progress:             true,
-		BlockSize:            4096,
-		BlockSizeRaw:         "4KB",
+		BlockSize:            0,
+		BlockSizeRaw:         "auto",
 		Deduplication:        false,
 		DedupStrategy:        "auto",
 		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
@@ -232,7 +246,7 @@ func LoadConfig() (*Config, error) {
 	generalFlags.Int("max_retries", defaultCfg.MaxRetries, "Maximum number of retries per block")
 	generalFlags.String("resume", defaultCfg.ResumeState, "Path to resume state file")
 	generalFlags.String("speed", defaultCfg.Speed, "Transfer speed limit")
-	generalFlags.String("block_size", defaultCfg.BlockSizeRaw, "Block size for data transfer; 0 for automatic detection")
+	generalFlags.String("block_size", defaultCfg.BlockSizeRaw, "Block size for data transfer; specify 'auto' or 0 for automatic detection")
 	generalFlags.CountP("verbose", "v", "Verbosity level")
 	generalFlags.Bool("verify_checksum", defaultCfg.VerifyChecksum, "Enable checksum verification")
 	generalFlags.String("checksum_algorithm", defaultCfg.ChecksumAlgorithm, fmt.Sprintf("Checksum algorithm: %v", SupportedChecksumAlgorithms))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,6 +49,20 @@ func TestDefaultConfigCompress(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigBlockSize(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.BlockSize != 0 || cfg.BlockSizeRaw != "auto" {
+		t.Fatalf("expected default block size auto, got %d (%s)", cfg.BlockSize, cfg.BlockSizeRaw)
+	}
+}
+
+func TestHumanBlockSize(t *testing.T) {
+	c := &Config{BlockSize: 0}
+	if c.HumanBlockSize() != "auto" {
+		t.Fatalf("expected auto, got %s", c.HumanBlockSize())
+	}
+}
+
 func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		v := viper.New()
@@ -159,21 +173,30 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 }
 
-func TestGetBlockSizeRaw(t *testing.T) {
-	t.Run("fromConfig", func(t *testing.T) {
+func TestBuildBlockSize(t *testing.T) {
+	t.Run("auto", func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", "16KB")
-		cb := &ConfigBuilder{v: v, defaults: &Config{BlockSizeRaw: "4KB"}}
-		if got := cb.getBlockSizeRaw(); got != "16KB" {
-			t.Fatalf("expected 16KB, got %s", got)
+		v.Set("block_size", "auto")
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		cfg, err := cb.Build()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.BlockSize != 0 || cfg.BlockSizeRaw != "auto" {
+			t.Fatalf("expected auto block size, got %d (%s)", cfg.BlockSize, cfg.BlockSizeRaw)
 		}
 	})
 
-	t.Run("fallback", func(t *testing.T) {
+	t.Run("numeric", func(t *testing.T) {
 		v := viper.New()
-		cb := &ConfigBuilder{v: v, defaults: &Config{BlockSizeRaw: "4KB"}}
-		if got := cb.getBlockSizeRaw(); got != "4KB" {
-			t.Fatalf("expected 4KB, got %s", got)
+		v.Set("block_size", "8KB")
+		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		cfg, err := cb.Build()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.BlockSize != 8000 || cfg.BlockSizeRaw != "8KB" {
+			t.Fatalf("expected 8000/8KB, got %d/%s", cfg.BlockSize, cfg.BlockSizeRaw)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Support explicit `auto` handling for block size, returning `auto` when unset and parsing it in the configuration builder.
- Default block size now auto-detects in both config defaults and CLI flags.
- Extended tests to cover new auto block-size behavior.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68924fa035ac832397cd020e119ca038