### PR TITLE
refactor: handle unused parameters

### DIFF
--- a/grpc/auth/auth_test.go
+++ b/grpc/auth/auth_test.go
@@ -27,7 +27,8 @@ func TestAuthInterceptor(t *testing.T) {
 		return peer.NewContext(context.Background(), p)
 	}
 
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		// ctx and req are unused in this test handler.
 		return "ok", nil
 	}
 

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -151,7 +151,7 @@ func TestLockVolume(t *testing.T) {
 		msg   string
 	}{
 		{"success", &mockAgent{}, true, ""},
-		{"lock held", &mockAgent{lock: func(ctx context.Context, v, r string) error { return errors.New("already locked") }}, false, "already locked"},
+		{"lock held", &mockAgent{lock: func(_ context.Context, _, _ string) error { return errors.New("already locked") }}, false, "already locked"}, // parameters unused
 		{"no agent", nil, false, "agent not configured"},
 	}
 	for _, tt := range tests {
@@ -169,10 +169,12 @@ func TestGetVolumeMetadata(t *testing.T) {
 		agent   lvmagent.Agent
 		wantErr bool
 	}{
-		{"success", &mockAgent{getMeta: func(ctx context.Context, v string) (lvmagent.VolumeMetadata, error) {
+		{"success", &mockAgent{getMeta: func(_ context.Context, v string) (lvmagent.VolumeMetadata, error) {
+			// ctx is unused.
 			return lvmagent.VolumeMetadata{VolumeName: v, SizeBytes: 1, ChunkSize: 2}, nil
 		}}, false},
-		{"agent error", &mockAgent{getMeta: func(ctx context.Context, v string) (lvmagent.VolumeMetadata, error) {
+		{"agent error", &mockAgent{getMeta: func(_ context.Context, _ string) (lvmagent.VolumeMetadata, error) {
+			// parameters are unused in this mock.
 			return lvmagent.VolumeMetadata{}, errors.New("fail")
 		}}, true},
 		{"no agent", nil, true},
@@ -209,7 +211,7 @@ func TestSendVolumeMetadata(t *testing.T) {
 		msg   string
 	}{
 		{"success", &mockAgent{}, true, ""},
-		{"agent error", &mockAgent{sendMeta: func(ctx context.Context, md lvmagent.VolumeMetadata) error { return errors.New("checksum mismatch") }}, false, "checksum mismatch"},
+		{"agent error", &mockAgent{sendMeta: func(_ context.Context, _ lvmagent.VolumeMetadata) error { return errors.New("checksum mismatch") }}, false, "checksum mismatch"}, // parameters unused
 		{"no agent", nil, false, "agent not configured"},
 	}
 	for _, tt := range tests {
@@ -229,7 +231,7 @@ func TestStartTransferSession(t *testing.T) {
 		msg   string
 	}{
 		{"success", &mockAgent{}, true, ""},
-		{"agent error", &mockAgent{startSess: func(ctx context.Context, v, r string) error { return errors.New("session failed") }}, false, "session failed"},
+		{"agent error", &mockAgent{startSess: func(_ context.Context, _, _ string) error { return errors.New("session failed") }}, false, "session failed"}, // parameters unused
 		{"no agent", nil, false, "agent not configured"},
 	}
 	for _, tt := range tests {
@@ -248,9 +250,9 @@ func TestFinalizeSync(t *testing.T) {
 		ok    bool
 		msg   string
 	}{
-		{"success", &mockAgent{finalize: func(ctx context.Context, v, r string) error { return nil }, unlock: func(ctx context.Context, v, r string) error { return nil }}, true, ""},
-		{"finalize error", &mockAgent{finalize: func(ctx context.Context, v, r string) error { return errors.New("sync fail") }}, false, "sync fail"},
-		{"unlock error", &mockAgent{finalize: func(ctx context.Context, v, r string) error { return nil }, unlock: func(ctx context.Context, v, r string) error { return errors.New("unlock fail") }}, false, "unlock fail"},
+		{"success", &mockAgent{finalize: func(_ context.Context, _, _ string) error { return nil }, unlock: func(_ context.Context, _, _ string) error { return nil }}, true, ""},                                        // parameters unused
+		{"finalize error", &mockAgent{finalize: func(_ context.Context, _, _ string) error { return errors.New("sync fail") }}, false, "sync fail"},                                                                      // parameters unused
+		{"unlock error", &mockAgent{finalize: func(_ context.Context, _, _ string) error { return nil }, unlock: func(_ context.Context, _, _ string) error { return errors.New("unlock fail") }}, false, "unlock fail"}, // parameters unused
 		{"no agent", nil, false, "agent not configured"},
 	}
 	for _, tt := range tests {
@@ -269,8 +271,8 @@ func TestGetStatus(t *testing.T) {
 		ok    bool
 		msg   string
 	}{
-		{"success", &mockAgent{status: func(ctx context.Context, v, r string) (string, error) { return "ok", nil }}, true, "ok"},
-		{"agent error", &mockAgent{status: func(ctx context.Context, v, r string) (string, error) { return "", errors.New("bad") }}, false, "bad"},
+		{"success", &mockAgent{status: func(_ context.Context, _, _ string) (string, error) { return "ok", nil }}, true, "ok"},                   // parameters unused
+		{"agent error", &mockAgent{status: func(_ context.Context, _, _ string) (string, error) { return "", errors.New("bad") }}, false, "bad"}, // parameters unused
 		{"no agent", nil, false, "agent not configured"},
 	}
 	for _, tt := range tests {

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -76,7 +76,8 @@ func (s *sudoAgent) SendMetadata(_ context.Context, _ VolumeMetadata) error {
 	return nil
 }
 
-func (s *sudoAgent) StartTransferSession(_ context.Context, volume, requester string) error {
+func (s *sudoAgent) StartTransferSession(_ context.Context, _ string, _ string) error {
+	// volume and requester are ignored until LVM operations are implemented.
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
@@ -84,7 +85,8 @@ func (s *sudoAgent) StartTransferSession(_ context.Context, volume, requester st
 	return nil
 }
 
-func (s *sudoAgent) FinalizeSync(_ context.Context, volume, requester string) error {
+func (s *sudoAgent) FinalizeSync(_ context.Context, _ string, _ string) error {
+	// volume and requester are ignored until LVM operations are implemented.
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
@@ -92,7 +94,8 @@ func (s *sudoAgent) FinalizeSync(_ context.Context, volume, requester string) er
 	return nil
 }
 
-func (s *sudoAgent) GetStatus(_ context.Context, volume, requester string) (string, error) {
+func (s *sudoAgent) GetStatus(_ context.Context, _ string, _ string) (string, error) {
+	// volume and requester are ignored until LVM operations are implemented.
 	if err := s.ensureRoot(); err != nil {
 		return "", err
 	}

--- a/lvm/backend_cgo.go
+++ b/lvm/backend_cgo.go
@@ -43,7 +43,8 @@ func (b *cgoBackend) RemoveSnapshot(_ context.Context, snapshotPath string) erro
 	return nil
 }
 
-func (b *cgoBackend) GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
+func (b *cgoBackend) GetSnapshotUsage(_ context.Context, snapshotPath string) (float64, error) {
+	// ctx is ignored because the underlying cgo library lacks context support.
 	usage, err := b.lvm.SnapshotUsage(snapshotPath)
 	if err != nil {
 		return 0, fmt.Errorf("cgo snapshot usage: %w", err)
@@ -51,7 +52,8 @@ func (b *cgoBackend) GetSnapshotUsage(ctx context.Context, snapshotPath string) 
 	return usage, nil
 }
 
-func (b *cgoBackend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
+func (b *cgoBackend) GetVolumeGroupFreeSpace(_ context.Context, vgName string) (uint64, error) {
+	// ctx is ignored because the underlying cgo library lacks context support.
 	free, err := b.lvm.VGFree(vgName)
 	if err != nil {
 		return 0, fmt.Errorf("cgo vg free space: %w", err)
@@ -59,7 +61,8 @@ func (b *cgoBackend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string)
 	return free, nil
 }
 
-func (b *cgoBackend) ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error) {
+func (b *cgoBackend) ListVolumeGroups(_ context.Context, candidates []string) ([]VolumeGroup, error) {
+	// ctx is ignored because the underlying cgo library lacks context support.
 	vgs, err := b.lvm.ListVGs()
 	if err != nil {
 		return nil, fmt.Errorf("cgo list volume groups: %w", err)

--- a/lvm/backend_stub.go
+++ b/lvm/backend_stub.go
@@ -16,7 +16,8 @@ func newBackendWithCGO(lvm cgo.LVM) lvmBackend { return &cgoBackend{lvm: lvm} }
 
 func newLVMBackend() lvmBackend { return newBackendWithCGO(cgo.New()) }
 
-func (b *cgoBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
+func (b *cgoBackend) CreateSnapshot(_ context.Context, lvPath, snapshotName, size string) error {
+	// ctx is ignored because the stub backend does not support cancellation.
 	bytes, percent, err := sizeparse.Parse(size)
 	if err != nil {
 		return fmt.Errorf("parse size %q: %w", size, err)
@@ -36,14 +37,16 @@ func (b *cgoBackend) CreateSnapshot(ctx context.Context, lvPath, snapshotName, s
 	return nil
 }
 
-func (b *cgoBackend) RemoveSnapshot(ctx context.Context, snapshotPath string) error {
+func (b *cgoBackend) RemoveSnapshot(_ context.Context, snapshotPath string) error {
+	// ctx is ignored because the stub backend does not support cancellation.
 	if err := b.lvm.RemoveLV(snapshotPath); err != nil {
 		return fmt.Errorf("cgo remove snapshot: %w", err)
 	}
 	return nil
 }
 
-func (b *cgoBackend) GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
+func (b *cgoBackend) GetSnapshotUsage(_ context.Context, snapshotPath string) (float64, error) {
+	// ctx is ignored because the stub backend does not support cancellation.
 	usage, err := b.lvm.SnapshotUsage(snapshotPath)
 	if err != nil {
 		return 0, fmt.Errorf("cgo snapshot usage: %w", err)
@@ -51,7 +54,8 @@ func (b *cgoBackend) GetSnapshotUsage(ctx context.Context, snapshotPath string) 
 	return usage, nil
 }
 
-func (b *cgoBackend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
+func (b *cgoBackend) GetVolumeGroupFreeSpace(_ context.Context, vgName string) (uint64, error) {
+	// ctx is ignored because the stub backend does not support cancellation.
 	free, err := b.lvm.VGFree(vgName)
 	if err != nil {
 		return 0, fmt.Errorf("cgo vg free space: %w", err)
@@ -59,7 +63,8 @@ func (b *cgoBackend) GetVolumeGroupFreeSpace(ctx context.Context, vgName string)
 	return free, nil
 }
 
-func (b *cgoBackend) ListVolumeGroups(ctx context.Context, candidates []string) ([]VolumeGroup, error) {
+func (b *cgoBackend) ListVolumeGroups(_ context.Context, candidates []string) ([]VolumeGroup, error) {
+	// ctx is ignored because the stub backend does not support cancellation.
 	vgs, err := b.lvm.ListVGs()
 	if err != nil {
 		return nil, fmt.Errorf("cgo list volume groups: %w", err)

--- a/main_remote_script_test.go
+++ b/main_remote_script_test.go
@@ -13,7 +13,7 @@ import (
 
 // Test that remote post script executes even when dumpChanges fails
 func TestRemotePostScriptRunsOnError(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
+	server := remotetest.NewMockSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	defer server.Close()
 
 	host, portStr, err := net.SplitHostPort(server.Addr)

--- a/remote/logger_test.go
+++ b/remote/logger_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRunRemoteScriptNoLogger(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
+	server := remotetest.NewMockSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	defer server.Close()
 	knownHosts := remotetest.CreateKnownHostsFile(t, server)
 	hostKeyCallback, hostKeyErr := knownhosts.New(knownHosts)
@@ -32,7 +32,7 @@ func TestRunRemoteScriptNoLogger(t *testing.T) {
 }
 
 func TestSendKeepAliveNoLogger(t *testing.T) {
-	server := remotetest.NewMockSSHServer(t, func(cmd string) int { return 0 })
+	server := remotetest.NewMockSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	defer server.Close()
 	knownHosts := remotetest.CreateKnownHostsFile(t, server)
 	hostKeyCallback, hostKeyErr := knownhosts.New(knownHosts)

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -28,7 +28,7 @@ func TestValidateRemoteCommand(t *testing.T) {
 }
 
 func TestRunRemoteScript(t *testing.T) {
-	server, client := newSSHServerClient(t, func(cmd string) int { return 0 })
+	server, client := newSSHServerClient(t, func(_ string) int { return 0 }) // cmd is unused
 
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(core)

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSendKeepAlive(t *testing.T) {
-	server, client := newSSHServerClient(t, func(cmd string) int { return 0 })
+	server, client := newSSHServerClient(t, func(_ string) int { return 0 }) // cmd is unused
 
 	if err := sendKeepAlive(client, "host"); err != nil {
 		t.Fatalf("sendKeepAlive error: %v", err)
@@ -21,7 +21,7 @@ func TestSendKeepAlive(t *testing.T) {
 }
 
 func TestStartKeepAlive(t *testing.T) {
-	server, client := newSSHServerClient(t, func(cmd string) int { return 0 })
+	server, client := newSSHServerClient(t, func(_ string) int { return 0 }) // cmd is unused
 
 	done := make(chan struct{})
 	go func() {
@@ -46,7 +46,7 @@ func TestStartKeepAlive(t *testing.T) {
 }
 
 func TestNewSSHClient(t *testing.T) {
-	server, host, port, knownHosts := newSSHServer(t, func(cmd string) int { return 0 })
+	server, host, port, knownHosts := newSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	keyPath := remotetest.CreateTempKey(t)
 	client, err := NewSSHClient(host, "test", keyPath, port, knownHosts, true, time.Second, 10*time.Millisecond, 0)
 	if err != nil {
@@ -63,7 +63,7 @@ func TestNewSSHClient(t *testing.T) {
 }
 
 func TestSSHManager(t *testing.T) {
-	server, host, port, knownHosts := newSSHServer(t, func(cmd string) int { return 0 })
+	server, host, port, knownHosts := newSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	keyPath := remotetest.CreateTempKey(t)
 	mgr, err := NewSSHManager("test", keyPath, time.Second, knownHosts)
 	if err != nil {

--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -16,11 +16,13 @@ type CompressionStrategy interface {
 
 type noneStrategy struct{}
 
-func (noneStrategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
+func (noneStrategy) NewWriter(dst io.Writer, _ int, _ int) (io.WriteCloser, error) {
+	// level and concurrency are ignored for the none strategy.
 	return nopWriteCloser{dst}, nil
 }
 
-func (noneStrategy) NewReader(src io.Reader, concurrency int) (io.ReadCloser, error) {
+func (noneStrategy) NewReader(src io.Reader, _ int) (io.ReadCloser, error) {
+	// concurrency is ignored for the none strategy.
 	return io.NopCloser(src), nil
 }
 

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -321,7 +321,8 @@ func (r *RollingHashDedup) loadState() error {
 	return nil
 }
 
-func (b *BloomFilterDedup) ShouldTransfer(offset int64, data []byte) bool {
+func (b *BloomFilterDedup) ShouldTransfer(_ int64, data []byte) bool {
+	// offset is ignored because the Bloom filter only tracks data hashes.
 	sum := b.strategy.Compute(data)
 	b.mu.RLock()
 	ok := !b.filter.Test(sum)
@@ -329,7 +330,8 @@ func (b *BloomFilterDedup) ShouldTransfer(offset int64, data []byte) bool {
 	return ok
 }
 
-func (b *BloomFilterDedup) RecordTransfer(offset int64, data []byte) {
+func (b *BloomFilterDedup) RecordTransfer(_ int64, data []byte) {
+	// offset is ignored because the Bloom filter only tracks data hashes.
 	b.mu.Lock()
 	b.filter.Add(b.strategy.Compute(data))
 	b.mu.Unlock()


### PR DESCRIPTION
## Summary
- mark intentionally unused parameters across the codebase
- document ignored context values in LVM backends
- clarify unused command arguments in remote tests

## Testing
- `golangci-lint run --enable revive`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689667f34acc83239c14c2e91d619436