### PR TITLE
Resolve symlinks when parsing LV paths

### DIFF
--- a/lvm/backend_test.go
+++ b/lvm/backend_test.go
@@ -1,20 +1,23 @@
 package lvm
 
 import (
-        "context"
-        "testing"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 
-        "lvmsync_go/lvm/cgo"
+	"lvmsync_go/lvm/cgo"
 )
 
 func TestBackend(t *testing.T) {
-        mc := newMockCGO()
-        mc.usage = 55.5
-        mc.vgFree["vg0"] = 1024
-        mc.vgFree["vg1"] = 2048
-        mc.vgs = []cgo.VolumeGroup{{Name: "vg0", Free: 1024}, {Name: "vg1", Free: 2048}}
-        b := newBackendWithCGO(mc)
-        ctx := context.Background()
+	mc := newMockCGO()
+	mc.usage = 55.5
+	mc.vgFree["vg0"] = 1024
+	mc.vgFree["vg1"] = 2048
+	mc.vgs = []cgo.VolumeGroup{{Name: "vg0", Free: 1024}, {Name: "vg1", Free: 2048}}
+	b := newBackendWithCGO(mc)
+	ctx := context.Background()
 
 	if err := b.CreateSnapshot(ctx, "/dev/vg0/origin", "snap", "1G"); err != nil {
 		t.Fatalf("CreateSnapshot failed: %v", err)
@@ -40,5 +43,78 @@ func TestBackend(t *testing.T) {
 	}
 	if len(mc.calls) < 2 || mc.calls[0] == "" {
 		t.Fatalf("expected calls to underlying cgo wrapper")
+	}
+}
+
+func TestParseLVPath(t *testing.T) {
+	root := t.TempDir()
+	dev := filepath.Join(root, "dev")
+	mapper := filepath.Join(dev, "mapper")
+	if err := os.MkdirAll(mapper, 0o755); err != nil {
+		t.Fatalf("mkdir mapper: %v", err)
+	}
+
+	// device representing /dev/mapper/vg-lv
+	device := filepath.Join(mapper, "vg-lv")
+	if err := os.WriteFile(device, nil, 0o644); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// /dev/vg/lv -> /dev/mapper/vg-lv
+	vgDir := filepath.Join(dev, "vg")
+	if err := os.MkdirAll(vgDir, 0o755); err != nil {
+		t.Fatalf("mkdir vg: %v", err)
+	}
+	devPath := filepath.Join(vgDir, "lv")
+	if err := os.Symlink(device, devPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// create plain /dev/vg2/lv2 without mapper symlink
+	vgPlain := filepath.Join(dev, "vg2")
+	if err := os.MkdirAll(vgPlain, 0o755); err != nil {
+		t.Fatalf("mkdir vg2: %v", err)
+	}
+	plain := filepath.Join(vgPlain, "lv2")
+	if err := os.WriteFile(plain, nil, 0o644); err != nil {
+		t.Fatalf("create plain: %v", err)
+	}
+
+	// alias symlink outside of vg/lv naming
+	aliasDir := filepath.Join(dev, "by-id")
+	if err := os.MkdirAll(aliasDir, 0o755); err != nil {
+		t.Fatalf("mkdir alias: %v", err)
+	}
+	aliasPath := filepath.Join(aliasDir, "alias")
+	if err := os.Symlink(device, aliasPath); err != nil {
+		t.Fatalf("symlink alias: %v", err)
+	}
+
+	replacer := strings.NewReplacer("-", "--")
+	encoded := filepath.Join(mapper, replacer.Replace("vg-hy")+"-"+replacer.Replace("lv-hy"))
+	if err := os.WriteFile(encoded, nil, 0o644); err != nil {
+		t.Fatalf("create encoded: %v", err)
+	}
+
+	tests := []struct {
+		path string
+		vg   string
+		lv   string
+	}{
+		{devPath, "vg", "lv"},
+		{plain, "vg2", "lv2"},
+		{device, "vg", "lv"},
+		{aliasPath, "vg", "lv"},
+		{encoded, "vg-hy", "lv-hy"},
+	}
+
+	for _, tt := range tests {
+		vg, lv, err := parseLVPath(tt.path)
+		if err != nil {
+			t.Fatalf("parseLVPath(%s) error: %v", tt.path, err)
+		}
+		if vg != tt.vg || lv != tt.lv {
+			t.Fatalf("parseLVPath(%s) = %s/%s, want %s/%s", tt.path, vg, lv, tt.vg, tt.lv)
+		}
 	}
 }

--- a/lvm/path.go
+++ b/lvm/path.go
@@ -1,0 +1,45 @@
+package lvm
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// parseLVPath splits a logical volume path into its volume group and logical volume names.
+// It resolves symlinks before parsing and understands both /dev/<vg>/<lv> and
+// /dev/mapper/<vg>-<lv> style paths.
+func parseLVPath(p string) (string, string, error) {
+	if p == "" {
+		return "", "", fmt.Errorf("empty logical volume path")
+	}
+
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve %s: %w", p, err)
+	}
+
+	resolved = filepath.Clean(resolved)
+	sep := string(filepath.Separator)
+	if strings.Contains(resolved, sep+"mapper"+sep) {
+		base := filepath.Base(resolved)
+		replaced := strings.ReplaceAll(base, "--", "\x00")
+		idx := strings.Index(replaced, "-")
+		if idx < 0 {
+			return "", "", fmt.Errorf("invalid logical volume path: %s", p)
+		}
+		vg := strings.ReplaceAll(replaced[:idx], "\x00", "-")
+		lv := strings.ReplaceAll(replaced[idx+1:], "\x00", "-")
+		if vg == "" || lv == "" {
+			return "", "", fmt.Errorf("invalid logical volume path: %s", p)
+		}
+		return vg, lv, nil
+	}
+
+	vg := filepath.Base(filepath.Dir(resolved))
+	lv := filepath.Base(resolved)
+	if vg == "" || lv == "" {
+		return "", "", fmt.Errorf("invalid logical volume path: %s", p)
+	}
+	return vg, lv, nil
+}


### PR DESCRIPTION
## Summary
- Resolve symlinks in `parseLVPath` and handle both `/dev/<vg>/<lv>` and `/dev/mapper/<vg>-<lv>` formats.
- Add unit tests covering direct paths, mapper paths with hyphen escaping, and symlinked aliases.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68948a17d92c83239fbb68c54abcb2c3