### PR TITLE
Implement volume group auto-selection by required space

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
   - Automatic snapshot creation and removal.
   - Configurable snapshot size (absolute or percentage-based).
   - Configurable volume group for constructing the snapshot device path.
+  - Auto-selection of source and target volume groups with sufficient free space.
   - Automatic privilege escalation (defaulting to `sudo -n`).
   - Snapshot health monitoring that fails fast if usage exceeds a threshold.
 - **Graceful Shutdown**: Signal handling ensures snapshots are cleaned up on interruption.
@@ -127,7 +128,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--skip_snapshot_creation` | Skip automatic snapshot creation | `false` |
 | `--skip_disk_check` | Skip disk space check before snapshot creation | `false` |
 | `--snapshot_size` | Snapshot size as an absolute value (e.g., `"20G"`) or as a percentage (e.g., `"20%"`) | `"20%"` |
-| `--volume_group` | Source volume group. If empty, the group with the most free space is selected automatically | `"vg0"` |
+| `--volume_group` | Source volume group. If empty, a group with sufficient free space is selected automatically | `""` |
 | `--target_volume_group` | Volume group name of the target LVM volume | `""` |
 | `--source_vgs` | Candidate source volume groups for auto-selection | `[]` |
 | `--target_vgs` | Candidate target volume groups for auto-selection | `[]` |
@@ -246,7 +247,7 @@ compress_concurrency: 0                # Number of goroutines for compression (0
 skip_snapshot_creation: false           # Skip automatic snapshot creation
 skip_disk_check: false                  # Skip disk space check before snapshot creation
 snapshot_size: "20%"                    # Snapshot size as an absolute value (e.g., "20G") or as a percentage (e.g., "20%")
-volume_group: "vg0"                     # Source volume group. Auto-selected by free space when empty
+volume_group: ""                        # Source volume group. Auto-selected with enough free space when empty
 target_volume_group: ""                 # Volume group name of the target LVM volume
 source_vgs: []                          # Candidate source VGs for auto-selection
 target_vgs: []                          # Candidate target VGs for auto-selection

--- a/config.yaml
+++ b/config.yaml
@@ -37,7 +37,7 @@ verbose: 0                             # Verbosity level (0 = silent, higher num
 skip_snapshot_creation: false          # Skip automatic snapshot creation
 skip_disk_check: false                 # Skip disk space check before snapshot creation
 snapshot_size: "20%"                   # Snapshot size as an absolute value (e.g. "20G") or as a percentage (e.g. "20%")
-volume_group: "vg0"                    # Source volume group. Auto-selected by free space when empty
+volume_group: ""                      # Source volume group. Auto-selected with enough free space when empty
 target_volume_group: ""                # Volume group name of the target LVM volume
 source_vgs: []                         # Candidate source VGs for auto-selection
 target_vgs: []                         # Candidate target VGs for auto-selection

--- a/config/config.go
+++ b/config/config.go
@@ -211,7 +211,7 @@ func DefaultConfig() *Config {
 		SkipSnapshotCreation: false,
 		SkipDiskCheck:        false,
 		SnapshotSize:         "20%",
-		VolumeGroup:          "vg0",
+		VolumeGroup:          "",
 		TargetVolumeGroup:    "",
 		SourceVGCandidates:   []string{},
 		TargetVGCandidates:   []string{},
@@ -323,21 +323,6 @@ func LoadConfig() (*Config, error) {
 	conf, err := builder.Build()
 	if err != nil {
 		return nil, err
-	}
-
-	if conf.VolumeGroup == "" {
-		vg, err := lvm.SelectVolumeGroup(context.Background(), conf.SourceVGCandidates, lvm.ByFreeSpace)
-		if err != nil {
-			return nil, fmt.Errorf("failed to select source volume group: %w", err)
-		}
-		conf.VolumeGroup = vg.Name
-	}
-	if conf.TargetVolumeGroup == "" && len(conf.TargetVGCandidates) > 0 {
-		vg, err := lvm.SelectVolumeGroup(context.Background(), conf.TargetVGCandidates, lvm.ByFreeSpace)
-		if err != nil {
-			return nil, fmt.Errorf("failed to select target volume group: %w", err)
-		}
-		conf.TargetVolumeGroup = vg.Name
 	}
 
 	return conf, nil

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -414,6 +414,42 @@ func ByFreeSpace(vgs []VolumeGroup) (VolumeGroup, error) {
 	return chosen, nil
 }
 
+// ByFreeSpaceFit returns a selector that chooses the volume group with the
+// largest amount of free space among those providing at least the required
+// amount of free bytes. It fails if no volume group satisfies the requirement.
+func ByFreeSpaceFit(required uint64) VolumeGroupSelector {
+	return func(vgs []VolumeGroup) (VolumeGroup, error) {
+		var (
+			chosen VolumeGroup
+			found  bool
+		)
+		for _, vg := range vgs {
+			if vg.Free < required {
+				continue
+			}
+			if !found || vg.Free > chosen.Free {
+				chosen = vg
+				found = true
+			}
+		}
+		if !found {
+			return VolumeGroup{}, fmt.Errorf("no volume group has %d bytes free", required)
+		}
+		return chosen, nil
+	}
+}
+
+// SelectVolumeGroupForSize selects a volume group from the given candidates
+// that has at least the required amount of free space. If required is zero it
+// behaves like SelectVolumeGroup with ByFreeSpace.
+func SelectVolumeGroupForSize(ctx context.Context, candidates []string, required uint64) (VolumeGroup, error) {
+	selector := ByFreeSpace
+	if required > 0 {
+		selector = ByFreeSpaceFit(required)
+	}
+	return SelectVolumeGroup(ctx, candidates, selector)
+}
+
 func Cleanup() {
 	deviceFDCache.Close()
 }

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -110,3 +110,24 @@ func TestSelectVolumeGroupCustomSelector(t *testing.T) {
 		t.Fatalf("expected vg0, got %s", vg.Name)
 	}
 }
+
+func TestSelectVolumeGroupForSize(t *testing.T) {
+	orig := checkPrivs
+	checkPrivs = func() error { return nil }
+	t.Cleanup(func() { checkPrivs = orig })
+	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
+	restore := SetBackend(fb)
+	defer restore()
+
+	vg, err := SelectVolumeGroupForSize(context.Background(), nil, 150)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vg.Name != "vg1" {
+		t.Fatalf("expected vg1, got %s", vg.Name)
+	}
+
+	if _, err := SelectVolumeGroupForSize(context.Background(), nil, 250); err == nil {
+		t.Fatalf("expected error when no vg has enough space")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -259,6 +259,28 @@ func main() {
 		logger.Fatal("Failed to parse snapshot size", zap.Error(err))
 	}
 
+	if cfg.VolumeGroup == "" {
+		vg, err := lvm.SelectVolumeGroupForSize(context.Background(), cfg.SourceVGCandidates, snapshotBytes)
+		if err != nil {
+			logger.Fatal("Failed to select source volume group", zap.Error(err))
+		}
+		cfg.VolumeGroup = vg.Name
+		logger.Info("Selected source volume group", zap.String("volume_group", cfg.VolumeGroup))
+	}
+
+	if cfg.TargetVolumeGroup == "" && len(cfg.TargetVGCandidates) > 0 {
+		lvSize, err := lvm.GetVolumeSize(originalVolume)
+		if err != nil {
+			logger.Fatal("Failed to determine volume size", zap.Error(err))
+		}
+		vg, err := lvm.SelectVolumeGroupForSize(context.Background(), cfg.TargetVGCandidates, lvSize)
+		if err != nil {
+			logger.Fatal("Failed to select target volume group", zap.Error(err))
+		}
+		cfg.TargetVolumeGroup = vg.Name
+		logger.Info("Selected target volume group", zap.String("target_volume_group", cfg.TargetVolumeGroup))
+	}
+
 	if !cfg.SkipDiskCheck {
 		freeSpace, err := lvm.CheckDiskSpace("/")
 		if err != nil {


### PR DESCRIPTION
## Summary
- choose volume groups providing enough free space using new selector
- auto-detect source and target volume groups during runtime
- document and default configuration updates for automatic VG selection

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892529d2eec83238f67ed23c014ca48