### PR TITLE
feat(grpc): add session handshake and control flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,14 @@ Environment override:
 LVMSYNC_SOURCE=/dev/vg0/snap1
 ```
 
+## Control Plane Flow
+
+- Clients perform a handshake sending `sector_size`, `alignment`, `max_concurrency`, and dedup/compression support.
+- Sessions exchange ephemeral X.509 certificates and a pre-shared key.
+- Resume bitmaps are streamed with a session ID to continue interrupted transfers.
+- Each session maintains a bidirectional `Ack` stream for pings and acknowledgements.
+- Finalization requests close the session by ID.
+
 ## Testing and Linting
 
 - Ensure [`golangci-lint`](https://golangci-lint.run/) v2 passes before submitting changes.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ because flags override environment variables, which override the config file.
 | `--allow_insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
 | `--sudo_path` | `LVMSYNC_SUDO_PATH` | `sudo_path` | Path to sudo executable |
 
+### Control Plane Flow
+
+1. **Handshake** – clients advertise `sector_size`, `alignment`, `max_concurrency`, and whether deduplication and compression are supported.
+2. **Session Creation** – the client sends an ephemeral certificate and receives a session ID, server certificate, and pre-shared key.
+3. **Resume Bitmap** – dirty block bitmaps are streamed with the session ID to resume interrupted transfers.
+4. **Ack/Ping Stream** – a bidirectional stream of `Ack` messages per session provides keep-alives and progress confirmation.
+5. **Finalization** – the client requests completion using the session ID when replication is done.
+
 ### `config.yaml` example
 
 ```yaml

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -2,10 +2,15 @@ package client
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"math/big"
 	"os"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -48,15 +53,34 @@ func Dial(addr string, conf Config, opts ...grpc.DialOption) (*grpc.ClientConn, 
 	return grpc.Dial(addr, opts...)
 }
 
-func Handshake(ctx context.Context, c proto.ReplicationClient, caps []string) ([]string, error) {
-	resp, err := c.ExchangeCapabilities(ctx, &proto.CapabilitySet{Capabilities: caps})
+func Handshake(ctx context.Context, c proto.ReplicationClient, hs *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+	return c.Handshake(ctx, hs)
+}
+
+func CreateSession(ctx context.Context, c proto.ReplicationClient, volume, device string) (*proto.SessionResponse, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
 	}
-	return resp.GetCapabilities(), nil
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(time.Now().UnixNano()), Subject: pkix.Name{CommonName: volume}, NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour)}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.CreateSession(ctx, &proto.SessionRequest{VolumeName: volume, DeviceUuid: device, ClientCert: der})
+	if err != nil {
+		return nil, err
+	}
+	if _, err := x509.ParseCertificate(resp.GetServerCert()); err != nil {
+		return nil, fmt.Errorf("invalid server cert: %w", err)
+	}
+	if len(resp.GetPsk()) == 0 {
+		return nil, fmt.Errorf("missing psk")
+	}
+	return resp, nil
 }
 
-func AckStream(ctx context.Context, c proto.ReplicationClient) (proto.Replication_AckStreamClient, error) {
+func AckStream(ctx context.Context, c proto.ReplicationClient, sessionID string) (proto.Replication_AckStreamClient, error) {
 	stream, err := c.AckStream(ctx)
 	if err != nil {
 		return nil, err
@@ -68,5 +92,8 @@ func AckStream(ctx context.Context, c proto.ReplicationClient) (proto.Replicatio
 			}
 		}
 	}()
+	if err := stream.Send(&proto.Ack{SessionId: sessionID, Ok: true, Message: "init"}); err != nil {
+		return nil, err
+	}
 	return stream, nil
 }

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -2,8 +2,14 @@ package client
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"net"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -44,21 +50,35 @@ func TestHandshakeAndAck(t *testing.T) {
 	client, cleanup := setupClient(t)
 	defer cleanup()
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("role", "replicator"))
-	caps, err := Handshake(ctx, client, []string{"foo"})
-	if err != nil {
+	if _, err := Handshake(ctx, client, &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: 1}); err != nil {
 		t.Fatalf("Handshake: %v", err)
 	}
-	if len(caps) != 1 || caps[0] != "foo" {
-		t.Fatalf("unexpected caps %v", caps)
+	sess, err := client.CreateSession(ctx, &proto.SessionRequest{VolumeName: "vol", DeviceUuid: "dev", ClientCert: dummyCert(t)})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
 	}
-	stream, err := AckStream(ctx, client)
+	stream, err := AckStream(ctx, client, sess.GetSessionId())
 	if err != nil {
 		t.Fatalf("AckStream: %v", err)
 	}
-	if err := stream.Send(&proto.StatusResponse{Ok: true, Message: "ping"}); err != nil {
+	if err := stream.Send(&proto.Ack{SessionId: sess.GetSessionId(), Ok: true, Message: "ping"}); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	if _, err := stream.Recv(); err != nil {
 		t.Fatalf("recv: %v", err)
 	}
+}
+
+func dummyCert(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "test"}, NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour)}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return der
 }

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -3,12 +3,16 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -148,11 +152,17 @@ func (s *replicationServer) Ping(_ context.Context, _ *proto.Empty) (*proto.Stat
 	return &proto.StatusResponse{Ok: true, Message: "pong"}, nil
 }
 
-func (s *replicationServer) ExchangeCapabilities(_ context.Context, caps *proto.CapabilitySet) (*proto.CapabilitySet, error) {
-	return caps, nil
+func (s *replicationServer) Handshake(_ context.Context, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+	if req.GetSectorSize() == 0 || req.GetAlignment() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "missing handshake parameters")
+	}
+	return &proto.HandshakeResponse{Ok: true, Message: "handshake ok"}, nil
 }
 
 func (s *replicationServer) CreateSession(_ context.Context, req *proto.SessionRequest) (*proto.SessionResponse, error) {
+	if _, err := x509.ParseCertificate(req.GetClientCert()); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid client cert")
+	}
 	sessionID := req.GetVolumeName() + "-session"
 	seed := make([]byte, 32)
 	if _, err := rand.Read(seed); err != nil {
@@ -163,7 +173,16 @@ func (s *replicationServer) CreateSession(_ context.Context, req *proto.SessionR
 	h.Write([]byte(req.GetDeviceUuid()))
 	h.Write(seed)
 	psk := h.Sum(nil)
-	return &proto.SessionResponse{SessionId: sessionID, Psk: psk}, nil
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(time.Now().UnixNano()), Subject: pkix.Name{CommonName: sessionID}, NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour)}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	return &proto.SessionResponse{SessionId: sessionID, Psk: psk, ServerCert: der}, nil
 }
 
 func (s *replicationServer) SendResumeBitmap(stream proto.Replication_SendResumeBitmapServer) error {
@@ -178,7 +197,7 @@ func (s *replicationServer) SendResumeBitmap(stream proto.Replication_SendResume
 	}
 }
 
-func (s *replicationServer) Finalize(_ context.Context, req *proto.SessionResponse) (*proto.StatusResponse, error) {
+func (s *replicationServer) Finalize(_ context.Context, req *proto.FinalizeRequest) (*proto.StatusResponse, error) {
 	return &proto.StatusResponse{Ok: true, Message: "finalized " + req.GetSessionId()}, nil
 }
 

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -369,47 +369,67 @@ func TestMTLSValidation(t *testing.T) {
 	})
 }
 
-func TestHandshakeSession(t *testing.T) {
+func TestSessionFlow(t *testing.T) {
 	client, cleanup := newInsecureClient(t, nil)
 	defer cleanup()
 	ctx := ctxWithRole("replicator")
-	caps, err := client.ExchangeCapabilities(ctx, &proto.CapabilitySet{Capabilities: []string{"cap"}})
-	if err != nil {
-		t.Fatalf("ExchangeCapabilities: %v", err)
+	hsResp, err := client.Handshake(ctx, &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: 1})
+	if err != nil || !hsResp.GetOk() {
+		t.Fatalf("Handshake: %v", err)
 	}
-	if len(caps.GetCapabilities()) != 1 || caps.GetCapabilities()[0] != "cap" {
-		t.Fatalf("unexpected caps %v", caps.GetCapabilities())
-	}
-	sess, err := client.CreateSession(ctx, &proto.SessionRequest{VolumeName: "vol", DeviceUuid: "dev"})
+	sess, err := client.CreateSession(ctx, &proto.SessionRequest{VolumeName: "vol", DeviceUuid: "dev", ClientCert: dummyCert(t)})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	if len(sess.GetPsk()) == 0 {
-		t.Fatalf("expected psk in session response")
+	if len(sess.GetPsk()) == 0 || len(sess.GetServerCert()) == 0 {
+		t.Fatalf("expected psk and cert in session response")
 	}
 	bmp, err := client.SendResumeBitmap(ctx)
 	if err != nil {
 		t.Fatalf("SendResumeBitmap: %v", err)
 	}
-	if err := bmp.Send(&proto.ResumeBitmap{Bitmap: []byte{1}}); err != nil {
+	if err := bmp.Send(&proto.ResumeBitmap{SessionId: sess.GetSessionId(), Bitmap: []byte{1}}); err != nil {
 		t.Fatalf("bitmap send: %v", err)
 	}
 	if _, err := bmp.CloseAndRecv(); err != nil {
 		t.Fatalf("bitmap close: %v", err)
 	}
-	if _, err := client.Finalize(ctx, sess); err != nil {
+	if _, err := client.Finalize(ctx, &proto.FinalizeRequest{SessionId: sess.GetSessionId()}); err != nil {
 		t.Fatalf("Finalize: %v", err)
 	}
 	ack, err := client.AckStream(ctx)
 	if err != nil {
 		t.Fatalf("AckStream: %v", err)
 	}
-	if err := ack.Send(&proto.StatusResponse{Ok: true, Message: "ping"}); err != nil {
+	if err := ack.Send(&proto.Ack{SessionId: sess.GetSessionId(), Ok: true, Message: "ping"}); err != nil {
 		t.Fatalf("ack send: %v", err)
 	}
 	if _, err := ack.Recv(); err != nil {
 		t.Fatalf("ack recv: %v", err)
 	}
+}
+
+func TestHandshakeFailure(t *testing.T) {
+	client, cleanup := newInsecureClient(t, nil)
+	defer cleanup()
+	ctx := ctxWithRole("replicator")
+	if _, err := client.Handshake(ctx, &proto.HandshakeRequest{}); err == nil {
+		t.Fatalf("expected handshake error")
+	}
+}
+
+func dummyCert(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "test"}, NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour)}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return der
 }
 
 func TestNewTLSFailures(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -332,24 +332,30 @@ func run() error {
 			return fmt.Errorf("gRPC dial: %w", err)
 		}
 		c := proto.NewReplicationClient(conn)
-		if _, err := grpcclient.Handshake(context.Background(), c, []string{"lvmsync"}); err != nil {
+		hs := &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: uint32(cfg.Parallel), DedupSupported: true, CompressionSupported: true}
+		if _, err := grpcclient.Handshake(context.Background(), c, hs); err != nil {
 			conn.Close()
 			return fmt.Errorf("handshake failed: %w", err)
 		}
-		stream, err := grpcclient.AckStream(context.Background(), c)
+		sess, err := grpcclient.CreateSession(context.Background(), c, "vol", "dev")
+		if err != nil {
+			conn.Close()
+			return fmt.Errorf("create session: %w", err)
+		}
+		stream, err := grpcclient.AckStream(context.Background(), c, sess.GetSessionId())
 		if err != nil {
 			conn.Close()
 			return fmt.Errorf("ack stream: %w", err)
 		}
-		go func() {
+		go func(id string) {
 			ticker := time.NewTicker(30 * time.Second)
 			defer ticker.Stop()
 			for range ticker.C {
-				if err := stream.Send(&proto.StatusResponse{Ok: true, Message: "ping"}); err != nil {
+				if err := stream.Send(&proto.Ack{SessionId: id, Ok: true, Message: "ping"}); err != nil {
 					return
 				}
 			}
-		}()
+		}(sess.GetSessionId())
 		defer stream.CloseSend()
 		defer conn.Close()
 	}

--- a/proto/replication.pb.go
+++ b/proto/replication.pb.go
@@ -221,27 +221,31 @@ func (*Empty) Descriptor() ([]byte, []int) {
 	return file_proto_replication_proto_rawDescGZIP(), []int{3}
 }
 
-type CapabilitySet struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Capabilities  []string               `protobuf:"bytes,1,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+type HandshakeRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	SectorSize           uint32                 `protobuf:"varint,1,opt,name=sector_size,json=sectorSize,proto3" json:"sector_size,omitempty"`
+	Alignment            uint32                 `protobuf:"varint,2,opt,name=alignment,proto3" json:"alignment,omitempty"`
+	MaxConcurrency       uint32                 `protobuf:"varint,3,opt,name=max_concurrency,json=maxConcurrency,proto3" json:"max_concurrency,omitempty"`
+	DedupSupported       bool                   `protobuf:"varint,4,opt,name=dedup_supported,json=dedupSupported,proto3" json:"dedup_supported,omitempty"`
+	CompressionSupported bool                   `protobuf:"varint,5,opt,name=compression_supported,json=compressionSupported,proto3" json:"compression_supported,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
-func (x *CapabilitySet) Reset() {
-	*x = CapabilitySet{}
+func (x *HandshakeRequest) Reset() {
+	*x = HandshakeRequest{}
 	mi := &file_proto_replication_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *CapabilitySet) String() string {
+func (x *HandshakeRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*CapabilitySet) ProtoMessage() {}
+func (*HandshakeRequest) ProtoMessage() {}
 
-func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
+func (x *HandshakeRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_replication_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -253,29 +257,110 @@ func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use CapabilitySet.ProtoReflect.Descriptor instead.
-func (*CapabilitySet) Descriptor() ([]byte, []int) {
+// Deprecated: Use HandshakeRequest.ProtoReflect.Descriptor instead.
+func (*HandshakeRequest) Descriptor() ([]byte, []int) {
 	return file_proto_replication_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *CapabilitySet) GetCapabilities() []string {
+func (x *HandshakeRequest) GetSectorSize() uint32 {
 	if x != nil {
-		return x.Capabilities
+		return x.SectorSize
 	}
-	return nil
+	return 0
+}
+
+func (x *HandshakeRequest) GetAlignment() uint32 {
+	if x != nil {
+		return x.Alignment
+	}
+	return 0
+}
+
+func (x *HandshakeRequest) GetMaxConcurrency() uint32 {
+	if x != nil {
+		return x.MaxConcurrency
+	}
+	return 0
+}
+
+func (x *HandshakeRequest) GetDedupSupported() bool {
+	if x != nil {
+		return x.DedupSupported
+	}
+	return false
+}
+
+func (x *HandshakeRequest) GetCompressionSupported() bool {
+	if x != nil {
+		return x.CompressionSupported
+	}
+	return false
+}
+
+type HandshakeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ok            bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HandshakeResponse) Reset() {
+	*x = HandshakeResponse{}
+	mi := &file_proto_replication_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HandshakeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HandshakeResponse) ProtoMessage() {}
+
+func (x *HandshakeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_replication_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HandshakeResponse.ProtoReflect.Descriptor instead.
+func (*HandshakeResponse) Descriptor() ([]byte, []int) {
+	return file_proto_replication_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *HandshakeResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
+func (x *HandshakeResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
 }
 
 type SessionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	VolumeName    string                 `protobuf:"bytes,1,opt,name=volume_name,json=volumeName,proto3" json:"volume_name,omitempty"`
 	DeviceUuid    string                 `protobuf:"bytes,2,opt,name=device_uuid,json=deviceUuid,proto3" json:"device_uuid,omitempty"`
+	ClientCert    []byte                 `protobuf:"bytes,3,opt,name=client_cert,json=clientCert,proto3" json:"client_cert,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SessionRequest) Reset() {
 	*x = SessionRequest{}
