### PR TITLE
Format Go code and enforce formatting in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,6 +76,16 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-${{ matrix.go-version }}-
 
+    - name: Verify formatting
+      run: |
+        go install golang.org/x/tools/cmd/goimports@latest
+        fmt_out=$(gofmt -l .)
+        if [ -n "$fmt_out" ]; then
+          echo "Run gofmt on the following files:"; echo "$fmt_out"; exit 1; fi
+        imp_out=$(goimports -l .)
+        if [ -n "$imp_out" ]; then
+          echo "Run goimports on the following files:"; echo "$imp_out"; exit 1; fi
+
     - name: Build project
       run: go build -v ./...
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,16 +7,17 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/pierrec/lz4/v4"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
 	"lvmsync_go/internal/compressiondetect"
 	"lvmsync_go/internal/sizeparse"
 	"lvmsync_go/lvm"
-	"runtime"
 )
 
 var SupportedCompression = []string{"none", "lz4", "zstd", "auto"}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pierrec/lz4/v4"
 	"github.com/spf13/viper"
+
 	compressiondetect "lvmsync_go/internal/compressiondetect"
 	"lvmsync_go/lvm"
 )

--- a/main_remote_script_test.go
+++ b/main_remote_script_test.go
@@ -16,6 +16,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+
 	"lvmsync_go/config"
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
-	"github.com/spf13/pflag"
-	"lvmsync_go/config"
 	"testing"
+
+	"github.com/spf13/pflag"
+
+	"lvmsync_go/config"
 )
 
 func TestApplyFlagTriggersApplyMode(t *testing.T) {

--- a/proto/replication.pb.go
+++ b/proto/replication.pb.go
@@ -7,11 +7,12 @@
 package proto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/proto/replication_grpc.pb.go
+++ b/proto/replication_grpc.pb.go
@@ -8,6 +8,7 @@ package proto
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/transfer/compression_auto_x86_test.go
+++ b/transfer/compression_auto_x86_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/klauspost/cpuid/v2"
 	"github.com/pierrec/lz4/v4"
+
 	compressiondetect "lvmsync_go/internal/compressiondetect"
 )
 

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bits-and-blooms/bloom/v3"
+
 	"lvmsync_go/config"
 )
 


### PR DESCRIPTION
## Summary
- run gofmt and goimports across Go sources
- group imports consistently and drop unused ones
- add CI step verifying gofmt and goimports

## Testing
- `gofmt -l .`
- `goimports -l .`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895e9d5f8d48323921b3adbdc90ee86