### PR TITLE
Add gRPC server with TLS and CLI

### DIFF
--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+
+	grpcserver "lvmsync_go/grpc/server"
+
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to init logger: %v\n", err)
+		os.Exit(1)
+	}
+	zap.ReplaceGlobals(logger)
+	defer func() { _ = logger.Sync() }()
+
+	port := getEnvInt("GRPC_PORT", 8443)
+	tlsCert := getEnv("TLS_CERT", "")
+	tlsKey := getEnv("TLS_KEY", "")
+	caCert := getEnv("CA_CERT", "")
+	allowInsecure := getEnvBool("ALLOW_INSECURE", false)
+
+	pflag.IntVar(&port, "grpc-port", port, "gRPC port to listen on")
+	pflag.StringVar(&tlsCert, "tls-cert", tlsCert, "TLS certificate file")
+	pflag.StringVar(&tlsKey, "tls-key", tlsKey, "TLS key file")
+	pflag.StringVar(&caCert, "ca-cert", caCert, "CA certificate file")
+	pflag.BoolVar(&allowInsecure, "allow-insecure", allowInsecure, "allow insecure (no TLS)")
+	pflag.Parse()
+
+	cfg := grpcserver.Config{
+		TLSCert:       tlsCert,
+		TLSKey:        tlsKey,
+		CACert:        caCert,
+		AllowInsecure: allowInsecure,
+	}
+
+	srv := grpcserver.New(cfg, nil)
+
+	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		zap.L().Fatal("listen", zap.Error(err))
+	}
+
+	zap.L().Info("gRPC server listening", zap.Int("port", port))
+	if err := srv.Serve(lis); err != nil {
+		zap.L().Fatal("serve", zap.Error(err))
+	}
+}
+
+func getEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func getEnvInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return def
+}
+
+func getEnvBool(key string, def bool) bool {
+	if v := os.Getenv(key); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
+		}
+	}
+	return def
+}

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+
+	"lvmsync_go/lvm"
+	"lvmsync_go/proto"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type Config struct {
+	TLSCert       string
+	TLSKey        string
+	CACert        string
+	AllowInsecure bool
+}
+
+func New(conf Config, l lvm.API) *grpc.Server {
+	opts := []grpc.ServerOption{
+		grpc.UnaryInterceptor(authorizeInterceptor),
+	}
+
+	if !conf.AllowInsecure {
+		cert, err := tls.LoadX509KeyPair(conf.TLSCert, conf.TLSKey)
+		if err != nil {
+			zap.L().Fatal("load TLS key pair", zap.Error(err))
+		}
+		caPEM, err := os.ReadFile(conf.CACert)
+		if err != nil {
+			zap.L().Fatal("read CA cert", zap.Error(err))
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			zap.L().Fatal("invalid CA cert")
+		}
+		tlsCfg := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			ClientCAs:    pool,
+			MinVersion:   tls.VersionTLS13,
+		}
+		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsCfg)))
+	}
+
+	srv := grpc.NewServer(opts...)
+	proto.RegisterReplicationServer(srv, &replicationServer{lvm: l})
+	return srv
+}
+
+func authorizeInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.PermissionDenied, "missing metadata")
+	}
+	roles := md.Get("role")
+	for _, r := range roles {
+		if r == "replicator" {
+			return handler(ctx, req)
+		}
+	}
+	return nil, status.Error(codes.PermissionDenied, "unauthorized role")
+}
+
+type replicationServer struct {
+	proto.UnimplementedReplicationServer
+	lvm lvm.API
+}

--- a/lvm/api.go
+++ b/lvm/api.go
@@ -1,0 +1,5 @@
+package lvm
+
+// API defines the set of methods required by the gRPC server.
+// It currently acts as a placeholder for future expansion.
+type API interface{}


### PR DESCRIPTION
## Summary
- implement gRPC server package with TLS 1.3, mutual cert verification, and role-based auth interceptor
- add grpcd command to parse flags/env and launch the server
- introduce placeholder LVM API interface

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894f3aeeaec8323852b08eb60619f2f