### PR TITLE
refactor: centralize snapshot prep and client execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ LVMSync is organized into modular packages to keep concerns separated:
 - `dedup` – houses Bloom filter helpers, chunking logic, and other deduplication utilities.
 - `grpc` – provides the gRPC server and authentication helpers used by the remote daemon.
 - `common` and `internal` – shared helpers and internal utilities such as multi-error handling.
-- `cmd/lvmsync` – CLI orchestrator broken into focused subpackages:
-  - `snapshot` for snapshot preparation
-  - `signals` for signal handling and cleanup
-  - `transfer` for client transfer execution
+- `internal/client` – coordinates snapshot preparation and client transfer execution.
+- `cmd/lvmsync` – CLI orchestrator with a `signals` subpackage for signal handling and cleanup.
 - `cmd/grpcd` – standalone gRPC daemon exposing LVMSync operations remotely.
 
 This structure allows individual packages to be developed and tested in isolation.
+
+### Refactoring Notes
+
+- Snapshot preparation helpers (`ensureVolumeGroups`, `checkDiskSpaceForSnapshot`, `createSnapshotIfNeeded`, `PrepareSnapshot`) and client execution logic are consolidated under `internal/client`.
+- These helpers no longer rely on global variables; configuration and loggers are passed explicitly.
+- `main.go` now orchestrates operations through the `internal/client` package.
 
 ## Logging
 

