### PR TITLE
style: group imports in remote helpers test

### DIFF
--- a/main_remote_helpers_test.go
+++ b/main_remote_helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
+
 	"lvmsync_go/config"
 	"lvmsync_go/remote"
 )


### PR DESCRIPTION
## Summary
- organize imports in main_remote_helpers_test.go per Go conventions

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: can't load config: swaggo is not a formatter)*

------
https://chatgpt.com/codex/tasks/task_e_68976be32b4083238e64db2884e82cf6