### PR TITLE
refactor(transfer): split modules for clarity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,4 @@ LVMSYNC_SOURCE=/dev/vg0/snap1
   ```
 
 - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s.
+- [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ LVMSync is organized into modular packages to keep concerns separated:
 
 - `lvm` – manages snapshot creation, monitoring, and cleanup.
 - `transfer` – performs block-level synchronization, compression, deduplication, and resume logic.
+  - Internally split into focused modules: `progress.go`, `handshake.go`, and `block_writer.go` for clearer responsibilities.
 - `remote` – wraps SSH functionality for running commands on remote hosts and coordinating transfers.
 - `config` – parses and validates configuration files and CLI options.
 - `common` and `internal` – shared helpers and internal utilities such as multi-error handling.

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -1,0 +1,134 @@
+package transfer
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+	"sync"
+	"time"
+
+	"lvmsync_go/config"
+)
+
+func validateOffsetAndSize(offset uint64, size int) (int64, uint32, error) {
+	if offset > math.MaxInt64 {
+		return 0, 0, fmt.Errorf("offset %d overflows int64", offset)
+	}
+	if size < 0 || size > int(math.MaxUint32) {
+		return 0, 0, fmt.Errorf("invalid block size %d: must be between 0 and %d", size, uint32(math.MaxUint32))
+	}
+	return int64(offset), uint32(size), nil
+}
+
+func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int) (int64, int, error) {
+	var totalBytes int64
+	skippedBlocks := 0
+	var header [12]byte
+	for _, r := range ranges {
+		offset, blockSize, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
+		if err != nil {
+			return totalBytes, skippedBlocks, err
+		}
+		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, pipeFds)
+		if err != nil {
+			return totalBytes, skippedBlocks, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
+		}
+		if dedup != nil {
+			if !dedup.ShouldTransfer(offset, data) {
+				skippedBlocks++
+				putBlockBuffer(data)
+				continue
+			}
+			dedup.RecordTransfer(offset, data)
+		}
+
+		binary.BigEndian.PutUint64(header[0:8], r.Start)
+		binary.BigEndian.PutUint32(header[8:12], blockSize)
+		if _, err := bufOut.Write(header[:]); err != nil {
+			putBlockBuffer(data)
+			return totalBytes, skippedBlocks, fmt.Errorf("failed to write header: %w", err)
+		}
+		if _, err := bufOut.Write(data); err != nil {
+			putBlockBuffer(data)
+			return totalBytes, skippedBlocks, fmt.Errorf("failed to write block data: %w", err)
+		}
+		putBlockBuffer(data)
+
+		totalBytes += int64(blockSize)
+	}
+	return totalBytes, skippedBlocks, nil
+}
+
+func prepareResultHeader(cfg *config.Config, checksum ChecksumStrategy, res *BlockResult, header []byte) int {
+	binary.BigEndian.PutUint64(header[0:8], res.Offset)
+	binary.BigEndian.PutUint32(header[8:12], res.Size)
+	n := 12
+	if cfg.VerifyChecksum {
+		sum := checksum.Compute(res.Data)
+		copy(header[12:], sum)
+		n += checksum.Size()
+	}
+	return n
+}
+
+func writeResult(bufOut *bufio.Writer, header []byte, data []byte) error {
+	if _, err := bufOut.Write(header); err != nil {
+		return fmt.Errorf("failed to write header: %w", err)
+	}
+	if _, err := bufOut.Write(data); err != nil {
+		return fmt.Errorf("failed to write data: %w", err)
+	}
+	return nil
+}
+
+func processParallelResults(cfg *config.Config, results <-chan *BlockResult, bufOut *bufio.Writer, checksum ChecksumStrategy, totalDataSize int64, startTime time.Time) (int64, error) {
+	headerSize := 12
+	if cfg.VerifyChecksum {
+		headerSize += checksum.Size()
+	}
+	header := make([]byte, headerSize)
+	var totalBytesTransferred int64
+	for res := range results {
+		if res.Err != nil {
+			return totalBytesTransferred, fmt.Errorf("error in block %d: %w", res.Index, res.Err)
+		}
+
+		n := prepareResultHeader(cfg, checksum, res, header)
+		if err := writeResult(bufOut, header[:n], res.Data); err != nil {
+			putBlockBuffer(res.Data)
+			return totalBytesTransferred, err
+		}
+		putBlockBuffer(res.Data)
+
+		totalBytesTransferred += int64(res.Size)
+		saveResumeState(cfg, res.Index)
+		reportProgress(cfg, totalBytesTransferred, totalDataSize, res.Index, startTime)
+	}
+	return totalBytesTransferred, nil
+}
+
+func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
+	defer workerWG.Done()
+	for task := range tasks {
+		offset, blockSize, err := validateOffsetAndSize(task.R.Start, cfg.BlockSize)
+		if err != nil {
+			results <- &BlockResult{Index: task.Index, Err: err}
+			continue
+		}
+		data, err := ReadBlockWithRetries(cfg, srcFile, offset, false, [2]int{-1, -1})
+		results <- &BlockResult{
+			Index:  task.Index,
+			Offset: task.R.Start,
+			Size:   blockSize,
+			Data:   data,
+			Err:    err,
+		}
+	}
+}
+
+func finalizeResults(wg *sync.WaitGroup, results chan<- *BlockResult) {
+	wg.Wait()
+	close(results)
+}

--- a/transfer/block_writer_test.go
+++ b/transfer/block_writer_test.go
@@ -1,0 +1,31 @@
+package transfer
+
+import (
+	"math"
+	"testing"
+
+	"lvmsync_go/config"
+)
+
+func TestValidateOffsetAndSizeFunc(t *testing.T) {
+	if _, _, err := validateOffsetAndSize(0, 1024); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, _, err := validateOffsetAndSize(math.MaxUint64, 1024); err == nil {
+		t.Fatal("expected error for large offset")
+	}
+	if _, _, err := validateOffsetAndSize(0, -1); err == nil {
+		t.Fatal("expected error for negative size")
+	}
+}
+
+func TestPrepareResultHeader(t *testing.T) {
+	cfg := &config.Config{VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
+	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
+	res := &BlockResult{Offset: 5, Size: 4, Data: []byte("test")}
+	header := make([]byte, 12+checksum.Size())
+	n := prepareResultHeader(cfg, checksum, res, header)
+	if n != len(header) {
+		t.Fatalf("expected header length %d, got %d", len(header), n)
+	}
+}

--- a/transfer/handshake.go
+++ b/transfer/handshake.go
@@ -1,0 +1,58 @@
+package transfer
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"lvmsync_go/common"
+	"lvmsync_go/config"
+)
+
+func composeHandshake(cfg *config.Config, mode string) common.Handshake {
+	hs := common.Handshake{Compress: cfg.Compress}
+	switch mode {
+	case StrategyChecksum:
+		hs.Checksum = true
+	case StrategyChecksum + "-dedup":
+		hs.Checksum = true
+		hs.ChecksumDedup = true
+	}
+	return hs
+}
+
+func setupOutput(cfg *config.Config, out io.Writer, handshake string) (io.WriteCloser, *bufio.Writer, error) {
+	if err := common.WriteHandshake(out, composeHandshake(cfg, handshake)); err != nil {
+		return nil, nil, err
+	}
+	return prepareOutputWriter(out, cfg)
+}
+
+func prepareParallelHandshake(cfg *config.Config) string {
+	htokens := []string{common.ProtocolVersion}
+	if cfg.VerifyChecksum {
+		htokens = append(htokens, StrategyChecksum)
+	}
+	htokens = append(htokens, "compress:"+cfg.Compress)
+	return strings.Join(htokens, " ")
+}
+
+func writeParallelHandshake(cfg *config.Config, out io.Writer) error {
+	_, err := fmt.Fprintln(out, prepareParallelHandshake(cfg))
+	return err
+}
+
+func readAndValidateHandshake(bufReader *bufio.Reader, dedup DeduplicationStrategy, verify bool) (common.Handshake, error) {
+	hs, err := common.ReadHandshake(bufReader)
+	if err != nil {
+		return common.Handshake{}, fmt.Errorf("failed to read protocol handshake: %w", err)
+	}
+	if verify && !hs.Checksum {
+		return hs, fmt.Errorf("unexpected protocol handshake: %s", hs.String())
+	}
+	if dedup != nil && !hs.ChecksumDedup {
+		return hs, fmt.Errorf("unexpected protocol handshake: %s", hs.String())
+	}
+	return hs, nil
+}

--- a/transfer/handshake_test.go
+++ b/transfer/handshake_test.go
@@ -1,0 +1,44 @@
+package transfer
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"lvmsync_go/common"
+	"lvmsync_go/config"
+)
+
+func TestComposeHandshake(t *testing.T) {
+	cfg := &config.Config{Compress: "zstd"}
+	hs := composeHandshake(cfg, "")
+	if hs.Compress != "zstd" || hs.Checksum || hs.ChecksumDedup {
+		t.Fatalf("unexpected handshake: %+v", hs)
+	}
+	hs = composeHandshake(cfg, StrategyChecksum)
+	if !hs.Checksum || hs.ChecksumDedup {
+		t.Fatalf("checksum handshake not set correctly")
+	}
+	hs = composeHandshake(cfg, StrategyChecksum+"-dedup")
+	if !hs.Checksum || !hs.ChecksumDedup {
+		t.Fatalf("checksum-dedup handshake not set correctly")
+	}
+}
+
+func TestReadAndValidateHandshake(t *testing.T) {
+	buf := &bytes.Buffer{}
+	common.WriteHandshake(buf, common.Handshake{Checksum: true})
+	hs, err := readAndValidateHandshake(bufio.NewReader(buf), nil, true)
+	if err != nil || !hs.Checksum {
+		t.Fatalf("expected valid handshake, got %v %v", hs, err)
+	}
+}
+
+func TestReadAndValidateHandshakeError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	common.WriteHandshake(buf, common.Handshake{Checksum: false})
+	_, err := readAndValidateHandshake(bufio.NewReader(buf), nil, true)
+	if err == nil {
+		t.Fatal("expected error for missing checksum")
+	}
+}

--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -1,0 +1,46 @@
+package transfer
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"lvmsync_go/config"
+
+	"go.uber.org/zap"
+)
+
+func finalizeProgress(cfg *config.Config) {
+	if cfg.Progress {
+		fmt.Fprintln(os.Stderr, "")
+	}
+}
+
+func reportProgress(cfg *config.Config, transferred, total int64, index int, start time.Time) {
+	if cfg.Progress {
+		progressPercent := float64(transferred) / float64(total) * 100.0
+		fmt.Fprintf(os.Stderr, "\rProgress: %.2f%%", progressPercent)
+	}
+	if cfg.Verbose > 0 && index > 0 && index%100 == 0 {
+		elapsed := time.Since(start).Seconds()
+		speed := float64(transferred) / elapsed / 1048576.0
+		Logger.Debug("Parallel dump progress", zap.Int("block", index+1), zap.Float64("MB/s", speed))
+	}
+}
+
+func logSequentialSummary(bytes int64, skipped int, start time.Time) {
+	elapsed := time.Since(start).Seconds()
+	Logger.Info("Sequential transfer complete",
+		zap.Int64("bytes", bytes),
+		zap.Int("skippedBlocks", skipped),
+		zap.Float64("seconds", elapsed),
+		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
+}
+
+func logParallelSummary(bytes int64, start time.Time) {
+	elapsed := time.Since(start).Seconds()
+	Logger.Info("Parallel transfer complete",
+		zap.Int64("bytes", bytes),
+		zap.Float64("seconds", elapsed),
+		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
+}

--- a/transfer/progress_test.go
+++ b/transfer/progress_test.go
@@ -1,0 +1,54 @@
+package transfer
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/config"
+)
+
+func captureStderr(f func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	f()
+	w.Close()
+	os.Stderr = old
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+func TestFinalizeProgress(t *testing.T) {
+	cfg := &config.Config{Progress: true}
+	out := captureStderr(func() { finalizeProgress(cfg) })
+	if out != "\n" {
+		t.Fatalf("expected newline, got %q", out)
+	}
+}
+
+func TestReportProgress(t *testing.T) {
+	Logger = zap.NewNop()
+	cfg := &config.Config{Progress: true}
+	out := captureStderr(func() {
+		reportProgress(cfg, 50, 100, 1, time.Now())
+	})
+	if out == "" {
+		t.Fatal("expected progress output")
+	}
+}
+
+func TestLogSummaries(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	Logger = zap.New(core)
+	start := time.Now().Add(-time.Second)
+	logSequentialSummary(1024, 1, start)
+	logParallelSummary(2048, start)
+	if logs.Len() != 2 {
+		t.Fatalf("expected 2 log entries, got %d", logs.Len())
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -112,73 +112,6 @@ func cleanupOutput(buf *bufio.Writer, w io.WriteCloser) {
 	}
 }
 
-func composeHandshake(cfg *config.Config, mode string) common.Handshake {
-	hs := common.Handshake{Compress: cfg.Compress}
-	switch mode {
-	case StrategyChecksum:
-		hs.Checksum = true
-	case StrategyChecksum + "-dedup":
-		hs.Checksum = true
-		hs.ChecksumDedup = true
-	}
-	return hs
-}
-
-func validateOffsetAndSize(offset uint64, size int) (int64, uint32, error) {
-	if offset > math.MaxInt64 {
-		return 0, 0, fmt.Errorf("offset %d overflows int64", offset)
-	}
-	if size < 0 || size > int(math.MaxUint32) {
-		return 0, 0, fmt.Errorf("invalid block size %d: must be between 0 and %d", size, uint32(math.MaxUint32))
-	}
-	return int64(offset), uint32(size), nil
-}
-
-func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int) (int64, int, error) {
-	var totalBytes int64
-	skippedBlocks := 0
-	var header [12]byte
-	for _, r := range ranges {
-		offset, blockSize, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
-		if err != nil {
-			return totalBytes, skippedBlocks, err
-		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, pipeFds)
-		if err != nil {
-			return totalBytes, skippedBlocks, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
-		}
-		if dedup != nil {
-			if !dedup.ShouldTransfer(offset, data) {
-				skippedBlocks++
-				putBlockBuffer(data)
-				continue
-			}
-			dedup.RecordTransfer(offset, data)
-		}
-
-		binary.BigEndian.PutUint64(header[0:8], r.Start)
-		binary.BigEndian.PutUint32(header[8:12], blockSize)
-		if _, err := bufOut.Write(header[:]); err != nil {
-			putBlockBuffer(data)
-			return totalBytes, skippedBlocks, fmt.Errorf("failed to write header: %w", err)
-		}
-		if _, err := bufOut.Write(data); err != nil {
-			putBlockBuffer(data)
-			return totalBytes, skippedBlocks, fmt.Errorf("failed to write block data: %w", err)
-		}
-		putBlockBuffer(data)
-
-		totalBytes += int64(blockSize)
-	}
-	return totalBytes, skippedBlocks, nil
-}
-
-func finalizeProgress(cfg *config.Config) {
-	if cfg.Progress {
-		fmt.Fprintln(os.Stderr, "")
-	}
-}
-
 func detectBlockSize(cfg *config.Config, source string) error {
 	if cfg.BlockSize != 0 {
 		return nil
@@ -222,13 +155,6 @@ func prepareRanges(cfg *config.Config, snapshot, source string) ([]Range, error)
 	return ranges, nil
 }
 
-func setupOutput(cfg *config.Config, out io.Writer, handshake string) (io.WriteCloser, *bufio.Writer, error) {
-	if err := common.WriteHandshake(out, composeHandshake(cfg, handshake)); err != nil {
-		return nil, nil, err
-	}
-	return prepareOutputWriter(out, cfg)
-}
-
 func setupSourceFile(source string) (*os.File, error) {
 	srcFile, err := os.Open(source)
 	if err != nil {
@@ -256,15 +182,6 @@ func setupPipe(cfg *config.Config) ([2]int, func(), error) {
 		pipeFds[0], pipeFds[1] = -1, -1
 	}
 	return pipeFds, cleanup, nil
-}
-
-func logSequentialSummary(bytes int64, skipped int, start time.Time) {
-	elapsed := time.Since(start).Seconds()
-	Logger.Info("Sequential transfer complete",
-		zap.Int64("bytes", bytes),
-		zap.Int("skippedBlocks", skipped),
-		zap.Float64("seconds", elapsed),
-		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
 }
 
 func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
@@ -343,37 +260,6 @@ func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) err
 	return DumpChangesSequential(cfg, snapshot, source, out)
 }
 
-func prepareParallelHandshake(cfg *config.Config) string {
-	htokens := []string{common.ProtocolVersion}
-	if cfg.VerifyChecksum {
-		htokens = append(htokens, StrategyChecksum)
-	}
-	htokens = append(htokens, "compress:"+cfg.Compress)
-	return strings.Join(htokens, " ")
-}
-
-func prepareResultHeader(cfg *config.Config, checksum ChecksumStrategy, res *BlockResult, header []byte) int {
-	binary.BigEndian.PutUint64(header[0:8], res.Offset)
-	binary.BigEndian.PutUint32(header[8:12], res.Size)
-	n := 12
-	if cfg.VerifyChecksum {
-		sum := checksum.Compute(res.Data)
-		copy(header[12:], sum)
-		n += checksum.Size()
-	}
-	return n
-}
-
-func writeResult(bufOut *bufio.Writer, header []byte, data []byte) error {
-	if _, err := bufOut.Write(header); err != nil {
-		return fmt.Errorf("failed to write header: %w", err)
-	}
-	if _, err := bufOut.Write(data); err != nil {
-		return fmt.Errorf("failed to write data: %w", err)
-	}
-	return nil
-}
-
 func saveResumeState(cfg *config.Config, index int) {
 	if cfg.ResumeState == "" {
 		return
@@ -381,63 +267,6 @@ func saveResumeState(cfg *config.Config, index int) {
 	err := os.WriteFile(cfg.ResumeState, []byte(fmt.Sprintf("%d", index+1)), 0o600)
 	if err != nil {
 		Logger.Warn("Failed to update resume state", zap.Error(err))
-	}
-}
-
-func reportProgress(cfg *config.Config, transferred, total int64, index int, start time.Time) {
-	if cfg.Progress {
-		progressPercent := float64(transferred) / float64(total) * 100.0
-		fmt.Fprintf(os.Stderr, "\rProgress: %.2f%%", progressPercent)
-	}
-	if cfg.Verbose > 0 && index > 0 && index%100 == 0 {
-		elapsed := time.Since(start).Seconds()
-		speed := float64(transferred) / elapsed / 1048576.0
-		Logger.Debug("Parallel dump progress", zap.Int("block", index+1), zap.Float64("MB/s", speed))
-	}
-}
-
-func processParallelResults(cfg *config.Config, results <-chan *BlockResult, bufOut *bufio.Writer, checksum ChecksumStrategy, totalDataSize int64, startTime time.Time) (int64, error) {
-	headerSize := 12
-	if cfg.VerifyChecksum {
-		headerSize += checksum.Size()
-	}
-	header := make([]byte, headerSize)
-	var totalBytesTransferred int64
-	for res := range results {
-		if res.Err != nil {
-			return totalBytesTransferred, fmt.Errorf("error in block %d: %w", res.Index, res.Err)
-		}
-
-		n := prepareResultHeader(cfg, checksum, res, header)
-		if err := writeResult(bufOut, header[:n], res.Data); err != nil {
-			putBlockBuffer(res.Data)
-			return totalBytesTransferred, err
-		}
-		putBlockBuffer(res.Data)
-
-		totalBytesTransferred += int64(res.Size)
-		saveResumeState(cfg, res.Index)
-		reportProgress(cfg, totalBytesTransferred, totalDataSize, res.Index, startTime)
-	}
-	return totalBytesTransferred, nil
-}
-
-func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
-	defer workerWG.Done()
-	for task := range tasks {
-		offset, blockSize, err := validateOffsetAndSize(task.R.Start, cfg.BlockSize)
-		if err != nil {
-			results <- &BlockResult{Index: task.Index, Err: err}
-			continue
-		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, false, [2]int{-1, -1})
-		results <- &BlockResult{
-			Index:  task.Index,
-			Offset: task.R.Start,
-			Size:   blockSize,
-			Data:   data,
-			Err:    err,
-		}
 	}
 }
 
@@ -455,11 +284,6 @@ func calculateTotalDataSize(ranges []Range) int64 {
 		return math.MaxInt64
 	}
 	return int64(total)
-}
-
-func writeParallelHandshake(cfg *config.Config, out io.Writer) error {
-	_, err := fmt.Fprintln(out, prepareParallelHandshake(cfg))
-	return err
 }
 
 func readResumeStart(cfg *config.Config) int {
@@ -503,14 +327,6 @@ func startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, 
 	return results
 }
 
-func logParallelSummary(bytes int64, start time.Time) {
-	elapsed := time.Since(start).Seconds()
-	Logger.Info("Parallel transfer complete",
-		zap.Int64("bytes", bytes),
-		zap.Float64("seconds", elapsed),
-		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
-}
-
 func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
 	if cfg.ZeroCopy {
 		Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
@@ -552,25 +368,6 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	finalizeProgress(cfg)
 	logParallelSummary(totalBytesTransferred, startTime)
 	return nil
-}
-
-func finalizeResults(wg *sync.WaitGroup, results chan<- *BlockResult) {
-	wg.Wait()
-	close(results)
-}
-
-func readAndValidateHandshake(bufReader *bufio.Reader, dedup DeduplicationStrategy, verify bool) (common.Handshake, error) {
-	hs, err := common.ReadHandshake(bufReader)
-	if err != nil {
-		return common.Handshake{}, fmt.Errorf("failed to read protocol handshake: %w", err)
-	}
-	if verify && !hs.Checksum {
-		return hs, fmt.Errorf("unexpected protocol handshake: %s", hs.String())
-	}
-	if dedup != nil && !hs.ChecksumDedup {
-		return hs, fmt.Errorf("unexpected protocol handshake: %s", hs.String())
-	}
-	return hs, nil
 }
 
 func readBlockHeader(reader *bufio.Reader, headerBuf []byte, verify bool, checksum ChecksumStrategy) (uint64, uint32, []byte, error) {


### PR DESCRIPTION
## Summary
- split `transfer.go` into dedicated `progress`, `handshake`, and `block_writer` modules
- add unit tests for new progress, handshake, and block writer helpers
- document transfer decomposition and note TODO to keep modules focused

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: can't load config: swaggo is not a formatter)*

------
https://chatgpt.com/codex/tasks/task_e_6897a99c4c688323824586d5a9571efc