### PR TITLE
Log sync errors and check Serve errors in tests

### DIFF
--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -22,7 +22,7 @@ func main() {
 	zap.ReplaceGlobals(logger)
 	defer func() {
 		if err := logger.Sync(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to sync logger: %v\n", err)
+			logger.Error("failed to sync logger", zap.Error(err))
 			os.Exit(1)
 		}
 	}()

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -85,13 +85,14 @@ func (m *mockAgent) GetStatus(ctx context.Context, volume, requester string) (st
 }
 
 func newClient(t *testing.T, cfg Config, agent lvmagent.Agent, creds credentials.TransportCredentials) (proto.ReplicationClient, func()) {
+	t.Helper()
 	lis := bufconn.Listen(bufSize)
 	srv := New(cfg, agent)
-	go func() {
+	go func(t *testing.T) {
 		if err := srv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			t.Errorf("srv.Serve: %v", err)
 		}
-	}()
+	}(t)
 	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
 	conn, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(creds))
 	if err != nil {


### PR DESCRIPTION
## Summary
- log and exit if logger.Sync fails in gRPC daemon
- ensure gRPC server test captures Serve errors via t.Errorf

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68959f04c71483238a103ab9a0060140