### PR TITLE
test: check SSH operation errors

### DIFF
--- a/main_remote_script_test.go
+++ b/main_remote_script_test.go
@@ -60,7 +60,7 @@ func (s *mockSSHServer) serve(config *ssh.ServerConfig) {
 			go ssh.DiscardRequests(reqs)
 			for newCh := range chans {
 				if newCh.ChannelType() != "session" {
-					newCh.Reject(ssh.UnknownChannelType, "unknown channel type")
+					newCh.Reject(ssh.UnknownChannelType, "unknown channel type") //nolint:errcheck
 					continue
 				}
 				ch, requests, err := newCh.Accept()
@@ -69,13 +69,13 @@ func (s *mockSSHServer) serve(config *ssh.ServerConfig) {
 				}
 				go s.handleChannel(ch, requests)
 			}
-			serverConn.Close()
+			serverConn.Close() //nolint:errcheck
 		}(conn)
 	}
 }
 
 func (s *mockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
-	defer ch.Close()
+	defer ch.Close() //nolint:errcheck
 	for req := range in {
 		if req.Type == "exec" {
 			var payload struct {
@@ -86,14 +86,15 @@ func (s *mockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
 			s.commands = append(s.commands, payload.Command)
 			s.mu.Unlock()
 			status := s.handler(payload.Command)
-			req.Reply(true, nil)
-			ch.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{uint32(status)}))
+			req.Reply(true, nil) //nolint:errcheck
+			exitPayload := struct{ Status uint32 }{uint32(status)}
+			ch.SendRequest("exit-status", false, ssh.Marshal(exitPayload)) //nolint:errcheck
 			return
 		}
 	}
 }
 
-func (s *mockSSHServer) Close() { s.listener.Close() }
+func (s *mockSSHServer) Close() { s.listener.Close() /*nolint:errcheck*/ }
 
 func (s *mockSSHServer) Commands() []string {
 	s.mu.Lock()

--- a/remote/logger_test.go
+++ b/remote/logger_test.go
@@ -14,7 +14,7 @@ func TestRunRemoteScriptNoLogger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 
 	SetLogger(nil)
 
@@ -32,7 +32,7 @@ func TestSendKeepAliveNoLogger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 
 	SetLogger(nil)
 

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -59,7 +59,7 @@ func (s *mockSSHServer) serve(config *ssh.ServerConfig) {
 			go s.handleRequests(reqs)
 			for newCh := range chans {
 				if newCh.ChannelType() != "session" {
-					newCh.Reject(ssh.UnknownChannelType, "unknown channel type")
+					newCh.Reject(ssh.UnknownChannelType, "unknown channel type") //nolint:errcheck
 					continue
 				}
 				ch, requests, err := newCh.Accept()
@@ -68,13 +68,13 @@ func (s *mockSSHServer) serve(config *ssh.ServerConfig) {
 				}
 				go s.handleChannel(ch, requests)
 			}
-			serverConn.Close()
+			serverConn.Close() //nolint:errcheck
 		}(conn)
 	}
 }
 
 func (s *mockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
-	defer ch.Close()
+	defer ch.Close() //nolint:errcheck
 	for req := range in {
 		if req.Type == "exec" {
 			var payload struct {
@@ -85,8 +85,9 @@ func (s *mockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
 			s.commands = append(s.commands, payload.Command)
 			s.mu.Unlock()
 			status := s.handler(payload.Command)
-			req.Reply(true, nil)
-			ch.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{uint32(status)}))
+			req.Reply(true, nil) //nolint:errcheck
+			exitPayload := struct{ Status uint32 }{uint32(status)}
+			ch.SendRequest("exit-status", false, ssh.Marshal(exitPayload)) //nolint:errcheck
 			return
 		}
 	}
@@ -97,12 +98,12 @@ func (s *mockSSHServer) handleRequests(in <-chan *ssh.Request) {
 		s.mu.Lock()
 		s.globalReqs = append(s.globalReqs, req.Type)
 		s.mu.Unlock()
-		req.Reply(true, nil)
+		req.Reply(true, nil) //nolint:errcheck
 	}
 }
 
 func (s *mockSSHServer) Close() {
-	s.listener.Close()
+	s.listener.Close() //nolint:errcheck
 }
 
 func (s *mockSSHServer) Commands() []string {
@@ -140,7 +141,7 @@ func TestValidateRemoteCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 
 	if err := ValidateRemoteCommand(client, "echo"); err != nil {
 		t.Fatalf("expected success, got %v", err)
@@ -159,7 +160,7 @@ func TestRunRemoteScript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(core)

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -22,7 +22,7 @@ func TestSendKeepAlive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 
 	if err := sendKeepAlive(client, "host"); err != nil {
 		t.Fatalf("sendKeepAlive error: %v", err)
@@ -50,7 +50,9 @@ func TestStartKeepAlive(t *testing.T) {
 	}()
 
 	time.Sleep(30 * time.Millisecond)
-	client.Close()
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close error: %v", err)
+	}
 
 	select {
 	case <-done:
@@ -93,7 +95,9 @@ func TestNewSSHClient(t *testing.T) {
 		t.Fatalf("NewSSHClient error: %v", err)
 	}
 	time.Sleep(20 * time.Millisecond)
-	client.Close()
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close error: %v", err)
+	}
 
 	if len(server.GlobalRequests()) == 0 {
 		t.Fatalf("expected keepalive requests, got none")


### PR DESCRIPTION
## Summary
- silence deliberate SSH errors in tests with `//nolint:errcheck`
- add missing error handling for SSH client closures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68933e518b5c83239a7b2658a0e935a2