### PR TITLE
Add gRPC and TLS configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--target_vgs` | Candidate target volume groups for auto-selection | `[]` |
 | `--lvm_escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., `"sudo -n"`) | `"sudo -n"` |
 
+#### gRPC Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--grpc_port` | gRPC port to listen on | `8443` |
+| `--tls_cert` | TLS certificate file | `""` |
+| `--tls_key` | TLS key file | `""` |
+| `--ca_cert` | CA certificate file | `""` |
+| `--allow_insecure` | Allow insecure (disable TLS) | `true` |
+| `--sudo_path` | Path to sudo executable | `/usr/bin/sudo` |
+
 ### Examples
 
 #### Local Transfer

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,14 @@ zerocopy: false                        # Enable zero-copy transfers (only in seq
 max_retries: 3                         # Maximum number of retries per block
 resume: ""                             # Path to resume state file
 
+# gRPC Options
+grpc_port: 8443                        # gRPC port to listen on
+tls_cert: ""                          # TLS certificate file
+tls_key: ""                           # TLS key file
+ca_cert: ""                           # CA certificate file
+allow_insecure: true                  # Allow running without TLS
+sudo_path: "/usr/bin/sudo"           # Path to sudo executable
+
 # Deduplication Options
 dedup_strategy: "none"                   # Strategy: "none", "auto", "checksum", "rolling_hash", or "bloom" (use "none" to disable)
 dedup_state_file: "~/.lvmsync_dedup"    # Path to deduplication state file

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ var (
 	dedupFlags       *pflag.FlagSet
 	compressionFlags *pflag.FlagSet
 	lvmFlags         *pflag.FlagSet
+	grpcFlags        *pflag.FlagSet
 )
 
 var getEuid = os.Geteuid
@@ -75,6 +76,12 @@ type Config struct {
 	DedupStateFile       string   `mapstructure:"dedup_state_file"`
 	BloomEntries         int      `mapstructure:"bloom_entries"`
 	BloomFpRate          float64  `mapstructure:"bloom_fp_rate"`
+	GRPCPort             int      `mapstructure:"grpc_port"`
+	TLSCert              string   `mapstructure:"tls_cert"`
+	TLSKey               string   `mapstructure:"tls_key"`
+	CACert               string   `mapstructure:"ca_cert"`
+	AllowInsecure        bool     `mapstructure:"allow_insecure"`
+	SudoPath             string   `mapstructure:"sudo_path"`
 }
 
 func (c *Config) HumanBlockSize() string {
@@ -93,6 +100,16 @@ func (b *Builder) Build() (*Config, error) {
 	var conf Config
 	if err := b.v.Unmarshal(&conf); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
+	}
+
+	if !b.v.IsSet("allow_insecure") {
+		conf.AllowInsecure = b.defaults.AllowInsecure
+	}
+	if conf.GRPCPort == 0 {
+		conf.GRPCPort = b.defaults.GRPCPort
+	}
+	if conf.SudoPath == "" {
+		conf.SudoPath = b.defaults.SudoPath
 	}
 
 	bs, raw, err := b.parseBlockSize()
@@ -136,9 +153,26 @@ func (b *Builder) Build() (*Config, error) {
 		lvl := lz4.CompressionLevel(conf.CompressLevel)
 		switch lvl {
 		case lz4.Fast, lz4.Level1, lz4.Level2, lz4.Level3, lz4.Level4, lz4.Level5, lz4.Level6, lz4.Level7, lz4.Level8, lz4.Level9:
-		// valid
+			// valid
 		default:
 			return nil, fmt.Errorf("invalid lz4 compression level: %d", conf.CompressLevel)
+		}
+	}
+
+	if !conf.AllowInsecure {
+		if conf.TLSCert == "" || conf.TLSKey == "" {
+			return nil, fmt.Errorf("tls_cert and tls_key must be specified unless allow_insecure is set")
+		}
+		if _, err := os.Stat(conf.TLSCert); err != nil {
+			return nil, fmt.Errorf("tls_cert: %w", err)
+		}
+		if _, err := os.Stat(conf.TLSKey); err != nil {
+			return nil, fmt.Errorf("tls_key: %w", err)
+		}
+		if conf.CACert != "" {
+			if _, err := os.Stat(conf.CACert); err != nil {
+				return nil, fmt.Errorf("ca_cert: %w", err)
+			}
 		}
 	}
 
@@ -223,6 +257,12 @@ func DefaultConfig() (*Config, error) {
 		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
 		BloomEntries:         1000000,
 		BloomFpRate:          0.01,
+		GRPCPort:             8443,
+		TLSCert:              "",
+		TLSKey:               "",
+		CACert:               "",
+		AllowInsecure:        true,
+		SudoPath:             "/usr/bin/sudo",
 	}, nil
 }
 
