### PR TITLE
Add bounds checks for snapshot size conversions

### DIFF
--- a/lvm/backend_cgo.go
+++ b/lvm/backend_cgo.go
@@ -24,7 +24,13 @@ func (b *cgoBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, s
 	if percent {
 		return fmt.Errorf("percentage sizes not supported")
 	}
-	if err := b.lvm.CreateSnapshot(lvPath, snapshotName, uint64(bytes)); err != nil {
+
+	u := uint64(bytes)
+	if bytes < 0 || float64(u) != bytes {
+		return fmt.Errorf("size %q overflows uint64", size)
+	}
+
+	if err := b.lvm.CreateSnapshot(lvPath, snapshotName, u); err != nil {
 		return fmt.Errorf("cgo create snapshot: %w", err)
 	}
 	return nil

--- a/lvm/backend_stub.go
+++ b/lvm/backend_stub.go
@@ -24,7 +24,13 @@ func (b *cgoBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, s
 	if percent {
 		return fmt.Errorf("percentage sizes not supported")
 	}
-	if err := b.lvm.CreateSnapshot(lvPath, snapshotName, uint64(bytes)); err != nil {
+
+	u := uint64(bytes)
+	if bytes < 0 || float64(u) != bytes {
+		return fmt.Errorf("size %q overflows uint64", size)
+	}
+
+	if err := b.lvm.CreateSnapshot(lvPath, snapshotName, u); err != nil {
 		return fmt.Errorf("cgo create snapshot: %w", err)
 	}
 	return nil

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -323,7 +323,11 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 			return 0, fmt.Errorf("failed to get volume size for %q: %w", volumePath, err)
 		}
 
-		parsedSize := uint64(float64(volSize) * (val / 100.0))
+		res := float64(volSize) * (val / 100.0)
+		parsedSize := uint64(res)
+		if res < 0 || float64(parsedSize) != res {
+			return 0, fmt.Errorf("snapshot size %q overflows uint64", sizeStr)
+		}
 
 		zap.L().Debug("Parsed snapshot size from percentage",
 			zap.String("input", sizeStr),
@@ -333,6 +337,9 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 	}
 
 	parsedSize := uint64(val)
+	if val < 0 || float64(parsedSize) != val {
+		return 0, fmt.Errorf("snapshot size %q overflows uint64", sizeStr)
+	}
 
 	zap.L().Debug("Parsed snapshot size",
 		zap.String("input", sizeStr),

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -42,6 +42,7 @@ func TestParseSnapshotSize(t *testing.T) {
 		{"absolute", "1M", 1000000, false},
 		{"invalidPercent", "150%", 0, true},
 		{"invalidValue", "abc", 0, true},
+		{"negative", "-1", 0, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- guard snapshot size parsing against overflow before casting to uint64
- validate parsed sizes in CGO backends prior to snapshot creation
- test parsing rejects negative size inputs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895ad4704408323acdb26dbd3cb7d2f