### PR TITLE
Remove redundant casts in block operations

### DIFF
--- a/internal/blocksize/blocksize.go
+++ b/internal/blocksize/blocksize.go
@@ -28,7 +28,7 @@ func Detect(devicePath string) (int, error) {
 	if !ok {
 		return 0, fmt.Errorf("unsupported file info for %s", devicePath)
 	}
-	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(uint64(stat.Rdev)), unix.Minor(uint64(stat.Rdev))))
+	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(stat.Rdev), unix.Minor(stat.Rdev)))
 	return readPreferredSize(queuePath)
 }
 

--- a/transfer/block.go
+++ b/transfer/block.go
@@ -37,7 +37,7 @@ func ZeroCopyTransfer(src *os.File, dst *os.File, offset int64, length int64, pi
 		if err != nil {
 			return fmt.Errorf("splice write failed: %w", err)
 		}
-		remaining -= int64(n)
+		remaining -= n
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- drop unnecessary `uint64` conversions around `Rdev`
- update zero-copy transfer to decrement using splice result directly

## Testing
- `golangci-lint run internal/blocksize`
- `golangci-lint run transfer`


------
https://chatgpt.com/codex/tasks/task_e_68943b2fdc508323b086407a58974a88