### PR TITLE
fix(blocksize): remove redundant conversions

### DIFF
--- a/internal/blocksize/blocksize.go
+++ b/internal/blocksize/blocksize.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var sysDevBlock = "/sys/dev/block"
+
 // Detect determines an optimal block size for the given block device.
 // It inspects sysfs queue attributes in the following order of preference:
 //  1. optimal_io_size
@@ -31,7 +33,7 @@ func Detect(devicePath string) (int, error) {
 			return 0, fmt.Errorf("stat %s: %w", devicePath, err)
 		}
 	}
-	queuePath := filepath.Join("/sys/dev/block", fmt.Sprintf("%d:%d/queue", unix.Major(uint64(stat.Rdev)), unix.Minor(uint64(stat.Rdev))))
+	queuePath := filepath.Join(sysDevBlock, fmt.Sprintf("%d:%d/queue", unix.Major(stat.Rdev), unix.Minor(stat.Rdev)))
 	return readPreferredSize(queuePath)
 }
 

--- a/internal/blocksize/blocksize_test.go
+++ b/internal/blocksize/blocksize_test.go
@@ -81,3 +81,36 @@ func TestDetectFallback(t *testing.T) {
 		t.Fatalf("expected 4096, got %d", size)
 	}
 }
+
+func TestDetectQueuePath(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	devDir := t.TempDir()
+	devPath := filepath.Join(devDir, "ram0")
+	dev := unix.Mkdev(1, 0)
+	if err := unix.Mknod(devPath, unix.S_IFBLK|0600, int(dev)); err != nil {
+		t.Skipf("mknod: %v", err)
+	}
+
+	old := sysDevBlock
+	sysDir := t.TempDir()
+	sysDevBlock = sysDir
+	defer func() { sysDevBlock = old }()
+
+	queueDir := filepath.Join(sysDir, "1:0", "queue")
+	if err := os.MkdirAll(queueDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(queueDir, "logical_block_size"), []byte("8192\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	size, err := Detect(devPath)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if size != 8192 {
+		t.Fatalf("expected 8192, got %d", size)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid unnecessary conversions when computing queue path
- add test ensuring Detect reads from correct sysfs location

## Testing
- `go test -cover ./...`
- `golangci-lint run --no-config --enable=unconvert ./internal/blocksize`


------
https://chatgpt.com/codex/tasks/task_e_6897700496448323ac4aac44deb1e483