### PR TITLE
chore: fix YAML lint warnings

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,2 +1,3 @@
+---
 extends:
   - '@commitlint/config-conventional'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,9 +103,10 @@ jobs:
 
       - name: Install golangci-lint
         'run': |
-          curl -sSfL https://raw.githubusercontent.com/golangci/\
-            golangci-lint/master/install.sh | \
-            sh -s -- -b "$(go env GOPATH)/bin"
+          curl -sSfL \
+            https://raw.githubusercontent.com/ \
+            golangci/golangci-lint/master/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin"
 
       - name: Run golangci-lint
         'run': |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.57.1


### PR DESCRIPTION
## Summary
- add YAML document start markers
- wrap long curl command to appease yamllint

## Testing
- `yamllint .commitlintrc.yml .pre-commit-config.yaml .github/workflows/go.yml`


------
https://chatgpt.com/codex/tasks/task_e_689720d40d8c83239c656b5d6e0d2389