### PR TITLE
chore: set up workspace linting for multi-module repo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -101,6 +101,17 @@ jobs:
             exit 1
           fi
 
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+            sh -s -- -b $(go env GOPATH)/bin
+
+      - name: Run golangci-lint
+        run: |
+          for dir in . internal/multierr; do
+            (cd "$dir" && golangci-lint run ./...)
+          done
+
       - name: Build project
         run: go build -v ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Go workspace file
-go.work
 
 ### macOS ###
 # General

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ version: "2"
 run:
   timeout: 3m
   tests: true
+  workdir: .
 
 issues:
   max-issues-per-linter: 0

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.24.5
+
+use (
+    .
+    ./internal/multierr
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,1 @@
+google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 h1:ToEetK57OidYuqD4Q5w+vfEnPvPpuTwedCNVohYJfNk=


### PR DESCRIPTION
## Summary
- add go.work to manage root and internal/multierr modules
- enable golangci-lint to work from repository root
- run golangci-lint for each module in CI

## Testing
- `golangci-lint run ./...` (fails: errcheck & revive issues remain)
- `(cd internal/multierr && golangci-lint run ./...)`
- `go test ./...`
- `(cd internal/multierr && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_689679cdda848323bc64be5ddf1b1687