### PR TITLE
Quote GOPATH in workflow and wrap install command

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,8 +103,9 @@ jobs:
 
       - name: Install golangci-lint
         'run': |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b $(go env GOPATH)/bin
+          curl -sSfL https://raw.githubusercontent.com/golangci/\
+            golangci-lint/master/install.sh | \
+            sh -s -- -b "$(go env GOPATH)/bin"
 
       - name: Run golangci-lint
         'run': |


### PR DESCRIPTION
## Summary
- quote GOPATH when installing golangci-lint in workflow
- wrap golangci-lint install command to stay under 80 characters

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint`


------
https://chatgpt.com/codex/tasks/task_e_6896a9149ca88323a76ccd75455c89e8