### PR TITLE
Ensure yamllint passes on config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,7 @@ snapshot_size: "20%"
 volume_group: ""
 # Volume group name of the target LVM volume
 target_volume_group: ""
-target_vgs: []  # Candidate target VGs for auto-selection
+target_vgs: [ ]  # Candidate target VGs for auto-selection
 # Command used to re-execute the program with elevated privileges
 # when required
 lvm_escalation: "sudo -n"

--- a/config/config_yaml_test.go
+++ b/config/config_yaml_test.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigYAMLLint(t *testing.T) {
+	cfg := "{extends: default, rules: {brackets: {min-spaces-inside-empty: 1, max-spaces-inside-empty: 1}}}"
+	cmd := exec.Command("yamllint", "-d", cfg, "../config.yaml")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("yamllint reported issues: %v\nOutput: %s", err, output)
+	} else if len(output) > 0 {
+		t.Fatalf("yamllint produced warnings:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- style config.yaml target_vgs array with spaced brackets
- add yamllint-based test verifying config.yaml has no lint warnings

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689736c705608323b4140a007643ba7d