### PR TITLE
Refactor offset and block size validation

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -156,11 +156,8 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 	skippedBlocks := 0
 	var header [12]byte
 	for _, r := range ranges {
-		if r.Start < 0 || uint64(r.Start) > math.MaxUint64 {
-			return totalBytes, skippedBlocks, fmt.Errorf("block offset %d out of range", r.Start)
-		}
-		if cfg.BlockSize < 0 || uint64(cfg.BlockSize) > math.MaxUint32 {
-			return totalBytes, skippedBlocks, fmt.Errorf("block size %d out of range", cfg.BlockSize)
+		if err := validateOffsetAndSize(r.Start, cfg.BlockSize); err != nil {
+			return totalBytes, skippedBlocks, err
 		}
 		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy, pipeFds)
 		if err != nil {
@@ -438,12 +435,8 @@ func processParallelResults(cfg *config.Config, results <-chan *BlockResult, buf
 func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
 	defer workerWG.Done()
 	for task := range tasks {
-		if task.R.Start < 0 || uint64(task.R.Start) > math.MaxUint64 {
-			results <- &BlockResult{Index: task.Index, Err: fmt.Errorf("block offset %d out of range", task.R.Start)}
-			continue
-		}
-		if cfg.BlockSize < 0 || uint64(cfg.BlockSize) > math.MaxUint32 {
-			results <- &BlockResult{Index: task.Index, Err: fmt.Errorf("block size %d out of range", cfg.BlockSize)}
+		if err := validateOffsetAndSize(task.R.Start, cfg.BlockSize); err != nil {
+			results <- &BlockResult{Index: task.Index, Err: err}
 			continue
 		}
 		data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})


### PR DESCRIPTION
## Summary
- centralize offset and block size checks with `validateOffsetAndSize`
- streamline `iterateBlocks` and `worker` by removing redundant bounds checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689622f420688323b69b341055d56465