### PR TITLE
feat(transfer): log progress through zap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ LVMSYNC_SOURCE=/dev/vg0/snap1
 
 - [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit.
 - [ ] Remove stray `fmt.Print*` calls in favor of structured logs.
+- [ ] Monitor elimination of `fmt.Print*` calls to keep progress logging fully structured.
 - [ ] Expand unit test coverage for remote execution and client signal handling, and run coverage reports.
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This structure allows individual packages to be developed and tested in isolatio
 
 LVMSync emits structured logs using [zap](https://github.com/uber-go/zap). Errors are logged with
 structured fields instead of being written to stderr, and the logger is flushed on shutdown to
-ensure all entries are persisted.
+ensure all entries are persisted. When `--progress` is enabled, progress updates are emitted as
+structured log entries, allowing external tooling to track transfer completion.
 
 ## Installation
 

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -15,6 +15,7 @@ import (
 	"lvmsync_go/config"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // helper to create source and metadata files with deterministic ranges
@@ -103,6 +104,23 @@ func TestDumpChangesWithDeduplication(t *testing.T) {
 	expected := []int64{1 * blockSize}
 	if !reflect.DeepEqual(offsets, expected) {
 		t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
+	}
+}
+
+func TestDumpChangesParallelProgress(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	SetLogger(zap.New(core))
+	blockSize := int64(1024)
+	changed := []int{0}
+	src, snapshot := createDumpTestFiles(t, blockSize, changed)
+
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, MaxRetries: 1, Progress: true}
+	var buf bytes.Buffer
+	if err := DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChangesParallel failed: %v", err)
+	}
+	if logs.FilterMessage("transfer progress").Len() == 0 {
+		t.Fatalf("expected progress log, got %d entries", logs.Len())
 	}
 }
 

--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -1,8 +1,6 @@
 package transfer
 
 import (
-	"fmt"
-	"os"
 	"time"
 
 	"lvmsync_go/config"
@@ -11,36 +9,47 @@ import (
 )
 
 func finalizeProgress(cfg *config.Config) {
-	if cfg.Progress {
-		fmt.Fprintln(os.Stderr, "")
+	if cfg.Progress && Logger != nil {
+		Logger.Info("progress complete")
 	}
 }
 
 func reportProgress(cfg *config.Config, transferred, total int64, index int, start time.Time) {
+	if Logger == nil {
+		return
+	}
 	if cfg.Progress {
 		progressPercent := float64(transferred) / float64(total) * 100.0
-		fmt.Fprintf(os.Stderr, "\rProgress: %.2f%%", progressPercent)
+		Logger.Info("transfer progress", zap.Float64("progress_percent", progressPercent))
 	}
 	if cfg.Verbose > 0 && index > 0 && index%100 == 0 {
 		elapsed := time.Since(start).Seconds()
 		speed := float64(transferred) / elapsed / 1048576.0
-		Logger.Debug("Parallel dump progress", zap.Int("block", index+1), zap.Float64("MB/s", speed))
+		Logger.Debug("parallel dump progress",
+			zap.Int("block_index", index+1),
+			zap.Float64("mb_per_sec", speed))
 	}
 }
 
 func logSequentialSummary(bytes int64, skipped int, start time.Time) {
+	if Logger == nil {
+		return
+	}
 	elapsed := time.Since(start).Seconds()
 	Logger.Info("Sequential transfer complete",
-		zap.Int64("bytes", bytes),
-		zap.Int("skippedBlocks", skipped),
-		zap.Float64("seconds", elapsed),
-		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
+		zap.Int64("size_bytes", bytes),
+		zap.Int("skipped_blocks", skipped),
+		zap.Float64("duration_sec", elapsed),
+		zap.Float64("mb_per_sec", float64(bytes)/elapsed/1048576.0))
 }
 
 func logParallelSummary(bytes int64, start time.Time) {
+	if Logger == nil {
+		return
+	}
 	elapsed := time.Since(start).Seconds()
 	Logger.Info("Parallel transfer complete",
-		zap.Int64("bytes", bytes),
-		zap.Float64("seconds", elapsed),
-		zap.Float64("MB/s", float64(bytes)/elapsed/1048576.0))
+		zap.Int64("size_bytes", bytes),
+		zap.Float64("duration_sec", elapsed),
+		zap.Float64("mb_per_sec", float64(bytes)/elapsed/1048576.0))
 }

--- a/transfer/progress_test.go
+++ b/transfer/progress_test.go
@@ -1,8 +1,6 @@
 package transfer
 
 import (
-	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -12,33 +10,23 @@ import (
 	"lvmsync_go/config"
 )
 
-func captureStderr(f func()) string {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	f()
-	w.Close()
-	os.Stderr = old
-	out, _ := io.ReadAll(r)
-	return string(out)
-}
-
 func TestFinalizeProgress(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	Logger = zap.New(core)
 	cfg := &config.Config{Progress: true}
-	out := captureStderr(func() { finalizeProgress(cfg) })
-	if out != "\n" {
-		t.Fatalf("expected newline, got %q", out)
+	finalizeProgress(cfg)
+	if logs.FilterMessage("progress complete").Len() != 1 {
+		t.Fatalf("expected progress completion log, got %d", logs.FilterMessage("progress complete").Len())
 	}
 }
 
 func TestReportProgress(t *testing.T) {
-	Logger = zap.NewNop()
+	core, logs := observer.New(zap.InfoLevel)
+	Logger = zap.New(core)
 	cfg := &config.Config{Progress: true}
-	out := captureStderr(func() {
-		reportProgress(cfg, 50, 100, 1, time.Now())
-	})
-	if out == "" {
-		t.Fatal("expected progress output")
+	reportProgress(cfg, 50, 100, 1, time.Now())
+	if logs.FilterMessage("transfer progress").Len() == 0 {
+		t.Fatal("expected progress log")
 	}
 }
 

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -218,6 +218,9 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	finalizeProgress(cfg)
 
 	logSequentialSummary(totalBytesTransferred, skippedBlocks, startTime)
+	if Logger != nil {
+		_ = Logger.Sync()
+	}
 	return nil
 }
 
@@ -367,6 +370,9 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 	}
 	finalizeProgress(cfg)
 	logParallelSummary(totalBytesTransferred, startTime)
+	if Logger != nil {
+		_ = Logger.Sync()
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- route progress reporting through zap with structured fields
- flush logger at transfer completion for sequential and parallel modes
- document structured progress logging and track fmt.Print* removal

## Testing
- `go test -cover ./...` (fails: TestInitConfigPrecedence/env_overrides expected port 2222 got 1111)
- `golangci-lint run` (fails: can't load config: swaggo is not a formatter)


------
https://chatgpt.com/codex/tasks/task_e_6897b02f4c288323bb0b28c23367c95b