### PR TITLE
Refactor tests to separate scenarios

### DIFF
--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -11,66 +11,70 @@ import (
 	compressiondetect "lvmsync_go/internal/compressiondetect"
 )
 
-func TestNewCompressionWriterAutoX86(t *testing.T) {
+func TestNewCompressionWriterAutoX86Features(t *testing.T) {
 	original := cpuid.CPU
 	defer func() { cpuid.CPU = original }()
 
 	features := []cpuid.FeatureID{cpuid.AVX512F, cpuid.AVX2, cpuid.BMI2}
 	for _, feat := range features {
-		t.Run(feat.String(), func(t *testing.T) {
-			cpuid.CPU = cpuid.CPUInfo{}
-			cpuid.CPU.Enable(feat)
-			compressiondetect.ResetForTest()
-			w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
-			if err != nil {
-				t.Fatalf("NewCompressionWriter with %s: %v", feat.String(), err)
-			}
-			if _, ok := w.(*pooledZstdWriter); !ok {
-				t.Fatalf("expected zstd writer when %s is present", feat.String())
-			}
-			w.Close()
-		})
-	}
-
-	t.Run("cpu-metrics", func(t *testing.T) {
 		cpuid.CPU = cpuid.CPUInfo{}
-		cpuid.CPU.PhysicalCores = 8
-		cpuid.CPU.Cache.L3 = 8 << 20
+		cpuid.CPU.Enable(feat)
 		compressiondetect.ResetForTest()
 		w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
 		if err != nil {
-			t.Fatalf("NewCompressionWriter with cpu metrics: %v", err)
+			t.Fatalf("NewCompressionWriter with %s: %v", feat.String(), err)
 		}
 		if _, ok := w.(*pooledZstdWriter); !ok {
-			t.Fatalf("expected zstd writer when cores and cache are large")
+			t.Fatalf("expected zstd writer when %s is present", feat.String())
 		}
 		w.Close()
-	})
+	}
+}
 
