### PR TITLE
refactor(transfer): use snake_case log fields

### DIFF
--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -1,0 +1,69 @@
+package transfer
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/config"
+)
+
+func TestDumpChangesSequentialLogFields(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	SetLogger(zap.New(core))
+
+	blockSize := int64(1024)
+	changed := []int{0, 2}
+	src, snapshot := createDumpTestFiles(t, blockSize, changed)
+
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
+	var buf bytes.Buffer
+	if err := DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChangesSequential failed: %v", err)
+	}
+
+	using := logs.FilterMessage("Using block size").All()
+	if len(using) != 1 {
+		t.Fatalf("expected one 'Using block size' log, got %d", len(using))
+	}
+	if v, ok := using[0].ContextMap()["block_size_bytes"].(int64); !ok || v != blockSize {
+		t.Fatalf("expected block_size_bytes=%d, got %v", blockSize, using[0].ContextMap()["block_size_bytes"])
+	}
+
+	changedLogs := logs.FilterMessage("Changed blocks determined").All()
+	if len(changedLogs) != 1 {
+		t.Fatalf("expected one 'Changed blocks determined' log, got %d", len(changedLogs))
+	}
+	if v, ok := changedLogs[0].ContextMap()["block_count"].(int64); !ok || int(v) != len(changed) {
+		t.Fatalf("expected block_count=%d, got %v", len(changed), changedLogs[0].ContextMap()["block_count"])
+	}
+}
+
+func TestReadResumeStartLogField(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	Logger = zap.New(core)
+
+	tmp := t.TempDir()
+	stateFile := filepath.Join(tmp, "resume")
+	if err := os.WriteFile(stateFile, []byte("5"), 0o600); err != nil {
+		t.Fatalf("write resume state: %v", err)
+	}
+
+	cfg := &config.Config{ResumeState: stateFile}
+	val := readResumeStart(cfg)
+	if val != 5 {
+		t.Fatalf("expected resume value 5, got %d", val)
+	}
+
+	entries := logs.FilterMessage("Resuming from block").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one resume log, got %d", len(entries))
+	}
+	if v, ok := entries[0].ContextMap()["resume_start_block"].(int64); !ok || v != 5 {
+		t.Fatalf("expected resume_start_block=5, got %v", entries[0].ContextMap()["resume_start_block"])
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -123,7 +123,7 @@ func detectBlockSize(cfg *config.Config, source string) error {
 		return fmt.Errorf("auto-detect block size: %w", err)
 	}
 	cfg.BlockSize = bs
-	Logger.Info("Auto-detected block size", zap.Int("blockSize", cfg.BlockSize))
+	Logger.Info("Auto-detected block size", zap.Int("block_size_bytes", cfg.BlockSize))
 	return nil
 }
 
@@ -136,7 +136,7 @@ func gatherChangedRanges(snapshot string, blockSize int64) ([]Range, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting differences: %w", err)
 	}
-	Logger.Info("Changed blocks determined", zap.Int("blockCount", len(ranges)))
+	Logger.Info("Changed blocks determined", zap.Int("block_count", len(ranges)))
 	return ranges, nil
 }
 
@@ -144,7 +144,7 @@ func prepareRanges(cfg *config.Config, snapshot, source string) ([]Range, error)
 	if err := detectBlockSize(cfg, source); err != nil {
 		return nil, err
 	}
-	Logger.Info("Using block size", zap.Int("blockSize", cfg.BlockSize))
+	Logger.Info("Using block size", zap.Int("block_size_bytes", cfg.BlockSize))
 
 	_, blockSize, err := validateOffsetAndSize(0, cfg.BlockSize)
 	if err != nil {
@@ -303,7 +303,7 @@ func readResumeStart(cfg *config.Config) int {
 	if err != nil {
 		return 0
 	}
-	Logger.Info("Resuming from block", zap.Int("resumeStart", val))
+	Logger.Info("Resuming from block", zap.Int("resume_start_block", val))
 	return val
 }
 


### PR DESCRIPTION
## Summary
- replace camelCase log field names with snake_case and units
- add tests verifying log field names via zaptest/observer

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897ca4748e08323a0dfded38f9864e0