### PR TITLE
Handle file close errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,12 +88,21 @@ func runClientMode(snapshotDevice, dest string) (err error) {
 	return runLocalDump(snapshotDevice, originDevice, dest)
 }
 
-func runLocalDump(snapshotDevice, originDevice, dest string) error {
+func runLocalDump(snapshotDevice, originDevice, dest string) (err error) {
 	destFile, err := os.OpenFile(dest, os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("failed to open destination device %s: %w", dest, err)
 	}
-	defer destFile.Close()
+	defer func() {
+		if closeErr := destFile.Close(); closeErr != nil {
+			zap.L().Warn("Failed to close destination device", zap.Error(closeErr))
+			if err == nil {
+				err = fmt.Errorf("close destination device: %w", closeErr)
+			} else {
+				err = fmt.Errorf("%v; close destination device: %w", err, closeErr)
+			}
+		}
+	}()
 	limitedOut := transfer.WrapRateLimitedWriter(destFile, cfg.SpeedLimit)
 	return executeDump(cfg, snapshotDevice, originDevice, limitedOut)
 }

--- a/transfer/block_other.go
+++ b/transfer/block_other.go
@@ -42,10 +42,9 @@ func ReadBlock(src *os.File, offset int64, size int) ([]byte, error) {
 	return buf, nil
 }
 
-func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int) ([]byte, error) {
+func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int) (data []byte, err error) {
 	blockSize := cfg.BlockSize
 	maxRetries := cfg.MaxRetries
-	var data []byte
 
 	if useZeroCopy {
 		if pipeFds[0] == -1 && pipeFds[1] == -1 {
@@ -61,7 +60,18 @@ func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZer
 		if err != nil {
 			return nil, err
 		}
-		defer r.Close()
+		defer func() {
+			if closeErr := r.Close(); closeErr != nil {
+				if Logger != nil {
+					Logger.Warn("Failed to close pipe reader", zap.Error(closeErr))
+				}
+				if err == nil {
+					err = fmt.Errorf("close pipe reader: %w", closeErr)
+				} else {
+					err = fmt.Errorf("%v; close pipe reader: %w", err, closeErr)
+				}
+			}
+		}()
 
 		for attempt := 0; attempt < maxRetries; attempt++ {
 			err = ZeroCopyTransfer(src, w, offset, int64(blockSize), pipeFds)

--- a/transfer/metadata.go
+++ b/transfer/metadata.go
@@ -17,12 +17,20 @@ func SetMapperDir(dir string) {
 	mapperDir = dir
 }
 
-func ReadMetadataHeader(metadataPath string) (int64, error) {
+func ReadMetadataHeader(metadataPath string) (chunkSize int64, err error) {
 	file, err := os.Open(metadataPath)
 	if err != nil {
 		return 0, err
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			if err == nil {
+				err = fmt.Errorf("close metadata file: %w", closeErr)
+			} else {
+				err = fmt.Errorf("%v; close metadata file: %w", err, closeErr)
+			}
+		}
+	}()
 
 	buf := make([]byte, 16)
 	if _, err := io.ReadFull(file, buf); err != nil {
@@ -47,22 +55,29 @@ func ReadMetadataHeader(metadataPath string) (int64, error) {
 	return int64(chunk) * 512, nil
 }
 
-func GetDifferences(metadataPath string, chunkSize int64) ([]Range, error) {
+func GetDifferences(metadataPath string, chunkSize int64) (ranges []Range, err error) {
 	file, err := os.Open(metadataPath)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			if err == nil {
+				err = fmt.Errorf("close metadata file: %w", closeErr)
+			} else {
+				err = fmt.Errorf("%v; close metadata file: %w", err, closeErr)
+			}
+		}
+	}()
 
-	if _, err := file.Seek(chunkSize, io.SeekStart); err != nil {
+	if _, err = file.Seek(chunkSize, io.SeekStart); err != nil {
 		return nil, err
 	}
 
-	var ranges []Range
 	buf := make([]byte, 16)
 
 	for {
-		_, err := io.ReadFull(file, buf)
+		_, err = io.ReadFull(file, buf)
 		if err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				break

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -252,7 +252,7 @@ func logSequentialSummary(bytes int64, skipped int, start time.Time) {
 		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
 }
 
-func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) error {
+func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
 	if err := detectBlockSize(cfg, source); err != nil {
 		return err
 	}
@@ -273,7 +273,18 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	if err != nil {
 		return err
 	}
-	defer srcFile.Close()
+	defer func() {
+		if closeErr := srcFile.Close(); closeErr != nil {
+			if Logger != nil {
+				Logger.Warn("Failed to close source file", zap.Error(closeErr))
+			}
+			if err == nil {
+				err = fmt.Errorf("close source file: %w", closeErr)
+			} else {
+				err = fmt.Errorf("%v; close source file: %w", err, closeErr)
+			}
+		}
+	}()
 
 	pipeFds, cleanupPipe, err := setupPipe(cfg)
 	if err != nil {
@@ -282,7 +293,9 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	defer cleanupPipe()
 
 	startTime := time.Now()
-	totalBytesTransferred, skippedBlocks, err := iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds)
+	var totalBytesTransferred int64
+	var skippedBlocks int
+	totalBytesTransferred, skippedBlocks, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds)
 	if err != nil {
 		return err
 	}
@@ -483,7 +496,7 @@ func logParallelSummary(bytes int64, start time.Time) {
 		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
 }
 
-func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) error {
+func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
 	if cfg.ZeroCopy {
 		Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
 		return DumpChangesSequential(cfg, snapshot, source, out)
@@ -514,14 +527,26 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	if err != nil {
 		return err
 	}
-	defer srcFile.Close()
+	defer func() {
+		if closeErr := srcFile.Close(); closeErr != nil {
+			if Logger != nil {
+				Logger.Warn("Failed to close source file", zap.Error(closeErr))
+			}
+			if err == nil {
+				err = fmt.Errorf("close source file: %w", closeErr)
+			} else {
+				err = fmt.Errorf("%v; close source file: %w", err, closeErr)
+			}
+		}
+	}()
 
 	resumeStart := readResumeStart(cfg)
 	results := startParallelWorkers(cfg, srcFile, ranges, resumeStart)
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
-	totalBytesTransferred, err := processParallelResults(cfg, results, bufOut, checksum, totalDataSize, startTime)
+	var totalBytesTransferred int64
+	totalBytesTransferred, err = processParallelResults(cfg, results, bufOut, checksum, totalDataSize, startTime)
 	if err != nil {
 		return err
 	}
@@ -652,9 +677,10 @@ func applyBlocks(cfg *config.Config, reader *bufio.Reader, destFile *os.File, de
 	return totalBytes, nil
 }
 
-func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) error {
+func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
 	bufReader := bufio.NewReader(in)
-	hs, err := readAndValidateHandshake(bufReader, dedup, verify)
+	var hs common.Handshake
+	hs, err = readAndValidateHandshake(bufReader, dedup, verify)
 	if err != nil {
 		return err
 	}
@@ -675,11 +701,23 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 	if err != nil {
 		return fmt.Errorf("failed to open destination device %s: %w", destPath, err)
 	}
-	defer destFile.Close()
+	defer func() {
+		if closeErr := destFile.Close(); closeErr != nil {
+			if Logger != nil {
+				Logger.Warn("Failed to close destination device", zap.Error(closeErr))
+			}
+			if err == nil {
+				err = fmt.Errorf("close destination device: %w", closeErr)
+			} else {
+				err = fmt.Errorf("%v; close destination device: %w", err, closeErr)
+			}
+		}
+	}()
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
-	totalBytes, err := applyBlocks(cfg, reader, destFile, dedup, verify, checksum)
+	var totalBytes int64
+	totalBytes, err = applyBlocks(cfg, reader, destFile, dedup, verify, checksum)
 	if err != nil {
 		return err
 	}
@@ -703,16 +741,28 @@ func ProcessDumpData(cfg *config.Config, in io.Reader, destPath string) error {
 }
 
 // RunApply reads a dump file or stdin and writes the data to destDevice, optionally leveraging deduplication and saving its state.
-func RunApply(cfg *config.Config, applyFile, destDevice string) error {
+func RunApply(cfg *config.Config, applyFile, destDevice string) (err error) {
 	var in io.Reader
 	if applyFile == "-" {
 		in = os.Stdin
 	} else {
-		f, err := os.Open(applyFile)
+		var f *os.File
+		f, err = os.Open(applyFile)
 		if err != nil {
 			return fmt.Errorf("failed to open apply file %s: %w", applyFile, err)
 		}
-		defer f.Close()
+		defer func() {
+			if closeErr := f.Close(); closeErr != nil {
+				if Logger != nil {
+					Logger.Warn("Failed to close apply file", zap.Error(closeErr))
+				}
+				if err == nil {
+					err = fmt.Errorf("close apply file: %w", closeErr)
+				} else {
+					err = fmt.Errorf("%v; close apply file: %w", err, closeErr)
+				}
+			}
+		}()
 		in = f
 	}
 
@@ -720,8 +770,8 @@ func RunApply(cfg *config.Config, applyFile, destDevice string) error {
 	if dedup != nil {
 		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
 		defer func() {
-			if err := dedup.SaveState(); err != nil {
-				Logger.Error("Failed to save dedup state", zap.Error(err))
+			if err2 := dedup.SaveState(); err2 != nil {
+				Logger.Error("Failed to save dedup state", zap.Error(err2))
 			}
 		}()
 		return ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)


### PR DESCRIPTION
## Summary
- ensure destination file close errors in runLocalDump are logged and returned
- wrap metadata and transfer file closes with error-aware defers
- protect pipe reader closure in non-Linux block transfer implementation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68946d9de9988323869fb0239bb2ab94