### PR TITLE
Export file descriptor cache type

### DIFF
--- a/lvm/fd_cache.go
+++ b/lvm/fd_cache.go
@@ -17,8 +17,8 @@ type fdCacheEntry struct {
 	fd   int
 }
 
-// fdCache provides a simple LRU cache for file descriptors.
-type fdCache struct {
+// FDCache provides a simple LRU cache for file descriptors.
+type FDCache struct {
 	fds   map[string]*list.Element
 	order *list.List
 	mutex sync.Mutex
@@ -26,11 +26,11 @@ type fdCache struct {
 }
 
 // NewFDCache returns an initialized file descriptor cache with the given capacity.
-func NewFDCache(size int) *fdCache {
+func NewFDCache(size int) *FDCache {
 	if size <= 0 {
 		size = fdCacheSize
 	}
-	return &fdCache{
+	return &FDCache{
 		fds:   make(map[string]*list.Element, size),
 		order: list.New(),
 		size:  size,
@@ -40,7 +40,7 @@ func NewFDCache(size int) *fdCache {
 // getFD retrieves an open file descriptor for the specified device path.
 // It reuses descriptors when possible and evicts the least recently used entry
 // when the cache reaches its capacity.
-func (c *fdCache) getFD(devicePath string) (int, error) {
+func (c *FDCache) getFD(devicePath string) (int, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -71,7 +71,7 @@ func (c *fdCache) getFD(devicePath string) (int, error) {
 }
 
 // Close releases all cached file descriptors and resets the cache state.
-func (c *fdCache) Close() {
+func (c *FDCache) Close() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 

--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestFdCacheEvictionOrder(t *testing.T) {
+func TestFDCacheEvictionOrder(t *testing.T) {
 	cache := NewFDCache(fdCacheSize)
 
 	tmpDir := t.TempDir()
@@ -53,7 +53,7 @@ func TestFdCacheEvictionOrder(t *testing.T) {
 	cache.Close()
 }
 
-func TestFdCacheCloseClosesAll(t *testing.T) {
+func TestFDCacheCloseClosesAll(t *testing.T) {
 	cache := NewFDCache(fdCacheSize)
 	tmpDir := t.TempDir()
 	var fds []int


### PR DESCRIPTION
## Summary
- export FDCache to allow external use
- update tests to reflect exported FDCache

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893298e681483239f587c905d61b821