### PR TITLE
feat(transfer): add manifest and final checksum logging

### DIFF
--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -2,12 +2,15 @@ package transfer
 
 import (
 	"bufio"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/zeebo/blake3"
 
 	"lvmsync_go/config"
 )
@@ -22,18 +25,20 @@ func validateOffsetAndSize(offset uint64, size int) (int64, uint32, error) {
 	return int64(offset), uint32(size), nil
 }
 
-func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int) (int64, int, error) {
+func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int) (int64, int, *Manifest, error) {
 	var totalBytes int64
 	skippedBlocks := 0
 	var header [12]byte
+	manifest := &Manifest{}
+	sha := sha256.New()
 	for _, r := range ranges {
 		offset, blockSize, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
 		if err != nil {
-			return totalBytes, skippedBlocks, err
+			return totalBytes, skippedBlocks, manifest, err
 		}
 		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, pipeFds)
 		if err != nil {
-			return totalBytes, skippedBlocks, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
+			return totalBytes, skippedBlocks, manifest, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
 		}
 		if dedup != nil {
 			if !dedup.ShouldTransfer(offset, data) {
@@ -48,17 +53,23 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		binary.BigEndian.PutUint32(header[8:12], blockSize)
 		if _, err := bufOut.Write(header[:]); err != nil {
 			putBlockBuffer(data)
-			return totalBytes, skippedBlocks, fmt.Errorf("failed to write header: %w", err)
+			return totalBytes, skippedBlocks, manifest, fmt.Errorf("failed to write header: %w", err)
 		}
 		if _, err := bufOut.Write(data); err != nil {
 			putBlockBuffer(data)
-			return totalBytes, skippedBlocks, fmt.Errorf("failed to write block data: %w", err)
+			return totalBytes, skippedBlocks, manifest, fmt.Errorf("failed to write block data: %w", err)
 		}
+
+		sha.Write(data)
+		sum := blake3.Sum256(data)
+		manifest.Append(sum, int64(r.Start), int(blockSize))
+
 		putBlockBuffer(data)
 
 		totalBytes += int64(blockSize)
 	}
-	return totalBytes, skippedBlocks, nil
+	copy(manifest.FinalSHA256[:], sha.Sum(nil))
+	return totalBytes, skippedBlocks, manifest, nil
 }
 
 func prepareResultHeader(cfg *config.Config, checksum ChecksumStrategy, res *BlockResult, header []byte) int {

--- a/transfer/manifest.go
+++ b/transfer/manifest.go
@@ -1,0 +1,33 @@
+package transfer
+
+import "encoding/json"
+
+// Chunk describes a block in the transfer with its BLAKE3 hash.
+type Chunk struct {
+	Hash   [32]byte `json:"hash"`
+	Offset int64    `json:"offset"`
+	Length int      `json:"length"`
+}
+
+// Manifest records all transferred chunks and the final SHA-256 hash.
+type Manifest struct {
+	Chunks      []Chunk  `json:"chunks"`
+	FinalSHA256 [32]byte `json:"final_sha256"`
+}
+
+// Append adds a chunk entry to the manifest.
+func (m *Manifest) Append(hash [32]byte, offset int64, length int) {
+	m.Chunks = append(m.Chunks, Chunk{Hash: hash, Offset: offset, Length: length})
+}
+
+// Marshal encodes the manifest as JSON.
+func (m *Manifest) Marshal() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// UnmarshalManifest decodes a manifest from JSON.
+func UnmarshalManifest(b []byte) (Manifest, error) {
+	var m Manifest
+	err := json.Unmarshal(b, &m)
+	return m, err
+}

--- a/transfer/manifest_test.go
+++ b/transfer/manifest_test.go
@@ -1,0 +1,36 @@
+package transfer
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"testing"
+
+	"github.com/zeebo/blake3"
+)
+
+func TestManifestRoundTrip(t *testing.T) {
+	var m Manifest
+	data := []byte("hello world")
+	sum := blake3.Sum256(data)
+	m.Append(sum, 0, len(data))
+	sha := sha256.Sum256(data)
+	m.FinalSHA256 = sha
+
+	b, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	var m2 Manifest
+	if err := json.Unmarshal(b, &m2); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if len(m2.Chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(m2.Chunks))
+	}
+	if m2.Chunks[0].Offset != 0 || m2.Chunks[0].Length != len(data) {
+		t.Fatalf("unexpected chunk values: %#v", m2.Chunks[0])
+	}
+	if m2.FinalSHA256 != sha {
+		t.Fatalf("final SHA mismatch")
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -213,13 +213,19 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	startTime := time.Now()
 	var totalBytesTransferred int64
 	var skippedBlocks int
-	totalBytesTransferred, skippedBlocks, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds)
+	var manifest *Manifest
+	totalBytesTransferred, skippedBlocks, manifest, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds)
 	if err != nil {
 		return err
 	}
 	finalizeProgress(cfg)
 
 	logSequentialSummary(totalBytesTransferred, skippedBlocks, startTime)
+	if manifest != nil {
+		if Logger != nil {
+			Logger.Info("final checksum", zap.String("final_sha256", fmt.Sprintf("%x", manifest.FinalSHA256)))
+		}
+	}
 	if Logger != nil {
 		_ = Logger.Sync()
 	}

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -20,7 +20,7 @@ func TestIterateBlocksOffsetOverflow(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: 4096}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1})
+	_, _, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1})
 	if err == nil || !strings.Contains(err.Error(), "offset") {
 		t.Fatalf("expected offset error, got %v", err)
 	}
@@ -32,7 +32,7 @@ func TestIterateBlocksOversizedBlockSize(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(math.MaxUint32) + 1}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
+	_, _, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
 	if err == nil || !strings.Contains(err.Error(), "block size") {
 		t.Fatalf("expected block size error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- add manifest to capture per-chunk BLAKE3 hashes and final SHA-256
- compute manifest and final SHA-256 during block iteration and log checksum
- cover manifest with unit test

## Testing
- `go test ./transfer -run Manifest -cover`
- `golangci-lint run ./transfer/...` *(warnings, but no errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897e552893883238d29a73dc9ffaecf