### PR TITLE
ci: run golangci-lint across repo

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -53,11 +53,11 @@ jobs:
           # Core
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: "true"
 
           # Go: pass ONLY the package pattern (NO "run")
           GO_LINTER: golangci-lint
-          GO_LINT_FLAGS: ./...
+          GO_LINT_FLAGS: ./... # runs `golangci-lint run ./...` from repository root
           GOLANGCI_LINT_VERSION: v2.3.1
 
           # Formatters

--- a/README.md
+++ b/README.md
@@ -494,6 +494,15 @@ Contributions are welcome. Please follow the project's coding guidelines, includ
 
 ## Development
 
+### Development Setup
+
+The Super-Linter workflow validates the entire repository and runs `golangci-lint run ./...` from the repository root.
+Run the same command locally to mirror CI:
+
+```sh
+golangci-lint run ./...
+```
+
 To run the tests and static checks locally:
 
 ```sh


### PR DESCRIPTION
## Summary
- ensure super-linter validates the entire repository with `golangci-lint run ./...`
- document linter invocation in Development Setup instructions

## Testing
- `go test -cover ./...`
- `golangci-lint run ./...` *(fails: thelper: at least one option must be enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68977f0ca9a0832382bd2af6fa2200e5