### PR TITLE
test: rename handshake test package

### DIFF
--- a/common/handshake_test.go
+++ b/common/handshake_test.go
@@ -1,19 +1,21 @@
-package common
+package common_test
 
 import (
 	"bufio"
 	"bytes"
 	"reflect"
 	"testing"
+
+	"lvmsync_go/common"
 )
 
 func TestHandshakeRoundTrip(t *testing.T) {
-	original := Handshake{Version: ProtocolVersion, Compress: "gzip", Checksum: true}
+	original := common.Handshake{Version: common.ProtocolVersion, Compress: "gzip", Checksum: true}
 	var buf bytes.Buffer
-	if err := WriteHandshake(&buf, original); err != nil {
+	if err := common.WriteHandshake(&buf, original); err != nil {
 		t.Fatalf("write handshake: %v", err)
 	}
-	parsed, err := ReadHandshake(bufio.NewReader(&buf))
+	parsed, err := common.ReadHandshake(bufio.NewReader(&buf))
 	if err != nil {
 		t.Fatalf("read handshake: %v", err)
 	}
@@ -23,7 +25,7 @@ func TestHandshakeRoundTrip(t *testing.T) {
 }
 
 func TestHandshakeString(t *testing.T) {
-	h := Handshake{Compress: "none", Checksum: true, ChecksumDedup: true}
+	h := common.Handshake{Compress: "none", Checksum: true, ChecksumDedup: true}
 	expected := "lvmsync PROTO[3] checksum-dedup compress:none"
 	if h.String() != expected {
 		t.Fatalf("unexpected string: %s", h.String())


### PR DESCRIPTION
## Summary
- rename handshake test package to `common_test` and use exported API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68933044709c8323a0f6873371a54bb8