### PR TITLE
chore: add commitlint config and contributing guide

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - '@commitlint/config-conventional'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thanks for your interest in contributing to lvmsync_go!
+
+## Commit Message Policy
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+Commit messages should be structured as:
+
+```
+type(scope): subject
+```
+
+Use a short, imperative subject line and include a scope when helpful. Examples:
+
+```
+feat(lvm): add volume snapshot support
+chore(ci): update lint configuration
+```
+


### PR DESCRIPTION
## Summary
- add commitlint config using conventional commits
- document commit message policy in CONTRIBUTING

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689672bb21788323860a363a24db9abf