### PR TITLE
Handle flag parsing and binding errors in dedup config

### DIFF
--- a/dedup/config.go
+++ b/dedup/config.go
@@ -40,9 +40,13 @@ func LoadConfig(path string, args []string) (Config, error) {
 	flags.Uint64("ram_bytes", uint64(1<<30), "RAM budget for Bloom filter")
 	flags.Uint64("volume_size", 0, "size of the volume being processed")
 	flags.String("hash_key", "", "optional hex encoded key for BLAKE3")
-	_ = flags.Parse(args)
+	if err := flags.Parse(args); err != nil {
+		return Config{}, err
+	}
 
-	v.BindPFlags(flags)
+	if err := v.BindPFlags(flags); err != nil {
+		return Config{}, err
+	}
 	v.SetEnvPrefix("LVMSYNC")
 	v.AutomaticEnv()
 


### PR DESCRIPTION
## Summary
- return errors from `flags.Parse(args)`
- handle and return errors from `v.BindPFlags(flags)`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68931a9650588323ba83ae5d5ecc373b