### PR TITLE
Limit VG auto-selection to destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
   - Automatic snapshot creation and removal.
   - Configurable snapshot size (absolute or percentage-based).
   - Configurable volume group for constructing the snapshot device path.
-  - Auto-selection of source and target volume groups with sufficient free space.
+  - Auto-selection of target volume groups with sufficient free space.
   - Automatic privilege escalation (defaulting to `sudo -n`).
   - Snapshot health monitoring that fails fast if usage exceeds a threshold.
 - **Graceful Shutdown**: Signal handling ensures snapshots are cleaned up on interruption.
@@ -128,9 +128,8 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--skip_snapshot_creation` | Skip automatic snapshot creation | `false` |
 | `--skip_disk_check` | Skip disk space check before snapshot creation | `false` |
 | `--snapshot_size` | Snapshot size as an absolute value (e.g., `"20G"`) or as a percentage (e.g., `"20%"`) | `"20%"` |
-| `--volume_group` | Source volume group. If empty, a group with sufficient free space is selected automatically | `""` |
+| `--volume_group` | Source volume group. Derived from the source device path when empty | `""` |
 | `--target_volume_group` | Volume group name of the target LVM volume | `""` |
-| `--source_vgs` | Candidate source volume groups for auto-selection | `[]` |
 | `--target_vgs` | Candidate target volume groups for auto-selection | `[]` |
 | `--lvm_escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., `"sudo -n"`) | `"sudo -n"` |
 
@@ -247,9 +246,8 @@ compress_concurrency: 0                # Number of goroutines for compression (0
 skip_snapshot_creation: false           # Skip automatic snapshot creation
 skip_disk_check: false                  # Skip disk space check before snapshot creation
 snapshot_size: "20%"                    # Snapshot size as an absolute value (e.g., "20G") or as a percentage (e.g., "20%")
-volume_group: ""                        # Source volume group. Auto-selected with enough free space when empty
+volume_group: ""                        # Source volume group. Derived from the source path when empty
 target_volume_group: ""                 # Volume group name of the target LVM volume
-source_vgs: []                          # Candidate source VGs for auto-selection
 target_vgs: []                          # Candidate target VGs for auto-selection
 lvm_escalation: "sudo -n"               # Command used to re-execute the program with elevated privileges when needed
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -37,9 +37,8 @@ verbose: 0                             # Verbosity level (0 = silent, higher num
 skip_snapshot_creation: false          # Skip automatic snapshot creation
 skip_disk_check: false                 # Skip disk space check before snapshot creation
 snapshot_size: "20%"                   # Snapshot size as an absolute value (e.g. "20G") or as a percentage (e.g. "20%")
-volume_group: ""                      # Source volume group. Auto-selected with enough free space when empty
+volume_group: ""                      # Source volume group. Derived from the source path when empty
 target_volume_group: ""                # Volume group name of the target LVM volume
-source_vgs: []                         # Candidate source VGs for auto-selection
 target_vgs: []                         # Candidate target VGs for auto-selection
 lvm_escalation: "sudo -n"              # Command used to re-execute the program with elevated privileges when required
 progress: true                         # Enable progress display during transfer

--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,6 @@ type Config struct {
 	SnapshotSize         string   `mapstructure:"snapshot_size"`
 	VolumeGroup          string   `mapstructure:"volume_group"`
 	TargetVolumeGroup    string   `mapstructure:"target_volume_group"`
-	SourceVGCandidates   []string `mapstructure:"source_vgs"`
 	TargetVGCandidates   []string `mapstructure:"target_vgs"`
 	LVMEscalation        string   `mapstructure:"lvm_escalation"`
 	Progress             bool     `mapstructure:"progress"`
@@ -213,7 +212,6 @@ func DefaultConfig() *Config {
 		SnapshotSize:         "20%",
 		VolumeGroup:          "",
 		TargetVolumeGroup:    "",
-		SourceVGCandidates:   []string{},
 		TargetVGCandidates:   []string{},
 		LVMEscalation:        "sudo -n",
 		Progress:             true,
@@ -283,9 +281,8 @@ func LoadConfig() (*Config, error) {
 	lvmFlags.Bool("skip_disk_check", defaultCfg.SkipDiskCheck, "Skip disk space check before snapshot creation")
 	lvmFlags.String("snapshot_size", defaultCfg.SnapshotSize, "Snapshot size (e.g., '20G' or '20%')")
 	lvmFlags.String("lvm_escalation", defaultCfg.LVMEscalation, "Command used to escalate privileges for LVM commands")
-	lvmFlags.String("volume_group", defaultCfg.VolumeGroup, "Volume group name of the source LVM volume")
+	lvmFlags.String("volume_group", defaultCfg.VolumeGroup, "Source volume group; derived from the source device path when empty")
 	lvmFlags.String("target_volume_group", defaultCfg.TargetVolumeGroup, "Volume group name of the target LVM volume")
-	lvmFlags.StringSlice("source_vgs", defaultCfg.SourceVGCandidates, "Candidate source volume groups for auto-selection")
 	lvmFlags.StringSlice("target_vgs", defaultCfg.TargetVGCandidates, "Candidate target volume groups for auto-selection")
 
 	// Register flags and set usage

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -345,6 +345,18 @@ func GetSnapshotDevicePath(snapshotName, volumeGroup string) string {
 	return path
 }
 
+// GetVolumeGroupName extracts the volume group name from a logical volume path.
+// The path must be of the form /dev/<vg>/<lv>. It returns an error for invalid
+// paths.
+func GetVolumeGroupName(lvPath string) (string, error) {
+	trimmed := strings.TrimPrefix(lvPath, "/dev/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("invalid logical volume path: %s", lvPath)
+	}
+	return parts[0], nil
+}
+
 func GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
 	if err := checkPrivs(); err != nil {
 		return 0, err

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -13,6 +13,19 @@ func TestGetSnapshotDevicePath(t *testing.T) {
 	}
 }
 
+func TestGetVolumeGroupName(t *testing.T) {
+	vg, err := GetVolumeGroupName("/dev/vg0/lv1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vg != "vg0" {
+		t.Fatalf("expected vg0, got %s", vg)
+	}
+	if _, err := GetVolumeGroupName("/dev/invalid"); err == nil {
+		t.Fatalf("expected error for invalid path")
+	}
+}
+
 func TestParseSnapshotSize(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "vol")
 	if err := os.WriteFile(tmpFile, make([]byte, 1024*1024), 0644); err != nil {

--- a/main.go
+++ b/main.go
@@ -260,12 +260,12 @@ func main() {
 	}
 
 	if cfg.VolumeGroup == "" {
-		vg, err := lvm.SelectVolumeGroupForSize(context.Background(), cfg.SourceVGCandidates, snapshotBytes)
+		vg, err := lvm.GetVolumeGroupName(originalVolume)
 		if err != nil {
-			logger.Fatal("Failed to select source volume group", zap.Error(err))
+			logger.Fatal("Failed to determine source volume group", zap.Error(err))
 		}
-		cfg.VolumeGroup = vg.Name
-		logger.Info("Selected source volume group", zap.String("volume_group", cfg.VolumeGroup))
+		cfg.VolumeGroup = vg
+		logger.Info("Using source volume group", zap.String("volume_group", cfg.VolumeGroup))
 	}
 
 	if cfg.TargetVolumeGroup == "" && len(cfg.TargetVGCandidates) > 0 {


### PR DESCRIPTION
## Summary
- derive source volume group from source path instead of auto-selecting
- expose GetVolumeGroupName and drop source_vgs configuration
- document destination-only volume group auto-selection

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689255f7811c8323b0e096a1648521c1