### PR TITLE
internal/blocksize: call unix Major/Minor directly

### DIFF
--- a/internal/blocksize/blocksize.go
+++ b/internal/blocksize/blocksize.go
@@ -28,7 +28,7 @@ func Detect(devicePath string) (int, error) {
 	if !ok {
 		return 0, fmt.Errorf("unsupported file info for %s", devicePath)
 	}
-	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(uint64(stat.Rdev)), unix.Minor(uint64(stat.Rdev))))
+	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(stat.Rdev), unix.Minor(stat.Rdev)))
 	return readPreferredSize(queuePath)
 }
 


### PR DESCRIPTION
## Summary
- simplify queue path detection by calling `unix.Major` and `unix.Minor` directly

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896a1f68abc8323ae382a0a9ed4e272