### PR TITLE
fix: copy args when re-execing for root

### DIFF
--- a/internal/privesc/privesc.go
+++ b/internal/privesc/privesc.go
@@ -20,7 +20,7 @@ func EnsureRoot(escalationCmd string) error {
 		return fmt.Errorf("root privileges required")
 	}
 	parts := strings.Fields(escalationCmd)
-	argv := append(parts, os.Args...)
+	argv := append(append([]string{}, parts...), os.Args...)
 	if err := unix.Exec(parts[0], argv, os.Environ()); err != nil {
 		return fmt.Errorf("failed to exec %s: %w", parts[0], err)
 	}


### PR DESCRIPTION
## Summary
- ensure EnsureRoot copies `escalationCmd` args before re-exec

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68932ea017a88323af77606e27be6592