### PR TITLE
fix(blocksize): cast Rdev to uint64 for queue detection

### DIFF
--- a/internal/blocksize/blocksize.go
+++ b/internal/blocksize/blocksize.go
@@ -33,7 +33,8 @@ func Detect(devicePath string) (int, error) {
 			return 0, fmt.Errorf("stat %s: %w", devicePath, err)
 		}
 	}
-	queuePath := filepath.Join(sysDevBlock, fmt.Sprintf("%d:%d/queue", unix.Major(stat.Rdev), unix.Minor(stat.Rdev)))
+	rdev := uint64(stat.Rdev)
+	queuePath := filepath.Join(sysDevBlock, fmt.Sprintf("%d:%d/queue", unix.Major(rdev), unix.Minor(rdev)))
 	return readPreferredSize(queuePath)
 }
 


### PR DESCRIPTION
## Summary
- ensure device number is cast to uint64 before calling unix.Major and unix.Minor in block size detection

## Testing
- `go test -cover ./internal/blocksize`
- `golangci-lint run ./internal/blocksize`


------
https://chatgpt.com/codex/tasks/task_e_6897d17f1074832387c7d823550b0d53