--- a/dedup/bloom.go
+++ b/dedup/bloom.go
@@ -45,7 +45,7 @@ func MaxChunks(ramBytes uint64, fpRate float64) uint64 {
 // AdaptiveAvgChunk computes the average chunk size based on volume size,
 // available RAM and false positive rate. The size is clamped between the
 // provided minimum and maximum values.
-func AdaptiveAvgChunk(volumeSize, ramBytes uint64, fpRate float64, minSize, maxSize uint64) (avg uint64, maxChunks uint64) {
+func AdaptiveAvgChunk(volumeSize, ramBytes uint64, fpRate float64, minSize, maxSize uint64) (avg, maxChunks uint64) {
 	maxChunks = MaxChunks(ramBytes, fpRate)
 	if maxChunks == 0 {
 		maxChunks = 1

--- a/grpc/auth/auth.go
+++ b/grpc/auth/auth.go
@@ -20,7 +20,7 @@ type Role struct {
 // NewAuthInterceptor returns a grpc.UnaryServerInterceptor that enforces
 // client certificate issuer and subject to match the provided role.
 func NewAuthInterceptor(role Role) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		p, ok := peer.FromContext(ctx)
 		if !ok {
 			return nil, status.Error(codes.Unauthenticated, "missing peer info")

--- a/internal/client/execute.go
+++ b/internal/client/execute.go
@@ -1,9 +1,9 @@
-package transfer
+package client
 
 import "fmt"
 
-// Execute runs the client transfer logic and handles signal and monitor errors.
-func Execute(runClient func(string, string) error, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error) error {
+// ExecuteClient runs the client transfer logic and handles signal and monitor errors.
+func ExecuteClient(runClient func(string, string) error, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error) error {
 	clientErrCh := make(chan error, 1)
 	go func() {
 		clientErrCh <- runClient(snapshotPath, destPath)

--- a/internal/client/execute_test.go
+++ b/internal/client/execute_test.go
@@ -1,4 +1,4 @@
-package transfer
+package client
 
 import (
 	"errors"
@@ -10,7 +10,7 @@ import (
 func TestExecuteRunError(t *testing.T) {
 	runClient := func(string, string) error { return errors.New("run") }
 	sigCh := make(chan error, 1)
-	err := Execute(runClient, "snap", "dest", sigCh, nil)
+	err := ExecuteClient(runClient, "snap", "dest", sigCh, nil)
 	if err == nil || !strings.Contains(err.Error(), "copy operation failed") {
 		t.Fatalf("expected copy failure, got %v", err)
 	}
@@ -27,7 +27,7 @@ func TestExecuteSignal(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		sigCh <- errors.New("signal")
 	}()
-	err := Execute(runClient, "snap", "dest", sigCh, nil)
+	err := ExecuteClient(runClient, "snap", "dest", sigCh, nil)
 	close(block)
 	if err == nil || !strings.Contains(err.Error(), "signal") {
 		t.Fatalf("expected signal error, got %v", err)
@@ -39,7 +39,7 @@ func TestExecuteMonitorError(t *testing.T) {
 	sigCh := make(chan error, 1)
 	monitorCh := make(chan error, 1)
 	monitorCh <- errors.New("monitor")
-	err := Execute(runClient, "snap", "dest", sigCh, monitorCh)
+	err := ExecuteClient(runClient, "snap", "dest", sigCh, monitorCh)
 	if err == nil || !strings.Contains(err.Error(), "snapshot monitor error") {
 		t.Fatalf("expected monitor error, got %v", err)
 	}

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -1,4 +1,4 @@
-package snapshot
+package client
 
 import (
 	"context"
@@ -24,9 +24,9 @@ var (
 	removeSnapshot           = lvm.RemoveSnapshot
 )
 
-// Prepare sets up a snapshot for the given original volume. It returns the snapshot path,
+// PrepareSnapshot sets up a snapshot for the given original volume. It returns the snapshot path,
 // an optional monitor error channel, a cleanup function, and any error encountered.
-func Prepare(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
 	snapshotBytes, err := calculateSnapshotSize(cfg, originalVolume)
 	if err != nil {
 		return "", nil, nil, err
@@ -111,7 +111,7 @@ func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotB
 	monitorCtx, cancel := context.WithCancel(context.Background())
 	go func() {
 		if err := monitorSnapshot(monitorCtx, snapshotPath, 80.0, 10*time.Second); err != nil && err != context.Canceled {
-			zap.L().Error("Snapshot monitor error", zap.Error(err))
+			logger.Error("Snapshot monitor error", zap.Error(err))
 			monitorErrCh <- err
 		}
 	}()

--- a/internal/client/snapshot_helpers_test.go
+++ b/internal/client/snapshot_helpers_test.go
@@ -1,6 +1,7 @@
-package main
+package client
 
 import (
+	"errors"
 	"math"
 	"testing"
 
@@ -10,8 +11,12 @@ import (
 
 func TestCalculateSnapshotSize(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		cfg = &config.Config{SnapshotSize: "1024"}
-		size, err := calculateSnapshotSize("/dev/vg/lv")
+		cfg := &config.Config{SnapshotSize: "1024"}
+		origParse := parseSnapshotSize
+		parseSnapshotSize = func(string, string) (uint64, error) { return 1024, nil }
+		defer func() { parseSnapshotSize = origParse }()
+
+		size, err := calculateSnapshotSize(cfg, "/dev/vg/lv")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -21,8 +26,12 @@ func TestCalculateSnapshotSize(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		cfg = &config.Config{SnapshotSize: "bad"}
-		if _, err := calculateSnapshotSize("/dev/vg/lv"); err == nil {
+		cfg := &config.Config{SnapshotSize: "bad"}
+		origParse := parseSnapshotSize
+		parseSnapshotSize = func(string, string) (uint64, error) { return 0, errors.New("bad") }
+		defer func() { parseSnapshotSize = origParse }()
+
+		if _, err := calculateSnapshotSize(cfg, "/dev/vg/lv"); err == nil {
 			t.Fatalf("expected error for invalid size")
 		}
 	})
@@ -32,8 +41,8 @@ func TestEnsureVolumeGroups(t *testing.T) {
 	logger := zap.NewNop()
 
 	t.Run("sets missing volume group", func(t *testing.T) {
-		cfg = &config.Config{}
-		if err := ensureVolumeGroups("/dev/sourcevg/lv1", logger); err != nil {
+		cfg := &config.Config{}
+		if err := ensureVolumeGroups(cfg, "/dev/sourcevg/lv1", logger); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.VolumeGroup != "sourcevg" {
@@ -42,8 +51,8 @@ func TestEnsureVolumeGroups(t *testing.T) {
 	})
 
 	t.Run("preserves existing volume group", func(t *testing.T) {
-		cfg = &config.Config{VolumeGroup: "existing"}
-		if err := ensureVolumeGroups("/dev/othervg/lv", logger); err != nil {
+		cfg := &config.Config{VolumeGroup: "existing"}
+		if err := ensureVolumeGroups(cfg, "/dev/othervg/lv", logger); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.VolumeGroup != "existing" {
@@ -54,16 +63,17 @@ func TestEnsureVolumeGroups(t *testing.T) {
 
 func TestCheckDiskSpaceForSnapshot(t *testing.T) {
 	logger := zap.NewNop()
-	cfg = &config.Config{SkipDiskCheck: false}
 
 	t.Run("sufficient", func(t *testing.T) {
-		if err := checkDiskSpaceForSnapshot(1, logger); err != nil {
+		cfg := &config.Config{SkipDiskCheck: false}
+		if err := checkDiskSpaceForSnapshot(cfg, 1, logger); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("insufficient", func(t *testing.T) {
-		if err := checkDiskSpaceForSnapshot(math.MaxUint64, logger); err == nil {
+		cfg := &config.Config{SkipDiskCheck: false}
+		if err := checkDiskSpaceForSnapshot(cfg, math.MaxUint64, logger); err == nil {
 			t.Fatalf("expected error for insufficient space")
 		}
 	})

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -1,4 +1,4 @@
-package snapshot
+package client
 
 import (
 	"testing"
@@ -22,7 +22,7 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 	defer func() { parseSnapshotSize = origParse }()
 
 	logger := zap.NewNop()
-	snap, monitorCh, cleanup, err := Prepare(cfg, "/dev/vg/orig", logger)
+	snap, monitorCh, cleanup, err := PrepareSnapshot(cfg, "/dev/vg/orig", logger)
 	if err != nil {
 		t.Fatalf("Prepare returned error: %v", err)
 	}

--- a/internal/compressiondetect/compressiondetect.go
+++ b/internal/compressiondetect/compressiondetect.go
@@ -9,9 +9,10 @@ import (
 	"sync"
 	"time"
 
-	zstd "github.com/klauspost/compress/zstd"
 	"github.com/klauspost/cpuid/v2"
 	"github.com/pierrec/lz4/v4"
+
+	zstd "github.com/klauspost/compress/zstd"
 )
 
 var (

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -76,7 +76,7 @@ func (s *sudoAgent) SendMetadata(_ context.Context, _ VolumeMetadata) error {
 	return nil
 }
 
-func (s *sudoAgent) StartTransferSession(_ context.Context, _ string, _ string) error {
+func (s *sudoAgent) StartTransferSession(_ context.Context, _, _ string) error {
 	// volume and requester are ignored until LVM operations are implemented.
 	if err := s.ensureRoot(); err != nil {
 		return err
@@ -85,7 +85,7 @@ func (s *sudoAgent) StartTransferSession(_ context.Context, _ string, _ string) 
 	return nil
 }
 
-func (s *sudoAgent) FinalizeSync(_ context.Context, _ string, _ string) error {
+func (s *sudoAgent) FinalizeSync(_ context.Context, _, _ string) error {
 	// volume and requester are ignored until LVM operations are implemented.
 	if err := s.ensureRoot(); err != nil {
 		return err
@@ -94,7 +94,7 @@ func (s *sudoAgent) FinalizeSync(_ context.Context, _ string, _ string) error {
 	return nil
 }
 
-func (s *sudoAgent) GetStatus(_ context.Context, _ string, _ string) (string, error) {
+func (s *sudoAgent) GetStatus(_ context.Context, _, _ string) (string, error) {
 	// volume and requester are ignored until LVM operations are implemented.
 	if err := s.ensureRoot(); err != nil {
 		return "", err

--- a/lvm/api.go
+++ b/lvm/api.go
@@ -2,4 +2,4 @@ package lvm
 
 // API defines the set of methods required by the gRPC server.
 // It currently acts as a placeholder for future expansion.
-type API interface{}
+type API any

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -4,7 +4,6 @@ package lvm
 import (
 	"context"
 	"fmt"
-	"lvmsync_go/internal/sizeparse"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,6 +13,8 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
+
+	"lvmsync_go/internal/sizeparse"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -15,10 +15,9 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	signalspkg "lvmsync_go/cmd/lvmsync/signals"
-	snapshotpkg "lvmsync_go/cmd/lvmsync/snapshot"
-	transferexec "lvmsync_go/cmd/lvmsync/transfer"
 	"lvmsync_go/common"
 	"lvmsync_go/config"
+	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privesc"
 	"lvmsync_go/lvm"
 	"lvmsync_go/remote"
@@ -321,13 +320,13 @@ func run() error {
 	}
 
 	var monitorErrCh chan error
-	snapshotPath, monitorErrCh, cleanup, err := snapshotpkg.Prepare(cfg, originalVolume, logger)
+	snapshotPath, monitorErrCh, cleanup, err := clientpkg.PrepareSnapshot(cfg, originalVolume, logger)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	return transferexec.Execute(runClientMode, snapshotPath, destPath, sigErrCh, monitorErrCh)
+	return clientpkg.ExecuteClient(runClientMode, snapshotPath, destPath, sigErrCh, monitorErrCh)
 }
 
 func main() {

--- a/transfer/block_common.go
+++ b/transfer/block_common.go
@@ -8,9 +8,9 @@ import (
 	"syscall"
 	"time"
 
-	"lvmsync_go/config"
-
 	"go.uber.org/zap"
+
+	"lvmsync_go/config"
 )
 
 // PipeCreationCount tracks the number of pipes created by ReadBlockWithRetries

--- a/transfer/block_linux.go
+++ b/transfer/block_linux.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func ZeroCopyTransfer(src *os.File, dst *os.File, offset int64, length int64, pipeFds [2]int) error {
+func ZeroCopyTransfer(src, dst *os.File, offset, length int64, pipeFds [2]int) error {
 	remaining := length
 	off := offset
 	for remaining > 0 {

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -73,7 +73,7 @@ func prepareResultHeader(cfg *config.Config, checksum ChecksumStrategy, res *Blo
 	return n
 }
 
-func writeResult(bufOut *bufio.Writer, header []byte, data []byte) error {
+func writeResult(bufOut *bufio.Writer, header, data []byte) error {
 	if _, err := bufOut.Write(header); err != nil {
 		return fmt.Errorf("failed to write header: %w", err)
 	}

--- a/transfer/bufferpool.go
+++ b/transfer/bufferpool.go
@@ -10,7 +10,7 @@ func getPool(size int) *sync.Pool {
 			return pool
 		}
 	}
-	p := &sync.Pool{New: func() interface{} {
+	p := &sync.Pool{New: func() any {
 		buf := make([]byte, size)
 		return &buf
 	}}

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -23,7 +23,7 @@ const (
 // `concurrency` is less than or equal to zero, it defaults to the number of
 // logical CPUs. It returns the configured `io.WriteCloser` or an error if the
 // compression type is unsupported.
-func NewCompressionWriter(dst io.Writer, compress string, level int, concurrency int) (io.WriteCloser, error) {
+func NewCompressionWriter(dst io.Writer, compress string, level, concurrency int) (io.WriteCloser, error) {
 	if compress == StrategyAuto {
 		compress = compressiondetect.DetectOptimalCompression()
 	}

--- a/transfer/compression_strategy.go
+++ b/transfer/compression_strategy.go
@@ -5,18 +5,19 @@ import (
 	"io"
 	"sync"
 
-	zstd "github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
+
+	zstd "github.com/klauspost/compress/zstd"
 )
 
 type CompressionStrategy interface {
-	NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error)
+	NewWriter(dst io.Writer, level, concurrency int) (io.WriteCloser, error)
 	NewReader(src io.Reader, concurrency int) (io.ReadCloser, error)
 }
 
 type noneStrategy struct{}
 
-func (noneStrategy) NewWriter(dst io.Writer, _ int, _ int) (io.WriteCloser, error) {
+func (noneStrategy) NewWriter(dst io.Writer, _, _ int) (io.WriteCloser, error) {
 	// level and concurrency are ignored for the none strategy.
 	return nopWriteCloser{dst}, nil
 }
@@ -51,7 +52,7 @@ func (w *pooledLz4Writer) Close() error {
 	return err
 }
 
-func (lz4Strategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
+func (lz4Strategy) NewWriter(dst io.Writer, level, concurrency int) (io.WriteCloser, error) {
 	var lvl lz4.CompressionLevel
 	switch level {
 	case int(lz4.Fast), int(lz4.Level1), int(lz4.Level2), int(lz4.Level3), int(lz4.Level4), int(lz4.Level5), int(lz4.Level6), int(lz4.Level7), int(lz4.Level8), int(lz4.Level9):
@@ -170,7 +171,7 @@ func (w *pooledZstdWriter) Close() error {
 	return err
 }
 
-func (zstdStrategy) NewWriter(dst io.Writer, level int, concurrency int) (io.WriteCloser, error) {
+func (zstdStrategy) NewWriter(dst io.Writer, level, concurrency int) (io.WriteCloser, error) {
 	if level < 1 || level > 22 {
 		return nil, fmt.Errorf("invalid zstd compression level: %d", level)
 	}

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -12,11 +12,11 @@ import (
 	"sync"
 	"unsafe"
 
-	"lvmsync_go/config"
-
 	"github.com/bits-and-blooms/bloom/v3"
 	"go.uber.org/zap"
 	"golang.org/x/sys/cpu"
+
+	"lvmsync_go/config"
 )
 
 var createStateFile = func(name string) (io.WriteCloser, error) {

--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -3,9 +3,9 @@ package transfer
 import (
 	"time"
 
-	"lvmsync_go/config"
-
 	"go.uber.org/zap"
+
+	"lvmsync_go/config"
 )
 
 func finalizeProgress(cfg *config.Config) {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -16,16 +16,18 @@ import (
 	"syscall"
 	"time"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/common"
 	"lvmsync_go/config"
 	"lvmsync_go/internal/blocksize"
-
-	"go.uber.org/zap"
 )
 
 // Logger holds the package-wide zap.Logger used for progress and error reporting.
-var Logger *zap.Logger
-var workerWG *sync.WaitGroup
+var (
+	Logger   *zap.Logger
+	workerWG *sync.WaitGroup
+)
 
 // SetLogger assigns Logger for package-wide logging and overrides any existing logger.
 func SetLogger(logger *zap.Logger) {
@@ -437,7 +439,7 @@ func writeData(destFile *os.File, offset uint64, data []byte) error {
 	return nil
 }
 
-func processBlock(destFile *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, offset uint64, transmitted []byte, data []byte) (bool, error) {
+func processBlock(destFile *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, offset uint64, transmitted, data []byte) (bool, error) {
 	if offset > math.MaxInt64 {
 		return false, fmt.Errorf("offset %d overflows int64", offset)
 	}


### PR DESCRIPTION
## Summary
- move snapshot helpers and client execution into internal/client
- inject config and logger instead of relying on globals
- update README and main.go to use new package

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897c323a16c8323aca796b782ff0a73