### PR TITLE
Log SSH agent connection closure errors

### DIFF
--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -148,5 +149,17 @@ func sshAgentAuth() (ssh.AuthMethod, error) {
 		return nil, fmt.Errorf("failed to connect to SSH agent: %w", err)
 	}
 
-	return ssh.PublicKeysCallback(agent.NewClient(conn).Signers), nil
+	agentClient := agent.NewClient(conn)
+	defer func() {
+		if err := conn.Close(); err != nil {
+			Logger.Warn("ssh agent connection close error", zap.Error(err))
+		}
+	}()
+
+	signers, err := agentClient.Signers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve signers from SSH agent: %w", err)
+	}
+
+	return ssh.PublicKeys(signers...), nil
 }


### PR DESCRIPTION
## Summary
- ensure sshAgentAuth closes its agent connection and logs close failures

## Testing
- `go build -x ./...`
- Attempted `go test ./...` but command hung with no output

------
https://chatgpt.com/codex/tasks/task_e_68946aff69008323ab9a59118a72885c