### PR TITLE
Handle WriteHandshake error in Handshake.String

### DIFF
--- a/common/handshake.go
+++ b/common/handshake.go
@@ -39,7 +39,9 @@ type Handshake struct {
 // WriteHandshake without the trailing newline.
 func (h Handshake) String() string {
 	var sb strings.Builder
-	_ = WriteHandshake(&sb, h) // Writing to strings.Builder never fails.
+	if err := WriteHandshake(&sb, h); err != nil {
+		return ""
+	}
 	return strings.TrimSpace(sb.String())
 }
 


### PR DESCRIPTION
## Summary
- handle potential errors returned by WriteHandshake when building Handshake string representation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689311ca99508323be0e162f030dafa1