### PR TITLE
Refactor tests to use shared helpers

### DIFF
--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -114,6 +114,20 @@ func ctxWithRole(role string) context.Context {
 	return metadata.NewOutgoingContext(context.Background(), metadata.Pairs("role", role))
 }
 
+// runStatusTest executes an RPC returning a StatusResponse and verifies ok/message fields.
+func runStatusTest(t *testing.T, agent lvmagent.Agent, ok bool, msg string, call func(proto.ReplicationClient) (*proto.StatusResponse, error)) {
+	t.Helper()
+	client, cleanup := newInsecureClient(t, agent)
+	defer cleanup()
+	resp, err := call(client)
+	if err != nil {
+		t.Fatalf("call failed: %v", err)
+	}
+	if resp.GetOk() != ok || resp.GetMessage() != msg {
+		t.Fatalf("unexpected response %#v", resp)
+	}
+}
+
 func TestAuthorizeInterceptor(t *testing.T) {
 	client, cleanup := newInsecureClient(t, nil)
 	defer cleanup()
@@ -142,15 +156,9 @@ func TestLockVolume(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, cleanup := newInsecureClient(t, tt.agent)
-			defer cleanup()
-			resp, err := client.LockVolume(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
-			if err != nil {
-				t.Fatalf("call failed: %v", err)
-			}
-			if resp.GetOk() != tt.ok || resp.GetMessage() != tt.msg {
-				t.Fatalf("unexpected response %#v", resp)
-			}
+			runStatusTest(t, tt.agent, tt.ok, tt.msg, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+				return client.LockVolume(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
+			})
 		})
 	}
 }
@@ -206,15 +214,9 @@ func TestSendVolumeMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, cleanup := newInsecureClient(t, tt.agent)
-			defer cleanup()
-			resp, err := client.SendVolumeMetadata(ctxWithRole("replicator"), &proto.VolumeMetadata{VolumeName: "vol"})
-			if err != nil {
-				t.Fatalf("call failed: %v", err)
-			}
-			if resp.GetOk() != tt.ok || resp.GetMessage() != tt.msg {
-				t.Fatalf("unexpected response %#v", resp)
-			}
+			runStatusTest(t, tt.agent, tt.ok, tt.msg, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+				return client.SendVolumeMetadata(ctxWithRole("replicator"), &proto.VolumeMetadata{VolumeName: "vol"})
+			})
 		})
 	}
 }
@@ -232,15 +234,9 @@ func TestStartTransferSession(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, cleanup := newInsecureClient(t, tt.agent)
-			defer cleanup()
-			resp, err := client.StartTransferSession(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
-			if err != nil {
-				t.Fatalf("call failed: %v", err)
-			}
-			if resp.GetOk() != tt.ok || resp.GetMessage() != tt.msg {
-				t.Fatalf("unexpected response %#v", resp)
-			}
+			runStatusTest(t, tt.agent, tt.ok, tt.msg, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+				return client.StartTransferSession(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
+			})
 		})
 	}
 }
@@ -259,15 +255,9 @@ func TestFinalizeSync(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, cleanup := newInsecureClient(t, tt.agent)
-			defer cleanup()
-			resp, err := client.FinalizeSync(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
-			if err != nil {
-				t.Fatalf("call failed: %v", err)
-			}
-			if resp.GetOk() != tt.ok || resp.GetMessage() != tt.msg {
-				t.Fatalf("unexpected response %#v", resp)
-			}
+			runStatusTest(t, tt.agent, tt.ok, tt.msg, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+				return client.FinalizeSync(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
+			})
 		})
 	}
 }
