### PR TITLE
Handle hashing errors in dedup

### DIFF
--- a/dedup/replicator.go
+++ b/dedup/replicator.go
@@ -28,7 +28,9 @@ func (r *Replicator) Process(src io.Reader) (Manifest, error) {
 			break
 		}
 		r.Hasher.Reset()
-		r.Hasher.Write(chunk.Data)
+		if _, err := r.Hasher.Write(chunk.Data); err != nil {
+			return Manifest{}, err
+		}
 		hash := r.Hasher.Sum256()
 		if !r.Bloom.TestAndAdd(hash[:]) {
 			if _, err := r.Writer.Write(chunk.Data); err != nil {

--- a/dedup/unit_test.go
+++ b/dedup/unit_test.go
@@ -10,7 +10,9 @@ import (
 func TestHasher(t *testing.T) {
 	h := NewHasher(nil)
 	msg := []byte("hello world")
-	h.Write(msg)
+	if _, err := h.Write(msg); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
 	sum := h.Sum256()
 	expected := "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24"
 	if hex.EncodeToString(sum[:]) != expected {
@@ -19,7 +21,9 @@ func TestHasher(t *testing.T) {
 
 	key := []byte("0123456789abcdef0123456789abcdef")
 	h = NewHasher(key)
-	h.Write(msg)
+	if _, err := h.Write(msg); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
 	sum2 := h.Sum256()
 	if bytes.Equal(sum[:], sum2[:]) {
 		t.Fatalf("keyed hash should differ")


### PR DESCRIPTION
## Summary
- handle `Hasher.Write` errors in replicator
- assert `Hasher.Write` success in tests

## Testing
- `go test ./dedup -run TestReplicator`
- `go test ./dedup`

------
https://chatgpt.com/codex/tasks/task_e_6894338a13d08323ac631447cfd6996d