### PR TITLE
chore: relax function length lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
         - name: error-naming
         - name: unexported-return
         - name: function-length
-          arguments: [50, 25]
+          arguments: [120, 100]
         - name: cognitive-complexity
           arguments: [15]
         - name: time-naming


### PR DESCRIPTION
## Summary
- relax revive's function-length rule

## Testing
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6893047e6d2883238bc1076b608399b5