### PR TITLE
feat(lvm): implement agent operations

### DIFF
--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -2,6 +2,7 @@ package lvm
 
 import (
 	"context"
+	"errors"
 
 	"lvmsync_go/internal/privesc"
 	lvmlib "lvmsync_go/lvm"
@@ -25,15 +26,29 @@ type Agent interface {
 	GetStatus(_ context.Context, volume, requester string) (string, error)
 }
 
+// lvmAPI defines the subset of methods used by the agent. It allows tests to
+// inject a mock implementation while the real implementation can satisfy the
+// interface implicitly.
+type lvmAPI interface {
+	Lock(context.Context, string, string) error
+	Unlock(context.Context, string, string) error
+	GetMetadata(context.Context, string) (VolumeMetadata, error)
+	SendMetadata(context.Context, VolumeMetadata) error
+	StartTransferSession(context.Context, string, string) error
+	FinalizeSync(context.Context, string, string) error
+	GetStatus(context.Context, string, string) (string, error)
+}
+
 // sudoAgent ensures root privileges via sudo before invoking LVM commands.
 type sudoAgent struct {
 	sudoPath string
-	lvm      lvmlib.API
+	lvm      lvmAPI
 }
 
 // NewSudoAgent returns an Agent implementation that escalates privileges using sudo.
 func NewSudoAgent(sudoPath string, l lvmlib.API) Agent {
-	return &sudoAgent{sudoPath: sudoPath, lvm: l}
+	api, _ := l.(lvmAPI)
+	return &sudoAgent{sudoPath: sudoPath, lvm: api}
 }
 
 func (s *sudoAgent) ensureRoot() error {
@@ -44,61 +59,72 @@ func (s *sudoAgent) ensureRoot() error {
 	return privesc.EnsureRoot(cmd)
 }
 
-func (s *sudoAgent) Lock(_ context.Context, _, _ string) error {
+func (s *sudoAgent) Lock(ctx context.Context, volume, requester string) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
-	// TODO: invoke lvm locking once available
-	return nil
+	if s.lvm == nil {
+		return errors.New("lvm api not provided")
+	}
+	return s.lvm.Lock(ctx, volume, requester)
 }
 
-func (s *sudoAgent) Unlock(_ context.Context, _, _ string) error {
+func (s *sudoAgent) Unlock(ctx context.Context, volume, requester string) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
-	// TODO: invoke lvm unlock once available
-	return nil
+	if s.lvm == nil {
+		return errors.New("lvm api not provided")
+	}
+	return s.lvm.Unlock(ctx, volume, requester)
 }
 
-func (s *sudoAgent) GetMetadata(_ context.Context, _ string) (VolumeMetadata, error) {
+func (s *sudoAgent) GetMetadata(ctx context.Context, volume string) (VolumeMetadata, error) {
 	if err := s.ensureRoot(); err != nil {
 		return VolumeMetadata{}, err
 	}
-	// TODO: fetch metadata using lvm
-	return VolumeMetadata{}, nil
+	if s.lvm == nil {
+		return VolumeMetadata{}, errors.New("lvm api not provided")
+	}
+	return s.lvm.GetMetadata(ctx, volume)
 }
 
-func (s *sudoAgent) SendMetadata(_ context.Context, _ VolumeMetadata) error {
+func (s *sudoAgent) SendMetadata(ctx context.Context, md VolumeMetadata) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
-	// TODO: send metadata using lvm
-	return nil
+	if s.lvm == nil {
+		return errors.New("lvm api not provided")
+	}
+	return s.lvm.SendMetadata(ctx, md)
 }
 
-func (s *sudoAgent) StartTransferSession(_ context.Context, _, _ string) error {
-	// volume and requester are ignored until LVM operations are implemented.
+func (s *sudoAgent) StartTransferSession(ctx context.Context, volume, requester string) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
-	// TODO: start transfer session via lvm
-	return nil
+	if s.lvm == nil {
+		return errors.New("lvm api not provided")
+	}
+	return s.lvm.StartTransferSession(ctx, volume, requester)
 }
 
-func (s *sudoAgent) FinalizeSync(_ context.Context, _, _ string) error {
-	// volume and requester are ignored until LVM operations are implemented.
+func (s *sudoAgent) FinalizeSync(ctx context.Context, volume, requester string) error {
 	if err := s.ensureRoot(); err != nil {
 		return err
 	}
-	// TODO: finalize sync via lvm
-	return nil
+	if s.lvm == nil {
+		return errors.New("lvm api not provided")
+	}
+	return s.lvm.FinalizeSync(ctx, volume, requester)
 }
 
-func (s *sudoAgent) GetStatus(_ context.Context, _, _ string) (string, error) {
-	// volume and requester are ignored until LVM operations are implemented.
+func (s *sudoAgent) GetStatus(ctx context.Context, volume, requester string) (string, error) {
 	if err := s.ensureRoot(); err != nil {
 		return "", err
 	}
-	// TODO: query status via lvm
-	return "", nil
+	if s.lvm == nil {
+		return "", errors.New("lvm api not provided")
+	}
+	return s.lvm.GetStatus(ctx, volume, requester)
 }

--- a/internal/lvm/agent_test.go
+++ b/internal/lvm/agent_test.go
@@ -1,0 +1,152 @@
+package lvm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type mockLVM struct {
+	lockErr         error
+	unlockErr       error
+	md              VolumeMetadata
+	getMetadataErr  error
+	sendMetadataErr error
+	startErr        error
+	finalizeErr     error
+	status          string
+	statusErr       error
+}
+
+func (m *mockLVM) Lock(_ context.Context, _, _ string) error {
+	return m.lockErr
+}
+
+func (m *mockLVM) Unlock(_ context.Context, _, _ string) error {
+	return m.unlockErr
+}
+
+func (m *mockLVM) GetMetadata(_ context.Context, _ string) (VolumeMetadata, error) {
+	return m.md, m.getMetadataErr
+}
+
+func (m *mockLVM) SendMetadata(_ context.Context, md VolumeMetadata) error {
+	m.md = md
+	return m.sendMetadataErr
+}
+
+func (m *mockLVM) StartTransferSession(_ context.Context, _, _ string) error {
+	return m.startErr
+}
+
+func (m *mockLVM) FinalizeSync(_ context.Context, _, _ string) error {
+	return m.finalizeErr
+}
+
+func (m *mockLVM) GetStatus(_ context.Context, _, _ string) (string, error) {
+	return m.status, m.statusErr
+}
+
+func TestSudoAgentLock(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockLVM{}
+	a := NewSudoAgent("", mock)
+	if err := a.Lock(ctx, "vol", "req"); err != nil {
+		t.Fatalf("lock failed: %v", err)
+	}
+	mock.lockErr = errors.New("boom")
+	if err := a.Lock(ctx, "vol", "req"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSudoAgentUnlock(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockLVM{}
+	a := NewSudoAgent("", mock)
+	if err := a.Unlock(ctx, "vol", "req"); err != nil {
+		t.Fatalf("unlock failed: %v", err)
+	}
+	mock.unlockErr = errors.New("boom")
+	if err := a.Unlock(ctx, "vol", "req"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSudoAgentGetMetadata(t *testing.T) {
+	ctx := context.Background()
+	expected := VolumeMetadata{VolumeName: "vol", SizeBytes: 1, ChunkSize: 2}
+	mock := &mockLVM{md: expected}
+	a := NewSudoAgent("", mock)
+	md, err := a.GetMetadata(ctx, "vol")
+	if err != nil {
+		t.Fatalf("get metadata failed: %v", err)
+	}
+	if md != expected {
+		t.Fatalf("unexpected metadata: %+v", md)
+	}
+	mock.getMetadataErr = errors.New("boom")
+	if _, err := a.GetMetadata(ctx, "vol"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSudoAgentSendMetadata(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockLVM{}
+	a := NewSudoAgent("", mock)
+	md := VolumeMetadata{VolumeName: "vol"}
+	if err := a.SendMetadata(ctx, md); err != nil {
+		t.Fatalf("send metadata failed: %v", err)
+	}
+	if mock.md != md {
+		t.Fatalf("metadata not forwarded: %+v", mock.md)
+	}
+	mock.sendMetadataErr = errors.New("boom")
+	if err := a.SendMetadata(ctx, md); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSudoAgentStartTransferSession(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockLVM{}
+	a := NewSudoAgent("", mock)
+	if err := a.StartTransferSession(ctx, "vol", "req"); err != nil {
+		t.Fatalf("start transfer failed: %v", err)
+	}
+	mock.startErr = errors.New("boom")
+	if err := a.StartTransferSession(ctx, "vol", "req"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSudoAgentFinalizeSync(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockLVM{}
+	a := NewSudoAgent("", mock)
+	if err := a.FinalizeSync(ctx, "vol", "req"); err != nil {
+		t.Fatalf("finalize sync failed: %v", err)
+	}
+	mock.finalizeErr = errors.New("boom")
+	if err := a.FinalizeSync(ctx, "vol", "req"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSudoAgentGetStatus(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockLVM{status: "ok"}
+	a := NewSudoAgent("", mock)
+	status, err := a.GetStatus(ctx, "vol", "req")
+	if err != nil {
+		t.Fatalf("get status failed: %v", err)
+	}
+	if status != "ok" {
+		t.Fatalf("unexpected status: %s", status)
+	}
+	mock.statusErr = errors.New("boom")
+	if _, err := a.GetStatus(ctx, "vol", "req"); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- flesh out LVM agent methods using injected API
- add comprehensive unit tests for agent behavior

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897ca3c2efc832381303371397a339a