### PR TITLE
Handle sync and serve errors

### DIFF
--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -20,7 +20,12 @@ func main() {
 		os.Exit(1)
 	}
 	zap.ReplaceGlobals(logger)
-	defer func() { _ = logger.Sync() }()
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to sync logger: %v\n", err)
+			os.Exit(1)
+		}
+	}()
 
 	port := getEnvInt("GRPC_PORT", 8443)
 	tlsCert := getEnv("TLS_CERT", "")

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -87,7 +87,11 @@ func (m *mockAgent) GetStatus(ctx context.Context, volume, requester string) (st
 func newClient(t *testing.T, cfg Config, agent lvmagent.Agent, creds credentials.TransportCredentials) (proto.ReplicationClient, func()) {
 	lis := bufconn.Listen(bufSize)
 	srv := New(cfg, agent)
-	go func() { _ = srv.Serve(lis) }()
+	go func() {
+		if err := srv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Errorf("srv.Serve: %v", err)
+		}
+	}()
 	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
 	conn, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(creds))
 	if err != nil {


### PR DESCRIPTION
## Summary
- exit on gRPC daemon logger sync failures
- surface Serve goroutine errors in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689536ae3af883238d1231819e0a9d33