### PR TITLE
fix: format Empty proto message

### DIFF
--- a/proto/replication.proto
+++ b/proto/replication.proto
@@ -20,7 +20,8 @@ message StatusResponse {
   string message = 2;
 }
 
-message Empty {}
+message Empty {
+}
 
 service Replication {
   rpc LockVolume(LockRequest) returns (StatusResponse);


### PR DESCRIPTION
## Summary
- split Empty message braces over multiple lines to match 2-space indentation style

## Testing
- `protolint lint proto/replication.proto`


------
https://chatgpt.com/codex/tasks/task_e_6895f9b53a2c832399e49cdae78514ec