### PR TITLE
feat: add golangci runner

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -101,7 +101,7 @@ jobs:
           fi
 
       - name: Run golangci-lint across modules
-        run: scripts/run_golangci_lint.sh
+        run: go run cmd/golangci_runner/main.go lint
 
       - name: Run Super-Linter with Auto-Fix
         uses: super-linter/super-linter@v8.0.0

--- a/cmd/golangci_runner/main.go
+++ b/cmd/golangci_runner/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var installLinter = func() error {
+	cmd := exec.Command("go", "install", "github.com/golangci/golangci-lint/cmd/golangci-lint@latest")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func ensureLinter() (string, error) {
+	if path, err := exec.LookPath("golangci-lint"); err == nil {
+		return path, nil
+	}
+	if err := installLinter(); err != nil {
+		return "", err
+	}
+	return exec.LookPath("golangci-lint")
+}
+
+func modulesFromGoWork() ([]string, error) {
+	f, err := os.Open("go.work")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var modules []string
+	inUse := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "use (") {
+			inUse = true
+			continue
+		}
+		if inUse {
+			if line == ")" {
+				break
+			}
+			if line != "" {
+				fields := strings.Fields(line)
+				if len(fields) > 0 {
+					modules = append(modules, fields[0])
+				}
+			}
+		}
+	}
+	return modules, scanner.Err()
+}
+
+func runLint() error {
+	if _, err := ensureLinter(); err != nil {
+		return err
+	}
+	modules, err := modulesFromGoWork()
+	if err != nil {
+		return err
+	}
+	for _, m := range modules {
+		cmd := exec.Command("golangci-lint", "run", "./...")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Dir = m
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: golangci_runner lint")
+		os.Exit(1)
+	}
+	switch os.Args[1] {
+	case "lint":
+		if err := runLint(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %s\n", os.Args[1])
+		os.Exit(1)
+	}
+}

--- a/cmd/golangci_runner/main_test.go
+++ b/cmd/golangci_runner/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureLinterFound(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	path := filepath.Join(binDir, "golangci-lint")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake linter: %v", err)
+	}
+	called := false
+	oldInstall := installLinter
+	t.Cleanup(func() { installLinter = oldInstall })
+	installLinter = func() error {
+		called = true
+		return nil
+	}
+
+	p, err := ensureLinter()
+	if err != nil {
+		t.Fatalf("ensureLinter: %v", err)
+	}
+	if called {
+		t.Fatalf("installLinter should not be called")
+	}
+	if p != path {
+		t.Fatalf("expected %s, got %s", path, p)
+	}
+}
+
+func TestEnsureLinterInstalls(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+
+	installCalled := false
+	oldInstall := installLinter
+	t.Cleanup(func() { installLinter = oldInstall })
+	installLinter = func() error {
+		installCalled = true
+		path := filepath.Join(binDir, "golangci-lint")
+		return os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755)
+	}
+
+	p, err := ensureLinter()
+	if err != nil {
+		t.Fatalf("ensureLinter: %v", err)
+	}
+	if !installCalled {
+		t.Fatalf("installLinter was not called")
+	}
+	expected := filepath.Join(binDir, "golangci-lint")
+	if p != expected {
+		t.Fatalf("expected %s, got %s", expected, p)
+	}
+}


### PR DESCRIPTION
## Summary
- add golangci_runner command that installs golangci-lint if missing and runs it across go.work modules
- switch workflow to invoke go-based linter runner
- test ensureLinter behaviour for existing and missing binaries

## Testing
- `go test ./cmd/golangci_runner -count=1`
- `go test ./... -count=1` *(fails: executable file not found in $PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68974c8dc8008323bdf8f6c0a3f974ae