### PR TITLE
lvm: split CGO backend by build tags

### DIFF
--- a/lvm/backend.go
+++ b/lvm/backend.go
@@ -1,12 +1,6 @@
 package lvm
 
-import (
-	"context"
-	"fmt"
-
-	"lvmsync_go/internal/sizeparse"
-	"lvmsync_go/lvm/cgo"
-)
+import "context"
 
 type lvmBackend interface {
 	CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error
@@ -14,54 +8,4 @@ type lvmBackend interface {
 	GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error)
 	GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error)
 	ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error)
-}
-
-type dmBackend struct{ dm cgo.LVM }
-
-func newBackendWithCGO(dm cgo.LVM) lvmBackend { return &dmBackend{dm: dm} }
-
-func newLVMBackend() lvmBackend { return newBackendWithCGO(cgo.New()) }
-
-func (b *dmBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
-	bytes, percent, err := sizeparse.Parse(size)
-	if err != nil {
-		return err
-	}
-	if percent {
-		return fmt.Errorf("percentage sizes not supported")
-	}
-	return b.dm.CreateSnapshot(lvPath, snapshotName, uint64(bytes))
-}
-
-func (b *dmBackend) RemoveSnapshot(ctx context.Context, snapshotPath string) error {
-	return b.dm.RemoveLV(snapshotPath)
-}
-
-func (b *dmBackend) GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
-	return b.dm.SnapshotUsage(snapshotPath)
-}
-
-func (b *dmBackend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
-	return b.dm.VGFree(vgName)
-}
-
-func (b *dmBackend) ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error) {
-	vgs, err := b.dm.ListVGs()
-	if err != nil {
-		return nil, err
-	}
-	include := make(map[string]bool)
-	if len(candidates) > 0 {
-		for _, c := range candidates {
-			include[c] = true
-		}
-	}
-	res := []VolumeGroup{}
-	for _, vg := range vgs {
-		if len(include) > 0 && !include[vg.Name] {
-			continue
-		}
-		res = append(res, VolumeGroup{Name: vg.Name, Free: vg.Free})
-	}
-	return res, nil
 }

--- a/lvm/backend_cgo.go
+++ b/lvm/backend_cgo.go
@@ -1,0 +1,61 @@
+//go:build linux && cgo
+
+package lvm
+
+import (
+	"context"
+	"fmt"
+
+	"lvmsync_go/internal/sizeparse"
+	"lvmsync_go/lvm/cgo"
+)
+
+type dmBackend struct{ dm cgo.LVM }
+
+func newBackendWithCGO(dm cgo.LVM) lvmBackend { return &dmBackend{dm: dm} }
+
+func newLVMBackend() lvmBackend { return newBackendWithCGO(cgo.New()) }
+
+func (b *dmBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
+	bytes, percent, err := sizeparse.Parse(size)
+	if err != nil {
+		return err
+	}
+	if percent {
+		return fmt.Errorf("percentage sizes not supported")
+	}
+	return b.dm.CreateSnapshot(lvPath, snapshotName, uint64(bytes))
+}
+
+func (b *dmBackend) RemoveSnapshot(ctx context.Context, snapshotPath string) error {
+	return b.dm.RemoveLV(snapshotPath)
+}
+
+func (b *dmBackend) GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
+	return b.dm.SnapshotUsage(snapshotPath)
+}
+
+func (b *dmBackend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
+	return b.dm.VGFree(vgName)
+}
+
+func (b *dmBackend) ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error) {
+	vgs, err := b.dm.ListVGs()
+	if err != nil {
+		return nil, err
+	}
+	include := make(map[string]bool)
+	if len(candidates) > 0 {
+		for _, c := range candidates {
+			include[c] = true
+		}
+	}
+	res := []VolumeGroup{}
+	for _, vg := range vgs {
+		if len(include) > 0 && !include[vg.Name] {
+			continue
+		}
+		res = append(res, VolumeGroup{Name: vg.Name, Free: vg.Free})
+	}
+	return res, nil
+}

--- a/lvm/backend_stub.go
+++ b/lvm/backend_stub.go
@@ -1,0 +1,61 @@
+//go:build !linux || !cgo
+
+package lvm
+
+import (
+	"context"
+	"fmt"
+
+	"lvmsync_go/internal/sizeparse"
+	"lvmsync_go/lvm/cgo"
+)
+
+type noopBackend struct{ dm cgo.LVM }
+
+func newBackendWithCGO(dm cgo.LVM) lvmBackend { return &noopBackend{dm: dm} }
+
+func newLVMBackend() lvmBackend { return newBackendWithCGO(cgo.New()) }
+
+func (b *noopBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
+	bytes, percent, err := sizeparse.Parse(size)
+	if err != nil {
+		return err
+	}
+	if percent {
+		return fmt.Errorf("percentage sizes not supported")
+	}
+	return b.dm.CreateSnapshot(lvPath, snapshotName, uint64(bytes))
+}
+
+func (b *noopBackend) RemoveSnapshot(ctx context.Context, snapshotPath string) error {
+	return b.dm.RemoveLV(snapshotPath)
+}
+
+func (b *noopBackend) GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
+	return b.dm.SnapshotUsage(snapshotPath)
+}
+
+func (b *noopBackend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
+	return b.dm.VGFree(vgName)
+}
+
+func (b *noopBackend) ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error) {
+	vgs, err := b.dm.ListVGs()
+	if err != nil {
+		return nil, err
+	}
+	include := make(map[string]bool)
+	if len(candidates) > 0 {
+		for _, c := range candidates {
+			include[c] = true
+		}
+	}
+	res := []VolumeGroup{}
+	for _, vg := range vgs {
+		if len(include) > 0 && !include[vg.Name] {
+			continue
+		}
+		res = append(res, VolumeGroup{Name: vg.Name, Free: vg.Free})
+	}
+	return res, nil
+}

--- a/lvm/cgo/devmapper_linux.go
+++ b/lvm/cgo/devmapper_linux.go
@@ -1,4 +1,4 @@
-//go:build devmapper
+//go:build linux && cgo
 
 package cgo
 

--- a/lvm/cgo/devmapper_stub.go
+++ b/lvm/cgo/devmapper_stub.go
@@ -1,3 +1,5 @@
+//go:build !linux || !cgo
+
 package cgo
 
 // VolumeGroup represents a volume group with its free space in bytes.
@@ -15,7 +17,7 @@ type LVM interface {
 	ListVGs() ([]VolumeGroup, error)
 }
 
-// DM is a stub implementation used when the devmapper build tag is not enabled.
+// DM is a stub implementation used when CGO is unavailable.
 type DM struct{}
 
 // New returns a stub DM implementation.


### PR DESCRIPTION
## Summary
- guard the device-mapper backend behind `linux && cgo` build tags
- add stub implementations for non-CGO platforms and wire backend selection through build constraints

## Testing
- `CGO_ENABLED=0 go test ./lvm -count=1`
- `CGO_ENABLED=0 go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68948cc05d58832382c1ffafc20d184c