### PR TITLE
Refactor LVM cgo layer with reusable connection

### DIFF
--- a/lvm/cgo/devmapper_linux.go
+++ b/lvm/cgo/devmapper_linux.go
@@ -74,7 +74,6 @@ import "C"
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"unsafe"
 )
@@ -83,6 +82,116 @@ import (
 type VolumeGroup struct {
 	Name string
 	Free uint64
+}
+
+// Conn represents an initialized liblvm handle.
+type Conn struct {
+	lvm C.lvm_t
+}
+
+// Open initializes a new liblvm connection.
+func Open() (*Conn, error) {
+	dmVersion()
+	lvm := C.cgo_lvm_init()
+	if lvm == nil {
+		return nil, fmt.Errorf("lvm_init failed")
+	}
+	return &Conn{lvm: lvm}, nil
+}
+
+// Close releases the underlying liblvm handle.
+func (c *Conn) Close() {
+	if c.lvm != nil {
+		C.cgo_lvm_quit(c.lvm)
+		c.lvm = nil
+	}
+}
+
+// VG represents an opened volume group.
+type VG struct {
+	conn *Conn
+	vg   C.vg_t
+	name string
+}
+
+// OpenVG opens the named volume group.
+func (c *Conn) OpenVG(name string) (*VG, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	vg := C.cgo_vg_open(c.lvm, cName)
+	if vg == nil {
+		return nil, fmt.Errorf("vg open failed")
+	}
+	return &VG{conn: c, vg: vg, name: name}, nil
+}
+
+// Close releases the volume group handle.
+func (v *VG) Close() error {
+	if v.vg == nil {
+		return nil
+	}
+	if C.cgo_vg_close(v.vg) != 0 {
+		return fmt.Errorf("vg close failed")
+	}
+	v.vg = nil
+	return nil
+}
+
+// FreeBytes returns free space in bytes for the volume group.
+func (v *VG) FreeBytes() uint64 { return uint64(C.cgo_vg_free(v.vg)) }
+
+// CreateSnapshot creates a snapshot of origin with the given name and size.
+func (v *VG) CreateSnapshot(origin, snapshot string, size uint64) error {
+	corigin := C.CString(origin)
+	csnap := C.CString(snapshot)
+	defer C.free(unsafe.Pointer(corigin))
+	defer C.free(unsafe.Pointer(csnap))
+	if ret := C.cgo_lv_create(v.vg, corigin, csnap, C.uint64_t(size)); ret != 0 {
+		return fmt.Errorf("lvcreate failed: %d", int(ret))
+	}
+	return nil
+}
+
+// RemoveLV removes the logical volume with the given name.
+func (v *VG) RemoveLV(name string) error {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	if ret := C.cgo_lv_remove(v.vg, cname); ret != 0 {
+		return fmt.Errorf("lvremove failed: %d", int(ret))
+	}
+	return nil
+}
+
+// SnapshotUsage returns the data usage percentage of the snapshot.
+func (v *VG) SnapshotUsage(name string) (float64, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	var val C.double
+	if C.cgo_snapshot_percent(v.vg, cname, &val) != 0 {
+		return 0, fmt.Errorf("get snapshot usage failed")
+	}
+	return float64(val), nil
+}
+
+// ListVolumeGroups returns all available volume groups.
+func (c *Conn) ListVolumeGroups() ([]VolumeGroup, error) {
+	list := C.cgo_list_vgs(c.lvm)
+	var vgs []VolumeGroup
+	for item := list; item != nil; item = item.next {
+		name := C.cgo_list_item_str(item)
+		if name == nil {
+			continue
+		}
+		vgName := C.GoString(name)
+		vg, err := c.OpenVG(vgName)
+		if err != nil {
+			continue
+		}
+		free := vg.FreeBytes()
+		vg.Close()
+		vgs = append(vgs, VolumeGroup{Name: vgName, Free: free})
+	}
+	return vgs, nil
 }
 
 // LVM provides access to LVM operations via device-mapper.
@@ -111,136 +220,88 @@ func dmVersion() string {
 
 // CreateSnapshot creates a snapshot of the logical volume at lvPath.
 func (d *DM) CreateSnapshot(lvPath, snapshotName string, sizeBytes uint64) error {
-	dmVersion()
 	vgName, lvName := filepath.Split(lvPath)
 	vgName = strings.Trim(vgName, "/")
 
-	clvm := C.cgo_lvm_init()
-	if clvm == nil {
-		return fmt.Errorf("lvm_init failed")
+	conn, err := Open()
+	if err != nil {
+		return err
 	}
-	defer C.cgo_lvm_quit(clvm)
+	defer conn.Close()
 
-	cvg := C.cgo_vg_open(clvm, C.CString(vgName))
-	if cvg == nil {
-		return fmt.Errorf("vg open failed")
+	vg, err := conn.OpenVG(vgName)
+	if err != nil {
+		return err
 	}
-	defer C.cgo_vg_close(cvg)
+	defer vg.Close()
 
-	origin := C.CString(lvName)
-	snap := C.CString(snapshotName)
-	defer C.free(unsafe.Pointer(origin))
-	defer C.free(unsafe.Pointer(snap))
-
-	ret := C.cgo_lv_create(cvg, origin, snap, C.uint64_t(sizeBytes))
-	if ret != 0 {
-		return fmt.Errorf("lvcreate failed: %d", int(ret))
-	}
-	return nil
+	return vg.CreateSnapshot(lvName, snapshotName, sizeBytes)
 }
 
 // RemoveLV removes the logical volume identified by lvPath.
 func (d *DM) RemoveLV(lvPath string) error {
-	dmVersion()
 	vgName, lvName := filepath.Split(lvPath)
 	vgName = strings.Trim(vgName, "/")
 
-	clvm := C.cgo_lvm_init()
-	if clvm == nil {
-		return fmt.Errorf("lvm_init failed")
+	conn, err := Open()
+	if err != nil {
+		return err
 	}
-	defer C.cgo_lvm_quit(clvm)
+	defer conn.Close()
 
-	cvg := C.cgo_vg_open(clvm, C.CString(vgName))
-	if cvg == nil {
-		return fmt.Errorf("vg open failed")
+	vg, err := conn.OpenVG(vgName)
+	if err != nil {
+		return err
 	}
-	defer C.cgo_vg_close(cvg)
+	defer vg.Close()
 
-	name := C.CString(lvName)
-	defer C.free(unsafe.Pointer(name))
-
-	ret := C.cgo_lv_remove(cvg, name)
-	if ret != 0 {
-		return fmt.Errorf("lvremove failed: %d", int(ret))
-	}
-	return nil
+	return vg.RemoveLV(lvName)
 }
 
 // SnapshotUsage returns the data usage percentage of the snapshot at lvPath.
 func (d *DM) SnapshotUsage(lvPath string) (float64, error) {
-	dmVersion()
 	vgName, lvName := filepath.Split(lvPath)
 	vgName = strings.Trim(vgName, "/")
 
-	clvm := C.cgo_lvm_init()
-	if clvm == nil {
-		return 0, fmt.Errorf("lvm_init failed")
+	conn, err := Open()
+	if err != nil {
+		return 0, err
 	}
-	defer C.cgo_lvm_quit(clvm)
+	defer conn.Close()
 
-	cvg := C.cgo_vg_open(clvm, C.CString(vgName))
-	if cvg == nil {
-		return 0, fmt.Errorf("vg open failed")
+	vg, err := conn.OpenVG(vgName)
+	if err != nil {
+		return 0, err
 	}
-	defer C.cgo_vg_close(cvg)
+	defer vg.Close()
 
-	name := C.CString(lvName)
-	defer C.free(unsafe.Pointer(name))
-
-	var val C.double
-	if C.cgo_snapshot_percent(cvg, name, &val) != 0 {
-		return 0, fmt.Errorf("get snapshot usage failed")
-	}
-	return float64(val), nil
+	return vg.SnapshotUsage(lvName)
 }
 
 // VGFree returns the free space of the specified volume group in bytes.
 func (d *DM) VGFree(vgName string) (uint64, error) {
-	dmVersion()
-	cName := C.CString(vgName)
-	defer C.free(unsafe.Pointer(cName))
-
-	clvm := C.cgo_lvm_init()
-	if clvm == nil {
-		return 0, fmt.Errorf("lvm_init failed")
+	conn, err := Open()
+	if err != nil {
+		return 0, err
 	}
-	defer C.cgo_lvm_quit(clvm)
+	defer conn.Close()
 
-	cvg := C.cgo_vg_open(clvm, cName)
-	if cvg == nil {
-		return 0, fmt.Errorf("vg open failed")
+	vg, err := conn.OpenVG(vgName)
+	if err != nil {
+		return 0, err
 	}
-	defer C.cgo_vg_close(cvg)
+	defer vg.Close()
 
-	free := C.cgo_vg_free(cvg)
-	return uint64(free), nil
+	return vg.FreeBytes(), nil
 }
 
 // ListVGs returns all available volume groups.
 func (d *DM) ListVGs() ([]VolumeGroup, error) {
-	dmVersion()
-	clvm := C.cgo_lvm_init()
-	if clvm == nil {
-		return nil, fmt.Errorf("lvm_init failed")
+	conn, err := Open()
+	if err != nil {
+		return nil, err
 	}
-	defer C.cgo_lvm_quit(clvm)
+	defer conn.Close()
 
-	list := C.cgo_list_vgs(clvm)
-	var vgs []VolumeGroup
-	for item := list; item != nil; item = item.next {
-		name := C.cgo_list_item_str(item)
-		if name == nil {
-			continue
-		}
-		vgName := C.GoString(name)
-		cvg := C.cgo_vg_open(clvm, C.CString(vgName))
-		if cvg == nil {
-			continue
-		}
-		free := C.cgo_vg_free(cvg)
-		C.cgo_vg_close(cvg)
-		vgs = append(vgs, VolumeGroup{Name: vgName, Free: uint64(free)})
-	}
-	return vgs, nil
+	return conn.ListVolumeGroups()
 }

--- a/lvm/cgo/devmapper_stub.go
+++ b/lvm/cgo/devmapper_stub.go
@@ -13,6 +13,39 @@ type VolumeGroup struct {
 	Free uint64
 }
 
+// Conn is a stub connection returned when CGO is unavailable.
+type Conn struct{}
+
+// Open returns ErrUnsupported when CGO is unavailable.
+func Open() (*Conn, error) { return nil, ErrUnsupported }
+
+// Close is a no-op for the stub.
+func (c *Conn) Close() {}
+
+// VG is a stub volume group handle.
+type VG struct{}
+
+// OpenVG returns ErrUnsupported when CGO is unavailable.
+func (c *Conn) OpenVG(string) (*VG, error) { return nil, ErrUnsupported }
+
+// Close returns ErrUnsupported for the stub.
+func (v *VG) Close() error { return ErrUnsupported }
+
+// FreeBytes returns zero for the stub.
+func (v *VG) FreeBytes() uint64 { return 0 }
+
+// CreateSnapshot always returns ErrUnsupported.
+func (v *VG) CreateSnapshot(string, string, uint64) error { return ErrUnsupported }
+
+// RemoveLV always returns ErrUnsupported.
+func (v *VG) RemoveLV(string) error { return ErrUnsupported }
+
+// SnapshotUsage always returns ErrUnsupported.
+func (v *VG) SnapshotUsage(string) (float64, error) { return 0, ErrUnsupported }
+
+// ListVolumeGroups always returns ErrUnsupported.
+func (c *Conn) ListVolumeGroups() ([]VolumeGroup, error) { return nil, ErrUnsupported }
+
 // LVM provides access to LVM operations via device-mapper.
 type LVM interface {
 	CreateSnapshot(lvPath, snapshotName string, sizeBytes uint64) error

--- a/lvm/cgo/devmapper_stub_test.go
+++ b/lvm/cgo/devmapper_stub_test.go
@@ -25,4 +25,8 @@ func TestStubReturnsErrUnsupported(t *testing.T) {
 	if _, err := dm.ListVGs(); !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("ListVGs error = %v, want ErrUnsupported", err)
 	}
+
+	if _, err := Open(); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("Open error = %v, want ErrUnsupported", err)
+	}
 }


### PR DESCRIPTION
## Summary
- add `Conn` and `VG` types for efficient liblvm interactions
- rewrite `DM` methods to reuse a single liblvm handle
- extend cgo stubs and tests for the new API

## Testing
- `go test ./...` *(fails: Package lvm2 was not found in the pkg-config search path)*
- `CGO_ENABLED=0 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894b32f68d48323be4ff64576139df6