### PR TITLE
refactor: centralize strategy names

### DIFF
--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -17,7 +17,7 @@ const (
 // No shared state is kept between decompression readers.
 
 func NewCompressionWriter(dst io.Writer, compress string, level int, concurrency int) (io.WriteCloser, error) {
-	if compress == "auto" {
+	if compress == StrategyAuto {
 		compress = compressiondetect.DetectOptimalCompression()
 	}
 

--- a/transfer/constants.go
+++ b/transfer/constants.go
@@ -1,0 +1,11 @@
+package transfer
+
+// Strategy constants used for compression and deduplication.
+const (
+	// StrategyAuto selects an optimal strategy automatically.
+	StrategyAuto = "auto"
+	// StrategyChecksum uses checksum-based deduplication.
+	StrategyChecksum = "checksum"
+	// StrategyRollingHash uses a rolling hash for deduplication.
+	StrategyRollingHash = "rolling_hash"
+)

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -60,9 +60,9 @@ var rollingHashPool = sync.Pool{
 // is used.
 var detectBestStrategy = func() string {
 	if supportsChecksumAcceleration() {
-		return "checksum"
+		return StrategyChecksum
 	}
-	return "rolling_hash"
+	return StrategyRollingHash
 }
 
 func supportsChecksumAcceleration() bool {
@@ -71,14 +71,14 @@ func supportsChecksumAcceleration() bool {
 
 func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 	strategy := cfg.DedupStrategy
-	if strategy == "auto" {
+	if strategy == StrategyAuto {
 		strategy = detectBestStrategy()
 		cfg.DedupStrategy = strategy
 	}
 	switch strategy {
 	case "none":
 		return nil
-	case "rolling_hash":
+	case StrategyRollingHash:
 		d := &RollingHashDedup{
 			stateFile: cfg.DedupStateFile,
 			hashes:    make(map[int64]uint64),


### PR DESCRIPTION
## Summary
- add shared strategy constants for "auto", "checksum", and "rolling_hash"
- use these constants in compression and dedup strategies

## Testing
- `golangci-lint run transfer/...`


------
https://chatgpt.com/codex/tasks/task_e_68943d01f75083238eb927887eeaeb86