### PR TITLE
refactor: replace if/else with switch for byte suffixes

### DIFF
--- a/stubs/github.com/dustin/go-humanize/bytes.go
+++ b/stubs/github.com/dustin/go-humanize/bytes.go
@@ -9,13 +9,14 @@ import (
 func ParseBytes(s string) (uint64, error) {
 	s = strings.TrimSpace(s)
 	mult := uint64(1)
-	if strings.HasSuffix(s, "K") {
+	switch {
+	case strings.HasSuffix(s, "K"):
 		mult = 1024
 		s = strings.TrimSuffix(s, "K")
-	} else if strings.HasSuffix(s, "M") {
+	case strings.HasSuffix(s, "M"):
 		mult = 1024 * 1024
 		s = strings.TrimSuffix(s, "M")
-	} else if strings.HasSuffix(s, "G") {
+	case strings.HasSuffix(s, "G"):
 		mult = 1024 * 1024 * 1024
 		s = strings.TrimSuffix(s, "G")
 	}


### PR DESCRIPTION
## Summary
- refactor byte parsing to use switch for suffixes K/M/G

## Testing
- `golangci-lint run stubs/github.com/dustin/go-humanize/bytes.go`


------
https://chatgpt.com/codex/tasks/task_e_6895feb3c72c8323a9383fb0a00a6d1d