### PR TITLE
dedup: clarify size parameter names

### DIFF
--- a/dedup/bloom.go
+++ b/dedup/bloom.go
@@ -45,17 +45,17 @@ func MaxChunks(ramBytes uint64, fpRate float64) uint64 {
 // AdaptiveAvgChunk computes the average chunk size based on volume size,
 // available RAM and false positive rate. The size is clamped between the
 // provided minimum and maximum values.
-func AdaptiveAvgChunk(volumeSize, ramBytes uint64, fpRate float64, min, max uint64) (avg uint64, maxChunks uint64) {
+func AdaptiveAvgChunk(volumeSize, ramBytes uint64, fpRate float64, minSize, maxSize uint64) (avg uint64, maxChunks uint64) {
 	maxChunks = MaxChunks(ramBytes, fpRate)
 	if maxChunks == 0 {
 		maxChunks = 1
 	}
 	avg = volumeSize / maxChunks
-	if avg < min {
-		avg = min
+	if avg < minSize {
+		avg = minSize
 	}
-	if avg > max {
-		avg = max
+	if avg > maxSize {
+		avg = maxSize
 	}
 	return
 }

--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -28,13 +28,13 @@ type Chunker struct {
 }
 
 // NewChunker returns a new chunker configured with the provided
-// min/avg/max chunk sizes. All sizes are in bytes. The mask values are
+// minimum, average, and maximum chunk sizes. All sizes are in bytes. The mask values are
 // derived from the average size.
-func NewChunker(min, avg, max int) *Chunker {
-	c := &Chunker{Min: min, Avg: avg, Max: max}
+func NewChunker(minSize, avgSize, maxSize int) *Chunker {
+	c := &Chunker{Min: minSize, Avg: avgSize, Max: maxSize}
 	// derive masks for different entropy levels. The mask controls the
 	// probability of finding a boundary. Higher mask -> larger chunks.
-	bits := uint64(math.Log2(float64(avg)))
+	bits := uint64(math.Log2(float64(avgSize)))
 	if bits < 1 {
 		bits = 1
 	}


### PR DESCRIPTION
## Summary
- rename min/max parameters to minSize/maxSize in AdaptiveAvgChunk
- rename min/avg/max parameters to minSize/avgSize/maxSize in NewChunker and update docs

## Testing
- `go test ./... | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895b597379c83239cd8c3ba7e120643