### PR TITLE
Add TLS role-based auth interceptor

### DIFF
--- a/grpc/auth/auth.go
+++ b/grpc/auth/auth.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"context"
+	"crypto/x509"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// Role describes an allowed certificate issuer and subject pair.
+type Role struct {
+	Issuer  string
+	Subject string
+}
+
+// NewAuthInterceptor returns a grpc.UnaryServerInterceptor that enforces
+// client certificate issuer and subject to match the provided role.
+func NewAuthInterceptor(role Role) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		p, ok := peer.FromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing peer info")
+		}
+
+		tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing TLS info")
+		}
+
+		state := tlsInfo.State
+		if len(state.PeerCertificates) == 0 {
+			return nil, status.Error(codes.Unauthenticated, "no client certificate")
+		}
+		cert := state.PeerCertificates[0]
+
+		if !matchRole(cert, role) {
+			return nil, status.Error(codes.PermissionDenied, "unauthorized role")
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+func matchRole(cert *x509.Certificate, role Role) bool {
+	if cert == nil {
+		return false
+	}
+	issuer := cert.Issuer.CommonName
+	subject := cert.Subject.CommonName
+	return issuer == role.Issuer && subject == role.Subject
+}

--- a/grpc/auth/auth_test.go
+++ b/grpc/auth/auth_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+func TestAuthInterceptor(t *testing.T) {
+	role := Role{Issuer: "issuer", Subject: "subject"}
+	interceptor := NewAuthInterceptor(role)
+
+	mkCtx := func(cert *x509.Certificate) context.Context {
+		state := tls.ConnectionState{}
+		if cert != nil {
+			state.PeerCertificates = []*x509.Certificate{cert}
+		}
+		p := &peer.Peer{AuthInfo: credentials.TLSInfo{State: state}}
+		return peer.NewContext(context.Background(), p)
+	}
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	t.Run("allowed", func(t *testing.T) {
+		cert := &x509.Certificate{
+			Issuer:  pkixName("issuer"),
+			Subject: pkixName("subject"),
+		}
+		resp, err := interceptor(mkCtx(cert), nil, &grpc.UnaryServerInfo{}, handler)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.(string) != "ok" {
+			t.Fatalf("unexpected response %v", resp)
+		}
+	})
+
+	t.Run("mismatched", func(t *testing.T) {
+		cert := &x509.Certificate{
+			Issuer:  pkixName("other"),
+			Subject: pkixName("subject"),
+		}
+		_, err := interceptor(mkCtx(cert), nil, &grpc.UnaryServerInfo{}, handler)
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("expected permission denied, got %v", err)
+		}
+	})
+
+	t.Run("missing cert", func(t *testing.T) {
+		_, err := interceptor(mkCtx(nil), nil, &grpc.UnaryServerInfo{}, handler)
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected unauthenticated, got %v", err)
+		}
+	})
+}
+
+func pkixName(cn string) pkix.Name {
+	return pkix.Name{CommonName: cn}
+}


### PR DESCRIPTION
## Summary
- add `grpc/auth` package with role-based TLS interceptor
- validate client certificate issuer and subject
- cover allowed/denied scenarios in unit tests

## Testing
- `go test ./grpc/auth -run TestAuthInterceptor -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894f6b512d883238ff381d23c7ac064