### PR TITLE
Guard against int64 overflow when parsing metadata ranges

### DIFF
--- a/transfer/differences_test.go
+++ b/transfer/differences_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"encoding/binary"
+	"math"
 	"os"
 	"testing"
 )
@@ -49,5 +50,34 @@ func TestGetDifferences(t *testing.T) {
 	}
 	if ranges[1].Start != 4*chunkSize || ranges[1].End != (4+1)*chunkSize-1 {
 		t.Fatalf("unexpected second range: %+v", ranges[1])
+	}
+}
+
+func TestGetDifferencesOverflow(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "meta_overflow")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	chunkSize := int64(4096)
+
+	if _, err := tmpFile.Write(make([]byte, chunkSize)); err != nil {
+		t.Fatalf("failed to write header: %v", err)
+	}
+
+	buf := make([]byte, 16)
+	origin := uint64(math.MaxInt64)/uint64(chunkSize) + 1
+	binary.LittleEndian.PutUint64(buf[0:8], origin)
+	binary.LittleEndian.PutUint64(buf[8:16], 1)
+	if _, err := tmpFile.Write(buf); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := GetDifferences(tmpFile.Name(), chunkSize); err == nil {
+		t.Fatalf("expected overflow error")
 	}
 }

--- a/transfer/metadata.go
+++ b/transfer/metadata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,10 +93,20 @@ func GetDifferences(metadataPath string, chunkSize int64) (ranges []Range, err e
 			break
 		}
 
-		start := int64(originOffset) * chunkSize
-		end := (int64(originOffset)+1)*chunkSize - 1
+		chunkSizeU := uint64(chunkSize)
+		maxInt := uint64(math.MaxInt64)
 
-		ranges = append(ranges, Range{Start: start, End: end})
+		if originOffset > maxInt/chunkSizeU {
+			return nil, fmt.Errorf("range start overflows int64")
+		}
+		if originOffset >= (maxInt+1)/chunkSizeU {
+			return nil, fmt.Errorf("range end overflows int64")
+		}
+
+		start := originOffset * chunkSizeU
+		end := (originOffset+1)*chunkSizeU - 1
+
+		ranges = append(ranges, Range{Start: int64(start), End: int64(end)})
 	}
 
 	return ranges, nil


### PR DESCRIPTION
## Summary
- compute range bounds using uint64 math and ensure values stay within int64 limits before conversion
- add regression test covering range overflow handling

## Testing
- `go test ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_68961f145d7c8323b2b344dbeb67ed62