### PR TITLE
Store byte slice pointers in buffer pool

### DIFF
--- a/transfer/bufferpool.go
+++ b/transfer/bufferpool.go
@@ -9,16 +9,17 @@ func getPool(size int) *sync.Pool {
 		return p.(*sync.Pool)
 	}
 	p := &sync.Pool{New: func() interface{} {
-		return make([]byte, size)
+		buf := make([]byte, size)
+		return &buf
 	}}
 	actual, _ := bufferPools.LoadOrStore(size, p)
 	return actual.(*sync.Pool)
 }
 
 func getBlockBuffer(size int) []byte {
-	return getPool(size).Get().([]byte)
+	return *getPool(size).Get().(*[]byte)
 }
 
 func putBlockBuffer(buf []byte) {
-	getPool(len(buf)).Put(buf)
+	getPool(len(buf)).Put(&buf)
 }


### PR DESCRIPTION
## Summary
- Store pointers to byte slices in sync.Pool for block buffers
- Adjust retrieval to dereference pointer and update put helper accordingly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893316e76408323beb174cbbebbb5db