@@ -285,15 +275,9 @@ func TestGetStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, cleanup := newInsecureClient(t, tt.agent)
-			defer cleanup()
-			resp, err := client.GetStatus(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
-			if err != nil {
-				t.Fatalf("call failed: %v", err)
-			}
-			if resp.GetOk() != tt.ok || resp.GetMessage() != tt.msg {
-				t.Fatalf("unexpected response %#v", resp)
-			}
+			runStatusTest(t, tt.agent, tt.ok, tt.msg, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+				return client.GetStatus(ctxWithRole("replicator"), &proto.LockRequest{VolumeName: "vol", Requester: "req"})
+			})
 		})
 	}
 }

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -5,14 +5,10 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
-
-	remotetest "lvmsync_go/remote/testutil"
 )
 
 func TestValidateRemoteCommand(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int {
+	_, client := newSSHServerClient(t, func(cmd string) int {
 		switch cmd {
 		case "echo --version":
 			return 0
@@ -22,17 +18,6 @@ func TestValidateRemoteCommand(t *testing.T) {
 			return 0
 		}
 	})
-	defer server.Close()
-	knownHosts := remotetest.CreateKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
-	}
-	client, err := ssh.Dial("tcp", server.Addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
-	}
-	defer client.Close() //nolint:errcheck
 
 	if err := ValidateRemoteCommand(client, "echo"); err != nil {
 		t.Fatalf("expected success, got %v", err)
@@ -43,18 +28,7 @@ func TestValidateRemoteCommand(t *testing.T) {
 }
 
 func TestRunRemoteScript(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
-	defer server.Close()
-	knownHosts := remotetest.CreateKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
-	}
-	client, err := ssh.Dial("tcp", server.Addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
-	}
-	defer client.Close() //nolint:errcheck
+	server, client := newSSHServerClient(t, func(cmd string) int { return 0 })
 
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(core)

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -1,30 +1,14 @@
 package remote
 
 import (
-	"net"
-	"strconv"
 	"testing"
 	"time"
-
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 
 	remotetest "lvmsync_go/remote/testutil"
 )
 
 func TestSendKeepAlive(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
-	defer server.Close()
-	knownHosts := remotetest.CreateKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
-	}
-	client, err := ssh.Dial("tcp", server.Addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
-	}
-	defer client.Close() //nolint:errcheck
+	server, client := newSSHServerClient(t, func(cmd string) int { return 0 })
 
 	if err := sendKeepAlive(client, "host"); err != nil {
 		t.Fatalf("sendKeepAlive error: %v", err)
@@ -37,17 +21,7 @@ func TestSendKeepAlive(t *testing.T) {
 }
 
 func TestStartKeepAlive(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
-	defer server.Close()
-	knownHosts := remotetest.CreateKnownHostsFile(t, server)
-	hostKeyCallback, err := knownhosts.New(knownHosts)
-	if err != nil {
-		t.Fatalf("knownhosts.New: %v", err)
-	}
-	client, err := ssh.Dial("tcp", server.Addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
-	}
+	server, client := newSSHServerClient(t, func(cmd string) int { return 0 })
 
 	done := make(chan struct{})
 	go func() {
@@ -72,20 +46,8 @@ func TestStartKeepAlive(t *testing.T) {
 }
 
 func TestNewSSHClient(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
-	defer server.Close()
-
-	host, portStr, errSplit := net.SplitHostPort(server.Addr)
-	if errSplit != nil {
-		t.Fatalf("SplitHostPort: %v", errSplit)
-	}
-	port, errConv := strconv.Atoi(portStr)
-	if errConv != nil {
-		t.Fatalf("Atoi: %v", errConv)
-	}
-
+	server, host, port, knownHosts := newSSHServer(t, func(cmd string) int { return 0 })
 	keyPath := remotetest.CreateTempKey(t)
-	knownHosts := remotetest.CreateKnownHostsFile(t, server)
 	client, err := NewSSHClient(host, "test", keyPath, port, knownHosts, true, time.Second, 10*time.Millisecond, 0)
 	if err != nil {
 		t.Fatalf("NewSSHClient error: %v", err)
@@ -101,23 +63,11 @@ func TestNewSSHClient(t *testing.T) {
 }
 
 func TestSSHManager(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
-	defer server.Close()
-
+	server, host, port, knownHosts := newSSHServer(t, func(cmd string) int { return 0 })
 	keyPath := remotetest.CreateTempKey(t)
-	knownHosts := remotetest.CreateKnownHostsFile(t, server)
 	mgr, err := NewSSHManager("test", keyPath, time.Second, knownHosts)
 	if err != nil {
 		t.Fatalf("NewSSHManager error: %v", err)
-	}
-
-	host, portStr, errSplit := net.SplitHostPort(server.Addr)
-	if errSplit != nil {
-		t.Fatalf("SplitHostPort: %v", errSplit)
-	}
-	port, errConv := strconv.Atoi(portStr)
-	if errConv != nil {
-		t.Fatalf("Atoi: %v", errConv)
 	}
 
 	client1, err := mgr.GetClient(host, port)

--- a/remote/test_helpers_test.go
+++ b/remote/test_helpers_test.go
@@ -1,0 +1,49 @@
+package remote
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	remotetest "lvmsync_go/remote/testutil"
+)
+
+// newSSHServer sets up a mock SSH server and returns the server instance,
+// host, port, and path to a known_hosts file containing its key.
+func newSSHServer(t *testing.T, handler func(string) int) (*remotetest.MockSSHServer, string, int, string) {
+	t.Helper()
+	server := remotetest.NewMockSSHServer(t, handler)
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+	knownHosts := remotetest.CreateKnownHostsFile(t, server)
+	t.Cleanup(func() { server.Close() })
+	return server, host, port, knownHosts
+}
+
+// newSSHServerClient returns a mock SSH server and connected client.
+func newSSHServerClient(t *testing.T, handler func(string) int) (*remotetest.MockSSHServer, *ssh.Client) {
+	t.Helper()
+	server, _, _, knownHosts := newSSHServer(t, handler)
+	hostKeyCallback, err := knownhosts.New(knownHosts)
+	if err != nil {
+		t.Fatalf("knownhosts.New: %v", err)
+	}
+	client, err := ssh.Dial("tcp", server.Addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close() //nolint:errcheck
+		server.Close()
+	})
+	return server, client
+}

--- a/transfer/block_test.go
+++ b/transfer/block_test.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"bytes"
-	"os"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -20,10 +19,7 @@ func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
 	data := []byte{1, 2, 3, 4}
 	cfg := &config.Config{BlockSize: blockSize, MaxRetries: 3}
 
-	tmp, err := os.CreateTemp(t.TempDir(), "block")
-	if err != nil {
-		t.Fatalf("temp file: %v", err)
-	}
+	tmp := newTempFile(t, "block")
 	defer tmp.Close()
 
 	go func() {
@@ -54,10 +50,7 @@ func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
 	data := []byte{1, 2, 3, 4}
 	cfg := &config.Config{BlockSize: blockSize, MaxRetries: 1}
 
-	tmp, err := os.CreateTemp(t.TempDir(), "block")
-	if err != nil {
-		t.Fatalf("temp file: %v", err)
-	}
+	tmp := newTempFile(t, "block")
 	defer tmp.Close()
 	if _, err := tmp.WriteAt(data, 0); err != nil {
 		t.Fatalf("write: %v", err)

--- a/transfer/differences_test.go
+++ b/transfer/differences_test.go
@@ -8,10 +8,7 @@ import (
 )
 
 func TestGetDifferences(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "meta")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
+	tmpFile := newTempFile(t, "meta")
 	defer os.Remove(tmpFile.Name())
 
 	chunkSize := int64(4096)
@@ -54,10 +51,7 @@ func TestGetDifferences(t *testing.T) {
 }
 
 func TestGetDifferencesOverflow(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "meta_overflow")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
+	tmpFile := newTempFile(t, "meta_overflow")
 	defer os.Remove(tmpFile.Name())
 
 	chunkSize := int64(4096)

--- a/transfer/metadata_test.go
+++ b/transfer/metadata_test.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"encoding/binary"
-	"os"
 	"strings"
 	"testing"
 )
@@ -64,10 +63,7 @@ func TestReadMetadataHeader(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpFile, err := os.CreateTemp(t.TempDir(), "meta")
-			if err != nil {
-				t.Fatalf("failed to create temp file: %v", err)
-			}
+			tmpFile := newTempFile(t, "meta")
 			if _, err := tmpFile.Write(tt.header); err != nil {
 				t.Fatalf("failed to write header: %v", err)
 			}

--- a/transfer/test_helpers_test.go
+++ b/transfer/test_helpers_test.go
@@ -1,0 +1,16 @@
+package transfer
+
+import (
+	"os"
+	"testing"
+)
+
+// newTempFile creates a temporary file and fails the test on error.
+func newTempFile(t *testing.T, pattern string) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), pattern)
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	return f
+}

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -13,30 +13,24 @@ import (
 )
 
 func TestIterateBlocksOversizedOffset(t *testing.T) {
-	src, err := os.CreateTemp(t.TempDir(), "src")
-	if err != nil {
-		t.Fatalf("create temp file: %v", err)
-	}
+	src := newTempFile(t, "src")
 	defer src.Close()
 
 	cfg := &config.Config{BlockSize: 4096}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, err = iterateBlocks(cfg, []Range{{Start: -1, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
+	_, _, err := iterateBlocks(cfg, []Range{{Start: -1, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
 	if err == nil || !strings.Contains(err.Error(), "offset") {
 		t.Fatalf("expected offset error, got %v", err)
 	}
 }
 
 func TestIterateBlocksOversizedBlockSize(t *testing.T) {
-	src, err := os.CreateTemp(t.TempDir(), "src")
-	if err != nil {
-		t.Fatalf("create temp file: %v", err)
-	}
+	src := newTempFile(t, "src")
 	defer src.Close()
 
 	cfg := &config.Config{BlockSize: int(math.MaxUint32) + 1}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, err = iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
+	_, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
 	if err == nil || !strings.Contains(err.Error(), "block size") {
 		t.Fatalf("expected block size error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- add helper to build mock SSH server and client for remote tests
- add reusable temp file helper and consolidate transfer test setups
- factor repeated gRPC status checks into runStatusTest helper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68963dc4e87c8323ac73a79467f07c5a