### PR TITLE
feat(grpcd): add viper config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,4 @@ LVMSYNC_SOURCE=/dev/vg0/snap1
   ```
 
 - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s.
+- [ ] Document gRPC daemon configuration sources (flags, env vars, config file) and precedence.

--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 
 | Option             | Description                  | Default         |
 | ------------------ | ---------------------------- | --------------- |
-| `--grpc_port`      | gRPC port to listen on       | `8443`          |
-| `--tls_cert`       | TLS certificate file         | `""`            |
-| `--tls_key`        | TLS key file                 | `""`            |
-| `--ca_cert`        | CA certificate file          | `""`            |
-| `--allow_insecure` | Allow insecure (disable TLS) | `true`          |
+| `--grpc-port`      | gRPC port to listen on       | `8443`          |
+| `--tls-cert`       | TLS certificate file         | `""`            |
+| `--tls-key`        | TLS key file                 | `""`            |
+| `--ca-cert`        | CA certificate file          | `""`            |
+| `--allow-insecure` | Allow insecure (disable TLS) | `false`         |
 | `--sudo_path`      | Path to sudo executable      | `/usr/bin/sudo` |
 
 ### Examples
@@ -402,23 +402,28 @@ volume_group: vg_data
 
 #### gRPC
 
+`lvmsync-grpcd` accepts configuration via flags, environment variables prefixed with `LVMSYNC_GRPC_`, or a YAML file. Values are resolved in the following order: flags override environment variables, which override the config file.
+
 CLI:
 
 ```sh
-lvmsync-grpcd --grpc_port 9443
+lvmsync-grpcd --grpc-port 9443 --tls-cert cert.pem
 ```
 
 Environment:
 
 ```sh
-LVMSYNC_GRPC_PORT=9443 lvmsync-grpcd
+LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 ```
 
-YAML:
+YAML (`grpcd.yaml`):
 
 ```yaml
