### PR TITLE
feat(compression): expose algorithm flags and update policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,18 @@ Example usage selecting transports and ports:
 lvmsync --transport quic,h2,tcp+tls,ssh --quic-connect host:9000 --tcp-port 9443
 ```
 
+## Compression Policy
+
+- Sample 8 KiB from each chunk to estimate the compression ratio.
+- Skip compression when the ratio is greater than or equal to `--compress-threshold`.
+- Auto mode selects LZ4 for chunks under 256 KiB and Zstd level 1 for larger chunks on AVX2-capable CPUs.
+
+Example configuration:
+
+```sh
+lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
+```
+
 ## Control Plane Flow
 
 - Clients perform a handshake sending `sector_size`, `alignment`, `max_concurrency`, and dedup/compression support.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Zero-Copy Transfers**: Utilizes `splice()` for efficient data movement.
 - **Parallel Execution**: Configurable concurrency for optimal performance.
 - **Rate-Limiting**: Control bandwidth usage during transfers.
-- **Compression**: Supports LZ4 and Zstd (with configurable compression levels and an auto mode based on CPU features).
+- **Compression**: Samples 8 KiB per chunk, skipping compression when the ratio exceeds a threshold. Auto mode selects LZ4 for chunks <256 KiB and Zstd level 1 for larger chunks on AVX2-capable CPUs.
 - **Checksum Verification**: Ensures data integrity using SHA-256 or BLAKE3.
 - **Native LVM2 Integration**: Uses Go bindings to `liblvm2cmd` instead of shelling out.
 - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, Bloom filter, or FastCDC content-defined chunking with optional hybrid mode.
@@ -200,8 +200,10 @@ because flags override environment variables, which override the config file.
 | `--bloom_entries` | `LVMSYNC_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
 | `--bloom_fp_rate` | `LVMSYNC_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
 | `--compress` | `LVMSYNC_COMPRESS` | `compress` | Compression type: `none`, `lz4`, `zstd`, or `auto` |
-| `--compress_level` | `LVMSYNC_COMPRESS_LEVEL` | `compress_level` | Compression level. LZ4 accepts `lz4.Fast` or `lz4.Level1..lz4.Level9`; Zstd accepts `1-22` |
+| `--zstd_level` | `LVMSYNC_ZSTD_LEVEL` | `zstd_level` | Zstd compression level (`1-5`) |
+| `--lz4_level` | `LVMSYNC_LZ4_LEVEL` | `lz4_level` | LZ4 compression level: `fast` or `hc` |
 | `--compress_concurrency` | `LVMSYNC_COMPRESS_CONCURRENCY` | `compress_concurrency` | Compression concurrency (0 to use `GOMAXPROCS`) |
+| `--compress_threshold` | `LVMSYNC_COMPRESS_THRESHOLD` | `compress_threshold` | Skip compression when estimated ratio exceeds this value |
 | `--skip_snapshot_creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
 | `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
@@ -398,8 +400,10 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | Option                   | Description                                                       | Default  |
 | ------------------------ | ----------------------------------------------------------------- | -------- |
 | `--compress`             | Compression type (options: `"none"`, `"lz4"`, `"zstd"`, `"auto"`) | `"auto"` |
-| `--compress_level`       | Compression level for Zstd (ignored for LZ4)                      | `3`      |
+| `--zstd_level`           | Zstd compression level (`1-5`)                                   | `1`      |
+| `--lz4_level`            | LZ4 compression level: `fast` or `hc`                            | `fast`   |
 | `--compress_concurrency` | Number of goroutines used for compression (`0` to use all cores)  | `0`      |
+| `--compress_threshold`   | Skip compression when estimated ratio exceeds this value         | `0.9`    |
 
 #### LVM Options
 
@@ -455,7 +459,7 @@ lvmsync --apply dumpfile.lvm /dev/vg0/data
 Enable Zstd compression with a specified compression level:
 
 ```sh
