### PR TITLE
refactor(config): split config loading helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Internally, each group is set up through a dedicated helper such as
 `initGeneralFlags`, `initSSHFlags`, or `initCompressionFlags`, keeping flag
 definitions focused and easy to maintain.
 
+The overall loading flow works in three stages:
+
+1. `registerFlags()` adds all flag groups to the command line.
+2. `buildViper()` binds flags, `LVMSYNC_*` environment variables, and an optional `config.yaml` into a single configuration source.
+3. `LoadConfig()` merges those values with built-in defaults and validates the result.
+
 ### Precedence and environment variables
 
 Values are resolved in the following order (highest first):

--- a/config/config.go
+++ b/config/config.go
@@ -27,9 +27,11 @@ const (
 	Zstd = "zstd"
 )
 
-var SupportedCompression = []string{"none", "lz4", Zstd, Auto}
-var SupportedDedupStrategies = []string{"none", Auto, "checksum", "rolling_hash", "bloom"}
-var SupportedChecksumAlgorithms = []string{"sha256", "blake3", "blake3-512"}
+var (
+	SupportedCompression        = []string{"none", "lz4", Zstd, Auto}
+	SupportedDedupStrategies    = []string{"none", Auto, "checksum", "rolling_hash", "bloom"}
+	SupportedChecksumAlgorithms = []string{"sha256", "blake3", "blake3-512"}
+)
 
 var (
 	generalFlags     *pflag.FlagSet
@@ -398,13 +400,8 @@ func initFlagSets(defaultCfg *Config) {
 	grpcFlags = initGRPCFlags(defaultCfg)
 }
 
-func LoadConfig() (*Config, error) {
-	defaultCfg, err := DefaultConfig()
-	if err != nil {
-		return nil, err
-	}
+func registerFlags(defaultCfg *Config) {
 	initFlagSets(defaultCfg)
-	// Register flags and set usage
 	pflag.CommandLine.AddFlagSet(generalFlags)
 	pflag.CommandLine.AddFlagSet(sshFlags)
 	pflag.CommandLine.AddFlagSet(remoteFlags)
@@ -413,8 +410,9 @@ func LoadConfig() (*Config, error) {
 	pflag.CommandLine.AddFlagSet(lvmFlags)
 	pflag.CommandLine.AddFlagSet(grpcFlags)
 	pflag.Usage = printUsage
-	pflag.Parse()
+}
 
+func buildViper() (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")
@@ -423,14 +421,29 @@ func LoadConfig() (*Config, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer("_", "."))
 	v.SetEnvPrefix("LVMSYNC")
 
-	if err = v.BindPFlags(pflag.CommandLine); err != nil {
+	if err := v.BindPFlags(pflag.CommandLine); err != nil {
 		return nil, err
 	}
 	if cfgFile := v.GetString("config"); cfgFile != "" {
 		v.SetConfigFile(cfgFile)
-		if err = v.ReadInConfig(); err != nil {
+		if err := v.ReadInConfig(); err != nil {
 			return nil, fmt.Errorf("error reading config file %q: %w", cfgFile, err)
 		}
+	}
+	return v, nil
+}
+
+func LoadConfig() (*Config, error) {
+	defaultCfg, err := DefaultConfig()
+	if err != nil {
+		return nil, err
+	}
+	registerFlags(defaultCfg)
+	pflag.Parse()
+
+	v, err := buildViper()
+	if err != nil {
+		return nil, err
 	}
 
 	builder := &Builder{
@@ -444,6 +457,7 @@ func LoadConfig() (*Config, error) {
 
 	return conf, nil
 }
+
 func (c *Config) Validate() error {
 	if c.VolumeGroup != "" {
 		if _, err := lvm.GetVolumeGroupFreeSpace(context.Background(), c.VolumeGroup); err != nil {
@@ -473,7 +487,7 @@ func findInPath(name string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if info.IsDir() || info.Mode().Perm()&0111 == 0 {
+		if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
 			return "", fmt.Errorf("%s is not executable", name)
 		}
 		return name, nil
@@ -488,7 +502,7 @@ func findInPath(name string) (string, error) {
 		if err != nil {
 			continue
 		}
-		if !info.IsDir() && info.Mode().Perm()&0111 != 0 {
+		if !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
 			return full, nil
 		}
 	}

--- a/config/loadconfig_test.go
+++ b/config/loadconfig_test.go
@@ -27,41 +27,74 @@ func writeTempConfig(t *testing.T, content string) string {
 	return path
 }
 
-func TestLoadConfigPrecedence(t *testing.T) {
+func TestRegisterFlags(t *testing.T) {
+	resetFlags(nil)
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	registerFlags(cfg)
+	names := []string{"parallel", "ssh_user", "grpc_port"}
+	for _, name := range names {
+		if f := pflag.CommandLine.Lookup(name); f == nil {
+			t.Fatalf("missing %s flag", name)
+		}
+	}
+}
+
+func TestBuildViperPrecedence(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 
 	t.Run("config_overrides_defaults", func(t *testing.T) {
 		resetFlags([]string{"--config", cfgPath})
-		c, err := LoadConfig()
+		cfg, err := DefaultConfig()
 		if err != nil {
-			t.Fatalf("LoadConfig: %v", err)
+			t.Fatalf("DefaultConfig: %v", err)
 		}
-		if c.Parallel != 1 {
-			t.Fatalf("expected parallel 1, got %d", c.Parallel)
+		registerFlags(cfg)
+		pflag.Parse()
+		v, err := buildViper()
+		if err != nil {
+			t.Fatalf("buildViper: %v", err)
+		}
+		if got := v.GetInt("parallel"); got != 1 {
+			t.Fatalf("expected parallel 1, got %d", got)
 		}
 	})
 
 	t.Run("env_overrides_config", func(t *testing.T) {
 		resetFlags([]string{"--config", cfgPath})
 		t.Setenv("LVMSYNC.PARALLEL", "2")
-		c, err := LoadConfig()
+		cfg, err := DefaultConfig()
 		if err != nil {
-			t.Fatalf("LoadConfig: %v", err)
+			t.Fatalf("DefaultConfig: %v", err)
 		}
-		if c.Parallel != 2 {
-			t.Fatalf("expected parallel 2, got %d", c.Parallel)
+		registerFlags(cfg)
+		pflag.Parse()
+		v, err := buildViper()
+		if err != nil {
+			t.Fatalf("buildViper: %v", err)
+		}
+		if got := v.GetInt("parallel"); got != 2 {
+			t.Fatalf("expected parallel 2, got %d", got)
 		}
 	})
 
 	t.Run("flags_override_env", func(t *testing.T) {
 		resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
 		t.Setenv("LVMSYNC.PARALLEL", "2")
-		c, err := LoadConfig()
+		cfg, err := DefaultConfig()
 		if err != nil {
-			t.Fatalf("LoadConfig: %v", err)
+			t.Fatalf("DefaultConfig: %v", err)
 		}
-		if c.Parallel != 3 {
-			t.Fatalf("expected parallel 3, got %d", c.Parallel)
+		registerFlags(cfg)
+		pflag.Parse()
+		v, err := buildViper()
+		if err != nil {
+			t.Fatalf("buildViper: %v", err)
+		}
+		if got := v.GetInt("parallel"); got != 3 {
+			t.Fatalf("expected parallel 3, got %d", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- refactor config loading into registerFlags, buildViper, and LoadConfig
- test flag registration and precedence across config sources
- document configuration loading flow in README

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897baa5067c8323bb28be88168bb6d3