### PR TITLE
test: add mock cgo backend

### DIFF
--- a/lvm/backend_test.go
+++ b/lvm/backend_test.go
@@ -1,41 +1,20 @@
 package lvm
 
 import (
-	"context"
-	"fmt"
-	"testing"
+        "context"
+        "testing"
 
-	"lvmsync_go/lvm/cgo"
+        "lvmsync_go/lvm/cgo"
 )
 
-type mockCGO struct{ calls []string }
-
-func (m *mockCGO) CreateSnapshot(lvPath, snapName string, sizeBytes uint64) error {
-	m.calls = append(m.calls, fmt.Sprintf("create:%s:%s:%d", lvPath, snapName, sizeBytes))
-	return nil
-}
-func (m *mockCGO) RemoveLV(lvPath string) error {
-	m.calls = append(m.calls, fmt.Sprintf("remove:%s", lvPath))
-	return nil
-}
-func (m *mockCGO) SnapshotUsage(string) (float64, error) { return 55.5, nil }
-func (m *mockCGO) VGFree(vgName string) (uint64, error) {
-	if vgName == "vg0" {
-		return 1024, nil
-	}
-	if vgName == "vg1" {
-		return 2048, nil
-	}
-	return 0, fmt.Errorf("unknown vg")
-}
-func (m *mockCGO) ListVGs() ([]cgo.VolumeGroup, error) {
-	return []cgo.VolumeGroup{{Name: "vg0", Free: 1024}, {Name: "vg1", Free: 2048}}, nil
-}
-
 func TestBackend(t *testing.T) {
-	mc := &mockCGO{}
-	b := newBackendWithCGO(mc)
-	ctx := context.Background()
+        mc := newMockCGO()
+        mc.usage = 55.5
+        mc.vgFree["vg0"] = 1024
+        mc.vgFree["vg1"] = 2048
+        mc.vgs = []cgo.VolumeGroup{{Name: "vg0", Free: 1024}, {Name: "vg1", Free: 2048}}
+        b := newBackendWithCGO(mc)
+        ctx := context.Background()
 
 	if err := b.CreateSnapshot(ctx, "/dev/vg0/origin", "snap", "1G"); err != nil {
 		t.Fatalf("CreateSnapshot failed: %v", err)

--- a/lvm/mock_cgo_test.go
+++ b/lvm/mock_cgo_test.go
@@ -1,0 +1,39 @@
+package lvm
+
+import (
+    "fmt"
+
+    "lvmsync_go/lvm/cgo"
+)
+
+// mockCGO implements the cgo.LVM interface for tests and records calls.
+type mockCGO struct {
+    calls  []string
+    usage  float64
+    vgFree map[string]uint64
+    vgs    []cgo.VolumeGroup
+}
+
+func newMockCGO() *mockCGO { return &mockCGO{vgFree: make(map[string]uint64)} }
+
+func (m *mockCGO) CreateSnapshot(lvPath, snapName string, sizeBytes uint64) error {
+    m.calls = append(m.calls, fmt.Sprintf("create:%s:%s:%d", lvPath, snapName, sizeBytes))
+    return nil
+}
+
+func (m *mockCGO) RemoveLV(lvPath string) error {
+    m.calls = append(m.calls, fmt.Sprintf("remove:%s", lvPath))
+    return nil
+}
+
+func (m *mockCGO) SnapshotUsage(string) (float64, error) { return m.usage, nil }
+
+func (m *mockCGO) VGFree(vgName string) (uint64, error) {
+    if free, ok := m.vgFree[vgName]; ok {
+        return free, nil
+    }
+    return 0, fmt.Errorf("unknown vg")
+}
+
+func (m *mockCGO) ListVGs() ([]cgo.VolumeGroup, error) { return m.vgs, nil }
+


### PR DESCRIPTION
## Summary
- add shared mock for cgo LVM backend used by unit tests
- update backend tests to rely on new mock

## Testing
- `go test ./lvm -run TestBackend -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894863e46dc8323b44aa9492a6b0c2f