-grpc_port: 9443
+grpc-port: 9443
+tls-cert: cert.pem
 ```
+
+Use `--config` to provide an alternate config file path.
 
 ## Configuration File (`config.yaml`)
 

--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -1,15 +1,17 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
-	"strconv"
 
 	grpcserver "lvmsync_go/grpc/server"
 	lvmagent "lvmsync_go/internal/lvm"
 
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
 
@@ -21,35 +23,29 @@ var (
 func main() {
 	logger, err := newZapProduction()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to init logger: %v\n", err)
+		zap.NewNop().Error("init logger", zap.Error(err))
 		exitFunc(1)
 	}
 	zap.ReplaceGlobals(logger)
 	defer syncAndExit(logger)
 
-	port := getEnvInt("GRPC_PORT", 8443)
-	tlsCert := getEnv("TLS_CERT", "")
-	tlsKey := getEnv("TLS_KEY", "")
-	caCert := getEnv("CA_CERT", "")
-	allowInsecure := getEnvBool("ALLOW_INSECURE", false)
-
-	pflag.IntVar(&port, "grpc-port", port, "gRPC port to listen on")
-	pflag.StringVar(&tlsCert, "tls-cert", tlsCert, "TLS certificate file")
-	pflag.StringVar(&tlsKey, "tls-key", tlsKey, "TLS key file")
-	pflag.StringVar(&caCert, "ca-cert", caCert, "CA certificate file")
-	pflag.BoolVar(&allowInsecure, "allow-insecure", allowInsecure, "allow insecure (no TLS)")
-	pflag.Parse()
+	v, err := initConfig(os.Args[1:])
+	if err != nil {
+		zap.L().Error("init config", zap.Error(err))
+		exitFunc(1)
+	}
 
 	cfg := grpcserver.Config{
-		TLSCert:       tlsCert,
-		TLSKey:        tlsKey,
-		CACert:        caCert,
-		AllowInsecure: allowInsecure,
+		TLSCert:       v.GetString("tls-cert"),
+		TLSKey:        v.GetString("tls-key"),
+		CACert:        v.GetString("ca-cert"),
+		AllowInsecure: v.GetBool("allow-insecure"),
 	}
 
 	agent := lvmagent.NewSudoAgent("", nil)
 	srv := grpcserver.New(cfg, agent)
 
+	port := v.GetInt("grpc-port")
 	lis, listenErr := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if listenErr != nil {
 		zap.L().Fatal("listen", zap.Error(listenErr))
@@ -68,27 +64,46 @@ func syncAndExit(logger *zap.Logger) {
 	}
 }
 
-func getEnv(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
+func initConfig(args []string) (*viper.Viper, error) {
+	tlsFlags := pflag.NewFlagSet("tls", pflag.ContinueOnError)
+	tlsFlags.String("tls-cert", "", "TLS certificate file")
+	tlsFlags.String("tls-key", "", "TLS key file")
+	tlsFlags.String("ca-cert", "", "CA certificate file")
+	tlsFlags.Bool("allow-insecure", false, "allow insecure (no TLS)")
 
-func getEnvInt(key string, def int) int {
-	if v := os.Getenv(key); v != "" {
-		if i, err := strconv.Atoi(v); err == nil {
-			return i
+	netFlags := pflag.NewFlagSet("network", pflag.ContinueOnError)
+	netFlags.Int("grpc-port", 8443, "gRPC port to listen on")
+
+	fs := pflag.NewFlagSet("grpcd", pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.AddFlagSet(netFlags)
+	fs.AddFlagSet(tlsFlags)
+	fs.String("config", "", "configuration file")
+
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+
+	v := viper.New()
+	if err := v.BindPFlags(fs); err != nil {
+		return nil, err
+	}
+	v.SetEnvPrefix("LVMSYNC_GRPC")
+	v.AutomaticEnv()
+
+	if cfgFile := v.GetString("config"); cfgFile != "" {
+		v.SetConfigFile(cfgFile)
+	} else {
+		v.SetConfigName("grpcd")
+		v.AddConfigPath(".")
+	}
+
+	if err := v.ReadInConfig(); err != nil {
+		var cfgNotFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &cfgNotFound) {
+			return nil, err
 		}
 	}
-	return def
-}
 
-func getEnvBool(key string, def bool) bool {
-	if v := os.Getenv(key); v != "" {
-		if b, err := strconv.ParseBool(v); err == nil {
-			return b
-		}
-	}
-	return def
+	return v, nil
 }

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"go.uber.org/zap"
@@ -31,4 +33,56 @@ func TestSyncAndExitLogsError(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
+}
+
+func TestInitConfigPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "grpcd.yaml")
+	cfg := []byte("grpc-port: 1111\nallow-insecure: false\n")
+	if err := os.WriteFile(cfgFile, cfg, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	t.Run("config file", func(t *testing.T) {
+		v, err := initConfig([]string{"--config", cfgFile})
+		if err != nil {
+			t.Fatalf("initConfig: %v", err)
+		}
+		if port := v.GetInt("grpc-port"); port != 1111 {
+			t.Fatalf("expected port 1111, got %d", port)
+		}
+		if v.GetBool("allow-insecure") {
+			t.Fatalf("expected allow-insecure false")
+		}
+	})
+
+	t.Run("env overrides", func(t *testing.T) {
+		t.Setenv("LVMSYNC_GRPC_GRPC_PORT", "2222")
+		t.Setenv("LVMSYNC_GRPC_ALLOW_INSECURE", "true")
+		v, err := initConfig([]string{"--config", cfgFile})
+		if err != nil {
+			t.Fatalf("initConfig: %v", err)
+		}
+		if port := v.GetInt("grpc-port"); port != 2222 {
+			t.Fatalf("expected port 2222, got %d", port)
+		}
+		if !v.GetBool("allow-insecure") {
+			t.Fatalf("expected allow-insecure true")
+		}
+	})
+
+	t.Run("flag overrides", func(t *testing.T) {
+		t.Setenv("LVMSYNC_GRPC_GRPC_PORT", "2222")
+		t.Setenv("LVMSYNC_GRPC_ALLOW_INSECURE", "true")
+		v, err := initConfig([]string{"--config", cfgFile, "--grpc-port", "3333", "--allow-insecure=false"})
+		if err != nil {
+			t.Fatalf("initConfig: %v", err)
+		}
+		if port := v.GetInt("grpc-port"); port != 3333 {
+			t.Fatalf("expected port 3333, got %d", port)
+		}
+		if v.GetBool("allow-insecure") {
+			t.Fatalf("expected allow-insecure false")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- replace manual env helpers with grouped pflag FlagSet bound to viper
- allow gRPC daemon config via flags, LVMSYNC_GRPC_* env vars, or yaml file
- document new configuration precedence and add tests

## Testing
- `go test -cover ./...`
- `golangci-lint run` *(fails: can't load config: swaggo is not a formatter)*

------
https://chatgpt.com/codex/tasks/task_e_6897a983698483239f63849f8ec55fc6