### PR TITLE
test(client): expose snapshot size override for tests

### DIFF
--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -24,6 +24,14 @@ var (
 	removeSnapshot           = lvm.RemoveSnapshot
 )
 
+// SetParseSnapshotSizeForTest overrides the parseSnapshotSize helper for tests
+// and returns a function to restore the original behavior.
+func SetParseSnapshotSizeForTest(f func(string, string) (uint64, error)) func() {
+	orig := parseSnapshotSize
+	parseSnapshotSize = f
+	return func() { parseSnapshotSize = orig }
+}
+
 // PrepareSnapshot sets up a snapshot for the given original volume. It returns the snapshot path,
 // an optional monitor error channel, a cleanup function, and any error encountered.
 func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -1,10 +1,11 @@
-package client
+package client_test
 
 import (
 	"testing"
 
 	"go.uber.org/zap"
 	"lvmsync_go/config"
+	"lvmsync_go/internal/client"
 )
 
 func TestPrepareSkipSnapshot(t *testing.T) {
@@ -17,12 +18,11 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
 
-	origParse := parseSnapshotSize
-	parseSnapshotSize = func(string, string) (uint64, error) { return 1, nil }
-	defer func() { parseSnapshotSize = origParse }()
+	restore := client.SetParseSnapshotSizeForTest(func(string, string) (uint64, error) { return 1, nil })
+	defer restore()
 
 	logger := zap.NewNop()
-	snap, monitorCh, cleanup, err := PrepareSnapshot(cfg, "/dev/vg/orig", logger)
+	snap, monitorCh, cleanup, err := client.PrepareSnapshot(cfg, "/dev/vg/orig", logger)
 	if err != nil {
 		t.Fatalf("Prepare returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- expose SetParseSnapshotSizeForTest to override size parser during tests
- refactor snapshot test to use exported helper

## Testing
- `go test ./internal/client`
- `golangci-lint run`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897cf4a19ec8323bfe35bc98b13cb83