### PR TITLE
Validate transfer offsets and block size

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -8,6 +8,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -140,11 +141,24 @@ func composeHandshake(cfg *config.Config, mode string) common.Handshake {
 	return hs
 }
 
+func validateOffsetAndSize(offset int64, size int) error {
+	if offset < 0 {
+		return fmt.Errorf("invalid offset %d: must be non-negative", offset)
+	}
+	if size < 0 || size > int(math.MaxUint32) {
+		return fmt.Errorf("invalid block size %d: must be between 0 and %d", size, uint32(math.MaxUint32))
+	}
+	return nil
+}
+
 func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int) (int64, int, error) {
 	var totalBytes int64
 	skippedBlocks := 0
 	var header [12]byte
 	for _, r := range ranges {
+		if err := validateOffsetAndSize(r.Start, cfg.BlockSize); err != nil {
+			return totalBytes, skippedBlocks, err
+		}
 		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy, pipeFds)
 		if err != nil {
 			return totalBytes, skippedBlocks, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
@@ -374,7 +388,7 @@ func saveResumeState(cfg *config.Config, index int) {
 	if cfg.ResumeState == "" {
 		return
 	}
-	err := os.WriteFile(cfg.ResumeState, []byte(fmt.Sprintf("%d", index+1)), 0644)
+	err := os.WriteFile(cfg.ResumeState, []byte(fmt.Sprintf("%d", index+1)), 0o600)
 	if err != nil {
 		Logger.Warn("Failed to update resume state", zap.Error(err))
 	}
@@ -421,6 +435,10 @@ func processParallelResults(cfg *config.Config, results <-chan *BlockResult, buf
 func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
 	defer workerWG.Done()
 	for task := range tasks {
+		if err := validateOffsetAndSize(task.R.Start, cfg.BlockSize); err != nil {
+			results <- &BlockResult{Index: task.Index, Err: err}
+			continue
+		}
 		data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
 		results <- &BlockResult{
 			Index:  task.Index,

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -1,0 +1,57 @@
+package transfer
+
+import (
+	"bufio"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"lvmsync_go/config"
+)
+
+func TestIterateBlocksOversizedOffset(t *testing.T) {
+	src, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer src.Close()
+
+	cfg := &config.Config{BlockSize: 4096}
+	bufOut := bufio.NewWriter(io.Discard)
+	_, _, err = iterateBlocks(cfg, []Range{{Start: -1, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
+	if err == nil || !strings.Contains(err.Error(), "offset") {
+		t.Fatalf("expected offset error, got %v", err)
+	}
+}
+
+func TestIterateBlocksOversizedBlockSize(t *testing.T) {
+	src, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer src.Close()
+
+	cfg := &config.Config{BlockSize: int(math.MaxUint32) + 1}
+	bufOut := bufio.NewWriter(io.Discard)
+	_, _, err = iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
+	if err == nil || !strings.Contains(err.Error(), "block size") {
+		t.Fatalf("expected block size error, got %v", err)
+	}
+}
+
+func TestSaveResumeStatePermissions(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{ResumeState: filepath.Join(dir, "resume")}
+	saveResumeState(cfg, 0)
+
+	info, err := os.Stat(cfg.ResumeState)
+	if err != nil {
+		t.Fatalf("stat resume state: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected permissions 600, got %v", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## Summary
- ensure offsets and block sizes fit unsigned ranges before casting
- secure resume state files with 0600 permissions
- test oversized inputs and file permission handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895e50e54e88323af9da7120e3424a9