### PR TITLE
chore: suppress revive linter for common package

### DIFF
--- a/common/handshake.go
+++ b/common/handshake.go
@@ -1,4 +1,4 @@
-package common
+package common //nolint:revive // package name is established API
 
 import (
 	"bufio"


### PR DESCRIPTION
## Summary
- suppress revive linter warning for `common` package name

## Testing
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_689346823cb88323bbfddd5575811402