### PR TITLE
Sanitize mock SSH exit status

### DIFF
--- a/remote/testutil/ssh_mock.go
+++ b/remote/testutil/ssh_mock.go
@@ -93,6 +93,9 @@ func (s *MockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
 			s.commands = append(s.commands, payload.Command)
 			s.mu.Unlock()
 			status := s.handler(payload.Command)
+			if status < 0 || status > 255 {
+				status = 255
+			}
 			req.Reply(true, nil) //nolint:errcheck
 			exitPayload := struct{ Status uint32 }{uint32(status)}
 			ch.SendRequest("exit-status", false, ssh.Marshal(exitPayload)) //nolint:errcheck


### PR DESCRIPTION
## Summary
- bound mock server exit status to valid 0-255 range and cast to unsigned

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896149e983883239f57a8ce8b2f2e9d