### PR TITLE
Avoid variable shadowing and add logger sync test

### DIFF
--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -13,19 +13,19 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	newZapProduction = zap.NewProduction
+	exitFunc         = os.Exit
+)
+
 func main() {
-	logger, err := zap.NewProduction()
+	logger, err := newZapProduction()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to init logger: %v\n", err)
-		os.Exit(1)
+		exitFunc(1)
 	}
 	zap.ReplaceGlobals(logger)
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			logger.Error("failed to sync logger", zap.Error(err))
-			os.Exit(1)
-		}
-	}()
+	defer syncAndExit(logger)
 
 	port := getEnvInt("GRPC_PORT", 8443)
 	tlsCert := getEnv("TLS_CERT", "")
@@ -50,14 +50,21 @@ func main() {
 	agent := lvmagent.NewSudoAgent("", nil)
 	srv := grpcserver.New(cfg, agent)
 
-	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
-	if err != nil {
-		zap.L().Fatal("listen", zap.Error(err))
+	lis, listenErr := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if listenErr != nil {
+		zap.L().Fatal("listen", zap.Error(listenErr))
 	}
 
 	zap.L().Info("gRPC server listening", zap.Int("port", port))
-	if err := srv.Serve(lis); err != nil {
-		zap.L().Fatal("serve", zap.Error(err))
+	if serveErr := srv.Serve(lis); serveErr != nil {
+		zap.L().Fatal("serve", zap.Error(serveErr))
+	}
+}
+
+func syncAndExit(logger *zap.Logger) {
+	if syncErr := logger.Sync(); syncErr != nil {
+		logger.Error("failed to sync logger", zap.Error(syncErr))
+		exitFunc(1)
 	}
 }
 

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type failCore struct{}
+
+func (failCore) Enabled(zapcore.Level) bool        { return false }
+func (failCore) With([]zapcore.Field) zapcore.Core { return failCore{} }
+func (failCore) Check(zapcore.Entry, *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return nil
+}
+func (failCore) Write(zapcore.Entry, []zapcore.Field) error { return nil }
+func (failCore) Sync() error                                { return errors.New("sync failure") }
+
+func TestSyncAndExitLogsError(t *testing.T) {
+	logger := zap.New(failCore{})
+
+	oldExit := exitFunc
+	defer func() { exitFunc = oldExit }()
+
+	var code int
+	exitFunc = func(c int) { code = c }
+
+	syncAndExit(logger)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}

--- a/main_dump_test.go
+++ b/main_dump_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestExecuteDumpSequential(t *testing.T) {
-	cfg, err := config.DefaultConfig()
-	if err != nil {
-		t.Fatalf("DefaultConfig returned error: %v", err)
+	cfg, cfgErr := config.DefaultConfig()
+	if cfgErr != nil {
+		t.Fatalf("DefaultConfig returned error: %v", cfgErr)
 	}
 	cfg.DedupStrategy = "none"
 	cfg.Parallel = 1
@@ -24,8 +24,8 @@ func TestExecuteDumpSequential(t *testing.T) {
 	}
 	defer func() { dumpChangesSequential = original }()
 
-	if err := executeDump(cfg, "snap", "orig", io.Discard); err != nil {
-		t.Fatalf("executeDump returned error: %v", err)
+	if execErr := executeDump(cfg, "snap", "orig", io.Discard); execErr != nil {
+		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {
 		t.Fatalf("dumpChangesSequential was not called")
@@ -33,9 +33,9 @@ func TestExecuteDumpSequential(t *testing.T) {
 }
 
 func TestExecuteDumpParallel(t *testing.T) {
-	cfg, err := config.DefaultConfig()
-	if err != nil {
-		t.Fatalf("DefaultConfig returned error: %v", err)
+	cfg, cfgErr := config.DefaultConfig()
+	if cfgErr != nil {
+		t.Fatalf("DefaultConfig returned error: %v", cfgErr)
 	}
 	cfg.Parallel = 2
 
@@ -47,8 +47,8 @@ func TestExecuteDumpParallel(t *testing.T) {
 	}
 	defer func() { dumpChangesParallel = original }()
 
-	if err := executeDump(cfg, "snap", "orig", io.Discard); err != nil {
-		t.Fatalf("executeDump returned error: %v", err)
+	if execErr := executeDump(cfg, "snap", "orig", io.Discard); execErr != nil {
+		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {
 		t.Fatalf("dumpChangesParallel was not called")
@@ -56,9 +56,9 @@ func TestExecuteDumpParallel(t *testing.T) {
 }
 
 func TestExecuteDumpWithDedup(t *testing.T) {
-	cfg, err := config.DefaultConfig()
-	if err != nil {
-		t.Fatalf("DefaultConfig returned error: %v", err)
+	cfg, cfgErr := config.DefaultConfig()
+	if cfgErr != nil {
+		t.Fatalf("DefaultConfig returned error: %v", cfgErr)
 	}
 	cfg.DedupStrategy = "checksum"
 
@@ -73,8 +73,8 @@ func TestExecuteDumpWithDedup(t *testing.T) {
 	}
 	defer func() { dumpChangesWithDeduplication = original }()
 
-	if err := executeDump(cfg, "snap", "orig", io.Discard); err != nil {
-		t.Fatalf("executeDump returned error: %v", err)
+	if execErr := executeDump(cfg, "snap", "orig", io.Discard); execErr != nil {
+		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {
 		t.Fatalf("dumpChangesWithDeduplication was not called")

--- a/remote/logger_test.go
+++ b/remote/logger_test.go
@@ -11,21 +11,21 @@ func TestRunRemoteScriptNoLogger(t *testing.T) {
 	server := newMockSSHServer(t, func(cmd string) int { return 0 })
 	defer server.Close()
 	knownHosts := createKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
+	hostKeyCallback, hostKeyErr := knownhosts.New(knownHosts)
+	if hostKeyErr != nil {
+		t.Fatalf("knownhosts.New: %v", hostKeyErr)
 	}
-	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+	client, dialErr := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
+	if dialErr != nil {
+		t.Fatalf("failed to dial: %v", dialErr)
 	}
 	defer client.Close() //nolint:errcheck
 
 	SetLogger(nil)
 
 	script := "echo hi"
-	if err := RunRemoteScript(client, script); err != nil {
-		t.Fatalf("RunRemoteScript error: %v", err)
+	if scriptErr := RunRemoteScript(client, script); scriptErr != nil {
+		t.Fatalf("RunRemoteScript error: %v", scriptErr)
 	}
 }
 
@@ -33,19 +33,19 @@ func TestSendKeepAliveNoLogger(t *testing.T) {
 	server := newMockSSHServer(t, func(cmd string) int { return 0 })
 	defer server.Close()
 	knownHosts := createKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
+	hostKeyCallback, hostKeyErr := knownhosts.New(knownHosts)
+	if hostKeyErr != nil {
+		t.Fatalf("knownhosts.New: %v", hostKeyErr)
 	}
-	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+	client, dialErr := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
+	if dialErr != nil {
+		t.Fatalf("failed to dial: %v", dialErr)
 	}
 	defer client.Close() //nolint:errcheck
 
 	SetLogger(nil)
 
-	if err := sendKeepAlive(client, "host"); err != nil {
-		t.Fatalf("sendKeepAlive error: %v", err)
+	if keepErr := sendKeepAlive(client, "host"); keepErr != nil {
+		t.Fatalf("sendKeepAlive error: %v", keepErr)
 	}
 }

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -142,21 +142,21 @@ func TestValidateRemoteCommand(t *testing.T) {
 	})
 	defer server.Close()
 	knownHosts := createKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
+	hostKeyCallback, hostKeyErr := knownhosts.New(knownHosts)
+	if hostKeyErr != nil {
+		t.Fatalf("knownhosts.New: %v", hostKeyErr)
 	}
-	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+	client, dialErr := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
+	if dialErr != nil {
+		t.Fatalf("failed to dial: %v", dialErr)
 	}
 	defer client.Close() //nolint:errcheck
 
-	if err := ValidateRemoteCommand(client, "echo"); err != nil {
-		t.Fatalf("expected success, got %v", err)
+	if validateErr := ValidateRemoteCommand(client, "echo"); validateErr != nil {
+		t.Fatalf("expected success, got %v", validateErr)
 	}
 
-	if err := ValidateRemoteCommand(client, "nonexistent"); err == nil {
+	if validateErr := ValidateRemoteCommand(client, "nonexistent"); validateErr == nil {
 		t.Fatalf("expected error for nonexistent command")
 	}
 }
@@ -165,13 +165,13 @@ func TestRunRemoteScript(t *testing.T) {
 	server := newMockSSHServer(t, func(cmd string) int { return 0 })
 	defer server.Close()
 	knownHosts := createKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
+	hostKeyCallback, hostKeyErr := knownhosts.New(knownHosts)
+	if hostKeyErr != nil {
+		t.Fatalf("knownhosts.New: %v", hostKeyErr)
 	}
-	client, err := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+	client, dialErr := ssh.Dial("tcp", server.addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
+	if dialErr != nil {
+		t.Fatalf("failed to dial: %v", dialErr)
 	}
 	defer client.Close() //nolint:errcheck
 
@@ -181,8 +181,8 @@ func TestRunRemoteScript(t *testing.T) {
 	defer SetLogger(nil)
 
 	script := "echo hi"
-	if err := RunRemoteScript(client, script); err != nil {
-		t.Fatalf("RunRemoteScript error: %v", err)
+	if scriptErr := RunRemoteScript(client, script); scriptErr != nil {
+		t.Fatalf("RunRemoteScript error: %v", scriptErr)
 	}
 
 	cmds := server.Commands()

--- a/transfer/save_state_error_test.go
+++ b/transfer/save_state_error_test.go
@@ -23,8 +23,8 @@ func TestDumpChangesLogsSaveStateError(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", DedupStrategy: "checksum", DedupStateFile: filepath.Join(t.TempDir(), "missing", "state"), MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := DumpChanges(cfg, snapshot, src, &buf); err != nil {
-		t.Fatalf("DumpChanges failed: %v", err)
+	if dumpErr := DumpChanges(cfg, snapshot, src, &buf); dumpErr != nil {
+		t.Fatalf("DumpChanges failed: %v", dumpErr)
 	}
 	logs := observed.FilterMessage("Failed to save dedup state").All()
 	if len(logs) != 1 {


### PR DESCRIPTION
## Summary
- avoid redeclaration in gRPC daemon setup and tests
- add exit-safe logger syncing and accompanying unit test
- clean up shadowed error variables in transfer and remote tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895e572b1b483239c531d6d8b247bfa