-	t.Run("fallback", func(t *testing.T) {
-		cpuid.CPU = cpuid.CPUInfo{}
-		cpuid.CPU.PhysicalCores = 1
-		cpuid.CPU.Cache.L3 = 0
-		compressiondetect.ResetForTest()
-		algo := compressiondetect.DetectOptimalCompression()
-		lvl := 1
-		if algo == compressionLZ4 {
-			lvl = int(lz4.Level1)
+func TestNewCompressionWriterAutoX86CPUMetrics(t *testing.T) {
+	original := cpuid.CPU
+	defer func() { cpuid.CPU = original }()
+
+	cpuid.CPU = cpuid.CPUInfo{}
+	cpuid.CPU.PhysicalCores = 8
+	cpuid.CPU.Cache.L3 = 8 << 20
+	compressiondetect.ResetForTest()
+	w, err := NewCompressionWriter(io.Discard, "auto", 1, 1)
+	if err != nil {
+		t.Fatalf("NewCompressionWriter with cpu metrics: %v", err)
+	}
+	if _, ok := w.(*pooledZstdWriter); !ok {
+		t.Fatalf("expected zstd writer when cores and cache are large")
+	}
+	w.Close()
+}
+
+func TestNewCompressionWriterAutoX86Fallback(t *testing.T) {
+	original := cpuid.CPU
+	defer func() { cpuid.CPU = original }()
+
+	cpuid.CPU = cpuid.CPUInfo{}
+	cpuid.CPU.PhysicalCores = 1
+	cpuid.CPU.Cache.L3 = 0
+	compressiondetect.ResetForTest()
+	algo := compressiondetect.DetectOptimalCompression()
+	lvl := 1
+	if algo == compressionLZ4 {
+		lvl = int(lz4.Level1)
+	}
+	w, err := NewCompressionWriter(io.Discard, "auto", lvl, 1)
+	if err != nil {
+		t.Fatalf("NewCompressionWriter without features: %v", err)
+	}
+	switch algo {
+	case compressionLZ4:
+		if _, ok := w.(*pooledLz4Writer); !ok {
+			t.Fatalf("expected lz4 writer when benchmark prefers lz4")
 		}
-		w, err := NewCompressionWriter(io.Discard, "auto", lvl, 1)
-		if err != nil {
-			t.Fatalf("NewCompressionWriter without features: %v", err)
+	case compressionZSTD:
+		if _, ok := w.(*pooledZstdWriter); !ok {
+			t.Fatalf("expected zstd writer when benchmark prefers zstd")
 		}
-		switch algo {
-		case compressionLZ4:
-			if _, ok := w.(*pooledLz4Writer); !ok {
-				t.Fatalf("expected lz4 writer when benchmark prefers lz4")
-			}
-		case compressionZSTD:
-			if _, ok := w.(*pooledZstdWriter); !ok {
-				t.Fatalf("expected zstd writer when benchmark prefers zstd")
-			}
-		}
-		w.Close()
-	})
+	}
+	w.Close()
 }

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -86,29 +86,30 @@ func TestLZ4CompressionLevels(t *testing.T) {
 }
 
 func TestNewCompressionWriterLevel(t *testing.T) {
-	t.Run("zstdValid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 3, 1); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
+	tests := []struct {
+		name    string
+		algo    string
+		level   int
+		wantErr bool
+	}{
+		{"zstdValid", compressionZSTD, 3, false},
+		{"zstdInvalid", compressionZSTD, 100, true},
+		{"lz4Valid", compressionLZ4, int(lz4.Level3), false},
+		{"lz4Invalid", compressionLZ4, 3, true},
+	}
 
-	t.Run("zstdInvalid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionZSTD, 100, 1); err == nil {
-			t.Fatalf("expected error")
+	for _, tt := range tests {
+		_, err := NewCompressionWriter(io.Discard, tt.algo, tt.level, 1)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("%s: expected error", tt.name)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tt.name, err)
+			}
 		}
-	})
-
-	t.Run("lz4Valid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, int(lz4.Level3), 1); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("lz4Invalid", func(t *testing.T) {
-		if _, err := NewCompressionWriter(io.Discard, compressionLZ4, 3, 1); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
+	}
 }
 
 func TestLZ4WriterPoolReuse(t *testing.T) {

--- a/transfer/dedup_save_state_test.go
+++ b/transfer/dedup_save_state_test.go
@@ -24,54 +24,50 @@ func (fw *failingWriter) Write(p []byte) (int, error) {
 
 func (fw *failingWriter) Close() error { return nil }
 
-func TestChecksumDedupSaveStateWriteFailures(t *testing.T) {
+func TestChecksumDedupSaveStateBinaryWriteFailure(t *testing.T) {
 	hash := sha256.Sum256([]byte("data"))
-
-	t.Run("binary write failure", func(t *testing.T) {
-		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
-		fw := &failingWriter{failAfter: 0}
-		orig := createStateFile
-		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-		defer func() { createStateFile = orig }()
-		if err := c.SaveState(); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
-
-	t.Run("file write failure", func(t *testing.T) {
-		c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
-		fw := &failingWriter{failAfter: 1}
-		orig := createStateFile
-		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-		defer func() { createStateFile = orig }()
-		if err := c.SaveState(); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
+	c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
+	fw := &failingWriter{failAfter: 0}
+	orig := createStateFile
+	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+	defer func() { createStateFile = orig }()
+	if err := c.SaveState(); err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
-func TestRollingHashDedupSaveStateWriteFailures(t *testing.T) {
-	t.Run("binary write failure", func(t *testing.T) {
-		r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
-		fw := &failingWriter{failAfter: 0}
-		orig := createStateFile
-		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-		defer func() { createStateFile = orig }()
-		if err := r.SaveState(); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
+func TestChecksumDedupSaveStateFileWriteFailure(t *testing.T) {
+	hash := sha256.Sum256([]byte("data"))
+	c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
+	fw := &failingWriter{failAfter: 1}
+	orig := createStateFile
+	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+	defer func() { createStateFile = orig }()
+	if err := c.SaveState(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
 
-	t.Run("file write failure", func(t *testing.T) {
-		r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
-		fw := &failingWriter{failAfter: 1}
-		orig := createStateFile
-		createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-		defer func() { createStateFile = orig }()
-		if err := r.SaveState(); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
+func TestRollingHashDedupSaveStateBinaryWriteFailure(t *testing.T) {
+	r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
+	fw := &failingWriter{failAfter: 0}
+	orig := createStateFile
+	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+	defer func() { createStateFile = orig }()
+	if err := r.SaveState(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRollingHashDedupSaveStateFileWriteFailure(t *testing.T) {
+	r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
+	fw := &failingWriter{failAfter: 1}
+	orig := createStateFile
+	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
+	defer func() { createStateFile = orig }()
+	if err := r.SaveState(); err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
 func TestBloomFilterDedupSaveStateWriteFailure(t *testing.T) {


### PR DESCRIPTION
## Summary
- split dedup save state tests into individual scenario functions
- consolidate compression level checks into a table-driven test
- refactor auto compression writer tests into separate cases

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68933cab1f3c8323b1abe53f8edb68ec