### PR TITLE
Fix variable shadowing warnings

### DIFF
--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -83,7 +83,7 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("failed to create temp volume: %v", err)
 		}
 		defer f.Close()
-		if err := f.Truncate(int64(5 * 1024 * 1024 * 1024)); err != nil {
+		if err = f.Truncate(int64(5 * 1024 * 1024 * 1024)); err != nil {
 			t.Fatalf("truncate failed: %v", err)
 		}
 

--- a/main_dump_test.go
+++ b/main_dump_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestExecuteDumpSequential(t *testing.T) {
-	cfg, cfgErr := config.DefaultConfig()
+	cfg2, cfgErr := config.DefaultConfig()
 	if cfgErr != nil {
 		t.Fatalf("DefaultConfig returned error: %v", cfgErr)
 	}
-	cfg.DedupStrategy = "none"
-	cfg.Parallel = 1
+	cfg2.DedupStrategy = "none"
+	cfg2.Parallel = 1
 
 	called := false
 	original := dumpChangesSequential
@@ -24,7 +24,7 @@ func TestExecuteDumpSequential(t *testing.T) {
 	}
 	defer func() { dumpChangesSequential = original }()
 
-	if execErr := executeDump(cfg, "snap", "orig", io.Discard); execErr != nil {
+	if execErr := executeDump(cfg2, "snap", "orig", io.Discard); execErr != nil {
 		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {
@@ -33,11 +33,11 @@ func TestExecuteDumpSequential(t *testing.T) {
 }
 
 func TestExecuteDumpParallel(t *testing.T) {
-	cfg, cfgErr := config.DefaultConfig()
+	cfg2, cfgErr := config.DefaultConfig()
 	if cfgErr != nil {
 		t.Fatalf("DefaultConfig returned error: %v", cfgErr)
 	}
-	cfg.Parallel = 2
+	cfg2.Parallel = 2
 
 	called := false
 	original := dumpChangesParallel
@@ -47,7 +47,7 @@ func TestExecuteDumpParallel(t *testing.T) {
 	}
 	defer func() { dumpChangesParallel = original }()
 
-	if execErr := executeDump(cfg, "snap", "orig", io.Discard); execErr != nil {
+	if execErr := executeDump(cfg2, "snap", "orig", io.Discard); execErr != nil {
 		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {
@@ -56,11 +56,11 @@ func TestExecuteDumpParallel(t *testing.T) {
 }
 
 func TestExecuteDumpWithDedup(t *testing.T) {
-	cfg, cfgErr := config.DefaultConfig()
+	cfg2, cfgErr := config.DefaultConfig()
 	if cfgErr != nil {
 		t.Fatalf("DefaultConfig returned error: %v", cfgErr)
 	}
-	cfg.DedupStrategy = "checksum"
+	cfg2.DedupStrategy = "checksum"
 
 	called := false
 	original := dumpChangesWithDeduplication
@@ -73,7 +73,7 @@ func TestExecuteDumpWithDedup(t *testing.T) {
 	}
 	defer func() { dumpChangesWithDeduplication = original }()
 
-	if execErr := executeDump(cfg, "snap", "orig", io.Discard); execErr != nil {
+	if execErr := executeDump(cfg2, "snap", "orig", io.Discard); execErr != nil {
 		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {

--- a/main_stdout_test.go
+++ b/main_stdout_test.go
@@ -23,8 +23,8 @@ func TestRunClientModeStdout(t *testing.T) {
 
 	originalFunc := dumpChangesSequential
 	dumpChangesSequential = func(c *config.Config, snapshot, source string, out io.Writer) error {
-		_, err := out.Write([]byte(expected))
-		return err
+		_, writeErr := out.Write([]byte(expected))
+		return writeErr
 	}
 	defer func() { dumpChangesSequential = originalFunc }()
 
@@ -35,7 +35,7 @@ func TestRunClientModeStdout(t *testing.T) {
 	oldStdout := os.Stdout
 	os.Stdout = w
 
-	if err := runClientMode("/dev/snap", ""); err != nil {
+	if err = runClientMode("/dev/snap", ""); err != nil {
 		t.Fatalf("runClientMode returned error: %v", err)
 	}
 

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -84,7 +84,7 @@ func TestSSHManager(t *testing.T) {
 	}
 	waitForConnectionCount(t, server, 1)
 
-	if err := mgr.CloseAll(); err != nil {
+	if err = mgr.CloseAll(); err != nil {
 		t.Fatalf("CloseAll error: %v", err)
 	}
 
@@ -97,7 +97,7 @@ func TestSSHManager(t *testing.T) {
 	}
 	waitForConnectionCount(t, server, 2)
 
-	if err := mgr.CloseAll(); err != nil {
+	if err = mgr.CloseAll(); err != nil {
 		t.Fatalf("CloseAll error: %v", err)
 	}
 }

--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -157,8 +157,8 @@ func sshAgentAuth() (ssh.AuthMethod, error) {
 
 	agentClient := agent.NewClient(conn)
 	defer func() {
-		if err := conn.Close(); err != nil {
-			Logger.Warn("ssh agent connection close error", zap.Error(err))
+		if closeErr := conn.Close(); closeErr != nil {
+			Logger.Warn("ssh agent connection close error", zap.Error(closeErr))
 		}
 	}()
 

--- a/transfer/block_test.go
+++ b/transfer/block_test.go
@@ -70,17 +70,17 @@ func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
 	putBlockBuffer(buf)
 
 	fds := [2]int{}
-	if err := syscall.Pipe(fds[:]); err != nil {
+	if err = syscall.Pipe(fds[:]); err != nil {
 		t.Fatalf("pipe: %v", err)
 	}
 	defer func() {
-		if err := syscall.Close(fds[0]); err != nil {
-			t.Logf("close fd0: %v", err)
+		if closeErr := syscall.Close(fds[0]); closeErr != nil {
+			t.Logf("close fd0: %v", closeErr)
 		}
 	}()
 	defer func() {
-		if err := syscall.Close(fds[1]); err != nil {
-			t.Logf("close fd1: %v", err)
+		if closeErr := syscall.Close(fds[1]); closeErr != nil {
+			t.Logf("close fd1: %v", closeErr)
 		}
 	}()
 

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -113,10 +113,10 @@ func TestLZ4WriterPoolReuse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new writer: %v", err)
 	}
-	if _, err := w1.Write(data1); err != nil {
+	if _, err = w1.Write(data1); err != nil {
 		t.Fatalf("write1: %v", err)
 	}
-	if err := w1.Close(); err != nil {
+	if err = w1.Close(); err != nil {
 		t.Fatalf("close1: %v", err)
 	}
 
@@ -136,10 +136,10 @@ func TestLZ4WriterPoolReuse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new writer2: %v", err)
 	}
-	if _, err := w2.Write(data2); err != nil {
+	if _, err = w2.Write(data2); err != nil {
 		t.Fatalf("write2: %v", err)
 	}
-	if err := w2.Close(); err != nil {
+	if err = w2.Close(); err != nil {
 		t.Fatalf("close2: %v", err)
 	}
 
@@ -171,7 +171,7 @@ func TestLZ4ReaderPoolReuse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read1: %v", err)
 	}
-	if err := r1.Close(); err != nil {
+	if err = r1.Close(); err != nil {
 		t.Fatalf("close1: %v", err)
 	}
 	if !bytes.Equal(out1, data1) {
@@ -197,7 +197,7 @@ func TestLZ4ReaderPoolReuse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read2: %v", err)
 	}
-	if err := r2.Close(); err != nil {
+	if err = r2.Close(); err != nil {
 		t.Fatalf("close2: %v", err)
 	}
 	if !bytes.Equal(out2, data2) {

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -39,7 +39,7 @@ func createDumpTestFiles(t testing.TB, blockSize int64, changedBlocks []int) (sr
 	}
 	for i := 0; i < blockCount; i++ {
 		data := bytes.Repeat([]byte{byte(i + 1)}, int(blockSize))
-		if _, err := srcFile.Write(data); err != nil {
+		if _, err = srcFile.Write(data); err != nil {
 			t.Fatalf("failed to write block: %v", err)
 		}
 	}
@@ -51,18 +51,18 @@ func createDumpTestFiles(t testing.TB, blockSize int64, changedBlocks []int) (sr
 	if err != nil {
 		t.Fatalf("failed to create metadata: %v", err)
 	}
-	if _, err := metaFile.Write(make([]byte, blockSize)); err != nil {
+	if _, err = metaFile.Write(make([]byte, blockSize)); err != nil {
 		t.Fatalf("failed to write metadata header: %v", err)
 	}
 	for _, b := range changedBlocks {
 		buf := make([]byte, 16)
 		binary.LittleEndian.PutUint64(buf[0:8], uint64(b))
 		binary.LittleEndian.PutUint64(buf[8:16], uint64(b+1))
-		if _, err := metaFile.Write(buf); err != nil {
+		if _, err = metaFile.Write(buf); err != nil {
 			t.Fatalf("failed to write metadata entry: %v", err)
 		}
 	}
-	if _, err := metaFile.Write(make([]byte, 16)); err != nil {
+	if _, err = metaFile.Write(make([]byte, 16)); err != nil {
 		t.Fatalf("failed to write metadata terminator: %v", err)
 	}
 	metaFile.Close()
@@ -72,7 +72,7 @@ func createDumpTestFiles(t testing.TB, blockSize int64, changedBlocks []int) (sr
 	SetMapperDir(mapper)
 	snapshot = "testvg-testlv"
 	link := filepath.Join(mapper, "testvg-testlv-cow")
-	if err := os.Symlink(meta, link); err != nil {
+	if err = os.Symlink(meta, link); err != nil {
 		t.Fatalf("failed to create metadata symlink: %v", err)
 	}
 	t.Cleanup(func() {
@@ -195,13 +195,13 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create dest: %v", err)
 	}
-	if err := destFile.Truncate(info.Size()); err != nil {
+	if err = destFile.Truncate(info.Size()); err != nil {
 		t.Fatalf("truncate dest: %v", err)
 	}
 	destFile.Close()
 
 	cfgProcess := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
-	if err := ProcessDumpData(cfgProcess, bytes.NewReader(data), dest); err != nil {
+	if err = ProcessDumpData(cfgProcess, bytes.NewReader(data), dest); err != nil {
 		t.Fatalf("ProcessDumpData failed: %v", err)
 	}
 
@@ -210,7 +210,7 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 		t.Fatalf("open dest: %v", err)
 	}
 	got := make([]byte, blockSize)
-	if _, err := outFile.ReadAt(got, 0); err != nil {
+	if _, err = outFile.ReadAt(got, 0); err != nil {
 		t.Fatalf("read dest: %v", err)
 	}
 	outFile.Close()

--- a/transfer/pool_test.go
+++ b/transfer/pool_test.go
@@ -15,7 +15,7 @@ func BenchmarkReadBlockWithPool(b *testing.B) {
 	}
 	defer os.Remove(f.Name())
 	data := make([]byte, cfg.BlockSize)
-	if _, err := f.Write(data); err != nil {
+	if _, err = f.Write(data); err != nil {
 		b.Fatal(err)
 	}
 	f.Close()
@@ -44,7 +44,7 @@ func BenchmarkReadBlockWithMake(b *testing.B) {
 	}
 	defer os.Remove(f.Name())
 	data := make([]byte, cfg.BlockSize)
-	if _, err := f.Write(data); err != nil {
+	if _, err = f.Write(data); err != nil {
 		b.Fatal(err)
 	}
 	f.Close()
@@ -58,7 +58,7 @@ func BenchmarkReadBlockWithMake(b *testing.B) {
 	b.ResetTimer()
 	buf := make([]byte, cfg.BlockSize)
 	for i := 0; i < b.N; i++ {
-		if _, err := f.ReadAt(buf, 0); err != nil {
+		if _, err = f.ReadAt(buf, 0); err != nil {
 			b.Fatal(err)
 		}
 		buf = make([]byte, cfg.BlockSize)

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -32,7 +32,7 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int) (srcPath, sn
 	}
 	for i := 0; i < blockCount; i++ {
 		data := bytes.Repeat([]byte{byte(i + 1)}, int(blockSize))
-		if _, err := srcFile.Write(data); err != nil {
+		if _, err = srcFile.Write(data); err != nil {
 			t.Fatalf("failed to write block: %v", err)
 		}
 	}
@@ -44,18 +44,18 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int) (srcPath, sn
 	if err != nil {
 		t.Fatalf("failed to create metadata file: %v", err)
 	}
-	if _, err := metaFile.Write(make([]byte, blockSize)); err != nil {
+	if _, err = metaFile.Write(make([]byte, blockSize)); err != nil {
 		t.Fatalf("failed to write metadata header: %v", err)
 	}
 	for i := 0; i < blockCount; i++ {
 		buf := make([]byte, 16)
 		binary.LittleEndian.PutUint64(buf[0:8], uint64(i))
 		binary.LittleEndian.PutUint64(buf[8:16], uint64(i+1))
-		if _, err := metaFile.Write(buf); err != nil {
+		if _, err = metaFile.Write(buf); err != nil {
 			t.Fatalf("failed to write metadata entry: %v", err)
 		}
 	}
-	if _, err := metaFile.Write(make([]byte, 16)); err != nil {
+	if _, err = metaFile.Write(make([]byte, 16)); err != nil {
 		t.Fatalf("failed to write metadata terminator: %v", err)
 	}
 	metaFile.Close()
@@ -64,7 +64,7 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int) (srcPath, sn
 	mapper := t.TempDir()
 	SetMapperDir(mapper)
 	linkPath := filepath.Join(mapper, "vg-lv-cow")
-	if err := os.Symlink(metaPath, linkPath); err != nil {
+	if err = os.Symlink(metaPath, linkPath); err != nil {
 		t.Fatalf("failed to create metadata symlink: %v", err)
 	}
 	t.Cleanup(func() {
@@ -76,7 +76,7 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int) (srcPath, sn
 
 	// prepare resume state file skipping first two blocks
 	resumePath = filepath.Join(dir, "resume")
-	if err := os.WriteFile(resumePath, []byte("2"), 0644); err != nil {
+	if err = os.WriteFile(resumePath, []byte("2"), 0644); err != nil {
 		t.Fatalf("failed to write resume state: %v", err)
 	}
 
@@ -96,7 +96,7 @@ func parseOffsets(t *testing.T, data []byte, blockSize int64) []int64 {
 	var offsets []int64
 	for {
 		header := make([]byte, 12)
-		if _, err := io.ReadFull(reader, header); err != nil {
+		if _, err = io.ReadFull(reader, header); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				break
 			}
@@ -104,7 +104,7 @@ func parseOffsets(t *testing.T, data []byte, blockSize int64) []int64 {
 		}
 		off := int64(binary.BigEndian.Uint64(header[0:8]))
 		size := int(binary.BigEndian.Uint32(header[8:12]))
-		if _, err := io.CopyN(io.Discard, reader, int64(size)); err != nil {
+		if _, err = io.CopyN(io.Discard, reader, int64(size)); err != nil {
 			t.Fatalf("failed to read block data: %v", err)
 		}
 		offsets = append(offsets, off)

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -267,7 +267,7 @@ func logSequentialSummary(bytes int64, skipped int, start time.Time) {
 }
 
 func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
-	if err := detectBlockSize(cfg, source); err != nil {
+	if err = detectBlockSize(cfg, source); err != nil {
 		return err
 	}
 	Logger.Info("Using block size", zap.Int("blockSize", cfg.BlockSize))
@@ -520,7 +520,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 		return DumpChangesSequential(cfg, snapshot, source, out)
 	}
 
-	if err := detectBlockSize(cfg, source); err != nil {
+	if err = detectBlockSize(cfg, source); err != nil {
 		return err
 	}
 
@@ -531,7 +531,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	}
 
 	totalDataSize := calculateTotalDataSize(ranges)
-	if err := writeParallelHandshake(cfg, out); err != nil {
+	if err = writeParallelHandshake(cfg, out); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- resolve govet shadow warnings by reusing outer variables or renaming locals
- clean up tests and transfer helpers to avoid error shadowing

## Testing
- `$(go env GOBIN)/shadow ./...`
- `golangci-lint run --disable errcheck --disable revive`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689663bf1eb48323802c8943c51941a8