### PR TITLE
Refactor Builder Build into helper methods

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,20 @@ func (b *Builder) Build() (*Config, error) {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
 	}
 
+	if err := b.applyDefaults(&conf); err != nil {
+		return nil, err
+	}
+	if err := b.validateCompression(&conf); err != nil {
+		return nil, err
+	}
+	if err := b.finalizeConfig(&conf); err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}
+
+func (b *Builder) applyDefaults(conf *Config) error {
 	if !b.v.IsSet("allow_insecure") {
 		conf.AllowInsecure = b.defaults.AllowInsecure
 	}
@@ -114,7 +128,7 @@ func (b *Builder) Build() (*Config, error) {
 
 	bs, raw, err := b.parseBlockSize()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	conf.BlockSize = bs
 	conf.BlockSizeRaw = raw
@@ -123,23 +137,17 @@ func (b *Builder) Build() (*Config, error) {
 	}
 	sl, err := b.parseBytesOrFallback("speed", b.defaults.Speed)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	conf.SpeedLimit = sl
-
-	algo := strings.ToLower(conf.ChecksumAlgorithm)
-	switch algo {
-	case "sha256", "blake3", "blake3-512":
-		conf.ChecksumAlgorithm = algo
-	default:
-		return nil, fmt.Errorf("unsupported checksum algorithm: %s", conf.ChecksumAlgorithm)
-	}
 
 	if conf.CompressConcurrency <= 0 {
 		conf.CompressConcurrency = runtime.GOMAXPROCS(0)
 	}
+	return nil
+}
 
-	// Validate compression levels based on the resolved compression algorithm.
+func (b *Builder) validateCompression(conf *Config) error {
 	resolved := conf.Compress
 	if resolved == "auto" {
 		resolved = compressiondetect.DetectOptimalCompression()
@@ -147,7 +155,7 @@ func (b *Builder) Build() (*Config, error) {
 	switch resolved {
 	case "zstd":
 		if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
-			return nil, fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+			return fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
 		}
 	case "lz4":
 		lvl := lz4.CompressionLevel(conf.CompressLevel)
@@ -155,28 +163,38 @@ func (b *Builder) Build() (*Config, error) {
 		case lz4.Fast, lz4.Level1, lz4.Level2, lz4.Level3, lz4.Level4, lz4.Level5, lz4.Level6, lz4.Level7, lz4.Level8, lz4.Level9:
 			// valid
 		default:
-			return nil, fmt.Errorf("invalid lz4 compression level: %d", conf.CompressLevel)
+			return fmt.Errorf("invalid lz4 compression level: %d", conf.CompressLevel)
 		}
+	}
+	return nil
+}
+
+func (b *Builder) finalizeConfig(conf *Config) error {
+	algo := strings.ToLower(conf.ChecksumAlgorithm)
+	switch algo {
+	case "sha256", "blake3", "blake3-512":
+		conf.ChecksumAlgorithm = algo
+	default:
+		return fmt.Errorf("unsupported checksum algorithm: %s", conf.ChecksumAlgorithm)
 	}
 
 	if !conf.AllowInsecure {
 		if conf.TLSCert == "" || conf.TLSKey == "" {
-			return nil, fmt.Errorf("tls_cert and tls_key must be specified unless allow_insecure is set")
+			return fmt.Errorf("tls_cert and tls_key must be specified unless allow_insecure is set")
 		}
 		if _, err := os.Stat(conf.TLSCert); err != nil {
-			return nil, fmt.Errorf("tls_cert: %w", err)
+			return fmt.Errorf("tls_cert: %w", err)
 		}
 		if _, err := os.Stat(conf.TLSKey); err != nil {
-			return nil, fmt.Errorf("tls_key: %w", err)
+			return fmt.Errorf("tls_key: %w", err)
 		}
 		if conf.CACert != "" {
 			if _, err := os.Stat(conf.CACert); err != nil {
-				return nil, fmt.Errorf("ca_cert: %w", err)
+				return fmt.Errorf("ca_cert: %w", err)
 			}
 		}
 	}
-
-	return &conf, nil
+	return nil
 }
 
 func (b *Builder) parseBytesOrFallback(key, fallback string) (int, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/pierrec/lz4/v4"
@@ -124,6 +125,122 @@ func TestParseBytesOrFallback(t *testing.T) {
 		b := &Builder{v: v}
 		if _, err := b.parseBytesOrFallback("block_size", "4KB"); err == nil {
 			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestBuilderApplyDefaults(t *testing.T) {
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	v := viper.New()
+	b := &Builder{v: v, defaults: defaults}
+	var conf Config
+	if err := b.applyDefaults(&conf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conf.AllowInsecure != defaults.AllowInsecure {
+		t.Fatalf("expected AllowInsecure %v", defaults.AllowInsecure)
+	}
+	if conf.GRPCPort != defaults.GRPCPort {
+		t.Fatalf("expected GRPCPort %d, got %d", defaults.GRPCPort, conf.GRPCPort)
+	}
+	if conf.BlockSize != 0 || conf.BlockSizeRaw != "auto" {
+		t.Fatalf("expected auto block size, got %d/%s", conf.BlockSize, conf.BlockSizeRaw)
+	}
+	if conf.CompressConcurrency != runtime.GOMAXPROCS(0) {
+		t.Fatalf("expected default compress concurrency, got %d", conf.CompressConcurrency)
+	}
+
+	t.Run("invalidBlockSize", func(t *testing.T) {
+		v := viper.New()
+		v.Set("block_size", "bad")
+		b := &Builder{v: v, defaults: defaults}
+		if err := b.applyDefaults(&conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestBuilderValidateCompression(t *testing.T) {
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	b := &Builder{defaults: defaults}
+
+	t.Run("zstdValid", func(t *testing.T) {
+		conf := &Config{Compress: "zstd", CompressLevel: 3}
+		if err := b.validateCompression(conf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("zstdInvalid", func(t *testing.T) {
+		conf := &Config{Compress: "zstd", CompressLevel: 100}
+		if err := b.validateCompression(conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("auto", func(t *testing.T) {
+		conf := &Config{Compress: "auto"}
+		if compressiondetect.DetectOptimalCompression() == "zstd" {
+			conf.CompressLevel = 3
+		} else {
+			conf.CompressLevel = int(lz4.Level3)
+		}
+		if err := b.validateCompression(conf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestBuilderFinalizeConfig(t *testing.T) {
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	b := &Builder{defaults: defaults}
+
+	t.Run("validInsecure", func(t *testing.T) {
+		conf := &Config{AllowInsecure: true, ChecksumAlgorithm: "sha256"}
+		if err := b.finalizeConfig(conf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conf.ChecksumAlgorithm != "sha256" {
+			t.Fatalf("expected checksum algorithm normalized")
+		}
+	})
+
+	t.Run("invalidAlgorithm", func(t *testing.T) {
+		conf := &Config{AllowInsecure: true, ChecksumAlgorithm: "md5"}
+		if err := b.finalizeConfig(conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("missingTLS", func(t *testing.T) {
+		conf := &Config{AllowInsecure: false, ChecksumAlgorithm: "sha256"}
+		if err := b.finalizeConfig(conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("validTLS", func(t *testing.T) {
+		dir := t.TempDir()
+		cert := filepath.Join(dir, "cert.pem")
+		key := filepath.Join(dir, "key.pem")
+		if err := os.WriteFile(cert, []byte("cert"), 0o644); err != nil {
+			t.Fatalf("write cert: %v", err)
+		}
+		if err := os.WriteFile(key, []byte("key"), 0o644); err != nil {
+			t.Fatalf("write key: %v", err)
+		}
+		conf := &Config{AllowInsecure: false, TLSCert: cert, TLSKey: key, ChecksumAlgorithm: "sha256"}
+		if err := b.finalizeConfig(conf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- break Builder.Build into applyDefaults, validateCompression, and finalizeConfig
- add unit tests for each helper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895330e1330832392b37148b1610007