### PR TITLE
Validate integer casts and add boundary tests

### DIFF
--- a/remote/testutil/ssh_mock.go
+++ b/remote/testutil/ssh_mock.go
@@ -93,11 +93,14 @@ func (s *MockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
 			s.commands = append(s.commands, payload.Command)
 			s.mu.Unlock()
 			status := s.handler(payload.Command)
-			if status < 0 || status > 255 {
-				status = 255
+			var exitStatus uint32
+			if status >= 0 && status <= 255 {
+				exitStatus = uint32(status)
+			} else {
+				exitStatus = 255
 			}
 			req.Reply(true, nil) //nolint:errcheck
-			exitPayload := struct{ Status uint32 }{uint32(status)}
+			exitPayload := struct{ Status uint32 }{Status: exitStatus}
 			ch.SendRequest("exit-status", false, ssh.Marshal(exitPayload)) //nolint:errcheck
 			return
 		}

--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -50,10 +50,10 @@ func (w *pooledLz4Writer) Close() error {
 }
 
 func (lz4Strategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
-	lvl := lz4.CompressionLevel(level)
-	switch lvl {
-	case lz4.Fast, lz4.Level1, lz4.Level2, lz4.Level3, lz4.Level4, lz4.Level5, lz4.Level6, lz4.Level7, lz4.Level8, lz4.Level9:
-		// valid
+	var lvl lz4.CompressionLevel
+	switch level {
+	case int(lz4.Fast), int(lz4.Level1), int(lz4.Level2), int(lz4.Level3), int(lz4.Level4), int(lz4.Level5), int(lz4.Level6), int(lz4.Level7), int(lz4.Level8), int(lz4.Level9):
+		lvl = lz4.CompressionLevel(level)
 	default:
 		return nil, fmt.Errorf("invalid lz4 compression level: %d", level)
 	}

--- a/transfer/differences_test.go
+++ b/transfer/differences_test.go
@@ -75,3 +75,17 @@ func TestGetDifferencesOverflow(t *testing.T) {
 		t.Fatalf("expected overflow error")
 	}
 }
+
+func TestGetDifferencesInvalidChunkSize(t *testing.T) {
+	tmpFile := newTempFile(t, "meta_invalid")
+	defer os.Remove(tmpFile.Name())
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	for _, cs := range []int64{0, -1} {
+		if _, err := GetDifferences(tmpFile.Name(), cs); err == nil {
+			t.Fatalf("expected error for chunk size %d", cs)
+		}
+	}
+}

--- a/transfer/metadata.go
+++ b/transfer/metadata.go
@@ -57,6 +57,10 @@ func ReadMetadataHeader(metadataPath string) (chunkSize int64, err error) {
 }
 
 func GetDifferences(metadataPath string, chunkSize int64) (ranges []Range, err error) {
+	if chunkSize <= 0 {
+		return nil, fmt.Errorf("invalid chunk size %d", chunkSize)
+	}
+
 	file, err := os.Open(metadataPath)
 	if err != nil {
 		return nil, err

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -602,6 +602,9 @@ func readBlockHeader(reader *bufio.Reader, headerBuf []byte, verify bool, checks
 	}
 
 	offset := binary.BigEndian.Uint64(headerBuf[0:8])
+	if offset > math.MaxInt64 {
+		return 0, 0, nil, fmt.Errorf("offset %d overflows int64", offset)
+	}
 	chunkSize := binary.BigEndian.Uint32(headerBuf[8:12])
 
 	var transmittedSum []byte
@@ -637,6 +640,9 @@ func verifyChecksum(verify bool, checksum ChecksumStrategy, data, transmitted []
 }
 
 func writeData(destFile *os.File, offset uint64, data []byte) error {
+	if offset > math.MaxInt64 {
+		return fmt.Errorf("offset %d overflows int64", offset)
+	}
 	if _, err := destFile.Seek(int64(offset), io.SeekStart); err != nil {
 		Logger.Warn("Seek error", zap.Uint64("offset", offset), zap.Error(err))
 		return nil

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -2,6 +2,8 @@ package transfer
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/binary"
 	"io"
 	"math"
 	"os"
@@ -47,5 +49,40 @@ func TestSaveResumeStatePermissions(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("expected permissions 600, got %v", info.Mode().Perm())
+	}
+}
+
+func TestReadBlockHeaderOffsetBoundary(t *testing.T) {
+	header := make([]byte, 12)
+	offset := uint64(math.MaxInt64)
+	binary.BigEndian.PutUint64(header[0:8], offset)
+	binary.BigEndian.PutUint32(header[8:12], 1)
+	reader := bufio.NewReader(bytes.NewReader(header))
+	gotOffset, gotSize, _, err := readBlockHeader(reader, make([]byte, 12), false, nil)
+	if err != nil {
+		t.Fatalf("readBlockHeader returned error: %v", err)
+	}
+	if gotOffset != offset || gotSize != 1 {
+		t.Fatalf("unexpected header values %d %d", gotOffset, gotSize)
+	}
+}
+
+func TestReadBlockHeaderOffsetOverflow(t *testing.T) {
+	header := make([]byte, 12)
+	offset := uint64(math.MaxInt64) + 1
+	binary.BigEndian.PutUint64(header[0:8], offset)
+	binary.BigEndian.PutUint32(header[8:12], 1)
+	reader := bufio.NewReader(bytes.NewReader(header))
+	if _, _, _, err := readBlockHeader(reader, make([]byte, 12), false, nil); err == nil {
+		t.Fatalf("expected overflow error")
+	}
+}
+
+func TestWriteDataOffsetOverflow(t *testing.T) {
+	dest := newTempFile(t, "dest")
+	defer dest.Close()
+	err := writeData(dest, uint64(math.MaxInt64)+1, []byte("data"))
+	if err == nil || !strings.Contains(err.Error(), "overflows int64") {
+		t.Fatalf("expected overflow error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure SSH mock exit status stays within uint32 range
- validate compression level and metadata chunk sizes before casting
- guard transfer offsets against int64 overflow and test edge cases

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689648f972d48323af4608da9f221dba