### PR TITLE
feat(transfer): add mmap hash index for cdc dedup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 
 - Document every CLI flag, environment variable, and configuration option in `README.md`.
 - Update examples and default values to match new options.
-- Deduplication modes (`fixed`, `cdc`, `hybrid`) expose tunables `--cdc-min`, `--cdc-avg`, `--cdc-max`, and Bloom filter sizing with `--bloom-mbits`.
+- Deduplication modes (`fixed`, `cdc`, `hybrid`) expose tunables `--cdc-min`, `--cdc-avg`, `--cdc-max`, and Bloom filter sizing with `--bloom-mbits` for the mmap-backed index.
 
 ## Release Workflow
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Compression**: Samples 8 KiB per chunk, skipping compression when the ratio exceeds a threshold. Auto mode selects LZ4 for chunks <256 KiB and Zstd level 1 for larger chunks on AVX2-capable CPUs.
 - **Checksum Verification**: Ensures data integrity using SHA-256 or BLAKE3.
 - **Native LVM2 Integration**: Uses Go bindings to `liblvm2cmd` instead of shelling out.
-- **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, Bloom filter, or FastCDC content-defined chunking with optional hybrid mode.
+- **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or a Bloom filter with optional FastCDC content-defined chunking and mmap-backed index.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers.
 - **LVM Snapshot Management**:

--- a/transfer/dedup_cdc.go
+++ b/transfer/dedup_cdc.go
@@ -6,10 +6,12 @@ import (
 	"encoding/binary"
 	"hash"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/zeebo/blake3"
+	"golang.org/x/sys/unix"
 
 	"lvmsync_go/config"
 	"lvmsync_go/dedup"
@@ -17,12 +19,15 @@ import (
 
 // CDCDedup implements a simple FastCDC based deduplication helper. It
 // chunks data using the dedup.Chunker and records per chunk hashes in a
-// Bloom filter and an in-memory index. Each chunk is hashed with BLAKE3
-// while a final SHA-256 digest is computed over the chunk digests.
+// Bloom filter and an optional mmap backed bitset index. Each chunk is
+// hashed with BLAKE3 while a final SHA-256 digest is computed over the
+// chunk digests.
 type CDCDedup struct {
 	chunker   *dedup.Chunker
 	bloom     *bloom.BloomFilter
-	index     map[[32]byte]struct{}
+	index     []byte
+	indexFile *os.File
+	indexMask uint64
 	stateFile string
 
 	mu  sync.Mutex
@@ -32,13 +37,31 @@ type CDCDedup struct {
 // NewCDCDedup constructs a CDCDedup using the tunables provided in cfg.
 func NewCDCDedup(cfg *config.Config) *CDCDedup {
 	bf := bloom.NewWithEstimates(uint(cfg.BloomEntries), cfg.BloomFpRate)
-	return &CDCDedup{
+	cd := &CDCDedup{
 		chunker:   dedup.NewChunker(cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax),
 		bloom:     bf,
-		index:     make(map[[32]byte]struct{}),
 		stateFile: cfg.DedupStateFile,
 		sha:       sha256.New(),
 	}
+	if cfg.BloomMBits > 0 {
+		size := 1 << (cfg.BloomMBits - 3)
+		f, err := os.OpenFile(cfg.DedupStateFile+".idx", os.O_RDWR|os.O_CREATE, 0o600)
+		if err == nil {
+			if err := f.Truncate(int64(size)); err == nil {
+				data, err := unix.Mmap(int(f.Fd()), 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+				if err == nil {
+					cd.index = data
+					cd.indexFile = f
+					cd.indexMask = (1 << cfg.BloomMBits) - 1
+				} else {
+					f.Close()
+				}
+			} else {
+				f.Close()
+			}
+		}
+	}
+	return cd
 }
 
 // ChunkAndHash splits p into FastCDC chunks recording hashes. The returned
@@ -62,7 +85,12 @@ func (c *CDCDedup) ChunkAndHash(p []byte) ([]dedup.Chunk, [32]byte, error) {
 		digest := blake3.Sum256(ch.Data)
 		if !c.bloom.Test(digest[:]) {
 			c.bloom.Add(digest[:])
-			c.index[digest] = struct{}{}
+		}
+		if len(c.index) > 0 {
+			idx := binary.LittleEndian.Uint64(digest[:8]) & c.indexMask
+			byteIdx := idx >> 3
+			bit := byte(1 << (idx & 7))
+			c.index[byteIdx] |= bit
 		}
 		c.sha.Write(digest[:])
 		ch.Offset = offset
@@ -83,12 +111,19 @@ func (c *CDCDedup) ChunkAndHash(p []byte) ([]dedup.Chunk, [32]byte, error) {
 func (c *CDCDedup) SaveState() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return saveStateFile(c.stateFile, func(w io.Writer) error {
-		for h := range c.index {
-			if err := binary.Write(w, binary.LittleEndian, h); err != nil {
-				return err
-			}
+	if err := saveStateFile(c.stateFile, func(w io.Writer) error {
+		_, err := c.bloom.WriteTo(w)
+		return err
+	}); err != nil {
+		return err
+	}
+	if len(c.index) > 0 {
+		if err := unix.Msync(c.index, unix.MS_SYNC); err != nil {
+			return err
 		}
-		return nil
-	})
+		if c.indexFile != nil {
+			return c.indexFile.Sync()
+		}
+	}
+	return nil
 }

--- a/transfer/dedup_cdc_test.go
+++ b/transfer/dedup_cdc_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bytes"
 	"io"
+	"path/filepath"
 	"testing"
 
 	"lvmsync_go/config"
@@ -49,14 +50,25 @@ func TestCDCDedupSaveStateWriteFailure(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	d := NewCDCDedup(cfg)
-	var h [32]byte
-	h[0] = 1
-	d.index[h] = struct{}{}
 	fw := &cdcFailingWriter{failAfter: 0}
 	orig := createStateFile
 	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
 	defer func() { createStateFile = orig }()
 	if err := d.SaveState(); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCDCDedupMmapIndex(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.BloomMBits = 8
+	cfg.DedupStateFile = filepath.Join(t.TempDir(), "state")
+	d := NewCDCDedup(cfg)
+	expected := 1 << (cfg.BloomMBits - 3)
+	if len(d.index) != expected {
+		t.Fatalf("unexpected index size %d want %d", len(d.index), expected)
 	}
 }


### PR DESCRIPTION
## Summary
- add mmap-backed bitset index to FastCDC dedup helper
- persist Bloom filter and sync mapped index
- document mmap index option and add tests

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68988bf3462c83238fc58837f134eb47