### PR TITLE
Add range checks for integer conversions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,11 +84,35 @@ type Config struct {
 	SudoPath             string   `mapstructure:"sudo_path"`
 }
 
+func FormatBlockSize(blockSize int) (string, error) {
+	if blockSize < 0 {
+		return "", fmt.Errorf("block size %d cannot be negative", blockSize)
+	}
+	if uint64(blockSize) > math.MaxUint64 {
+		return "", fmt.Errorf("block size %d overflows uint64", blockSize)
+	}
+	return sizeparse.FormatBytes(uint64(blockSize)), nil
+}
+
+func LZ4Level(level int) (uint32, error) {
+	if level < 0 {
+		return 0, fmt.Errorf("lz4 level %d cannot be negative", level)
+	}
+	if uint64(level) > math.MaxUint32 {
+		return 0, fmt.Errorf("lz4 level %d overflows uint32", level)
+	}
+	return uint32(level), nil
+}
+
 func (c *Config) HumanBlockSize() string {
 	if c.BlockSize == 0 {
 		return "auto"
 	}
-	return sizeparse.FormatBytes(uint64(c.BlockSize))
+	bs, err := FormatBlockSize(c.BlockSize)
+	if err != nil {
+		return ""
+	}
+	return bs
 }
 
 type Builder struct {

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -157,6 +157,10 @@ func CheckDiskSpace(mountPoint string) (uint64, error) {
 		return 0, fmt.Errorf("failed to get disk stats for %q: %w", mountPoint, err)
 	}
 
+	if stat.Bsize < 0 {
+		return 0, fmt.Errorf("negative block size for %q: %d", mountPoint, stat.Bsize)
+	}
+
 	available := stat.Bavail * uint64(stat.Bsize)
 	zap.L().Debug("Disk space check",
 		zap.String("mount_point", mountPoint),
@@ -187,7 +191,11 @@ func GetVolumeSize(volumePath string) (uint64, error) {
 			if statErr != nil {
 				return 0, fmt.Errorf("stat failed on %q: %w", volumePath, statErr)
 			}
-			size = uint64(info.Size())
+			s := info.Size()
+			if s < 0 {
+				return 0, fmt.Errorf("size of %q is negative: %d", volumePath, s)
+			}
+			size = uint64(s)
 		} else {
 			return 0, fmt.Errorf("ioctl BLKGETSIZE64 failed on %q: %w", volumePath, err)
 		}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -8,6 +8,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -145,6 +146,12 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 	skippedBlocks := 0
 	var header [12]byte
 	for _, r := range ranges {
+		if r.Start < 0 || uint64(r.Start) > math.MaxUint64 {
+			return totalBytes, skippedBlocks, fmt.Errorf("block offset %d out of range", r.Start)
+		}
+		if cfg.BlockSize < 0 || uint64(cfg.BlockSize) > math.MaxUint32 {
+			return totalBytes, skippedBlocks, fmt.Errorf("block size %d out of range", cfg.BlockSize)
+		}
 		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy, pipeFds)
 		if err != nil {
 			return totalBytes, skippedBlocks, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
@@ -421,6 +428,14 @@ func processParallelResults(cfg *config.Config, results <-chan *BlockResult, buf
 func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
 	defer workerWG.Done()
 	for task := range tasks {
+		if task.R.Start < 0 || uint64(task.R.Start) > math.MaxUint64 {
+			results <- &BlockResult{Index: task.Index, Err: fmt.Errorf("block offset %d out of range", task.R.Start)}
+			continue
+		}
+		if cfg.BlockSize < 0 || uint64(cfg.BlockSize) > math.MaxUint32 {
+			results <- &BlockResult{Index: task.Index, Err: fmt.Errorf("block size %d out of range", cfg.BlockSize)}
+			continue
+		}
 		data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
 		results <- &BlockResult{
 			Index:  task.Index,


### PR DESCRIPTION
## Summary
- add FormatBlockSize and LZ4Level helpers with overflow checks
- validate disk and volume sizes before casting to unsigned ints
- guard block offsets and sizes in transfer routines

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895e5065958832397b7c6f257219ded