### PR TITLE
Validate BloomEntries before constructing Bloom filter

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/maphash"
 	"io"
+	"math"
 	"os"
 	"sync"
 	"unsafe"
@@ -122,10 +123,15 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 		}
 		return d
 	case "bloom":
+		if cfg.BloomEntries < 0 || uint64(cfg.BloomEntries) > uint64(math.MaxUint) {
+			zap.L().Warn("invalid bloom entries", zap.Int("entries", cfg.BloomEntries))
+			return nil
+		}
+		entries := uint(cfg.BloomEntries)
 		d := &BloomFilterDedup{
-			filter:    bloom.NewWithEstimates(uint(cfg.BloomEntries), cfg.BloomFpRate),
+			filter:    bloom.NewWithEstimates(entries, cfg.BloomFpRate),
 			stateFile: cfg.DedupStateFile,
-			entries:   uint(cfg.BloomEntries),
+			entries:   entries,
 			fpRate:    cfg.BloomFpRate,
 			strategy:  GetChecksumStrategy(cfg.ChecksumAlgorithm),
 		}

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -63,3 +63,10 @@ func TestNewDeduplicationStrategy(t *testing.T) {
 		t.Fatal("expected checksum strategy for auto")
 	}
 }
+
+func TestNewDeduplicationStrategyInvalidBloomEntries(t *testing.T) {
+	cfg := &config.Config{DedupStrategy: "bloom", BloomEntries: -1, BloomFpRate: 0.05}
+	if NewDeduplicationStrategy(cfg) != nil {
+		t.Fatal("expected nil strategy for invalid bloom entries")
+	}
+}


### PR DESCRIPTION
## Summary
- validate BloomEntries is within 0..math.MaxUint before constructing BloomFilterDedup
- add test for invalid BloomEntries values

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68961c5d19488323b1f26158c6967c54