@@ -238,6 +278,7 @@ func LoadConfig() (*Config, error) {
 	dedupFlags = pflag.NewFlagSet("Deduplication Options", pflag.ExitOnError)
 	compressionFlags = pflag.NewFlagSet("Compression Options", pflag.ExitOnError)
 	lvmFlags = pflag.NewFlagSet("LVM Options", pflag.ExitOnError)
+	grpcFlags = pflag.NewFlagSet("gRPC Options", pflag.ExitOnError)
 
 	// General Options
 	generalFlags.String("config", "", "Path to config YAML file")
@@ -288,6 +329,14 @@ func LoadConfig() (*Config, error) {
 	lvmFlags.String("target_volume_group", defaultCfg.TargetVolumeGroup, "Volume group name of the target LVM volume")
 	lvmFlags.StringSlice("target_vgs", defaultCfg.TargetVGCandidates, "Candidate target volume groups for auto-selection")
 
+	// gRPC Options
+	grpcFlags.Int("grpc_port", defaultCfg.GRPCPort, "gRPC port to listen on")
+	grpcFlags.String("tls_cert", defaultCfg.TLSCert, "TLS certificate file")
+	grpcFlags.String("tls_key", defaultCfg.TLSKey, "TLS key file")
+	grpcFlags.String("ca_cert", defaultCfg.CACert, "CA certificate file")
+	grpcFlags.Bool("allow_insecure", defaultCfg.AllowInsecure, "Allow insecure (no TLS)")
+	grpcFlags.String("sudo_path", defaultCfg.SudoPath, "Path to sudo executable")
+
 	// Register flags and set usage
 	pflag.CommandLine.AddFlagSet(generalFlags)
 	pflag.CommandLine.AddFlagSet(sshFlags)
@@ -295,6 +344,7 @@ func LoadConfig() (*Config, error) {
 	pflag.CommandLine.AddFlagSet(dedupFlags)
 	pflag.CommandLine.AddFlagSet(compressionFlags)
 	pflag.CommandLine.AddFlagSet(lvmFlags)
+	pflag.CommandLine.AddFlagSet(grpcFlags)
 	pflag.Usage = printUsage
 	pflag.Parse()
 
@@ -392,4 +442,6 @@ func printUsage() {
 	compressionFlags.PrintDefaults()
 	fmt.Fprintf(os.Stderr, "\nLVM Options:\n")
 	lvmFlags.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\ngRPC Options:\n")
+	grpcFlags.PrintDefaults()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -345,3 +345,49 @@ func TestCompressConcurrency(t *testing.T) {
 		}
 	})
 }
+
+func TestTLSFileValidation(t *testing.T) {
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+
+	t.Run("insecure", func(t *testing.T) {
+		v := viper.New()
+		v.Set("allow_insecure", true)
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missingFiles", func(t *testing.T) {
+		v := viper.New()
+		v.Set("allow_insecure", false)
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("validFiles", func(t *testing.T) {
+		dir := t.TempDir()
+		cert := filepath.Join(dir, "cert.pem")
+		key := filepath.Join(dir, "key.pem")
+		ca := filepath.Join(dir, "ca.pem")
+		for _, f := range []string{cert, key, ca} {
+			if err := os.WriteFile(f, []byte("dummy"), 0o644); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+		}
+		v := viper.New()
+		v.Set("allow_insecure", false)
+		v.Set("tls_cert", cert)
+		v.Set("tls_key", key)
+		v.Set("ca_cert", ca)
+		b := &Builder{v: v, defaults: defaults}
+		if _, err := b.Build(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- support gRPC/TLS configuration in config builder with new fields and validation
- expose command line flags and defaults for gRPC port, TLS files, insecure mode, and sudo path
- document new gRPC options

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689508d5a44483239e718ee89de6d917