### PR TITLE
refactor: use zap for progress logging and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ LVMSYNC_SOURCE=/dev/vg0/snap1
 
 ## Testing and Linting
 
-- Every function should have accompanying unit tests.
+- Provide unit tests for every new function.
 - Ensure [`golangci-lint`](https://golangci-lint.run/) v2 passes before submitting changes.
 
 ### Coverage
@@ -120,3 +120,6 @@ LVMSYNC_SOURCE=/dev/vg0/snap1
 - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s.
 - [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).
 - [ ] Document gRPC daemon configuration sources (flags, env vars, config file) and precedence.
+- [ ] Keep `README` configuration documentation current with code changes.
+- [ ] Track decomposition of large files like `transfer/transfer.go`.
+- [ ] Ensure progress logging uses `zap` exclusively.

--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -1,8 +1,6 @@
 package transfer
 
 import (
-	"fmt"
-	"os"
 	"time"
 
 	"lvmsync_go/config"
@@ -10,16 +8,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func finalizeProgress(cfg *config.Config) {
-	if cfg.Progress {
-		fmt.Fprintln(os.Stderr, "")
-	}
-}
+func finalizeProgress(cfg *config.Config) {}
 
 func reportProgress(cfg *config.Config, transferred, total int64, index int, start time.Time) {
 	if cfg.Progress {
 		progressPercent := float64(transferred) / float64(total) * 100.0
-		fmt.Fprintf(os.Stderr, "\rProgress: %.2f%%", progressPercent)
+		Logger.Info("Progress", zap.Float64("percent", progressPercent))
 	}
 	if cfg.Verbose > 0 && index > 0 && index%100 == 0 {
 		elapsed := time.Since(start).Seconds()

--- a/transfer/progress_test.go
+++ b/transfer/progress_test.go
@@ -1,8 +1,6 @@
 package transfer
 
 import (
-	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -12,33 +10,23 @@ import (
 	"lvmsync_go/config"
 )
 
-func captureStderr(f func()) string {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	f()
-	w.Close()
-	os.Stderr = old
-	out, _ := io.ReadAll(r)
-	return string(out)
-}
-
 func TestFinalizeProgress(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	Logger = zap.New(core)
 	cfg := &config.Config{Progress: true}
-	out := captureStderr(func() { finalizeProgress(cfg) })
-	if out != "\n" {
-		t.Fatalf("expected newline, got %q", out)
+	finalizeProgress(cfg)
+	if logs.Len() != 0 {
+		t.Fatalf("expected no logs, got %d", logs.Len())
 	}
 }
 
 func TestReportProgress(t *testing.T) {
-	Logger = zap.NewNop()
+	core, logs := observer.New(zap.InfoLevel)
+	Logger = zap.New(core)
 	cfg := &config.Config{Progress: true}
-	out := captureStderr(func() {
-		reportProgress(cfg, 50, 100, 1, time.Now())
-	})
-	if out == "" {
-		t.Fatal("expected progress output")
+	reportProgress(cfg, 50, 100, 1, time.Now())
+	if logs.Len() == 0 {
+		t.Fatal("expected progress log entry")
 	}
 }
 


### PR DESCRIPTION
## Summary
- refactor progress reporting to use zap logging
- document requirement for tests on new functions and add maintenance TODOs

## Testing
- `go test -cover ./...` *(fails: expected port 2222, got 1111)*
- `golangci-lint run` *(fails: can't load config: swaggo is not a formatter)*
- `go test -cover ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_6897b1abe66083238d632af3bcbbee84