### PR TITLE
chore: tidy yaml brackets

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,11 +9,11 @@
 
 name: Go
 
-on:
+'on':
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 # Explicitly define minimal top-level permissions
 permissions:


### PR DESCRIPTION
## Summary
- remove extra bracket spacing in Go workflow
- ensure workflow key `on` is quoted for YAML

## Testing
- `yamllint .github/workflows/go.yml config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68967456a040832397d3209e10cd8595