### PR TITLE
Use crypto/rand for compression detection benchmark

### DIFF
--- a/internal/compressiondetect/compressiondetect.go
+++ b/internal/compressiondetect/compressiondetect.go
@@ -2,9 +2,9 @@ package compressiondetect
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"io"
-	"math/rand"
 	"runtime"
 	"sync"
 	"time"
@@ -50,8 +50,7 @@ func DetectOptimalCompression() string {
 func BenchmarkCompression() string {
 	sample := make([]byte, 1<<16) // 64KB sample block
 	copy(sample[:1<<15], bytes.Repeat([]byte("a"), 1<<15))
-	prng := rand.New(rand.NewSource(0))
-	if _, err := prng.Read(sample[1<<15:]); err != nil {
+	if _, err := rand.Read(sample[1<<15:]); err != nil {
 		return "lz4"
 	}
 


### PR DESCRIPTION
## Summary
- replace math/rand with crypto/rand in compression detection benchmark
- handle errors from crypto/rand.Read

## Testing
- `go test ./internal/compressiondetect`
- `golangci-lint run ./internal/compressiondetect/...`


------
https://chatgpt.com/codex/tasks/task_e_689431fc40e48323941645cb1b8d33bb