### PR TITLE
refactor: drop unused params in tests and transfer logic

### DIFF
--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -15,7 +15,7 @@ type vgBackend struct {
 func (f *vgBackend) CreateSnapshot(context.Context, string, string, string) error { return nil }
 func (f *vgBackend) RemoveSnapshot(context.Context, string) error                 { return nil }
 func (f *vgBackend) GetSnapshotUsage(context.Context, string) (float64, error)    { return 0, nil }
-func (f *vgBackend) GetVolumeGroupFreeSpace(ctx context.Context, name string) (uint64, error) {
+func (f *vgBackend) GetVolumeGroupFreeSpace(_ context.Context, name string) (uint64, error) {
 	for _, vg := range f.vgs {
 		if vg.Name == name {
 			return vg.Free, nil

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -636,7 +636,7 @@ func processBlock(destFile *os.File, dedup DeduplicationStrategy, verify bool, c
 	return true, nil
 }
 
-func applyBlocks(cfg *config.Config, reader *bufio.Reader, destFile *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy) (int64, error) {
+func applyBlocks(reader *bufio.Reader, destFile *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy) (int64, error) {
 	var totalBytes int64
 	headerLen := 12
 	if verify {
@@ -700,7 +700,7 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	var totalBytes int64
-	totalBytes, err = applyBlocks(cfg, reader, destFile, dedup, verify, checksum)
+	totalBytes, err = applyBlocks(reader, destFile, dedup, verify, checksum)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- clarify unused parameters by renaming to `_`
- remove unused config parameter from `applyBlocks`

## Testing
- `go test ./...`
- `staticcheck ./...` *(fails: module requires at least go1.24.5, but Staticcheck was built with go1.24.3)*

------
https://chatgpt.com/codex/tasks/task_e_6896a48f96388323b3ffdf93332f4200