### PR TITLE
Return explicit error when CGO unsupported

### DIFF
--- a/lvm/cgo/devmapper_stub.go
+++ b/lvm/cgo/devmapper_stub.go
@@ -2,6 +2,11 @@
 
 package cgo
 
+import "errors"
+
+// ErrUnsupported is returned when CGO support is unavailable.
+var ErrUnsupported = errors.New("lvm unsupported")
+
 // VolumeGroup represents a volume group with its free space in bytes.
 type VolumeGroup struct {
 	Name string
@@ -23,8 +28,22 @@ type DM struct{}
 // New returns a stub DM implementation.
 func New() LVM { return &DM{} }
 
-func (d *DM) CreateSnapshot(lvPath, snapshotName string, sizeBytes uint64) error { return nil }
-func (d *DM) RemoveLV(lvPath string) error                                       { return nil }
-func (d *DM) SnapshotUsage(lvPath string) (float64, error)                       { return 0, nil }
-func (d *DM) VGFree(vgName string) (uint64, error)                               { return 0, nil }
-func (d *DM) ListVGs() ([]VolumeGroup, error)                                    { return []VolumeGroup{}, nil }
+func (d *DM) CreateSnapshot(lvPath, snapshotName string, sizeBytes uint64) error {
+	return ErrUnsupported
+}
+
+func (d *DM) RemoveLV(lvPath string) error {
+	return ErrUnsupported
+}
+
+func (d *DM) SnapshotUsage(lvPath string) (float64, error) {
+	return 0, ErrUnsupported
+}
+
+func (d *DM) VGFree(vgName string) (uint64, error) {
+	return 0, ErrUnsupported
+}
+
+func (d *DM) ListVGs() ([]VolumeGroup, error) {
+	return nil, ErrUnsupported
+}

--- a/lvm/cgo/devmapper_stub_test.go
+++ b/lvm/cgo/devmapper_stub_test.go
@@ -1,0 +1,28 @@
+//go:build !linux || !cgo
+
+package cgo
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStubReturnsErrUnsupported(t *testing.T) {
+	dm := New()
+
+	if err := dm.CreateSnapshot("lv", "snap", 1); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("CreateSnapshot error = %v, want ErrUnsupported", err)
+	}
+	if err := dm.RemoveLV("lv"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("RemoveLV error = %v, want ErrUnsupported", err)
+	}
+	if _, err := dm.SnapshotUsage("lv"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("SnapshotUsage error = %v, want ErrUnsupported", err)
+	}
+	if _, err := dm.VGFree("vg"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("VGFree error = %v, want ErrUnsupported", err)
+	}
+	if _, err := dm.ListVGs(); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("ListVGs error = %v, want ErrUnsupported", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ErrUnsupported` to CGO stub to signal missing LVM support
- make stub methods return `ErrUnsupported`
- test for `ErrUnsupported` from stub implementation

## Testing
- `CGO_ENABLED=0 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894a57e85a0832380040f3cf8907d9b