### PR TITLE
refactor(lvm): inject ensureRoot for sudoAgent

### DIFF
--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -43,7 +43,7 @@ func main() {
 		AllowInsecure: v.GetBool("allow-insecure"),
 	}
 
-	agent := lvmagent.NewSudoAgent("", nil)
+	agent := lvmagent.NewSudoAgent("", nil, nil)
 	srv, srvErr := grpcserver.New(cfg, agent)
 	if srvErr != nil {
 		zap.L().Fatal("init gRPC server", zap.Error(srvErr))

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -41,22 +41,26 @@ type lvmAPI interface {
 
 // sudoAgent ensures root privileges via sudo before invoking LVM commands.
 type sudoAgent struct {
-	sudoPath string
-	lvm      lvmAPI
+	sudoPath   string
+	lvm        lvmAPI
+	ensureRoot func() error
 }
 
 // NewSudoAgent returns an Agent implementation that escalates privileges using sudo.
-func NewSudoAgent(sudoPath string, l lvmlib.API) Agent {
+// An optional ensureRoot function can be provided (primarily for tests). When nil,
+// privesc.EnsureRoot is used with the configured sudo path.
+func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error) Agent {
 	api, _ := l.(lvmAPI)
-	return &sudoAgent{sudoPath: sudoPath, lvm: api}
-}
-
-func (s *sudoAgent) ensureRoot() error {
-	cmd := s.sudoPath
-	if cmd == "" {
-		cmd = "sudo -n"
+	if ensureRoot == nil {
+		ensureRoot = func() error {
+			cmd := sudoPath
+			if cmd == "" {
+				cmd = "sudo -n"
+			}
+			return privesc.EnsureRoot(cmd)
+		}
 	}
-	return privesc.EnsureRoot(cmd)
+	return &sudoAgent{sudoPath: sudoPath, lvm: api, ensureRoot: ensureRoot}
 }
 
 func (s *sudoAgent) Lock(ctx context.Context, volume, requester string) error {

--- a/internal/lvm/agent_test.go
+++ b/internal/lvm/agent_test.go
@@ -50,7 +50,7 @@ func (m *mockLVM) GetStatus(_ context.Context, _, _ string) (string, error) {
 func TestSudoAgentLock(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewSudoAgent("", mock)
+	a := NewSudoAgent("", mock, func() error { return nil })
 	if err := a.Lock(ctx, "vol", "req"); err != nil {
 		t.Fatalf("lock failed: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestSudoAgentLock(t *testing.T) {
 func TestSudoAgentUnlock(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewSudoAgent("", mock)
+	a := NewSudoAgent("", mock, func() error { return nil })
 	if err := a.Unlock(ctx, "vol", "req"); err != nil {
 		t.Fatalf("unlock failed: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestSudoAgentGetMetadata(t *testing.T) {
 	ctx := context.Background()
 	expected := VolumeMetadata{VolumeName: "vol", SizeBytes: 1, ChunkSize: 2}
 	mock := &mockLVM{md: expected}
-	a := NewSudoAgent("", mock)
+	a := NewSudoAgent("", mock, func() error { return nil })
 	md, err := a.GetMetadata(ctx, "vol")
 	if err != nil {
 		t.Fatalf("get metadata failed: %v", err)
@@ -94,7 +94,7 @@ func TestSudoAgentGetMetadata(t *testing.T) {
 func TestSudoAgentSendMetadata(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewSudoAgent("", mock)
+	a := NewSudoAgent("", mock, func() error { return nil })
 	md := VolumeMetadata{VolumeName: "vol"}
 	if err := a.SendMetadata(ctx, md); err != nil {
 		t.Fatalf("send metadata failed: %v", err)
@@ -111,7 +111,7 @@ func TestSudoAgentSendMetadata(t *testing.T) {
 func TestSudoAgentStartTransferSession(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewSudoAgent("", mock)
+	a := NewSudoAgent("", mock, func() error { return nil })
 	if err := a.StartTransferSession(ctx, "vol", "req"); err != nil {
 		t.Fatalf("start transfer failed: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestSudoAgentStartTransferSession(t *testing.T) {
 func TestSudoAgentFinalizeSync(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewSudoAgent("", mock)
+	a := NewSudoAgent("", mock, func() error { return nil })
 	if err := a.FinalizeSync(ctx, "vol", "req"); err != nil {
 		t.Fatalf("finalize sync failed: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestSudoAgentFinalizeSync(t *testing.T) {
 func TestSudoAgentGetStatus(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{status: "ok"}
-	a := NewSudoAgent("", mock)
+	a := NewSudoAgent("", mock, func() error { return nil })
 	status, err := a.GetStatus(ctx, "vol", "req")
 	if err != nil {
 		t.Fatalf("get status failed: %v", err)


### PR DESCRIPTION
## Summary
- make sudoAgent's root check injectable and default to privesc.EnsureRoot
- allow tests to bypass sudo by providing a stub ensureRoot function
- update gRPC daemon to use new sudoAgent constructor

## Testing
- `go test ./internal/lvm -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6897d1880c2883238ce58b01eda84cbc