### PR TITLE
feat: update goreleaser config to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 
 builds:
   - id: default
@@ -51,15 +51,11 @@ dockers:
     dockerfile: ./Dockerfile
     use: buildx
     goos: linux
-    goarch:
-      - amd64
-      - arm64
     build_flag_templates:
       - "--platform=linux/{{ .Arch }}"
-    skip_push: {{ eq (env "SKIP_DOCKER_PUSH") "true" }}
+    skip_push: '{{ eq (env "SKIP_DOCKER_PUSH") "true" }}'
 
 release:
-  github:
-    draft: false
-    prerelease: false
-    name_template: '{{ .Env.GORELEASER_CURRENT_TAG }}'
+  draft: false
+  prerelease: false
+  name_template: '{{ .Env.GORELEASER_CURRENT_TAG }}'


### PR DESCRIPTION
## Summary
- update GoReleaser config to version 2
- restructure docker and release sections for v2 compatibility

## Testing
- `goreleaser check` *(fails: configuration is invalid: unable to get upstream while qualifying relative remote)*
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6895d89ef26c8323920573230130f8a6