### PR TITLE
feat: add dedup mode configuration and CDC tunables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ const (
 var (
 	SupportedCompression        = []string{"none", "lz4", Zstd, Auto}
 	SupportedDedupStrategies    = []string{"none", Auto, "checksum", "rolling_hash", "bloom"}
+	SupportedDedupModes         = []string{"fixed", "cdc", "hybrid"}
 	SupportedChecksumAlgorithms = []string{"sha256", "blake3", "blake3-512"}
 )
 
@@ -83,10 +84,15 @@ type Config struct {
 	Progress             bool     `mapstructure:"progress"`
 	BlockSize            int      `mapstructure:"-"`
 	BlockSizeRaw         string   `mapstructure:"-"`
+	DedupMode            string   `mapstructure:"dedup"`
+	CDCMin               int      `mapstructure:"cdc_min"`
+	CDCAvg               int      `mapstructure:"cdc_avg"`
+	CDCMax               int      `mapstructure:"cdc_max"`
 	DedupStrategy        string   `mapstructure:"dedup_strategy"`
 	DedupStateFile       string   `mapstructure:"dedup_state_file"`
 	BloomEntries         int      `mapstructure:"bloom_entries"`
 	BloomFpRate          float64  `mapstructure:"bloom_fp_rate"`
+	BloomMBits           uint     `mapstructure:"bloom_mbits"`
 	GRPCPort             int      `mapstructure:"grpc_port"`
 	TLSCert              string   `mapstructure:"tls_cert"`
 	TLSKey               string   `mapstructure:"tls_key"`
@@ -300,10 +306,15 @@ func DefaultConfig() (*Config, error) {
 		Progress:             true,
 		BlockSize:            0,
 		BlockSizeRaw:         Auto,
+		DedupMode:            "fixed",
+		CDCMin:               4 * 1024,
+		CDCAvg:               64 * 1024,
+		CDCMax:               1 * 1024 * 1024,
 		DedupStrategy:        "none",
 		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
 		BloomEntries:         1000000,
 		BloomFpRate:          0.01,
+		BloomMBits:           0,
 		GRPCPort:             8443,
 		TLSCert:              "",
 		TLSKey:               "",
@@ -353,10 +364,15 @@ func initRemoteFlags(cfg *Config) *pflag.FlagSet {
 
 func initDedupFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Deduplication Options", pflag.ExitOnError)
+	fs.String("dedup", cfg.DedupMode, fmt.Sprintf("Deduplication mode: %v", SupportedDedupModes))
+	fs.Int("cdc_min", cfg.CDCMin, "Minimum chunk size for CDC")
+	fs.Int("cdc_avg", cfg.CDCAvg, "Average chunk size for CDC")
+	fs.Int("cdc_max", cfg.CDCMax, "Maximum chunk size for CDC")
 	fs.String("dedup_strategy", cfg.DedupStrategy, fmt.Sprintf("Deduplication strategy: %v", SupportedDedupStrategies))
 	fs.String("dedup_state_file", cfg.DedupStateFile, "Path to deduplication state file")
 	fs.Int("bloom_entries", cfg.BloomEntries, "Estimated number of entries for bloom filter")
 	fs.Float64("bloom_fp_rate", cfg.BloomFpRate, "False positive rate for bloom filter")
+	fs.Uint("bloom_mbits", cfg.BloomMBits, "Bloom filter m bits power")
 	return fs
 }
 

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -93,10 +93,15 @@ func TestInitDedupFlags(t *testing.T) {
 	}
 	fs := initDedupFlags(cfg)
 	cases := []struct{ name, want string }{
+		{"dedup", cfg.DedupMode},
+		{"cdc_min", strconv.Itoa(cfg.CDCMin)},
+		{"cdc_avg", strconv.Itoa(cfg.CDCAvg)},
+		{"cdc_max", strconv.Itoa(cfg.CDCMax)},
 		{"dedup_strategy", cfg.DedupStrategy},
 		{"dedup_state_file", cfg.DedupStateFile},
 		{"bloom_entries", strconv.Itoa(cfg.BloomEntries)},
 		{"bloom_fp_rate", fmt.Sprint(cfg.BloomFpRate)},
+		{"bloom_mbits", strconv.FormatUint(uint64(cfg.BloomMBits), 10)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)

--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -125,6 +125,30 @@ func (c *Chunker) selectMask(e float64) uint64 {
 	}
 }
 
+// FastCDC chunks the entirety of r using the FastCDC algorithm with the
+// provided size targets. It returns all detected chunks.
+func FastCDC(r io.Reader, min, avg, max int) ([]Chunk, error) {
+	ch := NewChunker(min, avg, max)
+	var out []Chunk
+	var offset int64
+	for {
+		c, err := ch.NextChunk(r)
+		if err == io.EOF && c.Length == 0 {
+			break
+		}
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		c.Offset = offset
+		offset += int64(c.Length)
+		out = append(out, c)
+		if err == io.EOF {
+			break
+		}
+	}
+	return out, nil
+}
+
 // gear table taken from FastCDC reference implementation.
 var gear = [256]uint64{
 	0x9ae16a3b2f90404f, 0x4f1bbf83b5dc07d3, 0x5c6bfb31e933b7f1, 0x81f69c5e0d6cc818,

--- a/dedup/unit_test.go
+++ b/dedup/unit_test.go
@@ -58,3 +58,19 @@ func TestChunkerBounds(t *testing.T) {
 		}
 	}
 }
+
+func TestFastCDC(t *testing.T) {
+	data := bytes.Repeat([]byte("a"), 1<<16)
+	chunks, err := FastCDC(bytes.NewReader(data), 64, 128, 256)
+	if err != nil {
+		t.Fatalf("FastCDC failed: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatalf("expected chunks")
+	}
+	for _, c := range chunks {
+		if c.Length < 64 || c.Length > 256 {
+			t.Fatalf("chunk out of bounds %d", c.Length)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `--dedup` mode flag with CDC size tunables
- expose `FastCDC` helper for chunking

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897e1efb640832388e2415138a7ad7d