### PR TITLE
refactor(config): use pflag usage for grouped help

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -400,15 +401,39 @@ func initFlagSets(defaultCfg *Config) {
 	grpcFlags = initGRPCFlags(defaultCfg)
 }
 
+func printFlagSetUsage(out io.Writer, fs *pflag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	fmt.Fprintln(out, fs.Name()+":")
+	fs.SetOutput(out)
+	fs.PrintDefaults()
+	fmt.Fprintln(out)
+}
+
 func registerFlags(defaultCfg *Config) {
 	initFlagSets(defaultCfg)
-	pflag.CommandLine.AddFlagSet(generalFlags)
-	pflag.CommandLine.AddFlagSet(sshFlags)
-	pflag.CommandLine.AddFlagSet(remoteFlags)
-	pflag.CommandLine.AddFlagSet(dedupFlags)
-	pflag.CommandLine.AddFlagSet(compressionFlags)
-	pflag.CommandLine.AddFlagSet(lvmFlags)
-	pflag.CommandLine.AddFlagSet(grpcFlags)
+	flagSets := []*pflag.FlagSet{
+		generalFlags,
+		sshFlags,
+		remoteFlags,
+		dedupFlags,
+		compressionFlags,
+		lvmFlags,
+		grpcFlags,
+	}
+	for _, fs := range flagSets {
+		pflag.CommandLine.AddFlagSet(fs)
+	}
+	pflag.CommandLine.Usage = func() {
+		out := pflag.CommandLine.Output()
+		fmt.Fprintln(out, "Usage of", os.Args[0]+":")
+		fmt.Fprintln(out)
+		for _, fs := range flagSets {
+			printFlagSetUsage(out, fs)
+		}
+	}
+	pflag.Usage = pflag.CommandLine.Usage
 }
 
 func buildViper() (*viper.Viper, error) {

--- a/config/loadconfig_test.go
+++ b/config/loadconfig_test.go
@@ -111,7 +111,15 @@ func TestUsageOutput(t *testing.T) {
 	pflag.CommandLine.SetOutput(buf)
 	pflag.Usage()
 	out := buf.String()
-	wants := []string{"--config", "--ssh_user", "--grpc_port"}
+	wants := []string{
+		"General Options:", "--config",
+		"SSH Options:", "--ssh_user",
+		"Remote Options:", "--lvmsync_path",
+		"Deduplication Options:", "--dedup_strategy",
+		"Compression Options:", "--compress",
+		"LVM Options:", "--skip_snapshot_creation",
+		"gRPC Options:", "--grpc_port",
+	}
 	for _, w := range wants {
 		if !strings.Contains(out, w) {
 			t.Fatalf("usage missing %q", w)


### PR DESCRIPTION
## Summary
- route flag help through `pflag`'s Usage to ensure all help text is captured
- verify grouped flag help output with unit tests

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897d8240e5c83239bab96298f414ea1