### PR TITLE
refactor(config): rely on pflag usage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -409,7 +409,6 @@ func registerFlags(defaultCfg *Config) {
 	pflag.CommandLine.AddFlagSet(compressionFlags)
 	pflag.CommandLine.AddFlagSet(lvmFlags)
 	pflag.CommandLine.AddFlagSet(grpcFlags)
-	pflag.Usage = printUsage
 }
 
 func buildViper() (*viper.Viper, error) {
@@ -507,22 +506,4 @@ func findInPath(name string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("executable %q not found in $PATH", name)
-}
-
-func printUsage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s [options] <snapshot|lvm device> <destination>\n\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "General Options:\n")
-	generalFlags.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\nSSH Options:\n")
-	sshFlags.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\nRemote Options:\n")
-	remoteFlags.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\nDeduplication Options:\n")
-	dedupFlags.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\nCompression Options:\n")
-	compressionFlags.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\nLVM Options:\n")
-	lvmFlags.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\ngRPC Options:\n")
-	grpcFlags.PrintDefaults()
 }

--- a/config/loadconfig_test.go
+++ b/config/loadconfig_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -99,39 +100,21 @@ func TestBuildViperPrecedence(t *testing.T) {
 	})
 }
 
-func TestUsageIncludesFlagGroups(t *testing.T) {
+func TestUsageOutput(t *testing.T) {
+	resetFlags(nil)
 	cfg, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	initFlagSets(cfg)
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	old := os.Stderr
-	os.Stderr = w
-	printUsage()
-	w.Close()
-	os.Stderr = old
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	s := string(out)
-	headings := []string{
-		"General Options:",
-		"SSH Options:",
-		"Remote Options:",
-		"Deduplication Options:",
-		"Compression Options:",
-		"LVM Options:",
-		"gRPC Options:",
-	}
-	for _, h := range headings {
-		if !strings.Contains(s, h) {
-			t.Fatalf("usage missing %q", h)
+	registerFlags(cfg)
+	buf := &bytes.Buffer{}
+	pflag.CommandLine.SetOutput(buf)
+	pflag.Usage()
+	out := buf.String()
+	wants := []string{"--config", "--ssh_user", "--grpc_port"}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Fatalf("usage missing %q", w)
 		}
 	}
 }

--- a/config/usage_test.go
+++ b/config/usage_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestFlagSetUsage(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	sets := []struct {
+		fs   *pflag.FlagSet
+		want string
+	}{
+		{initGeneralFlags(cfg), "--config"},
+		{initSSHFlags(cfg), "--ssh_user"},
+		{initRemoteFlags(cfg), "--lvmsync_path"},
+		{initDedupFlags(cfg), "--dedup_strategy"},
+		{initCompressionFlags(cfg), "--compress"},
+		{initLVMFlags(cfg), "--skip_snapshot_creation"},
+		{initGRPCFlags(cfg), "--grpc_port"},
+	}
+	for _, tt := range sets {
+		buf := &bytes.Buffer{}
+		tt.fs.SetOutput(buf)
+		tt.fs.PrintDefaults()
+		if !strings.Contains(buf.String(), tt.want) {
+			t.Fatalf("usage for %s missing %q", tt.fs.Name(), tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- rely on pflag's default usage instead of manual printing
- add tests ensuring usage output lists expected flags

## Testing
- `go test ./...`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897cd2699408323b25086aa094a4283