### PR TITLE
feat: log main errors with zap and flush before exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ LVMSync is organized into modular packages to keep concerns separated:
 
 This structure allows individual packages to be developed and tested in isolation.
 
+## Logging
+
+LVMSync emits structured logs using [zap](https://github.com/uber-go/zap). Errors are logged with
+structured fields instead of being written to stderr, and the logger is flushed on shutdown to
+ensure all entries are persisted.
+
 ## Installation
 
 ### Requirements

--- a/main.go
+++ b/main.go
@@ -51,6 +51,8 @@ var (
 	dumpChangesWithDeduplication = transfer.DumpChangesWithDeduplication
 	newSSHClient                 = remote.NewSSHClient
 	openFile                     = os.OpenFile
+	runFunc                      = run
+	exitFunc                     = os.Exit
 )
 
 func runApplyMode(applyFile string) error {
@@ -473,8 +475,10 @@ func run() error {
 }
 
 func main() {
-	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+	if err := runFunc(); err != nil {
+		logger := zap.L()
+		logger.Error("run failed", zap.Error(err))
+		syncLogger(logger)
+		exitFunc(1)
 	}
 }

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type syncCheckCore struct {
+	zapcore.Core
+	synced *bool
+}
+
+func (c *syncCheckCore) Sync() error {
+	*c.synced = true
+	return c.Core.Sync()
+}
+
+func TestMainLogsStructuredError(t *testing.T) {
+	// stub run to force an error
+	oldRun := runFunc
+	runFunc = func() error { return errors.New("boom") }
+	defer func() { runFunc = oldRun }()
+
+	// capture exit code
+	oldExit := exitFunc
+	var code int
+	exitFunc = func(c int) { code = c }
+	defer func() { exitFunc = oldExit }()
+
+	core, logs := observer.New(zap.ErrorLevel)
+	synced := false
+	logger := zap.New(&syncCheckCore{Core: core, synced: &synced})
+	zap.ReplaceGlobals(logger)
+	defer zap.ReplaceGlobals(zap.NewNop())
+
+	main()
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+
+	entries := logs.FilterMessage("run failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+
+	if !synced {
+		t.Fatalf("logger was not synced")
+	}
+}


### PR DESCRIPTION
## Summary
- replace stderr writes in `main.go` with structured zap error logs
- add unit test for structured error logging and logger sync
- document logging behavior in README

## Testing
- `golangci-lint run` *(fails: can't load config: swaggo is not a formatter)*
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68977c3ee7f88323969fd11e1391e560