### PR TITLE
defer ssh agent conn closure

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -66,9 +66,12 @@ func selectAuthMethods(keyPath string) ([]ssh.AuthMethod, error) {
 			if err == nil {
 				agentClient := agent.NewClient(conn)
 				authMethods = append(authMethods, ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {
-					signers, err := agentClient.Signers()
-					_ = conn.Close()
-					return signers, err
+					defer func() {
+						if cerr := conn.Close(); cerr != nil {
+							Logger.Warn("ssh agent connection close error", zap.Error(cerr))
+						}
+					}()
+					return agentClient.Signers()
 				}))
 			}
 		}


### PR DESCRIPTION
## Summary
- ensure ssh agent connections are closed with deferred handling and warnings on error

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: cognitive-complexity: function selectAuthMethods has cognitive complexity 24 (> max enabled 15))*

------
https://chatgpt.com/codex/tasks/task_e_68946da3a5b08323ba027ff7c1dc4df9