### PR TITLE
Replace unused parameter names with underscores

### DIFF
--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -44,7 +44,7 @@ func (s *sudoAgent) ensureRoot() error {
 	return privesc.EnsureRoot(cmd)
 }
 
-func (s *sudoAgent) Lock(_ context.Context, volume, requester string) error {
+func (s *sudoAgent) Lock(_ context.Context, _, _ string) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (s *sudoAgent) Lock(_ context.Context, volume, requester string) error {
 	return nil
 }
 
-func (s *sudoAgent) Unlock(_ context.Context, volume, requester string) error {
+func (s *sudoAgent) Unlock(_ context.Context, _, _ string) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (s *sudoAgent) Unlock(_ context.Context, volume, requester string) error {
 	return nil
 }
 
-func (s *sudoAgent) GetMetadata(_ context.Context, volume string) (VolumeMetadata, error) {
+func (s *sudoAgent) GetMetadata(_ context.Context, _ string) (VolumeMetadata, error) {
 	if err := s.ensureRoot(); err != nil {
 		return VolumeMetadata{}, err
 	}
@@ -68,7 +68,7 @@ func (s *sudoAgent) GetMetadata(_ context.Context, volume string) (VolumeMetadat
 	return VolumeMetadata{}, nil
 }
 
-func (s *sudoAgent) SendMetadata(_ context.Context, md VolumeMetadata) error {
+func (s *sudoAgent) SendMetadata(_ context.Context, _ VolumeMetadata) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}

--- a/lvm/backend_cgo.go
+++ b/lvm/backend_cgo.go
@@ -16,7 +16,7 @@ func newBackendWithCGO(lvm cgo.LVM) lvmBackend { return &cgoBackend{lvm: lvm} }
 
 func newLVMBackend() lvmBackend { return newBackendWithCGO(cgo.New()) }
 
-func (b *cgoBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
+func (b *cgoBackend) CreateSnapshot(_ context.Context, lvPath, snapshotName, size string) error {
 	bytes, percent, err := sizeparse.Parse(size)
 	if err != nil {
 		return fmt.Errorf("parse size %q: %w", size, err)
@@ -36,7 +36,7 @@ func (b *cgoBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, s
 	return nil
 }
 
-func (b *cgoBackend) RemoveSnapshot(ctx context.Context, snapshotPath string) error {
+func (b *cgoBackend) RemoveSnapshot(_ context.Context, snapshotPath string) error {
 	if err := b.lvm.RemoveLV(snapshotPath); err != nil {
 		return fmt.Errorf("cgo remove snapshot: %w", err)
 	}


### PR DESCRIPTION
## Summary
- replace unused parameters in agent methods with `_`
- mark unused ctx parameters in cgo backend snapshot operations

## Testing
- `go test ./...` *(fails: hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68963b93e4e483239c4cd3f0003dcce4