### PR TITLE
docs: add compression writer and reader comments

### DIFF
--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -16,6 +16,13 @@ const (
 
 // No shared state is kept between decompression readers.
 
+// NewCompressionWriter creates a compression writer that wraps the destination
+// `dst`. The `compress` parameter selects the compression algorithm and may
+// be set to StrategyAuto to automatically detect the optimal compression. The
+// `level` parameter controls the compression level when supported. If
+// `concurrency` is less than or equal to zero, it defaults to the number of
+// logical CPUs. It returns the configured `io.WriteCloser` or an error if the
+// compression type is unsupported.
 func NewCompressionWriter(dst io.Writer, compress string, level int, concurrency int) (io.WriteCloser, error) {
 	if compress == StrategyAuto {
 		compress = compressiondetect.DetectOptimalCompression()
@@ -32,6 +39,11 @@ func NewCompressionWriter(dst io.Writer, compress string, level int, concurrency
 	return strategy.NewWriter(dst, level, concurrency)
 }
 
+// NewDecompressionReader returns a reader that decompresses data from `r`
+// using the specified `compress` strategy. If `concurrency` is less than or
+// equal to zero, the number of logical CPUs is used. An `io.ReadCloser` is
+// returned to provide the decompressed stream, or an error if the compression
+// type is unsupported.
 func NewDecompressionReader(r io.Reader, compress string, concurrency int) (io.ReadCloser, error) {
 	if concurrency <= 0 {
 		concurrency = runtime.GOMAXPROCS(0)


### PR DESCRIPTION
## Summary
- clarify behavior and arguments for NewCompressionWriter
- document NewDecompressionReader parameters and defaults

## Testing
- `go test ./transfer` *(hangs, terminated after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68946932ca10832387c66cf2df0ad4bb