### PR TITLE
test(config): add block size and lz4 level tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -125,3 +125,6 @@ jobs:
 
       - name: Run tests
         'run': go test -v -race -cover ./...
+
+      - name: Report config coverage
+        'run': go test -cover ./config

--- a/README.md
+++ b/README.md
@@ -494,9 +494,10 @@ To run the tests and static checks locally:
 go fmt ./...
 go vet ./...
 go test ./...
+go test -cover ./config
 ```
 
-The same steps run in GitHub Actions under `.github/workflows/go.yml`.
+The last command generates a coverage report for the `config` package. The same steps run in GitHub Actions under `.github/workflows/go.yml`.
 
 ## License
 

--- a/config/format_block_size_test.go
+++ b/config/format_block_size_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"math"
+	"testing"
+
+	"lvmsync_go/internal/sizeparse"
+)
+
+func TestFormatBlockSize(t *testing.T) {
+	overflow := uint64(math.MaxInt)
+	overflow++
+
+	tests := []struct {
+		name    string
+		input   int
+		want    string
+		wantErr bool
+	}{
+		{name: "negative", input: -1, wantErr: true},
+		{name: "overflow", input: int(overflow), wantErr: true},
+		{name: "valid", input: 1024, want: sizeparse.FormatBytes(1024)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := FormatBlockSize(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/config/lz4_level_test.go
+++ b/config/lz4_level_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"math"
+	"testing"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+func TestLZ4Level(t *testing.T) {
+	tests := []struct {
+		name    string
+		level   int
+		want    uint32
+		wantErr bool
+	}{
+		{name: "fast", level: int(lz4.Fast), want: uint32(lz4.Fast)},
+		{name: "level3", level: int(lz4.Level3), want: uint32(lz4.Level3)},
+		{name: "negative", level: -1, wantErr: true},
+		{name: "overflow", level: int(math.MaxUint32) + 1, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := LZ4Level(tc.level)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for `FormatBlockSize`
- cover `LZ4Level` with valid and error paths
- document config coverage command and run it in CI

## Testing
- `go test -cover ./config`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68977c5440588323a335b7cd69bbf2df