### PR TITLE
Use StrategyChecksum constant in transfer handshake

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -131,9 +131,9 @@ func cleanupOutput(buf *bufio.Writer, w io.WriteCloser) {
 func composeHandshake(cfg *config.Config, mode string) common.Handshake {
 	hs := common.Handshake{Compress: cfg.Compress}
 	switch mode {
-	case "checksum":
+	case StrategyChecksum:
 		hs.Checksum = true
-	case "checksum-dedup":
+	case StrategyChecksum + "-dedup":
 		hs.Checksum = true
 		hs.ChecksumDedup = true
 	}
@@ -342,7 +342,7 @@ func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) err
 func prepareParallelHandshake(cfg *config.Config) string {
 	htokens := []string{common.ProtocolVersion}
 	if cfg.VerifyChecksum {
-		htokens = append(htokens, "checksum")
+		htokens = append(htokens, StrategyChecksum)
 	}
 	htokens = append(htokens, "compress:"+cfg.Compress)
 	return strings.Join(htokens, " ")


### PR DESCRIPTION
## Summary
- replace literal "checksum" with StrategyChecksum in handshake logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895c5621ce88323a1f7e7030d448178