### PR TITLE
docs: clarify protocol version

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -1,4 +1,7 @@
 // common/common.go
 package common //nolint:revive // package name is established API
 
+// ProtocolVersion identifies the string exchanged during the initial handshake.
+// It follows the format "lvmsync PROTO[<n>]" where <n> is the protocol version
+// number both peers must support.
 const ProtocolVersion = "lvmsync PROTO[3]"


### PR DESCRIPTION
## Summary
- document protocol version constant and its format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689461e53c848323ba8559069e26440c