### PR TITLE
refactor: return errors instead of fatal

### DIFF
--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"strings"
 
-	grpcserver "lvmsync_go/grpc/server"
-	lvmagent "lvmsync_go/internal/lvm"
-
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+
+	grpcserver "lvmsync_go/grpc/server"
+	lvmagent "lvmsync_go/internal/lvm"
 )
 
 var (
@@ -44,7 +44,10 @@ func main() {
 	}
 
 	agent := lvmagent.NewSudoAgent("", nil)
-	srv := grpcserver.New(cfg, agent)
+	srv, srvErr := grpcserver.New(cfg, agent)
+	if srvErr != nil {
+		zap.L().Fatal("init gRPC server", zap.Error(srvErr))
+	}
 
 	port := v.GetInt("grpc-port")
 	lis, listenErr := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 
-	lvmagent "lvmsync_go/internal/lvm"
-	"lvmsync_go/proto"
-
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	lvmagent "lvmsync_go/internal/lvm"
+	"lvmsync_go/proto"
 )
 
 type Config struct {
@@ -24,7 +24,7 @@ type Config struct {
 	AllowInsecure bool
 }
 
-func New(conf Config, a lvmagent.Agent) *grpc.Server {
+func New(conf Config, a lvmagent.Agent) (*grpc.Server, error) {
 	opts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(authorizeInterceptor),
 	}
@@ -32,15 +32,15 @@ func New(conf Config, a lvmagent.Agent) *grpc.Server {
 	if !conf.AllowInsecure {
 		cert, err := tls.LoadX509KeyPair(conf.TLSCert, conf.TLSKey)
 		if err != nil {
-			zap.L().Fatal("load TLS key pair", zap.Error(err))
+			return nil, fmt.Errorf("load TLS key pair: %w", err)
 		}
 		caPEM, err := os.ReadFile(conf.CACert)
 		if err != nil {
-			zap.L().Fatal("read CA cert", zap.Error(err))
+			return nil, fmt.Errorf("read CA cert: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caPEM) {
-			zap.L().Fatal("invalid CA cert")
+			return nil, fmt.Errorf("invalid CA cert")
 		}
 		tlsCfg := &tls.Config{
 			Certificates: []tls.Certificate{cert},
@@ -53,10 +53,10 @@ func New(conf Config, a lvmagent.Agent) *grpc.Server {
 
 	srv := grpc.NewServer(opts...)
 	proto.RegisterReplicationServer(srv, &replicationServer{agent: a})
-	return srv
+	return srv, nil
 }
 
-func authorizeInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func authorizeInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, status.Error(codes.PermissionDenied, "missing metadata")

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -87,7 +87,10 @@ func (m *mockAgent) GetStatus(ctx context.Context, volume, requester string) (st
 func newClient(t *testing.T, cfg Config, agent lvmagent.Agent, creds credentials.TransportCredentials) (proto.ReplicationClient, func()) {
 	t.Helper()
 	lis := bufconn.Listen(bufSize)
-	srv := New(cfg, agent)
+	srv, err := New(cfg, agent)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	go func(t *testing.T) {
 		err := srv.Serve(lis)
 		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
@@ -361,6 +364,34 @@ func TestMTLSValidation(t *testing.T) {
 		client, cleanup := newClient(t, cfg, nil, credentials.NewTLS(bad))
 		defer cleanup()
 		if _, err := client.Ping(ctxWithRole("replicator"), &proto.Empty{}); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestNewTLSFailures(t *testing.T) {
+	t.Run("missing key pair", func(t *testing.T) {
+		if _, err := New(Config{TLSCert: "nope", TLSKey: "nope", CACert: "nope"}, nil); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("missing CA", func(t *testing.T) {
+		cfg, _, _ := generateTLS(t)
+		cfg.CACert = "nope"
+		if _, err := New(cfg, nil); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("invalid CA", func(t *testing.T) {
+		cfg, _, _ := generateTLS(t)
+		badCA := filepath.Join(t.TempDir(), "bad.pem")
+		if err := os.WriteFile(badCA, []byte("invalid"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		cfg.CACert = badCA
+		if _, err := New(cfg, nil); err == nil {
 			t.Fatalf("expected error")
 		}
 	})

--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -70,17 +70,20 @@ func (s *SSHSession) Close() {
 }
 
 func RunSSHCommand(host, user, keyPath, hostKeyPath string, port int, command string, timeout time.Duration) error {
-	publicKey, err := loadHostPublicKeyMust(hostKeyPath)
+	publicKey, err := readHostPublicKey(hostKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to load host public key: %w", err)
 	}
+	signer, err := readPrivateKey(keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load private key: %w", err)
+	}
 	client, err := dialSSH(fmt.Sprintf("%s:%d", host, port), &ssh.ClientConfig{
 		User:            user,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(loadPrivateKeyMust(keyPath))},
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		HostKeyCallback: ssh.FixedHostKey(publicKey),
 		Timeout:         timeout,
 	}, timeout)
-
 	if err != nil {
 		return fmt.Errorf("failed to establish SSH connection: %w", err)
 	}
@@ -111,29 +114,27 @@ func RunSSHCommand(host, user, keyPath, hostKeyPath string, port int, command st
 	return nil
 }
 
-func loadPrivateKeyMust(keyPath string) ssh.Signer {
+func readPrivateKey(keyPath string) (ssh.Signer, error) {
 	key, err := os.ReadFile(keyPath)
 	if err != nil {
-		Logger.Fatal("Failed to read SSH private key", zap.String("keyPath", keyPath), zap.Error(err))
+		return nil, fmt.Errorf("read SSH private key: %w", err)
 	}
 	signer, err := ssh.ParsePrivateKey(key)
 	if err != nil {
-		Logger.Fatal("Failed to parse SSH private key", zap.String("keyPath", keyPath), zap.Error(err))
+		return nil, fmt.Errorf("parse SSH private key: %w", err)
 	}
-	return signer
+	return signer, nil
 }
 
-// loadHostPublicKeyMust loads the allowed host public key from the given path and parses it.
-func loadHostPublicKeyMust(keyPath string) (ssh.PublicKey, error) {
+// readHostPublicKey loads the allowed host public key from the given path and parses it.
+func readHostPublicKey(keyPath string) (ssh.PublicKey, error) {
 	key, err := os.ReadFile(keyPath)
 	if err != nil {
-		zap.L().Fatal("Failed to read SSH host public key", zap.String("keyPath", keyPath), zap.Error(err))
-		return nil, err
+		return nil, fmt.Errorf("read SSH host public key: %w", err)
 	}
 	publicKey, err := ssh.ParsePublicKey(key)
 	if err != nil {
-		zap.L().Fatal("Failed to parse SSH host public key", zap.String("keyPath", keyPath), zap.Error(err))
-		return nil, err
+		return nil, fmt.Errorf("parse SSH host public key: %w", err)
 	}
 	return publicKey, nil
 }

--- a/remote/ssh_session_test.go
+++ b/remote/ssh_session_test.go
@@ -1,0 +1,49 @@
+package remote
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"os"
+	"path/filepath"
+	"testing"
+
+	remotetest "lvmsync_go/remote/testutil"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestLoadPrivateKey(t *testing.T) {
+	keyFile := remotetest.CreateTempKey(t)
+	if _, err := readPrivateKey(keyFile); err != nil {
+		t.Fatalf("loadPrivateKey valid: %v", err)
+	}
+	if _, err := readPrivateKey(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected error for missing key")
+	}
+}
+
+func TestLoadHostPublicKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	pub, err := ssh.NewPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	file := filepath.Join(t.TempDir(), "host_key.pub")
+	if err := os.WriteFile(file, pub.Marshal(), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	loaded, err := readHostPublicKey(file)
+	if err != nil {
+		t.Fatalf("loadHostPublicKey valid: %v", err)
+	}
+	if !bytes.Equal(loaded.Marshal(), pub.Marshal()) {
+		t.Fatalf("loaded key mismatch")
+	}
+	if _, err := readHostPublicKey(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected error for missing host key")
+	}
+}


### PR DESCRIPTION
## Summary
- allow callers to handle TLS setup errors when creating gRPC server
- surface SSH key loading errors instead of terminating the process
- add tests for TLS server creation and SSH key loading error paths

## Testing
- `go test -cover ./...` *(fails: undefined calculateSnapshotSize, ensureVolumeGroups, checkDiskSpaceForSnapshot)*
- `go test -cover ./grpc/server ./remote`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897beb823d483239dbb6f0044c2505c