### PR TITLE
Rename config builder type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,27 +84,27 @@ func (c *Config) HumanBlockSize() string {
 	return sizeparse.FormatBytes(uint64(c.BlockSize))
 }
 
-type ConfigBuilder struct {
+type Builder struct {
 	v        *viper.Viper
 	defaults *Config
 }
 
-func (cb *ConfigBuilder) Build() (*Config, error) {
+func (b *Builder) Build() (*Config, error) {
 	var conf Config
-	if err := cb.v.Unmarshal(&conf); err != nil {
+	if err := b.v.Unmarshal(&conf); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
 	}
 
-	bs, raw, err := cb.parseBlockSize()
+	bs, raw, err := b.parseBlockSize()
 	if err != nil {
 		return nil, err
 	}
 	conf.BlockSize = bs
 	conf.BlockSizeRaw = raw
 	if conf.ChecksumAlgorithm == "" {
-		conf.ChecksumAlgorithm = cb.defaults.ChecksumAlgorithm
+		conf.ChecksumAlgorithm = b.defaults.ChecksumAlgorithm
 	}
-	sl, err := cb.parseBytesOrFallback("speed", cb.defaults.Speed)
+	sl, err := b.parseBytesOrFallback("speed", b.defaults.Speed)
 	if err != nil {
 		return nil, err
 	}
@@ -145,8 +145,8 @@ func (cb *ConfigBuilder) Build() (*Config, error) {
 	return &conf, nil
 }
 
-func (cb *ConfigBuilder) parseBytesOrFallback(key, fallback string) (int, error) {
-	raw := strings.ReplaceAll(cb.v.GetString(key), " ", "")
+func (b *Builder) parseBytesOrFallback(key, fallback string) (int, error) {
+	raw := strings.ReplaceAll(b.v.GetString(key), " ", "")
 	if raw == "" {
 		raw = fallback
 	}
@@ -161,10 +161,10 @@ func (cb *ConfigBuilder) parseBytesOrFallback(key, fallback string) (int, error)
 	return int(u), nil
 }
 
-func (cb *ConfigBuilder) parseBlockSize() (int, string, error) {
-	raw := strings.ReplaceAll(strings.TrimSpace(cb.v.GetString("block_size")), " ", "")
+func (b *Builder) parseBlockSize() (int, string, error) {
+	raw := strings.ReplaceAll(strings.TrimSpace(b.v.GetString("block_size")), " ", "")
 	if raw == "" {
-		raw = cb.defaults.BlockSizeRaw
+		raw = b.defaults.BlockSizeRaw
 	}
 	if strings.EqualFold(raw, "auto") {
 		return 0, raw, nil
@@ -316,7 +316,7 @@ func LoadConfig() (*Config, error) {
 		}
 	}
 
-	builder := &ConfigBuilder{
+	builder := &Builder{
 		v:        v,
 		defaults: defaultCfg,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -74,8 +74,8 @@ func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", "1KB")
-		cb := &ConfigBuilder{v: v}
-		got, err := cb.parseBytesOrFallback("block_size", "4KB")
+		b := &Builder{v: v}
+		got, err := b.parseBytesOrFallback("block_size", "4KB")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -86,8 +86,8 @@ func TestParseBytesOrFallback(t *testing.T) {
 
 	t.Run("fallback", func(t *testing.T) {
 		v := viper.New()
-		cb := &ConfigBuilder{v: v}
-		got, err := cb.parseBytesOrFallback("block_size", "2KB")
+		b := &Builder{v: v}
+		got, err := b.parseBytesOrFallback("block_size", "2KB")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -99,8 +99,8 @@ func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", "notbytes")
-		cb := &ConfigBuilder{v: v}
-		if _, err := cb.parseBytesOrFallback("block_size", "4KB"); err == nil {
+		b := &Builder{v: v}
+		if _, err := b.parseBytesOrFallback("block_size", "4KB"); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -108,8 +108,8 @@ func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("nearMaxInt", func(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", fmt.Sprintf("%d", uint64(math.MaxInt-1023)))
-		cb := &ConfigBuilder{v: v}
-		got, err := cb.parseBytesOrFallback("block_size", "4KB")
+		b := &Builder{v: v}
+		got, err := b.parseBytesOrFallback("block_size", "4KB")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -121,8 +121,8 @@ func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("overflow", func(t *testing.T) {
 		v := viper.New()
 		v.Set("block_size", fmt.Sprintf("%d", uint64(math.MaxInt)+1))
-		cb := &ConfigBuilder{v: v}
-		if _, err := cb.parseBytesOrFallback("block_size", "4KB"); err == nil {
+		b := &Builder{v: v}
+		if _, err := b.parseBytesOrFallback("block_size", "4KB"); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -188,8 +188,8 @@ func TestBuildBlockSize(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		cfg, err := cb.Build()
+		b := &Builder{v: v, defaults: defaults}
+		cfg, err := b.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -205,8 +205,8 @@ func TestBuildBlockSize(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		cfg, err := cb.Build()
+		b := &Builder{v: v, defaults: defaults}
+		cfg, err := b.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -226,8 +226,8 @@ func TestCompressLevelValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		if _, err := cb.Build(); err != nil {
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 	})
@@ -240,8 +240,8 @@ func TestCompressLevelValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		if _, err := cb.Build(); err == nil {
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -258,8 +258,8 @@ func TestCompressLevelValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		if _, err := cb.Build(); err != nil {
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 	})
@@ -276,8 +276,8 @@ func TestCompressLevelValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		if _, err := cb.Build(); err == nil {
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -290,8 +290,8 @@ func TestCompressLevelValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		if _, err := cb.Build(); err != nil {
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 	})
@@ -304,8 +304,8 @@ func TestCompressLevelValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		if _, err := cb.Build(); err == nil {
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -318,8 +318,8 @@ func TestCompressConcurrency(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		cfg, err := cb.Build()
+		b := &Builder{v: v, defaults: defaults}
+		cfg, err := b.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -335,8 +335,8 @@ func TestCompressConcurrency(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
 		}
-		cb := &ConfigBuilder{v: v, defaults: defaults}
-		cfg, err := cb.Build()
+		b := &Builder{v: v, defaults: defaults}
+		cfg, err := b.Build()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
## Summary
- rename `ConfigBuilder` to `Builder`
- update tests for new builder type

## Testing
- `go vet ./config`
- `golangci-lint run ./config`
- `go test ./config`


------
https://chatgpt.com/codex/tasks/task_e_689435fa8ca08323b70df887e06b9645