### PR TITLE
docs: expand repository guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,23 +5,78 @@ This project maintains a set of conventions to keep contributions consistent and
 ## Logging
 - Use [zap](https://github.com/uber-go/zap) for structured logging.
 - Always call `Sync()` (e.g., `defer logger.Sync()`) before program exit to flush buffers.
+### Field Naming
+- Use `snake_case` for all field keys.
+- Include the unit in the name when relevant:
+  - `resource_id` for identifiers
+  - `duration_ms` for durations in milliseconds
+  - `size_bytes` for sizes
+### Log Levels
+- `Debug` for verbose details useful during development.
+- `Info` for lifecycle events and high-level progress.
+- `Warn` for unexpected situations that do not stop execution.
+- `Error` for failures that require user action.
+- Avoid `Fatal` in libraries; return an error instead.
+### Example
+```go
+logger.Info("snapshot complete",
+    zap.String("resource_id", snapshotID),
+    zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+)
+```
 
 ## CLI Patterns
 - Prefer [`pflag`](https://github.com/spf13/pflag) for flag parsing.
 - Bind flags to [`viper`](https://github.com/spf13/viper) to support configuration from flags, config files, and environment variables.
 - Group related options into `FlagSet`s to share common configuration across commands.
 - Expose configuration via both config files and environment variables for easy automation.
+### Flag Grouping Example
+```go
+func initConfig() *viper.Viper {
+    v := viper.New()
+    syncFlags := pflag.NewFlagSet("sync", pflag.ExitOnError)
+    syncFlags.String("source", "", "snapshot device")
+    syncFlags.String("dest", "", "destination path")
+    pflag.CommandLine.AddFlagSet(syncFlags)
+
+    v.BindPFlags(syncFlags)
+    v.SetConfigName("config")
+    v.AddConfigPath(".")
+    v.SetEnvPrefix("LVMSYNC")
+    v.AutomaticEnv()
+    return v
+}
+```
+Sample `config.yaml`:
+```yaml
+source: /dev/vg0/snap0
+dest: /mnt/backup
+```
+Environment override:
+```sh
+LVMSYNC_SOURCE=/dev/vg0/snap1
+```
 
 ## Testing and Linting
 - Every function should have accompanying unit tests.
 - Ensure [`golangci-lint`](https://golangci-lint.run/) v2 passes before submitting changes.
+### Coverage
+- Run `go test -cover ./...` to generate coverage statistics.
+- For a file `coverage.out`, view details with `go tool cover -func=coverage.out`.
+- Enforce a minimum threshold by failing the build when the total coverage is below the desired percentage.
+
+## Release Workflow
+- Tags follow `vX.Y.Z` semantic versioning.
+- Pushing a tag triggers `.github/workflows/release.yml` which builds and publishes artifacts.
+- Each release must include a `CHANGELOG.md` entry using the [Keep a Changelog](https://keepachangelog.com/) format:
+  ```
+  ## [vX.Y.Z] - YYYY-MM-DD
+  ### Added
+  - ...
+  ### Fixed
+  - ...
+  ```
 
 ## Contribution and Commit Messages
 - Follow the guidelines in `CONTRIBUTING.md`.
 - Commit messages must follow the Conventional Commits format: `type(scope): description`.
-
-## TODO
-- TODO: Document structured logging field conventions.
-- TODO: Provide detailed examples for complex flag grouping.
-- TODO: Expand guidance on measuring test coverage.
-- TODO: Clarify release tagging workflow.


### PR DESCRIPTION
## Summary
- document structured logging field names and zap examples
- show pflag/viper flag grouping with config and env overrides
- add coverage and release tagging guidance

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: can't load config: swaggo is not a formatter)*

------
https://chatgpt.com/codex/tasks/task_e_689764b6a1a08323bc7c53cfd72da588