### PR TITLE
chore: update goreleaser config for v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,9 +23,10 @@ builds:
 
 archives:
   - id: default
-    builds:
+    ids:
       - default
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: '{{ .ProjectName }}_{{ .Env.GORELEASER_CURRENT_TAG }}_{{ .Os }}_{{ .Arch }}'
     files:
       - LICENSE


### PR DESCRIPTION
## Summary
- update goreleaser config to version 2
- replace deprecated archives.format/builds with formats/ids

## Testing
- `goreleaser check`


------
https://chatgpt.com/codex/tasks/task_e_6895f3367ca48323b26980a6a60eb0ef