### PR TITLE
chore: update goreleaser v2 config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,10 +23,9 @@ builds:
 
 archives:
   - id: default
-    ids:
+    builds:
       - default
-    formats:
-      - tar.gz
+    format: tar.gz
     name_template: >-
       {{ .ProjectName }}_{{ .Env.GORELEASER_CURRENT_TAG
       }}_{{ .Os }}_{{ .Arch }}


### PR DESCRIPTION
## Summary
- align goreleaser config with v2 syntax

## Testing
- `goreleaser check` *(fails: configuration is invalid: no remote configured to list refs from)*

------
https://chatgpt.com/codex/tasks/task_e_68966a68ff048323b1a11c16cce34141