### PR TITLE
chore: run golangci-lint across modules

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,6 +26,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DEFAULT_BRANCH: main
       VALIDATE_ALL_CODEBASE: true
+      VALIDATE_GO: false
+      VALIDATE_GO_MODULES: false
 
       GO_LINTER: golangci-lint
       GO_LINT_FLAGS: ./...
@@ -90,11 +92,16 @@ jobs:
             rm -rf lvm2
           fi
 
+      - name: Run golangci-lint across modules
+        run: scripts/run_golangci_lint.sh
+
       - name: Run Super-Linter with Auto-Fix
         uses: super-linter/super-linter@v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: true
+          VALIDATE_GO: false
+          VALIDATE_GO_MODULES: false
           FIX_GO_GOFMT: true
           FIX_GO_IMPORTS: true
           FIX_YAML_PRETTIER: true

--- a/scripts/run_golangci_lint.sh
+++ b/scripts/run_golangci_lint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root (one level up from this script's directory)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+cd "${REPO_ROOT}"
+
+# Extract module paths from go.work
+modules=$(awk '/^use \(/, /^\)/ {if ($1 != "use" && $1 != ")") print $1}' go.work)
+
+for module in $modules; do
+  echo "Running golangci-lint in ${module}"
+  (cd "${module}" && golangci-lint run ./...)
+done

--- a/scripts/tests/run_golangci_lint_test.bats
+++ b/scripts/tests/run_golangci_lint_test.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/../.."
+}
+
+@test "run_golangci_lint succeeds on clean code" {
+  run scripts/run_golangci_lint.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "run_golangci_lint fails on invalid code in root module" {
+  cat <<'EOGO' > bad.go
+package main
+func bad(){ fmt.Println("oops") }
+EOGO
+  run scripts/run_golangci_lint.sh
+  [ "$status" -ne 0 ]
+  rm bad.go
+}
+
+@test "run_golangci_lint fails on invalid code in internal module" {
+  cat <<'EOGO' > internal/multierr/bad.go
+package multierr
+func bad(){ fmt.Println("oops") }
+EOGO
+  run scripts/run_golangci_lint.sh
+  [ "$status" -ne 0 ]
+  rm internal/multierr/bad.go
+}


### PR DESCRIPTION
## Summary
- add `scripts/run_golangci_lint.sh` to lint each module from `go.work`
- cover lint script with bats tests
- run lint script in CI before Super-Linter and disable built-in Go linters

## Testing
- `./scripts/run_golangci_lint.sh`
- `bats scripts/tests/run_golangci_lint_test.bats`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68972ad3affc8323a3f2817570facf5f