### PR TITLE
Replace devmapper library with direct cgo calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24.5
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
-	github.com/dswarbrick/devmapper v0.0.0-20180105234447-48f6140a67ea
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/cpuid/v2 v2.2.7
 	github.com/pierrec/lz4/v4 v4.1.22

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/bits-and-blooms/bloom/v3 v3.7.0 h1:VfknkqV4xI+PsaDIsoHueyxVDZrfvMn56j
 github.com/bits-and-blooms/bloom/v3 v3.7.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iHb1kOL2tfHTgyJBHg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dswarbrick/devmapper v0.0.0-20180105234447-48f6140a67ea h1:JBdvbm8ZYhKmxJ5EvK36nax/6JT6Qy7rAonUdsp6cfo=
-github.com/dswarbrick/devmapper v0.0.0-20180105234447-48f6140a67ea/go.mod h1:Bqyo2ge+ya6+K8g20up31hSQ9tsEmeWqduk+h3Oa0XY=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/lvm/cgo/devmapper_linux.go
+++ b/lvm/cgo/devmapper_linux.go
@@ -2,8 +2,26 @@
 
 package cgo
 
+/*
+#cgo pkg-config: lvm2app devmapper
+#include <stdlib.h>
+#include <lvm2cmd.h>
+#include <libdevmapper.h>
+
+extern void goLog(int level, const char *file, int line, int dm_errno, const char *message);
+
+static void bridge_log(int level, const char *file, int line, int dm_errno, const char *message) {
+    goLog(level, file, line, dm_errno, message);
+}
+*/
+import "C"
+
 import (
-	dm "github.com/dswarbrick/devmapper"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"unsafe"
 )
 
 // VolumeGroup represents a volume group with its free space in bytes.
@@ -21,40 +39,129 @@ type LVM interface {
 	ListVGs() ([]VolumeGroup, error)
 }
 
-// DM implements the LVM interface using github.com/dswarbrick/devmapper.
+// DM implements the LVM interface using direct liblvm2/libdevmapper calls.
 type DM struct{}
 
 // New returns a new DM instance.
 func New() LVM { return &DM{} }
 
+var (
+	logMu  sync.Mutex
+	logBuf strings.Builder
+)
+
+//export goLog
+func goLog(level C.int, file *C.char, line C.int, dmErrno C.int, message *C.char) {
+	if level != C.LVM2_LOG_PRINT && level != C.LVM2_LOG_ERROR {
+		return
+	}
+	if message == nil {
+		return
+	}
+	logBuf.WriteString(C.GoString(message))
+	logBuf.WriteByte('\n')
+}
+
+func runLVM(args ...string) (string, error) {
+	cmd := strings.Join(args, " ")
+	ccmd := C.CString(cmd)
+	defer C.free(unsafe.Pointer(ccmd))
+
+	logMu.Lock()
+	logBuf.Reset()
+	C.lvm2_log_fn((C.lvm2_log_fn_t)(unsafe.Pointer(C.bridge_log)))
+	ret := C.lvm2_run(nil, ccmd)
+	out := logBuf.String()
+	logMu.Unlock()
+
+	if ret != C.LVM2_COMMAND_SUCCEEDED {
+		return out, fmt.Errorf("lvm command failed: %s", strings.TrimSpace(out))
+	}
+	return out, nil
+}
+
+// dmVersion calls into libdevmapper to ensure linkage.
+func dmVersion() string {
+	var buf [128]C.char
+	if C.dm_get_library_version(&buf[0], 128) == 0 {
+		return ""
+	}
+	return C.GoString(&buf[0])
+}
+
 // CreateSnapshot creates a snapshot of the logical volume at lvPath.
 func (d *DM) CreateSnapshot(lvPath, snapshotName string, sizeBytes uint64) error {
-	// Placeholder implementation demonstrating devmapper usage.
-	// Real implementation would configure a snapshot target.
-	_ = dm.GetLibraryVersion()
+	dmVersion()
+	size := fmt.Sprintf("%dB", sizeBytes)
+	_, err := runLVM("lvcreate", "--snapshot", "--name", snapshotName, "--size", size, lvPath)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 // RemoveLV removes the logical volume identified by lvPath.
 func (d *DM) RemoveLV(lvPath string) error {
-	_ = dm.GetLibraryVersion()
-	return nil
+	dmVersion()
+	_, err := runLVM("lvremove", "-f", lvPath)
+	return err
 }
 
 // SnapshotUsage returns the data usage percentage of the snapshot at lvPath.
 func (d *DM) SnapshotUsage(lvPath string) (float64, error) {
-	_ = dm.GetLibraryVersion()
-	return 0, nil
+	dmVersion()
+	out, err := runLVM("lvs", "--noheadings", "--units", "b", "--nosuffix", "-o", "data_percent", lvPath)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("unable to parse lvs output: %q", out)
+	}
+	val, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
 }
 
 // VGFree returns the free space of the specified volume group in bytes.
 func (d *DM) VGFree(vgName string) (uint64, error) {
-	_ = dm.GetLibraryVersion()
-	return 0, nil
+	dmVersion()
+	out, err := runLVM("vgs", "--noheadings", "--units", "b", "--nosuffix", "-o", "vg_free", vgName)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("unable to parse vgs output: %q", out)
+	}
+	val, err := strconv.ParseUint(fields[0], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
 }
 
 // ListVGs returns all available volume groups.
 func (d *DM) ListVGs() ([]VolumeGroup, error) {
-	_ = dm.GetLibraryVersion()
-	return []VolumeGroup{}, nil
+	dmVersion()
+	out, err := runLVM("vgs", "--noheadings", "--units", "b", "--nosuffix", "-o", "vg_name,vg_free")
+	if err != nil {
+		return nil, err
+	}
+	var vgs []VolumeGroup
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		free, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		vgs = append(vgs, VolumeGroup{Name: fields[0], Free: free})
+	}
+	return vgs, nil
 }


### PR DESCRIPTION
## Summary
- remove github.com/dswarbrick/devmapper
- add cgo bindings to liblvm2 and libdevmapper
- implement snapshot and volume group helpers using lvm2cmd via cgo

## Testing
- `go test ./...` *(fails: Package lvm2app was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_6894961a0f688323ba4217a8cdaf3fe5