### PR TITLE
test: add snapshot preparation test

### DIFF
--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -32,6 +32,38 @@ func SetParseSnapshotSizeForTest(f func(string, string) (uint64, error)) func() 
 	return func() { parseSnapshotSize = orig }
 }
 
+// SetCreateSnapshotForTest overrides the createSnapshot helper for tests and
+// returns a function to restore the original behavior.
+func SetCreateSnapshotForTest(f func(context.Context, string, string, string) error) func() {
+	orig := createSnapshot
+	createSnapshot = f
+	return func() { createSnapshot = orig }
+}
+
+// SetGetSnapshotDevicePathForTest overrides the getSnapshotDevicePath helper
+// for tests and returns a function to restore the original behavior.
+func SetGetSnapshotDevicePathForTest(f func(string, string) string) func() {
+	orig := getSnapshotDevicePath
+	getSnapshotDevicePath = f
+	return func() { getSnapshotDevicePath = orig }
+}
+
+// SetMonitorSnapshotForTest overrides the monitorSnapshot helper for tests and
+// returns a function to restore the original behavior.
+func SetMonitorSnapshotForTest(f func(context.Context, string, float64, time.Duration) error) func() {
+	orig := monitorSnapshot
+	monitorSnapshot = f
+	return func() { monitorSnapshot = orig }
+}
+
+// SetRemoveSnapshotForTest overrides the removeSnapshot helper for tests and
+// returns a function to restore the original behavior.
+func SetRemoveSnapshotForTest(f func(context.Context, string) error) func() {
+	orig := removeSnapshot
+	removeSnapshot = f
+	return func() { removeSnapshot = orig }
+}
+
 // PrepareSnapshot sets up a snapshot for the given original volume. It returns the snapshot path,
 // an optional monitor error channel, a cleanup function, and any error encountered.
 func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -1,7 +1,10 @@
 package client_test
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"lvmsync_go/config"
@@ -33,4 +36,64 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 		t.Fatalf("expected nil monitor channel")
 	}
 	cleanup()
+}
+
+func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.SkipDiskCheck = true
+	cfg.VolumeGroup = "vg"
+	cfg.TargetVolumeGroup = "vg2"
+
+	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string) (uint64, error) { return 1024, nil })
+	defer restoreParse()
+
+	var created bool
+	restoreCreate := client.SetCreateSnapshotForTest(func(ctx context.Context, orig, name, size string) error {
+		created = true
+		if size != "1024" {
+			t.Fatalf("unexpected size: %s", size)
+		}
+		return nil
+	})
+	defer restoreCreate()
+
+	restorePath := client.SetGetSnapshotDevicePathForTest(func(name, vg string) string {
+		return "/dev/" + vg + "/" + name
+	})
+	defer restorePath()
+
+	restoreMonitor := client.SetMonitorSnapshotForTest(func(ctx context.Context, path string, threshold float64, interval time.Duration) error {
+		return nil
+	})
+	defer restoreMonitor()
+
+	var removedPath string
+	restoreRemove := client.SetRemoveSnapshotForTest(func(ctx context.Context, path string) error {
+		removedPath = path
+		return nil
+	})
+	defer restoreRemove()
+
+	logger := zap.NewNop()
+	snap, monitorCh, cleanup, err := client.PrepareSnapshot(cfg, "/dev/vg/orig", logger)
+	if err != nil {
+		t.Fatalf("PrepareSnapshot error: %v", err)
+	}
+	if !strings.HasPrefix(snap, "/dev/vg/snap-") {
+		t.Fatalf("unexpected snapshot path: %s", snap)
+	}
+	if monitorCh == nil {
+		t.Fatalf("expected monitor channel")
+	}
+	if !created {
+		t.Fatalf("createSnapshot not invoked")
+	}
+
+	cleanup()
+	if removedPath != snap {
+		t.Fatalf("removeSnapshot called with %q, expected %q", removedPath, snap)
+	}
 }


### PR DESCRIPTION
## Summary
- expose snapshot helper overrides for testing
- add test covering snapshot creation and cleanup

## Testing
- `go test ./internal/client -count=1`
- `go test -cover ./... 2>&1 | tee /tmp/unit.log` *(fails: yamllint: executable file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d34f5abc8323a2a027e1cdc5b383