### PR TITLE
Handle os.UserHomeDir error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -180,8 +180,11 @@ func (cb *ConfigBuilder) parseBlockSize() (int, string, error) {
 	return int(u), raw, nil
 }
 
-func DefaultConfig() *Config {
-	homeDir, _ := os.UserHomeDir()
+func DefaultConfig() (*Config, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user home directory: %w", err)
+	}
 	return &Config{
 		ApplyMode:            "",
 		StdoutMode:           false,
@@ -220,11 +223,14 @@ func DefaultConfig() *Config {
 		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
 		BloomEntries:         1000000,
 		BloomFpRate:          0.01,
-	}
+	}, nil
 }
 
 func LoadConfig() (*Config, error) {
-	defaultCfg := DefaultConfig()
+	defaultCfg, err := DefaultConfig()
+	if err != nil {
+		return nil, err
+	}
 
 	generalFlags = pflag.NewFlagSet("General Options", pflag.ExitOnError)
 	sshFlags = pflag.NewFlagSet("SSH Options", pflag.ExitOnError)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,14 +43,20 @@ func (f *fakeBackend) ListVolumeGroups(_ context.Context, candidates []string) (
 }
 
 func TestDefaultConfigCompress(t *testing.T) {
-	cfg := DefaultConfig()
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	if cfg.Compress != "auto" {
 		t.Fatalf("expected default Compress to be 'auto', got %q", cfg.Compress)
 	}
 }
 
 func TestDefaultConfigBlockSize(t *testing.T) {
-	cfg := DefaultConfig()
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	if cfg.BlockSize != 0 || cfg.BlockSizeRaw != "auto" {
 		t.Fatalf("expected default block size auto, got %d (%s)", cfg.BlockSize, cfg.BlockSizeRaw)
 	}
@@ -177,7 +183,11 @@ func TestBuildBlockSize(t *testing.T) {
 	t.Run("auto", func(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", "auto")
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		cfg, err := cb.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -190,7 +200,11 @@ func TestBuildBlockSize(t *testing.T) {
 	t.Run("numeric", func(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", "8KB")
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		cfg, err := cb.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -206,7 +220,11 @@ func TestCompressLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "zstd")
 		v.Set("compress_level", 3)
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		if _, err := cb.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -216,7 +234,11 @@ func TestCompressLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "zstd")
 		v.Set("compress_level", 100)
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		if _, err := cb.Build(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -230,7 +252,11 @@ func TestCompressLevelValidation(t *testing.T) {
 		} else {
 			v.Set("compress_level", int(lz4.Level3))
 		}
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		if _, err := cb.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -244,7 +270,11 @@ func TestCompressLevelValidation(t *testing.T) {
 		} else {
 			v.Set("compress_level", 3)
 		}
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		if _, err := cb.Build(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -254,7 +284,11 @@ func TestCompressLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "lz4")
 		v.Set("compress_level", int(lz4.Level3))
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		if _, err := cb.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -264,7 +298,11 @@ func TestCompressLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "lz4")
 		v.Set("compress_level", 3)
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		if _, err := cb.Build(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -274,7 +312,11 @@ func TestCompressLevelValidation(t *testing.T) {
 func TestCompressConcurrency(t *testing.T) {
 	t.Run("defaultPositive", func(t *testing.T) {
 		v := viper.New()
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		cfg, err := cb.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -287,7 +329,11 @@ func TestCompressConcurrency(t *testing.T) {
 	t.Run("override", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress_concurrency", 8)
-		cb := &ConfigBuilder{v: v, defaults: DefaultConfig()}
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		cb := &ConfigBuilder{v: v, defaults: defaults}
 		cfg, err := cb.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/main_dump_test.go
+++ b/main_dump_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func TestExecuteDumpSequential(t *testing.T) {
-	cfg := config.DefaultConfig()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.DedupStrategy = "none"
 	cfg.Parallel = 1
 
@@ -30,7 +33,10 @@ func TestExecuteDumpSequential(t *testing.T) {
 }
 
 func TestExecuteDumpParallel(t *testing.T) {
-	cfg := config.DefaultConfig()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.Parallel = 2
 
 	called := false
@@ -50,7 +56,10 @@ func TestExecuteDumpParallel(t *testing.T) {
 }
 
 func TestExecuteDumpWithDedup(t *testing.T) {
-	cfg := config.DefaultConfig()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.DedupStrategy = "checksum"
 
 	called := false

--- a/main_remote_script_test.go
+++ b/main_remote_script_test.go
@@ -126,7 +126,11 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	host, portStr, _ := strings.Cut(server.addr, ":")
 	port, _ := strconv.Atoi(portStr)
 
-	cfg = config.DefaultConfig()
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.RemotePreScript = "pre-script"
 	cfg.RemotePostScript = "post-script"
 	cfg.SSHUser = "test"
@@ -142,7 +146,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	defer func() { dumpChangesSequential = original }()
 
 	dest := host + ":/dev/null"
-	err := runClientMode("/dev/snap", dest)
+	err = runClientMode("/dev/snap", dest)
 	if err == nil || !strings.Contains(err.Error(), "dumpChanges") {
 		t.Fatalf("expected dumpChanges error, got %v", err)
 	}
@@ -169,7 +173,11 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	host, portStr, _ := strings.Cut(server.addr, ":")
 	port, _ := strconv.Atoi(portStr)
 
-	cfg = config.DefaultConfig()
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.RemotePreScript = "fail-pre"
 	cfg.RemotePostScript = "post-script"
 	cfg.SSHUser = "test"
@@ -179,7 +187,7 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 
 	dest := host + ":/dev/null"
-	err := runClientMode("/dev/snap", dest)
+	err = runClientMode("/dev/snap", dest)
 	if err == nil {
 		t.Fatalf("expected error from pre-script")
 	}

--- a/main_save_state_error_test.go
+++ b/main_save_state_error_test.go
@@ -13,7 +13,11 @@ import (
 )
 
 func TestRunClientModeLogsSaveStateError(t *testing.T) {
-	cfg = config.DefaultConfig()
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.StdoutMode = true
 	cfg.DedupStrategy = "checksum"
 	cfg.DedupStateFile = filepath.Join(t.TempDir(), "missing", "state")

--- a/main_stdout_test.go
+++ b/main_stdout_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 func TestRunClientModeStdout(t *testing.T) {
-	cfg = config.DefaultConfig()
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.StdoutMode = true
 	cfg.DedupStrategy = "none"
 	cfg.Parallel = 1

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,11 @@ import (
 
 func TestApplyFlagTriggersApplyMode(t *testing.T) {
 	// Setup configuration with apply file
-	cfg = config.DefaultConfig()
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
 	cfg.ApplyMode = "dumpfile"
 	dest := "/dev/null"
 

--- a/transfer/block_benchmark_test.go
+++ b/transfer/block_benchmark_test.go
@@ -30,7 +30,10 @@ func prepareTestFile(size int) (*os.File, func(), error) {
 }
 
 func BenchmarkReadBlockWithRetriesEphemeral(b *testing.B) {
-	cfg := config.DefaultConfig()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		b.Fatal(err)
+	}
 	cfg.ZeroCopy = true
 	fileSize := cfg.BlockSize * b.N
 	f, cleanup, err := prepareTestFile(fileSize)
@@ -49,7 +52,10 @@ func BenchmarkReadBlockWithRetriesEphemeral(b *testing.B) {
 }
 
 func BenchmarkReadBlockWithRetriesPersistent(b *testing.B) {
-	cfg := config.DefaultConfig()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		b.Fatal(err)
+	}
 	cfg.ZeroCopy = true
 	fileSize := cfg.BlockSize * b.N
 	f, cleanup, err := prepareTestFile(fileSize)


### PR DESCRIPTION
## Summary
- capture and return os.UserHomeDir failure in DefaultConfig
- propagate user home directory errors in LoadConfig

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893138b2dd48323ab8ceb00a5e80f8c