-lvmsync --compress zstd --compress_level 3 /dev/vg0/snap0 /dev/vg0/data
+lvmsync --compress zstd --zstd_level 3 /dev/vg0/snap0 /dev/vg0/data
 ```
 
 #### Rate Limiting
@@ -597,14 +601,14 @@ lvmsync --compress zstd --compress-level 5 /dev/vg0/snap0 /dev/vg0/data
 Environment:
 
 ```sh
-LVMSYNC_COMPRESS=zstd LVMSYNC_COMPRESS_LEVEL=5 lvmsync /dev/vg0/snap0 /dev/vg0/data
+LVMSYNC_COMPRESS=zstd LVMSYNC_ZSTD_LEVEL=5 lvmsync /dev/vg0/snap0 /dev/vg0/data
 ```
 
 YAML:
 
 ```yaml
 compress: zstd
-compress_level: 5
+zstd_level: 5
 ```
 
 #### LVM

--- a/config.yaml
+++ b/config.yaml
@@ -45,10 +45,14 @@ remote_post_script: ""
 
 # Compression method (options: "none", "lz4", "zstd", "auto")
 compress: "auto"
-# Compression level for zstd (ignored for lz4)
-compress_level: 3
+# Zstd compression level (1-5)
+zstd_level: 1
+# LZ4 compression level: fast or hc
+lz4_level: fast
 # Number of goroutines for compression (0 to use all cores)
 compress_concurrency: 0
+# Skip compression when estimated ratio exceeds this value
+compress_threshold: 0.9
 speed: "100MB"  # Speed limit (e.g. "100MB")
 # Enable checksum verification for data integrity
 verify_checksum: false

--- a/config/config.go
+++ b/config/config.go
@@ -49,28 +49,29 @@ var (
 var getEuid = os.Geteuid
 
 type Config struct {
-	ConfigFile           string        `mapstructure:"config"`
-	ApplyMode            string        `mapstructure:"apply"`
-	StdoutMode           bool          `mapstructure:"stdout"`
-	Mode                 string        `mapstructure:"mode"`
-	Parallel             int           `mapstructure:"parallel"`
-	ZeroCopy             bool          `mapstructure:"zerocopy"`
-	ODirect              bool          `mapstructure:"odirect"`
-	MaxRetries           int           `mapstructure:"max_retries"`
-	ResumeState          string        `mapstructure:"resume"`
-	SSHUser              string        `mapstructure:"ssh_user"`
-	SSHKeyPath           string        `mapstructure:"ssh_key"`
-	SSHPort              int           `mapstructure:"ssh_port"`
-	SSHTimeout           time.Duration `mapstructure:"ssh_timeout"`
-	SSHKeepAliveInterval time.Duration `mapstructure:"ssh_keepalive"`
-	KnownHosts           string        `mapstructure:"known_hosts"`
-	StrictHostKeyCheck   bool          `mapstructure:"strict_host_key_checking"`
-	LVMSyncPath          string        `mapstructure:"lvmsync_path"`
-	RemotePreScript      string        `mapstructure:"remote_pre_script"`
-	RemotePostScript     string        `mapstructure:"remote_post_script"`
-	Compress             string        `mapstructure:"compress"`
-	// For LZ4 use lz4.Fast or lz4.Level1 through lz4.Level9; ZSTD accepts levels 1-22.
-	CompressLevel         int           `mapstructure:"compress_level"`
+	ConfigFile            string        `mapstructure:"config"`
+	ApplyMode             string        `mapstructure:"apply"`
+	StdoutMode            bool          `mapstructure:"stdout"`
+	Mode                  string        `mapstructure:"mode"`
+	Parallel              int           `mapstructure:"parallel"`
+	ZeroCopy              bool          `mapstructure:"zerocopy"`
+	ODirect               bool          `mapstructure:"odirect"`
+	MaxRetries            int           `mapstructure:"max_retries"`
+	ResumeState           string        `mapstructure:"resume"`
+	SSHUser               string        `mapstructure:"ssh_user"`
+	SSHKeyPath            string        `mapstructure:"ssh_key"`
+	SSHPort               int           `mapstructure:"ssh_port"`
+	SSHTimeout            time.Duration `mapstructure:"ssh_timeout"`
+	SSHKeepAliveInterval  time.Duration `mapstructure:"ssh_keepalive"`
+	KnownHosts            string        `mapstructure:"known_hosts"`
+	StrictHostKeyCheck    bool          `mapstructure:"strict_host_key_checking"`
+	LVMSyncPath           string        `mapstructure:"lvmsync_path"`
+	RemotePreScript       string        `mapstructure:"remote_pre_script"`
+	RemotePostScript      string        `mapstructure:"remote_post_script"`
+	Compress              string        `mapstructure:"compress"`
+	ZstdLevel             int           `mapstructure:"zstd_level"`
+	LZ4Level              string        `mapstructure:"lz4_level"`
+	CompressLevel         int           `mapstructure:"-"`
 	CompressConcurrency   int           `mapstructure:"compress_concurrency"`
 	CompressThreshold     float64       `mapstructure:"compress_threshold"`
 	Speed                 string        `mapstructure:"speed"`
@@ -215,6 +216,12 @@ func (b *Builder) applyDefaults(conf *Config) error {
 	if conf.CompressThreshold <= 0 {
 		conf.CompressThreshold = b.defaults.CompressThreshold
 	}
+	if conf.ZstdLevel == 0 {
+		conf.ZstdLevel = b.defaults.ZstdLevel
+	}
+	if conf.LZ4Level == "" {
+		conf.LZ4Level = b.defaults.LZ4Level
+	}
 	if conf.Mode == "throughput" {
 		b.applyThroughput(conf)
 	}
@@ -255,14 +262,19 @@ func (b *Builder) validateCompression(conf *Config) error {
 	}
 	switch resolved {
 	case Zstd:
-		if conf.CompressLevel < 1 || conf.CompressLevel > 22 {
-			return fmt.Errorf("invalid zstd compression level: %d", conf.CompressLevel)
+		if conf.ZstdLevel < 1 || conf.ZstdLevel > 5 {
+			return fmt.Errorf("invalid zstd compression level: %d", conf.ZstdLevel)
 		}
+		conf.CompressLevel = conf.ZstdLevel
 	case "lz4":
-		if conf.CompressLevel < int(lz4.Fast) || conf.CompressLevel > int(lz4.Level9) {
-			return fmt.Errorf("invalid lz4 compression level: %d", conf.CompressLevel)
+		switch strings.ToLower(conf.LZ4Level) {
+		case "fast":
+			conf.CompressLevel = int(lz4.Fast)
+		case "hc":
+			conf.CompressLevel = int(lz4.Level9)
+		default:
+			return fmt.Errorf("invalid lz4 compression level: %s", conf.LZ4Level)
 		}
-		_ = lz4.CompressionLevel(conf.CompressLevel)
 	}
 	if conf.CompressThreshold <= 0 || conf.CompressThreshold > 1 {
 		return fmt.Errorf("invalid compress threshold: %f", conf.CompressThreshold)
@@ -357,7 +369,8 @@ func DefaultConfig() (*Config, error) {
 		RemotePreScript:       "",
 		RemotePostScript:      "",
 		Compress:              Auto,
-		CompressLevel:         3,
+		ZstdLevel:             1,
+		LZ4Level:              "fast",
 		CompressConcurrency:   runtime.GOMAXPROCS(0),
 		CompressThreshold:     0.9,
 		Speed:                 "100MB",
@@ -461,7 +474,8 @@ func initDedupFlags(cfg *Config) *pflag.FlagSet {
 func initCompressionFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Compression Options", pflag.ExitOnError)
 	fs.String("compress", cfg.Compress, fmt.Sprintf("Compression type, options: %v", SupportedCompression))
-	fs.Int("compress_level", cfg.CompressLevel, "Compression level. LZ4 accepts lz4.Fast or lz4.Level1..lz4.Level9; ZSTD accepts 1-22")
+	fs.Int("zstd_level", cfg.ZstdLevel, "Zstd compression level (1-5)")
+	fs.String("lz4_level", cfg.LZ4Level, "LZ4 compression level: fast or hc")
 	fs.Int("compress_concurrency", cfg.CompressConcurrency, "Compression concurrency (0 to use GOMAXPROCS)")
 	fs.Float64("compress_threshold", cfg.CompressThreshold, "Skip compression when estimated ratio exceeds this value")
 	return fs

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/pierrec/lz4/v4"
 	"github.com/spf13/viper"
 
 	compressiondetect "lvmsync_go/internal/compressiondetect"
@@ -175,14 +174,14 @@ func TestBuilderValidateCompression(t *testing.T) {
 	b := &Builder{defaults: defaults}
 
 	t.Run(Zstd+"Valid", func(t *testing.T) {
-		conf := &Config{Compress: Zstd, CompressLevel: 3, CompressThreshold: 0.9}
+		conf := &Config{Compress: Zstd, ZstdLevel: 3, CompressThreshold: 0.9}
 		if err := b.validateCompression(conf); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run(Zstd+"Invalid", func(t *testing.T) {
-		conf := &Config{Compress: Zstd, CompressLevel: 100, CompressThreshold: 0.9}
+		conf := &Config{Compress: Zstd, ZstdLevel: 6, CompressThreshold: 0.9}
 		if err := b.validateCompression(conf); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -191,9 +190,9 @@ func TestBuilderValidateCompression(t *testing.T) {
 	t.Run(Auto, func(t *testing.T) {
 		conf := &Config{Compress: Auto, CompressThreshold: 0.9}
 		if compressiondetect.DetectOptimalCompression() == Zstd {
-			conf.CompressLevel = 3
+			conf.ZstdLevel = 2
 		} else {
-			conf.CompressLevel = int(lz4.Level3)
+			conf.LZ4Level = "fast"
 		}
 		if err := b.validateCompression(conf); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -369,11 +368,11 @@ func TestBuildBlockSize(t *testing.T) {
 }
 
 //nolint:revive // complex validation scenarios
-func TestCompressLevelValidation(t *testing.T) {
+func TestCompressionLevelValidation(t *testing.T) {
 	t.Run(Zstd+"Valid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Zstd)
-		v.Set("compress_level", 3)
+		v.Set("zstd_level", 3)
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -387,7 +386,7 @@ func TestCompressLevelValidation(t *testing.T) {
 	t.Run(Zstd+"Invalid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Zstd)
-		v.Set("compress_level", 100)
+		v.Set("zstd_level", 6)
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -402,9 +401,9 @@ func TestCompressLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Auto)
 		if compressiondetect.DetectOptimalCompression() == Zstd {
-			v.Set("compress_level", 3)
+			v.Set("zstd_level", 2)
 		} else {
-			v.Set("compress_level", int(lz4.Level3))
+			v.Set("lz4_level", "fast")
 		}
 		defaults, err := DefaultConfig()
 		if err != nil {
@@ -420,9 +419,9 @@ func TestCompressLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Auto)
 		if compressiondetect.DetectOptimalCompression() == Zstd {
-			v.Set("compress_level", 100)
+			v.Set("zstd_level", 6)
 		} else {
-			v.Set("compress_level", int(lz4.Level9)+1)
+			v.Set("lz4_level", "bad")
 		}
 		defaults, err := DefaultConfig()
 		if err != nil {
@@ -437,7 +436,7 @@ func TestCompressLevelValidation(t *testing.T) {
 	t.Run("lz4Valid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "lz4")
-		v.Set("compress_level", int(lz4.Level3))
+		v.Set("lz4_level", "hc")
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -451,7 +450,7 @@ func TestCompressLevelValidation(t *testing.T) {
 	t.Run("lz4Invalid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "lz4")
-		v.Set("compress_level", int(lz4.Level9)+1)
+		v.Set("lz4_level", "slow")
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -126,7 +126,8 @@ func TestInitCompressionFlags(t *testing.T) {
 	fs := initCompressionFlags(cfg)
 	cases := []struct{ name, want string }{
 		{"compress", cfg.Compress},
-		{"compress_level", strconv.Itoa(cfg.CompressLevel)},
+		{"zstd_level", strconv.Itoa(cfg.ZstdLevel)},
+		{"lz4_level", cfg.LZ4Level},
 		{"compress_concurrency", strconv.Itoa(cfg.CompressConcurrency)},
 		{"compress_threshold", strconv.FormatFloat(cfg.CompressThreshold, 'f', -1, 64)},
 	}

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -17,6 +17,10 @@ const (
 	compressionZSTD = "zstd"
 )
 
+// hasAVX2 reports whether the current CPU supports AVX2 instructions. It is
+// a variable to allow tests to override the detection behavior.
+var hasAVX2 = compressiondetect.HasAVX2
+
 // No shared state is kept between decompression readers.
 
 // NewCompressionWriter creates a compression writer that wraps the destination
@@ -74,7 +78,7 @@ func selectAlgorithm(chunkLen int, compress string, level int) (string, int) {
 			}
 			return compressionLZ4, level
 		}
-		if compressiondetect.HasAVX2() {
+		if hasAVX2() {
 			return compressionZSTD, defaultZstdLv
 		}
 		if level == 0 {

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -160,6 +160,28 @@ func TestCompressChunkThreshold(t *testing.T) {
 	}
 }
 
+func TestSelectAlgorithm(t *testing.T) {
+	orig := hasAVX2
+	defer func() { hasAVX2 = orig }()
+
+	algo, lvl := selectAlgorithm(64*1024, StrategyAuto, 0)
+	if algo != compressionLZ4 || lvl != int(lz4.Level1) {
+		t.Fatalf("expected lz4 level1, got %s level %d", algo, lvl)
+	}
+
+	hasAVX2 = func() bool { return true }
+	algo, lvl = selectAlgorithm(300*1024, StrategyAuto, 0)
+	if algo != compressionZSTD || lvl != defaultZstdLv {
+		t.Fatalf("expected zstd level %d, got %s level %d", defaultZstdLv, algo, lvl)
+	}
+
+	hasAVX2 = func() bool { return false }
+	algo, lvl = selectAlgorithm(300*1024, StrategyAuto, 0)
+	if algo != compressionLZ4 || lvl != int(lz4.Level1) {
+		t.Fatalf("expected lz4 level1 fallback, got %s level %d", algo, lvl)
+	}
+}
+
 //nolint:revive // complex reuse test
 func TestLZ4WriterPoolReuse(t *testing.T) {
 	data1 := []byte("first payload")

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -130,7 +130,7 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 	changed := []int{0}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
 
-	cfgDump := &config.Config{BlockSize: int(blockSize), Compress: "zstd", CompressLevel: 1, VerifyChecksum: true, Parallel: 1, MaxRetries: 1}
+	cfgDump := &config.Config{BlockSize: int(blockSize), Compress: "zstd", ZstdLevel: 1, CompressLevel: 1, VerifyChecksum: true, Parallel: 1, MaxRetries: 1}
 	var buf bytes.Buffer
 	if err := DumpChangesParallel(cfgDump, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)


### PR DESCRIPTION
## Summary
- add AVX2 stub and enforce 8KiB sampling with ratio-based compression skip
- expose `--compress`, `--zstd_level`, `--lz4_level`, and `--compress_threshold`
- document compression policy and configuration examples

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68987eb85cf88323a20c5d771e1d5da1