### PR TITLE
test(main): add remote dump and execute client tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ LVMSYNC_SOURCE=/dev/vg0/snap1
 
 - [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit.
 - [ ] Remove stray `fmt.Print*` calls in favor of structured logs.
-- [ ] Expand unit test coverage and run coverage reports.
+- [ ] Expand unit test coverage for remote execution and client signal handling, and run coverage reports.
 
   ```sh
   go test -cover ./...

--- a/main_execute_client_test.go
+++ b/main_execute_client_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"lvmsync_go/config"
+)
+
+func setupExecuteClientTest(t *testing.T) {
+	t.Helper()
+	var err error
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	cfg.StdoutMode = true
+	cfg.DedupStrategy = "none"
+	cfg.Parallel = 1
+	cfg.SpeedLimit = 0
+}
+
+func TestExecuteClientRunError(t *testing.T) {
+	setupExecuteClientTest(t)
+	orig := dumpChangesSequential
+	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+		return errors.New("dump")
+	}
+	defer func() { dumpChangesSequential = orig }()
+
+	sigCh := make(chan error, 1)
+	err := executeClient("snap", "dest", sigCh, nil)
+	if err == nil || !strings.Contains(err.Error(), "copy operation failed") {
+		t.Fatalf("expected copy failure, got %v", err)
+	}
+}
+
+func TestExecuteClientSignal(t *testing.T) {
+	setupExecuteClientTest(t)
+	block := make(chan struct{})
+	orig := dumpChangesSequential
+	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+		<-block
+		return nil
+	}
+	defer func() { dumpChangesSequential = orig }()
+
+	sigCh := make(chan error, 1)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		sigCh <- errors.New("signal")
+	}()
+	err := executeClient("snap", "dest", sigCh, nil)
+	close(block)
+	if err == nil || !strings.Contains(err.Error(), "signal") {
+		t.Fatalf("expected signal error, got %v", err)
+	}
+}
+
+func TestExecuteClientMonitorError(t *testing.T) {
+	setupExecuteClientTest(t)
+	orig := dumpChangesSequential
+	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+		return nil
+	}
+	defer func() { dumpChangesSequential = orig }()
+
+	sigCh := make(chan error, 1)
+	monitorCh := make(chan error, 1)
+	monitorCh <- errors.New("monitor")
+	err := executeClient("snap", "dest", sigCh, monitorCh)
+	if err == nil || !strings.Contains(err.Error(), "snapshot monitor error") {
+		t.Fatalf("expected monitor error, got %v", err)
+	}
+}

--- a/main_remote_dump_test.go
+++ b/main_remote_dump_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+
+	"lvmsync_go/config"
+	remotetest "lvmsync_go/remote/testutil"
+)
+
+// TestRunRemoteDump executes a remote apply command through SSH.
+func TestRunRemoteDump(t *testing.T) {
+	server := remotetest.NewMockSSHServer(t, func(cmd string) int {
+		switch {
+		case cmd == "lvmsync --version":
+			return 0
+		case strings.HasPrefix(cmd, "lvmsync --apply - /dev/null"):
+			return 0
+		default:
+			t.Fatalf("unexpected command: %s", cmd)
+			return 1
+		}
+	})
+	defer server.Close()
+
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	cfg.SSHUser = "test"
+	cfg.SSHPort = port
+	cfg.SSHKeyPath = remotetest.CreateTempKey(t)
+	cfg.KnownHosts = remotetest.CreateKnownHostsFile(t, server)
+	cfg.StrictHostKeyCheck = true
+	cfg.LVMSyncPath = "lvmsync"
+	cfg.Parallel = 1
+
+	origDump := dumpChangesSequential
+	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+		if snap != "snap" || origin != "origin" {
+			t.Fatalf("unexpected devices: %s %s", snap, origin)
+		}
+		return nil
+	}
+	defer func() { dumpChangesSequential = origDump }()
+
+	dest := host + ":/dev/null"
+	if err := runRemoteDump("snap", "origin", dest); err != nil {
+		t.Fatalf("runRemoteDump returned error: %v", err)
+	}
+
+	cmds := server.Commands()
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %d: %v", len(cmds), cmds)
+	}
+	if cmds[0] != "lvmsync --version" || cmds[1] != "lvmsync --apply - /dev/null" {
+		t.Fatalf("unexpected commands: %v", cmds)
+	}
+}
+
+// TestRunRemoteDumpError verifies that remote command errors are propagated.
+func TestRunRemoteDumpError(t *testing.T) {
+	server := remotetest.NewMockSSHServer(t, func(cmd string) int {
+		if cmd == "lvmsync --version" {
+			return 0
+		}
+		if strings.HasPrefix(cmd, "lvmsync --apply - /dev/null") {
+			return 1
+		}
+		return 0
+	})
+	defer server.Close()
+
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+
+	cfg, err = config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	cfg.SSHUser = "test"
+	cfg.SSHPort = port
+	cfg.SSHKeyPath = remotetest.CreateTempKey(t)
+	cfg.KnownHosts = remotetest.CreateKnownHostsFile(t, server)
+	cfg.StrictHostKeyCheck = true
+	cfg.LVMSyncPath = "lvmsync"
+	cfg.Parallel = 1
+
+	origDump := dumpChangesSequential
+	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+		return nil
+	}
+	defer func() { dumpChangesSequential = origDump }()
+
+	dest := host + ":/dev/null"
+	err = runRemoteDump("snap", "origin", dest)
+	if err == nil || !strings.Contains(err.Error(), "remote command error") {
+		t.Fatalf("expected remote command error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests simulating remote dump command execution via mock SSH server
- verify executeClient signal handling and error paths
- clarify coverage expectations in AGENTS checklist

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68977efb48308323964aa1fd7eb7e5de