### PR TITLE
test: add snapshot helper tests

### DIFF
--- a/main_snapshot_helpers_test.go
+++ b/main_snapshot_helpers_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"math"
+	"testing"
+
+	"go.uber.org/zap"
+	"lvmsync_go/config"
+)
+
+func TestCalculateSnapshotSize(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		cfg = &config.Config{SnapshotSize: "1024"}
+		size, err := calculateSnapshotSize("/dev/vg/lv")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if size != 1024 {
+			t.Fatalf("expected 1024, got %d", size)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		cfg = &config.Config{SnapshotSize: "bad"}
+		if _, err := calculateSnapshotSize("/dev/vg/lv"); err == nil {
+			t.Fatalf("expected error for invalid size")
+		}
+	})
+}
+
+func TestEnsureVolumeGroups(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("sets missing volume group", func(t *testing.T) {
+		cfg = &config.Config{}
+		if err := ensureVolumeGroups("/dev/sourcevg/lv1", logger); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.VolumeGroup != "sourcevg" {
+			t.Fatalf("expected volume group 'sourcevg', got %q", cfg.VolumeGroup)
+		}
+	})
+
+	t.Run("preserves existing volume group", func(t *testing.T) {
+		cfg = &config.Config{VolumeGroup: "existing"}
+		if err := ensureVolumeGroups("/dev/othervg/lv", logger); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.VolumeGroup != "existing" {
+			t.Fatalf("volume group changed to %q", cfg.VolumeGroup)
+		}
+	})
+}
+
+func TestCheckDiskSpaceForSnapshot(t *testing.T) {
+	logger := zap.NewNop()
+	cfg = &config.Config{SkipDiskCheck: false}
+
+	t.Run("sufficient", func(t *testing.T) {
+		if err := checkDiskSpaceForSnapshot(1, logger); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("insufficient", func(t *testing.T) {
+		if err := checkDiskSpaceForSnapshot(math.MaxUint64, logger); err == nil {
+			t.Fatalf("expected error for insufficient space")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add tests for snapshot size parsing
- cover volume group selection scenarios
- verify disk space checks for snapshots

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897bab2e3f48323a96cce06ec2b958e