### PR TITLE
Use uint64 for transfer ranges and add max-offset tests

### DIFF
--- a/transfer/differences_test.go
+++ b/transfer/differences_test.go
@@ -42,10 +42,10 @@ func TestGetDifferences(t *testing.T) {
 		t.Fatalf("expected 2 ranges, got %d", len(ranges))
 	}
 
-	if ranges[0].Start != 2*chunkSize || ranges[0].End != (2+1)*chunkSize-1 {
+	if ranges[0].Start != uint64(2)*uint64(chunkSize) || ranges[0].End != (uint64(2)+1)*uint64(chunkSize)-1 {
 		t.Fatalf("unexpected first range: %+v", ranges[0])
 	}
-	if ranges[1].Start != 4*chunkSize || ranges[1].End != (4+1)*chunkSize-1 {
+	if ranges[1].Start != uint64(4)*uint64(chunkSize) || ranges[1].End != (uint64(4)+1)*uint64(chunkSize)-1 {
 		t.Fatalf("unexpected second range: %+v", ranges[1])
 	}
 }
@@ -61,7 +61,7 @@ func TestGetDifferencesOverflow(t *testing.T) {
 	}
 
 	buf := make([]byte, 16)
-	origin := uint64(math.MaxInt64)/uint64(chunkSize) + 1
+	origin := math.MaxUint64/uint64(chunkSize) + 1
 	binary.LittleEndian.PutUint64(buf[0:8], origin)
 	binary.LittleEndian.PutUint64(buf[8:16], 1)
 	if _, err := tmpFile.Write(buf); err != nil {

--- a/transfer/metadata.go
+++ b/transfer/metadata.go
@@ -99,19 +99,18 @@ func GetDifferences(metadataPath string, chunkSize int64) (ranges []Range, err e
 		}
 
 		chunkSizeU := uint64(chunkSize)
-		maxInt := uint64(math.MaxInt64)
 
-		if originOffset > maxInt/chunkSizeU {
-			return nil, fmt.Errorf("range start overflows int64")
-		}
-		if originOffset >= (maxInt+1)/chunkSizeU {
-			return nil, fmt.Errorf("range end overflows int64")
+		if originOffset > math.MaxUint64/chunkSizeU {
+			return nil, fmt.Errorf("range start overflows uint64")
 		}
 
 		start := originOffset * chunkSizeU
-		end := (originOffset+1)*chunkSizeU - 1
+		end := start + chunkSizeU - 1
+		if end < start {
+			return nil, fmt.Errorf("range end overflows uint64")
+		}
 
-		ranges = append(ranges, Range{Start: int64(start), End: int64(end)})
+		ranges = append(ranges, Range{Start: start, End: end})
 	}
 
 	return ranges, nil

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -142,9 +142,9 @@ func composeHandshake(cfg *config.Config, mode string) common.Handshake {
 	return hs
 }
 
-func validateOffsetAndSize(offset int64, size int) error {
-	if offset < 0 {
-		return fmt.Errorf("invalid offset %d: must be non-negative", offset)
+func validateOffsetAndSize(offset uint64, size int) error {
+	if offset > math.MaxInt64 {
+		return fmt.Errorf("offset %d overflows int64", offset)
 	}
 	if size < 0 || size > int(math.MaxUint32) {
 		return fmt.Errorf("invalid block size %d: must be between 0 and %d", size, uint32(math.MaxUint32))
@@ -160,20 +160,20 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		if err := validateOffsetAndSize(r.Start, cfg.BlockSize); err != nil {
 			return totalBytes, skippedBlocks, err
 		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, r.Start, cfg.ZeroCopy, pipeFds)
+		data, err := ReadBlockWithRetries(cfg, srcFile, int64(r.Start), cfg.ZeroCopy, pipeFds)
 		if err != nil {
 			return totalBytes, skippedBlocks, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
 		}
 		if dedup != nil {
-			if !dedup.ShouldTransfer(r.Start, data) {
+			if !dedup.ShouldTransfer(int64(r.Start), data) {
 				skippedBlocks++
 				putBlockBuffer(data)
 				continue
 			}
-			dedup.RecordTransfer(r.Start, data)
+			dedup.RecordTransfer(int64(r.Start), data)
 		}
 
-		binary.BigEndian.PutUint64(header[0:8], uint64(r.Start))
+		binary.BigEndian.PutUint64(header[0:8], r.Start)
 		binary.BigEndian.PutUint32(header[8:12], uint32(cfg.BlockSize))
 		if _, err := bufOut.Write(header[:]); err != nil {
 			putBlockBuffer(data)
@@ -440,10 +440,10 @@ func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, result
 			results <- &BlockResult{Index: task.Index, Err: err}
 			continue
 		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, task.R.Start, false, [2]int{-1, -1})
+		data, err := ReadBlockWithRetries(cfg, srcFile, int64(task.R.Start), false, [2]int{-1, -1})
 		results <- &BlockResult{
 			Index:  task.Index,
-			Offset: uint64(task.R.Start),
+			Offset: task.R.Start,
 			Size:   uint32(cfg.BlockSize),
 			Data:   data,
 			Err:    err,
@@ -454,11 +454,17 @@ func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, result
 // DumpChangesParallel transfers changed blocks using multiple goroutines and updates resume state as blocks complete.
 
 func calculateTotalDataSize(ranges []Range) int64 {
-	var total int64
+	var total uint64
 	for _, r := range ranges {
-		total += (r.End - r.Start + 1)
+		if r.End < r.Start {
+			continue
+		}
+		total += r.End - r.Start + 1
 	}
-	return total
+	if total > uint64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	return int64(total)
 }
 
 func writeParallelHandshake(cfg *config.Config, out io.Writer) error {

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -14,13 +14,13 @@ import (
 	"lvmsync_go/config"
 )
 
-func TestIterateBlocksOversizedOffset(t *testing.T) {
+func TestIterateBlocksOffsetOverflow(t *testing.T) {
 	src := newTempFile(t, "src")
 	defer src.Close()
 
 	cfg := &config.Config{BlockSize: 4096}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, err := iterateBlocks(cfg, []Range{{Start: -1, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
+	_, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1})
 	if err == nil || !strings.Contains(err.Error(), "offset") {
 		t.Fatalf("expected offset error, got %v", err)
 	}
@@ -69,7 +69,7 @@ func TestReadBlockHeaderOffsetBoundary(t *testing.T) {
 
 func TestReadBlockHeaderOffsetOverflow(t *testing.T) {
 	header := make([]byte, 12)
-	offset := uint64(math.MaxInt64) + 1
+	offset := uint64(math.MaxUint64)
 	binary.BigEndian.PutUint64(header[0:8], offset)
 	binary.BigEndian.PutUint32(header[8:12], 1)
 	reader := bufio.NewReader(bytes.NewReader(header))
@@ -81,7 +81,7 @@ func TestReadBlockHeaderOffsetOverflow(t *testing.T) {
 func TestWriteDataOffsetOverflow(t *testing.T) {
 	dest := newTempFile(t, "dest")
 	defer dest.Close()
-	err := writeData(dest, uint64(math.MaxInt64)+1, []byte("data"))
+	err := writeData(dest, math.MaxUint64, []byte("data"))
 	if err == nil || !strings.Contains(err.Error(), "overflows int64") {
 		t.Fatalf("expected overflow error, got %v", err)
 	}

--- a/transfer/types.go
+++ b/transfer/types.go
@@ -2,8 +2,8 @@
 package transfer
 
 type Range struct {
-	Start int64
-	End   int64
+	Start uint64
+	End   uint64
 }
 
 type BlockTask struct {


### PR DESCRIPTION
## Summary
- switch Range start/end to uint64 and update callers
- compute metadata ranges with uint64 arithmetic and bounds checks
- add tests for offset overflow around math.MaxUint64

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896920497248323bacec63cc59d4aa2