### PR TITLE
test(main): add runLocalDump tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	dumpChangesParallel          = transfer.DumpChangesParallel
 	dumpChangesWithDeduplication = transfer.DumpChangesWithDeduplication
 	newSSHClient                 = remote.NewSSHClient
+	openFile                     = os.OpenFile
 )
 
 func runApplyMode(applyFile string) error {
@@ -91,7 +92,7 @@ func runClientMode(snapshotDevice, dest string) (err error) {
 }
 
 func runLocalDump(snapshotDevice, originDevice, dest string) (err error) {
-	destFile, err := os.OpenFile(dest, os.O_RDWR, 0)
+	destFile, err := openFile(dest, os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("failed to open destination device %s: %w", dest, err)
 	}

--- a/main_local_dump_test.go
+++ b/main_local_dump_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"lvmsync_go/config"
+)
+
+func TestRunLocalDumpSuccess(t *testing.T) {
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	cfg.DedupStrategy = "none"
+	cfg.Parallel = 1
+	cfg.SpeedLimit = 0
+
+	originalOpen := openFile
+	var openCalled bool
+	openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		openCalled = true
+		if name != "/fake/dest" {
+			t.Fatalf("expected dest /fake/dest, got %s", name)
+		}
+		return os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	}
+	defer func() { openFile = originalOpen }()
+
+	originalDump := dumpChangesSequential
+	var dumpCalled bool
+	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+		dumpCalled = true
+		if snap != "snap" || origin != "orig" {
+			t.Fatalf("unexpected devices: %s %s", snap, origin)
+		}
+		return nil
+	}
+	defer func() { dumpChangesSequential = originalDump }()
+
+	if err := runLocalDump("snap", "orig", "/fake/dest"); err != nil {
+		t.Fatalf("runLocalDump returned error: %v", err)
+	}
+	if !openCalled {
+		t.Fatalf("openFile was not called")
+	}
+	if !dumpCalled {
+		t.Fatalf("dumpChangesSequential was not called")
+	}
+}
+
+func TestRunLocalDumpOpenError(t *testing.T) {
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+
+	originalOpen := openFile
+	openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		return nil, errors.New("open error")
+	}
+	defer func() { openFile = originalOpen }()
+
+	originalDump := dumpChangesSequential
+	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+		t.Fatalf("dumpChangesSequential should not be called on open error")
+		return nil
+	}
+	defer func() { dumpChangesSequential = originalDump }()
+
+	if err := runLocalDump("snap", "orig", "/fake/dest"); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- allow runLocalDump to inject file operations via an `openFile` variable for easier testing
- add unit tests covering success and error paths of `runLocalDump`

## Testing
- `go test -cover ./...`
- `golangci-lint run` *(fails: can't load config: swaggo is not a formatter)*

------
https://chatgpt.com/codex/tasks/task_e_689778031310832380918761d41d6ebe