### PR TITLE
chore: simplify lvm backend var

### DIFF
--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -46,7 +46,7 @@ func SetPrivilegeChecker(fn func() error) func() {
 }
 
 // backend is used to execute LVM operations. It can be overridden for tests.
-var backend lvmBackend = newLVMBackend()
+var backend = newLVMBackend()
 
 // SetBackend overrides the LVM backend. It returns a restore function to reset the original behavior.
 func SetBackend(b lvmBackend) func() {


### PR DESCRIPTION
## Summary
- simplify LVM backend variable declaration to satisfy revive var-declaration lint

## Testing
- `go test ./...`
- `revive ./... 2>&1 | grep 'should omit type'`

------
https://chatgpt.com/codex/tasks/task_e_6896837ac0008323b657df508048f544