### PR TITLE
Handle none dedup strategy

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,8 +60,8 @@ func runApplyMode(applyFile string) error {
 }
 
 func executeDump(cfg *config.Config, snapshotDevice, originDevice string, out io.Writer) error {
-	if cfg.DedupStrategy != "none" {
-		dedup := transfer.NewDeduplicationStrategy(cfg)
+	dedup := transfer.NewDeduplicationStrategy(cfg)
+	if dedup != nil {
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
 				zap.L().Error("Failed to save dedup state", zap.Error(err))
@@ -218,7 +218,6 @@ func main() {
 	logger.Info("Effective configuration",
 		zap.String("block_size", cfg.HumanBlockSize()),
 		zap.Int("parallel", cfg.Parallel),
-		zap.Bool("deduplication", cfg.DedupStrategy != "none"),
 		zap.String("dedup_strategy", cfg.DedupStrategy),
 		zap.String("compress", cfg.Compress),
 		zap.Int("compress_level", cfg.CompressLevel),

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -76,6 +76,8 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 		cfg.DedupStrategy = strategy
 	}
 	switch strategy {
+	case "none":
+		return nil
 	case "rolling_hash":
 		d := &RollingHashDedup{
 			stateFile: cfg.DedupStateFile,

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -201,9 +201,8 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 }
 
 func DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.Writer) error {
-	var dedup DeduplicationStrategy
-	if cfg.DedupStrategy != "none" {
-		dedup = NewDeduplicationStrategy(cfg)
+	dedup := NewDeduplicationStrategy(cfg)
+	if dedup != nil {
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
 				Logger.Error("Failed to save dedup state", zap.Error(err))
@@ -218,8 +217,8 @@ func DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, o
 }
 
 func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
-	if cfg.DedupStrategy != "none" {
-		dedup := NewDeduplicationStrategy(cfg)
+	dedup := NewDeduplicationStrategy(cfg)
+	if dedup != nil {
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
 				Logger.Error("Failed to save dedup state", zap.Error(err))
@@ -480,7 +479,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 			}
 		}
 
-		if dedup != nil && cfg.DedupStrategy != "none" {
+		if dedup != nil {
 			if !dedup.ShouldTransfer(int64(offset), data) {
 				putBlockBuffer(data)
 				continue
@@ -530,8 +529,8 @@ func RunApply(cfg *config.Config, applyFile, destDevice string) error {
 		in = f
 	}
 
-	if cfg.DedupStrategy != "none" {
-		dedup := NewDeduplicationStrategy(cfg)
+	dedup := NewDeduplicationStrategy(cfg)
+	if dedup != nil {
 		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
 		defer func() {
 			if err := dedup.SaveState(); err != nil {


### PR DESCRIPTION
## Summary
- handle `none` deduplication strategy by returning `nil` strategy
- gate deduplication and state saving on presence of a strategy
- remove boolean deduplication log and only log strategy value

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68926ddc2168832391b3560f94b3ce78