### PR TITLE
Add Makefile for build and test tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: proto build test
+
+proto:
+	protoc --go_out=. --go-grpc_out=. --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative proto/replication.proto
+
+build:
+	mkdir -p bin
+	go build -o bin/lvmsync .
+	go build -o bin/grpcd ./cmd/grpcd
+
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ To build on systems without LVM2, disable CGO. This uses stub implementations an
 CGO_ENABLED=0 go build -o lvmsync .
 ```
 
+### Makefile
+
+```sh
+make proto   # generate gRPC code
+make build   # build binaries
+make test    # run tests
+```
+
 ## Usage
 
 ### Basic Syntax


### PR DESCRIPTION
## Summary
- add a Makefile with proto, build, and test targets
- document Makefile usage in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689522b701cc8323ac206ff6da2e3137