### PR TITLE
Check zstd close error on write failure

### DIFF
--- a/internal/compressiondetect/compressiondetect.go
+++ b/internal/compressiondetect/compressiondetect.go
@@ -96,7 +96,9 @@ func benchZSTD(sample []byte) time.Duration {
 	}
 	start := time.Now()
 	if _, err := zw.Write(sample); err != nil {
-		zw.Close()
+		if err := zw.Close(); err != nil {
+			return time.Hour
+		}
 		return time.Hour
 	}
 	if err := zw.Close(); err != nil {


### PR DESCRIPTION
## Summary
- handle zw.Close error when write to zstd writer fails

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68931ef76040832393defe910e78470e