### PR TITLE
Add block size detection tests and handle device major/minor

### DIFF
--- a/internal/blocksize/blocksize.go
+++ b/internal/blocksize/blocksize.go
@@ -26,9 +26,12 @@ func Detect(devicePath string) (int, error) {
 	}
 	stat, ok := fi.Sys().(*unix.Stat_t)
 	if !ok {
-		return 0, fmt.Errorf("unsupported file info for %s", devicePath)
+		stat = &unix.Stat_t{}
+		if err := unix.Stat(devicePath, stat); err != nil {
+			return 0, fmt.Errorf("stat %s: %w", devicePath, err)
+		}
 	}
-	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(stat.Rdev), unix.Minor(stat.Rdev)))
+	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(uint64(stat.Rdev)), unix.Minor(uint64(stat.Rdev))))
 	return readPreferredSize(queuePath)
 }
 

--- a/internal/blocksize/blocksize_test.go
+++ b/internal/blocksize/blocksize_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestReadPreferredSize(t *testing.T) {
@@ -35,5 +37,47 @@ func TestReadPreferredSizeOrder(t *testing.T) {
 	}
 	if size != 32768 {
 		t.Fatalf("expected 32768, got %d", size)
+	}
+}
+
+func TestReadPreferredSizeFallback(t *testing.T) {
+	dir := t.TempDir()
+	size, err := readPreferredSize(dir)
+	if err != nil {
+		t.Fatalf("readPreferredSize error: %v", err)
+	}
+	if size != 4096 {
+		t.Fatalf("expected 4096, got %d", size)
+	}
+}
+
+func TestDetect(t *testing.T) {
+	dir := t.TempDir()
+	devPath := filepath.Join(dir, "ram0")
+	dev := unix.Mkdev(1, 0)
+	if err := unix.Mknod(devPath, unix.S_IFBLK|0600, int(dev)); err != nil {
+		t.Skipf("mknod: %v", err)
+	}
+	size, err := Detect(devPath)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if size != 4096 {
+		t.Fatalf("expected 4096, got %d", size)
+	}
+}
+
+func TestDetectFallback(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file")
+	if err := os.WriteFile(file, nil, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	size, err := Detect(file)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if size != 4096 {
+		t.Fatalf("expected 4096, got %d", size)
 	}
 }


### PR DESCRIPTION
## Summary
- Cast device `Rdev` to `uint64` when deriving major/minor numbers
- Expand block size detection tests, covering preference order and fallback behavior

## Testing
- `go test ./internal/blocksize -v`
- `go test ./...` *(fails: goreleaser check: configuration is invalid: no remote configured)*

------
https://chatgpt.com/codex/tasks/task_e_689756883b188323996a9d886c1ca844