### PR TITLE
Use dedup_strategy to control deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--deduplication` | Enable deduplication to avoid re-transferring unchanged blocks | `false` |
-| `--dedup_strategy` | Deduplication strategy (`"auto"`, `"checksum"`, `"rolling_hash"`, or `"bloom"`) | `"auto"` |
+| `--dedup_strategy` | Deduplication strategy (`"none"`, `"auto"`, `"checksum"`, `"rolling_hash"`, or `"bloom"`); use `none` to disable | `"none"` |
 | `--dedup_state_file` | Path to deduplication state file | `~/.lvmsync_dedup` |
 | `--bloom_entries` | Estimated number of entries for bloom filter | `1000000` |
 | `--bloom_fp_rate` | False positive rate for bloom filter | `0.01` |
@@ -219,8 +218,7 @@ verify_checksum: false                  # Enable checksum verification
 progress: true                          # Show progress percentage during the transfer
 
 # Deduplication Options:
-deduplication: false                    # Enable deduplication to avoid re-transferring unchanged blocks
-dedup_strategy: "auto"                   # Strategy: "auto", "checksum", "rolling_hash", or "bloom"
+dedup_strategy: "none"                   # Strategy: "none", "auto", "checksum", "rolling_hash", or "bloom" (use "none" to disable)
 dedup_state_file: "~/.lvmsync_dedup"    # Path to deduplication state file
 bloom_entries: 1000000                  # Estimated number of entries for bloom filter
 bloom_fp_rate: 0.01                     # False positive rate for bloom filter

--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,7 @@ max_retries: 3                         # Maximum number of retries per block
 resume: ""                             # Path to resume state file
 
 # Deduplication Options
-deduplication: false                    # Enable deduplication to avoid re-transferring unchanged blocks
-dedup_strategy: "checksum"               # Strategy: "checksum", "rolling_hash", or "bloom"
+dedup_strategy: "none"                   # Strategy: "none", "auto", "checksum", "rolling_hash", or "bloom" (use "none" to disable)
 dedup_state_file: "~/.lvmsync_dedup"    # Path to deduplication state file
 bloom_entries: 1000000                  # Estimated number of entries for bloom filter
 bloom_fp_rate: 0.01                     # False positive rate for bloom filter

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ import (
 )
 
 var SupportedCompression = []string{"none", "lz4", "zstd", "auto"}
-var SupportedDedupStrategies = []string{"auto", "checksum", "rolling_hash", "bloom"}
+var SupportedDedupStrategies = []string{"none", "auto", "checksum", "rolling_hash", "bloom"}
 var SupportedChecksumAlgorithms = []string{"sha256", "blake3", "blake3-512"}
 
 var (
@@ -71,7 +71,6 @@ type Config struct {
 	Progress             bool     `mapstructure:"progress"`
 	BlockSize            int      `mapstructure:"-"`
 	BlockSizeRaw         string   `mapstructure:"-"`
-	Deduplication        bool     `mapstructure:"deduplication"`
 	DedupStrategy        string   `mapstructure:"dedup_strategy"`
 	DedupStateFile       string   `mapstructure:"dedup_state_file"`
 	BloomEntries         int      `mapstructure:"bloom_entries"`
@@ -217,8 +216,7 @@ func DefaultConfig() *Config {
 		Progress:             true,
 		BlockSize:            0,
 		BlockSizeRaw:         "auto",
-		Deduplication:        false,
-		DedupStrategy:        "auto",
+		DedupStrategy:        "none",
 		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
 		BloomEntries:         1000000,
 		BloomFpRate:          0.01,
@@ -265,7 +263,6 @@ func LoadConfig() (*Config, error) {
 	remoteFlags.String("remote_post_script", defaultCfg.RemotePostScript, "Remote script to run after transfer")
 
 	// Deduplication Options
-	dedupFlags.Bool("deduplication", defaultCfg.Deduplication, "Enable deduplication to avoid re-transferring unchanged blocks")
 	dedupFlags.String("dedup_strategy", defaultCfg.DedupStrategy, fmt.Sprintf("Deduplication strategy: %v", SupportedDedupStrategies))
 	dedupFlags.String("dedup_state_file", defaultCfg.DedupStateFile, "Path to deduplication state file")
 	dedupFlags.Int("bloom_entries", defaultCfg.BloomEntries, "Estimated number of entries for bloom filter")

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func runApplyMode(applyFile string) error {
 }
 
 func executeDump(cfg *config.Config, snapshotDevice, originDevice string, out io.Writer) error {
-	if cfg.Deduplication {
+	if cfg.DedupStrategy != "none" {
 		dedup := transfer.NewDeduplicationStrategy(cfg)
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
@@ -218,7 +218,7 @@ func main() {
 	logger.Info("Effective configuration",
 		zap.String("block_size", cfg.HumanBlockSize()),
 		zap.Int("parallel", cfg.Parallel),
-		zap.Bool("deduplication", cfg.Deduplication),
+		zap.Bool("deduplication", cfg.DedupStrategy != "none"),
 		zap.String("dedup_strategy", cfg.DedupStrategy),
 		zap.String("compress", cfg.Compress),
 		zap.Int("compress_level", cfg.CompressLevel),

--- a/main_dump_test.go
+++ b/main_dump_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestExecuteDumpSequential(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.Deduplication = false
+	cfg.DedupStrategy = "none"
 	cfg.Parallel = 1
 
 	called := false
@@ -51,7 +51,7 @@ func TestExecuteDumpParallel(t *testing.T) {
 
 func TestExecuteDumpWithDedup(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.Deduplication = true
+	cfg.DedupStrategy = "checksum"
 
 	called := false
 	original := dumpChangesWithDeduplication

--- a/main_save_state_error_test.go
+++ b/main_save_state_error_test.go
@@ -15,7 +15,6 @@ import (
 func TestRunClientModeLogsSaveStateError(t *testing.T) {
 	cfg = config.DefaultConfig()
 	cfg.StdoutMode = true
-	cfg.Deduplication = true
 	cfg.DedupStrategy = "checksum"
 	cfg.DedupStateFile = filepath.Join(t.TempDir(), "missing", "state")
 	cfg.BlockSize = 1024

--- a/main_stdout_test.go
+++ b/main_stdout_test.go
@@ -11,7 +11,7 @@ import (
 func TestRunClientModeStdout(t *testing.T) {
 	cfg = config.DefaultConfig()
 	cfg.StdoutMode = true
-	cfg.Deduplication = false
+	cfg.DedupStrategy = "none"
 	cfg.Parallel = 1
 	cfg.SpeedLimit = 0
 

--- a/transfer/save_state_error_test.go
+++ b/transfer/save_state_error_test.go
@@ -21,7 +21,7 @@ func TestDumpChangesLogsSaveStateError(t *testing.T) {
 	changed := []int{0}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
 
-	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Deduplication: true, DedupStrategy: "checksum", DedupStateFile: filepath.Join(t.TempDir(), "missing", "state"), MaxRetries: 1}
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", DedupStrategy: "checksum", DedupStateFile: filepath.Join(t.TempDir(), "missing", "state"), MaxRetries: 1}
 	var buf bytes.Buffer
 	if err := DumpChanges(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChanges failed: %v", err)

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -202,7 +202,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 
 func DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.Writer) error {
 	var dedup DeduplicationStrategy
-	if cfg.Deduplication {
+	if cfg.DedupStrategy != "none" {
 		dedup = NewDeduplicationStrategy(cfg)
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
@@ -218,7 +218,7 @@ func DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, o
 }
 
 func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
-	if cfg.Deduplication {
+	if cfg.DedupStrategy != "none" {
 		dedup := NewDeduplicationStrategy(cfg)
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
@@ -480,7 +480,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 			}
 		}
 
-		if dedup != nil && cfg.Deduplication {
+		if dedup != nil && cfg.DedupStrategy != "none" {
 			if !dedup.ShouldTransfer(int64(offset), data) {
 				putBlockBuffer(data)
 				continue
@@ -530,7 +530,7 @@ func RunApply(cfg *config.Config, applyFile, destDevice string) error {
 		in = f
 	}
 
-	if cfg.Deduplication {
+	if cfg.DedupStrategy != "none" {
 		dedup := NewDeduplicationStrategy(cfg)
 		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
 		defer func() {


### PR DESCRIPTION
## Summary
- default deduplication strategy is now `none`
- remove deprecated `--deduplication` boolean flag
- document using `--dedup_strategy none` to disable deduplication

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689266a50bf48323a0f944beab80f851