### PR TITLE
Add systemd service for lvmsync gRPC daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ To build on systems without LVM2, disable CGO. This uses stub implementations an
 CGO_ENABLED=0 go build -o lvmsync .
 ```
 
+### systemd Service
+
+Install the gRPC daemon as a systemd service:
+
+```sh
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin lvmsync
+sudo cp packaging/systemd/lvmsync-grpcd.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now lvmsync-grpcd
+```
+
+Logs are collected by journald and can be viewed with:
+
+```sh
+journalctl -u lvmsync-grpcd
+```
+
 ## Usage
 
 ### Basic Syntax

--- a/packaging/systemd/lvmsync-grpcd.service
+++ b/packaging/systemd/lvmsync-grpcd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=LVMSync gRPC daemon
+
+[Service]
+User=lvmsync
+ExecStart=/usr/bin/lvmsync_grpcd --config /etc/lvmsync.yaml
+Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add lvmsync-grpcd systemd unit
- document service installation and journald logging

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689522bc40688323b149ac5c1dd54e1f