-	mi := &file_proto_replication_proto_msgTypes[5]
+	mi := &file_proto_replication_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -287,7 +372,7 @@ func (x *SessionRequest) String() string {
 func (*SessionRequest) ProtoMessage() {}
 
 func (x *SessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_replication_proto_msgTypes[5]
+	mi := &file_proto_replication_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -300,7 +385,7 @@ func (x *SessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionRequest.ProtoReflect.Descriptor instead.
 func (*SessionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_replication_proto_rawDescGZIP(), []int{5}
+	return file_proto_replication_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SessionRequest) GetVolumeName() string {
@@ -317,17 +402,25 @@ func (x *SessionRequest) GetDeviceUuid() string {
 	return ""
 }
 
+func (x *SessionRequest) GetClientCert() []byte {
+	if x != nil {
+		return x.ClientCert
+	}
+	return nil
+}
+
 type SessionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	Psk           []byte                 `protobuf:"bytes,2,opt,name=psk,proto3" json:"psk,omitempty"`
+	ServerCert    []byte                 `protobuf:"bytes,3,opt,name=server_cert,json=serverCert,proto3" json:"server_cert,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SessionResponse) Reset() {
 	*x = SessionResponse{}
-	mi := &file_proto_replication_proto_msgTypes[6]
+	mi := &file_proto_replication_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -339,7 +432,7 @@ func (x *SessionResponse) String() string {
 func (*SessionResponse) ProtoMessage() {}
 
 func (x *SessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_replication_proto_msgTypes[6]
+	mi := &file_proto_replication_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -352,7 +445,7 @@ func (x *SessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionResponse.ProtoReflect.Descriptor instead.
 func (*SessionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_replication_proto_rawDescGZIP(), []int{6}
+	return file_proto_replication_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SessionResponse) GetSessionId() string {
@@ -369,16 +462,24 @@ func (x *SessionResponse) GetPsk() []byte {
 	return nil
 }
 
+func (x *SessionResponse) GetServerCert() []byte {
+	if x != nil {
+		return x.ServerCert
+	}
+	return nil
+}
+
 type ResumeBitmap struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Bitmap        []byte                 `protobuf:"bytes,1,opt,name=bitmap,proto3" json:"bitmap,omitempty"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Bitmap        []byte                 `protobuf:"bytes,2,opt,name=bitmap,proto3" json:"bitmap,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ResumeBitmap) Reset() {
 	*x = ResumeBitmap{}
-	mi := &file_proto_replication_proto_msgTypes[7]
+	mi := &file_proto_replication_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -390,7 +491,7 @@ func (x *ResumeBitmap) String() string {
 func (*ResumeBitmap) ProtoMessage() {}
 
 func (x *ResumeBitmap) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_replication_proto_msgTypes[7]
+	mi := &file_proto_replication_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -403,7 +504,14 @@ func (x *ResumeBitmap) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeBitmap.ProtoReflect.Descriptor instead.
 func (*ResumeBitmap) Descriptor() ([]byte, []int) {
-	return file_proto_replication_proto_rawDescGZIP(), []int{7}
+	return file_proto_replication_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ResumeBitmap) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
 }
 
 func (x *ResumeBitmap) GetBitmap() []byte {
@@ -411,6 +519,110 @@ func (x *ResumeBitmap) GetBitmap() []byte {
 		return x.Bitmap
 	}
 	return nil
+}
+
+type FinalizeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FinalizeRequest) Reset() {
+	*x = FinalizeRequest{}
+	mi := &file_proto_replication_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FinalizeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FinalizeRequest) ProtoMessage() {}
+
+func (x *FinalizeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_replication_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FinalizeRequest.ProtoReflect.Descriptor instead.
+func (*FinalizeRequest) Descriptor() ([]byte, []int) {
+	return file_proto_replication_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *FinalizeRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type Ack struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Ok            bool                   `protobuf:"varint,2,opt,name=ok,proto3" json:"ok,omitempty"`
+	Message       string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Ack) Reset() {
+	*x = Ack{}
+	mi := &file_proto_replication_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Ack) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Ack) ProtoMessage() {}
+
+func (x *Ack) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_replication_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Ack.ProtoReflect.Descriptor instead.
+func (*Ack) Descriptor() ([]byte, []int) {
+	return file_proto_replication_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *Ack) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *Ack) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
+func (x *Ack) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
 }
 
 var File_proto_replication_proto protoreflect.FileDescriptor
@@ -432,20 +644,42 @@ const file_proto_replication_proto_rawDesc = "" +
 	"\x0eStatusResponse\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\a\n" +
-	"\x05Empty\"3\n" +
-	"\rCapabilitySet\x12\"\n" +
-	"\fcapabilities\x18\x01 \x03(\tR\fcapabilities\"R\n" +
+	"\x05Empty\"\xd8\x01\n" +
+	"\x10HandshakeRequest\x12\x1f\n" +
+	"\vsector_size\x18\x01 \x01(\rR\n" +
+	"sectorSize\x12\x1c\n" +
+	"\talignment\x18\x02 \x01(\rR\talignment\x12'\n" +
+	"\x0fmax_concurrency\x18\x03 \x01(\rR\x0emaxConcurrency\x12'\n" +
+	"\x0fdedup_supported\x18\x04 \x01(\bR\x0ededupSupported\x123\n" +
+	"\x15compression_supported\x18\x05 \x01(\bR\x14compressionSupported\"=\n" +
+	"\x11HandshakeResponse\x12\x0e\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"s\n" +
 	"\x0eSessionRequest\x12\x1f\n" +
 	"\vvolume_name\x18\x01 \x01(\tR\n" +
 	"volumeName\x12\x1f\n" +
 	"\vdevice_uuid\x18\x02 \x01(\tR\n" +
-	"deviceUuid\"B\n" +
+	"deviceUuid\x12\x1f\n" +
+	"\vclient_cert\x18\x03 \x01(\fR\n" +
+	"clientCert\"c\n" +
 	"\x0fSessionResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x10\n" +
-	"\x03psk\x18\x02 \x01(\fR\x03psk\"&\n" +
-	"\fResumeBitmap\x12\x16\n" +
-	"\x06bitmap\x18\x01 \x01(\fR\x06bitmap2\xfd\x06\n" +
+	"\x03psk\x18\x02 \x01(\fR\x03psk\x12\x1f\n" +
+	"\vserver_cert\x18\x03 \x01(\fR\n" +
+	"serverCert\"E\n" +
+	"\fResumeBitmap\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
+	"\x06bitmap\x18\x02 \x01(\fR\x06bitmap\"0\n" +
+	"\x0fFinalizeRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"N\n" +
+	"\x03Ack\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x0e\n" +
+	"\x02ok\x18\x02 \x01(\bR\x02ok\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage2\xe3\x06\n" +
 	"\vReplication\x12C\n" +
 	"\n" +
 	"LockVolume\x12\x18.replication.LockRequest\x1a\x1b.replication.StatusResponse\x12J\n" +
@@ -454,12 +688,12 @@ const file_proto_replication_proto_rawDesc = "" +
 	"\x14StartTransferSession\x12\x18.replication.LockRequest\x1a\x1b.replication.StatusResponse\x12E\n" +
 	"\fFinalizeSync\x12\x18.replication.LockRequest\x1a\x1b.replication.StatusResponse\x12B\n" +
 	"\tGetStatus\x12\x18.replication.LockRequest\x1a\x1b.replication.StatusResponse\x127\n" +
-	"\x04Ping\x12\x12.replication.Empty\x1a\x1b.replication.StatusResponse\x12N\n" +
-	"\x14ExchangeCapabilities\x12\x1a.replication.CapabilitySet\x1a\x1a.replication.CapabilitySet\x12J\n" +
+	"\x04Ping\x12\x12.replication.Empty\x1a\x1b.replication.StatusResponse\x12J\n" +
+	"\tHandshake\x12\x1d.replication.HandshakeRequest\x1a\x1e.replication.HandshakeResponse\x12J\n" +
 	"\rCreateSession\x12\x1b.replication.SessionRequest\x1a\x1c.replication.SessionResponse\x12L\n" +
 	"\x10SendResumeBitmap\x12\x19.replication.ResumeBitmap\x1a\x1b.replication.StatusResponse(\x01\x12E\n" +
-	"\bFinalize\x12\x1c.replication.SessionResponse\x1a\x1b.replication.StatusResponse\x12I\n" +
-	"\tAckStream\x12\x1b.replication.StatusResponse\x1a\x1b.replication.StatusResponse(\x010\x01B\x18Z\x16lvmsync_go/proto;protob\x06proto3"
+	"\bFinalize\x12\x1c.replication.FinalizeRequest\x1a\x1b.replication.StatusResponse\x123\n" +
+	"\tAckStream\x12\x10.replication.Ack\x1a\x10.replication.Ack(\x010\x01B\x18Z\x16lvmsync_go/proto;protob\x06proto3"
 
 var (
 	file_proto_replication_proto_rawDescOnce sync.Once
@@ -473,16 +707,19 @@ func file_proto_replication_proto_rawDescGZIP() []byte {
 	return file_proto_replication_proto_rawDescData
 }
 
-var file_proto_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_proto_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_proto_replication_proto_goTypes = []any{
-	(*VolumeMetadata)(nil),  // 0: replication.VolumeMetadata
-	(*LockRequest)(nil),     // 1: replication.LockRequest
-	(*StatusResponse)(nil),  // 2: replication.StatusResponse
-	(*Empty)(nil),           // 3: replication.Empty
-	(*CapabilitySet)(nil),   // 4: replication.CapabilitySet
-	(*SessionRequest)(nil),  // 5: replication.SessionRequest
-	(*SessionResponse)(nil), // 6: replication.SessionResponse
-	(*ResumeBitmap)(nil),    // 7: replication.ResumeBitmap
+	(*VolumeMetadata)(nil),    // 0: replication.VolumeMetadata
+	(*LockRequest)(nil),       // 1: replication.LockRequest
+	(*StatusResponse)(nil),    // 2: replication.StatusResponse
+	(*Empty)(nil),             // 3: replication.Empty
+	(*HandshakeRequest)(nil),  // 4: replication.HandshakeRequest
+	(*HandshakeResponse)(nil), // 5: replication.HandshakeResponse
+	(*SessionRequest)(nil),    // 6: replication.SessionRequest
+	(*SessionResponse)(nil),   // 7: replication.SessionResponse
+	(*ResumeBitmap)(nil),      // 8: replication.ResumeBitmap
+	(*FinalizeRequest)(nil),   // 9: replication.FinalizeRequest
+	(*Ack)(nil),               // 10: replication.Ack
 }
 var file_proto_replication_proto_depIdxs = []int32{
 	1,  // 0: replication.Replication.LockVolume:input_type -> replication.LockRequest
@@ -492,11 +729,11 @@ var file_proto_replication_proto_depIdxs = []int32{
 	1,  // 4: replication.Replication.FinalizeSync:input_type -> replication.LockRequest
 	1,  // 5: replication.Replication.GetStatus:input_type -> replication.LockRequest
 	3,  // 6: replication.Replication.Ping:input_type -> replication.Empty
-	4,  // 7: replication.Replication.ExchangeCapabilities:input_type -> replication.CapabilitySet
-	5,  // 8: replication.Replication.CreateSession:input_type -> replication.SessionRequest
-	7,  // 9: replication.Replication.SendResumeBitmap:input_type -> replication.ResumeBitmap
-	6,  // 10: replication.Replication.Finalize:input_type -> replication.SessionResponse
-	2,  // 11: replication.Replication.AckStream:input_type -> replication.StatusResponse
+	4,  // 7: replication.Replication.Handshake:input_type -> replication.HandshakeRequest
+	6,  // 8: replication.Replication.CreateSession:input_type -> replication.SessionRequest
+	8,  // 9: replication.Replication.SendResumeBitmap:input_type -> replication.ResumeBitmap
+	9,  // 10: replication.Replication.Finalize:input_type -> replication.FinalizeRequest
+	10, // 11: replication.Replication.AckStream:input_type -> replication.Ack
 	2,  // 12: replication.Replication.LockVolume:output_type -> replication.StatusResponse
 	0,  // 13: replication.Replication.GetVolumeMetadata:output_type -> replication.VolumeMetadata
 	2,  // 14: replication.Replication.SendVolumeMetadata:output_type -> replication.StatusResponse
@@ -504,11 +741,11 @@ var file_proto_replication_proto_depIdxs = []int32{
 	2,  // 16: replication.Replication.FinalizeSync:output_type -> replication.StatusResponse
 	2,  // 17: replication.Replication.GetStatus:output_type -> replication.StatusResponse
 	2,  // 18: replication.Replication.Ping:output_type -> replication.StatusResponse
-	4,  // 19: replication.Replication.ExchangeCapabilities:output_type -> replication.CapabilitySet
-	6,  // 20: replication.Replication.CreateSession:output_type -> replication.SessionResponse
+	5,  // 19: replication.Replication.Handshake:output_type -> replication.HandshakeResponse
+	7,  // 20: replication.Replication.CreateSession:output_type -> replication.SessionResponse
 	2,  // 21: replication.Replication.SendResumeBitmap:output_type -> replication.StatusResponse
 	2,  // 22: replication.Replication.Finalize:output_type -> replication.StatusResponse
-	2,  // 23: replication.Replication.AckStream:output_type -> replication.StatusResponse
+	10, // 23: replication.Replication.AckStream:output_type -> replication.Ack
 	12, // [12:24] is the sub-list for method output_type
 	0,  // [0:12] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
@@ -527,7 +764,7 @@ func file_proto_replication_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_replication_proto_rawDesc), len(file_proto_replication_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/replication.proto
+++ b/proto/replication.proto
@@ -20,25 +20,44 @@ message StatusResponse {
   string message = 2;
 }
 
-message Empty {
+message Empty {}
+
+message HandshakeRequest {
+  uint32 sector_size = 1;
+  uint32 alignment = 2;
+  uint32 max_concurrency = 3;
+  bool dedup_supported = 4;
+  bool compression_supported = 5;
 }
 
-message CapabilitySet {
-  repeated string capabilities = 1;
+message HandshakeResponse {
+  bool ok = 1;
+  string message = 2;
 }
 
 message SessionRequest {
   string volume_name = 1;
   string device_uuid = 2;
+  bytes client_cert = 3;
 }
 
 message SessionResponse {
   string session_id = 1;
   bytes psk = 2;
+  bytes server_cert = 3;
 }
 
 message ResumeBitmap {
-  bytes bitmap = 1;
+  string session_id = 1;
+  bytes bitmap = 2;
+}
+
+message FinalizeRequest { string session_id = 1; }
+
+message Ack {
+  string session_id = 1;
+  bool ok = 2;
+  string message = 3;
 }
 
 service Replication {
@@ -49,9 +68,9 @@ service Replication {
   rpc FinalizeSync(LockRequest) returns (StatusResponse);
   rpc GetStatus(LockRequest) returns (StatusResponse);
   rpc Ping(Empty) returns (StatusResponse);
-  rpc ExchangeCapabilities(CapabilitySet) returns (CapabilitySet);
+  rpc Handshake(HandshakeRequest) returns (HandshakeResponse);
   rpc CreateSession(SessionRequest) returns (SessionResponse);
   rpc SendResumeBitmap(stream ResumeBitmap) returns (StatusResponse);
-  rpc Finalize(SessionResponse) returns (StatusResponse);
-  rpc AckStream(stream StatusResponse) returns (stream StatusResponse);
+  rpc Finalize(FinalizeRequest) returns (StatusResponse);
+  rpc AckStream(stream Ack) returns (stream Ack);
 }

--- a/proto/replication_grpc.pb.go
+++ b/proto/replication_grpc.pb.go
@@ -26,7 +26,7 @@ const (
 	Replication_FinalizeSync_FullMethodName         = "/replication.Replication/FinalizeSync"
 	Replication_GetStatus_FullMethodName            = "/replication.Replication/GetStatus"
 	Replication_Ping_FullMethodName                 = "/replication.Replication/Ping"
-	Replication_ExchangeCapabilities_FullMethodName = "/replication.Replication/ExchangeCapabilities"
+	Replication_Handshake_FullMethodName            = "/replication.Replication/Handshake"
 	Replication_CreateSession_FullMethodName        = "/replication.Replication/CreateSession"
 	Replication_SendResumeBitmap_FullMethodName     = "/replication.Replication/SendResumeBitmap"
 	Replication_Finalize_FullMethodName             = "/replication.Replication/Finalize"
@@ -44,11 +44,11 @@ type ReplicationClient interface {
 	FinalizeSync(ctx context.Context, in *LockRequest, opts ...grpc.CallOption) (*StatusResponse, error)
 	GetStatus(ctx context.Context, in *LockRequest, opts ...grpc.CallOption) (*StatusResponse, error)
 	Ping(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*StatusResponse, error)
-	ExchangeCapabilities(ctx context.Context, in *CapabilitySet, opts ...grpc.CallOption) (*CapabilitySet, error)
+	Handshake(ctx context.Context, in *HandshakeRequest, opts ...grpc.CallOption) (*HandshakeResponse, error)
 	CreateSession(ctx context.Context, in *SessionRequest, opts ...grpc.CallOption) (*SessionResponse, error)
 	SendResumeBitmap(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[ResumeBitmap, StatusResponse], error)
-	Finalize(ctx context.Context, in *SessionResponse, opts ...grpc.CallOption) (*StatusResponse, error)
-	AckStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[StatusResponse, StatusResponse], error)
+	Finalize(ctx context.Context, in *FinalizeRequest, opts ...grpc.CallOption) (*StatusResponse, error)
+	AckStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[Ack, Ack], error)
 }
 
 type replicationClient struct {
@@ -129,10 +129,10 @@ func (c *replicationClient) Ping(ctx context.Context, in *Empty, opts ...grpc.Ca
 	return out, nil
 }
 
-func (c *replicationClient) ExchangeCapabilities(ctx context.Context, in *CapabilitySet, opts ...grpc.CallOption) (*CapabilitySet, error) {
+func (c *replicationClient) Handshake(ctx context.Context, in *HandshakeRequest, opts ...grpc.CallOption) (*HandshakeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(CapabilitySet)
-	err := c.cc.Invoke(ctx, Replication_ExchangeCapabilities_FullMethodName, in, out, cOpts...)
+	out := new(HandshakeResponse)
+	err := c.cc.Invoke(ctx, Replication_Handshake_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (c *replicationClient) SendResumeBitmap(ctx context.Context, opts ...grpc.C
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Replication_SendResumeBitmapClient = grpc.ClientStreamingClient[ResumeBitmap, StatusResponse]
 
-func (c *replicationClient) Finalize(ctx context.Context, in *SessionResponse, opts ...grpc.CallOption) (*StatusResponse, error) {
+func (c *replicationClient) Finalize(ctx context.Context, in *FinalizeRequest, opts ...grpc.CallOption) (*StatusResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(StatusResponse)
 	err := c.cc.Invoke(ctx, Replication_Finalize_FullMethodName, in, out, cOpts...)
@@ -172,18 +172,18 @@ func (c *replicationClient) Finalize(ctx context.Context, in *SessionResponse, o
 	return out, nil
 }
 
-func (c *replicationClient) AckStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[StatusResponse, StatusResponse], error) {
+func (c *replicationClient) AckStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[Ack, Ack], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &Replication_ServiceDesc.Streams[1], Replication_AckStream_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[StatusResponse, StatusResponse]{ClientStream: stream}
+	x := &grpc.GenericClientStream[Ack, Ack]{ClientStream: stream}
 	return x, nil
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type Replication_AckStreamClient = grpc.BidiStreamingClient[StatusResponse, StatusResponse]
+type Replication_AckStreamClient = grpc.BidiStreamingClient[Ack, Ack]
 
 // ReplicationServer is the server API for Replication service.
 // All implementations must embed UnimplementedReplicationServer
@@ -196,11 +196,11 @@ type ReplicationServer interface {
 	FinalizeSync(context.Context, *LockRequest) (*StatusResponse, error)
 	GetStatus(context.Context, *LockRequest) (*StatusResponse, error)
 	Ping(context.Context, *Empty) (*StatusResponse, error)
-	ExchangeCapabilities(context.Context, *CapabilitySet) (*CapabilitySet, error)
+	Handshake(context.Context, *HandshakeRequest) (*HandshakeResponse, error)
 	CreateSession(context.Context, *SessionRequest) (*SessionResponse, error)
 	SendResumeBitmap(grpc.ClientStreamingServer[ResumeBitmap, StatusResponse]) error
-	Finalize(context.Context, *SessionResponse) (*StatusResponse, error)
-	AckStream(grpc.BidiStreamingServer[StatusResponse, StatusResponse]) error
+	Finalize(context.Context, *FinalizeRequest) (*StatusResponse, error)
+	AckStream(grpc.BidiStreamingServer[Ack, Ack]) error
 	mustEmbedUnimplementedReplicationServer()
 }
 
@@ -232,8 +232,8 @@ func (UnimplementedReplicationServer) GetStatus(context.Context, *LockRequest) (
 func (UnimplementedReplicationServer) Ping(context.Context, *Empty) (*StatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")
 }
-func (UnimplementedReplicationServer) ExchangeCapabilities(context.Context, *CapabilitySet) (*CapabilitySet, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ExchangeCapabilities not implemented")
+func (UnimplementedReplicationServer) Handshake(context.Context, *HandshakeRequest) (*HandshakeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Handshake not implemented")
 }
 func (UnimplementedReplicationServer) CreateSession(context.Context, *SessionRequest) (*SessionResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateSession not implemented")
@@ -241,10 +241,10 @@ func (UnimplementedReplicationServer) CreateSession(context.Context, *SessionReq
 func (UnimplementedReplicationServer) SendResumeBitmap(grpc.ClientStreamingServer[ResumeBitmap, StatusResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method SendResumeBitmap not implemented")
 }
-func (UnimplementedReplicationServer) Finalize(context.Context, *SessionResponse) (*StatusResponse, error) {
+func (UnimplementedReplicationServer) Finalize(context.Context, *FinalizeRequest) (*StatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Finalize not implemented")
 }
-func (UnimplementedReplicationServer) AckStream(grpc.BidiStreamingServer[StatusResponse, StatusResponse]) error {
+func (UnimplementedReplicationServer) AckStream(grpc.BidiStreamingServer[Ack, Ack]) error {
 	return status.Errorf(codes.Unimplemented, "method AckStream not implemented")
 }
 func (UnimplementedReplicationServer) mustEmbedUnimplementedReplicationServer() {}
@@ -394,20 +394,20 @@ func _Replication_Ping_Handler(srv interface{}, ctx context.Context, dec func(in
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Replication_ExchangeCapabilities_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CapabilitySet)
+func _Replication_Handshake_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(HandshakeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ReplicationServer).ExchangeCapabilities(ctx, in)
+		return srv.(ReplicationServer).Handshake(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: Replication_ExchangeCapabilities_FullMethodName,
+		FullMethod: Replication_Handshake_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ReplicationServer).ExchangeCapabilities(ctx, req.(*CapabilitySet))
+		return srv.(ReplicationServer).Handshake(ctx, req.(*HandshakeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -438,7 +438,7 @@ func _Replication_SendResumeBitmap_Handler(srv interface{}, stream grpc.ServerSt
 type Replication_SendResumeBitmapServer = grpc.ClientStreamingServer[ResumeBitmap, StatusResponse]
 
 func _Replication_Finalize_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(SessionResponse)
+	in := new(FinalizeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -450,17 +450,17 @@ func _Replication_Finalize_Handler(srv interface{}, ctx context.Context, dec fun
 		FullMethod: Replication_Finalize_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ReplicationServer).Finalize(ctx, req.(*SessionResponse))
+		return srv.(ReplicationServer).Finalize(ctx, req.(*FinalizeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _Replication_AckStream_Handler(srv interface{}, stream grpc.ServerStream) error {
-	return srv.(ReplicationServer).AckStream(&grpc.GenericServerStream[StatusResponse, StatusResponse]{ServerStream: stream})
+	return srv.(ReplicationServer).AckStream(&grpc.GenericServerStream[Ack, Ack]{ServerStream: stream})
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type Replication_AckStreamServer = grpc.BidiStreamingServer[StatusResponse, StatusResponse]
+type Replication_AckStreamServer = grpc.BidiStreamingServer[Ack, Ack]
 
 // Replication_ServiceDesc is the grpc.ServiceDesc for Replication service.
 // It's only intended for direct use with grpc.RegisterService,
@@ -498,8 +498,8 @@ var Replication_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Replication_Ping_Handler,
 		},
 		{
-			MethodName: "ExchangeCapabilities",
-			Handler:    _Replication_ExchangeCapabilities_Handler,
+			MethodName: "Handshake",
+			Handler:    _Replication_Handshake_Handler,
 		},
 		{
 			MethodName: "CreateSession",


### PR DESCRIPTION
## Summary
- expand replication proto with handshake, session, resume, and ack messages
- exchange ephemeral credentials and per-session acks in gRPC server/client
- document control-plane flow and CLI wiring

## Testing
- `go test -cover ./...` *(fails: ODirect redeclared in config/config.go)*
- `golangci-lint run` *(warnings present, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_6897fd3160d083238736b2bbf968c038