### PR TITLE
docs: document compression policy and add selection tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,9 @@ lvmsync --transport quic,h2,tcp+tls,ssh --quic-connect host:9000 --tcp-port 9443
 ## Compression Policy
 
 - Sample 8 KiB from each chunk to estimate the compression ratio.
-- Skip compression when the ratio is greater than or equal to `--compress-threshold`.
+- Skip compression when the ratio is greater than or equal to `--compress_threshold`.
 - Auto mode selects LZ4 for chunks under 256 KiB and Zstd level 1 for larger chunks on AVX2-capable CPUs.
+- Choose the algorithm with `--compress {auto|lz4|zstd|none}` and tune levels using `--zstd_level 1..5` or `--lz4_level {fast|hc}`.
 
 Example configuration:
 

--- a/README.md
+++ b/README.md
@@ -456,10 +456,10 @@ lvmsync --apply dumpfile.lvm /dev/vg0/data
 
 #### Using Compression
 
-Enable Zstd compression with a specified compression level:
+Estimate a sample of each chunk and compress only when it's worthwhile:
 
 ```sh
-lvmsync --compress zstd --zstd_level 3 /dev/vg0/snap0 /dev/vg0/data
+lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85 /dev/vg0/snap0 /dev/vg0/data
 ```
 
 #### Rate Limiting
@@ -592,23 +592,30 @@ dedup_state_file: ~/.lvmsync_state
 
 #### Compression
 
+LVMSync samples 8 KiB from each chunk to gauge compression efficiency. If the
+compressed sample ratio is greater than or equal to `--compress_threshold`, the
+chunk is sent uncompressed. In `auto` mode, chunks smaller than 256 KiB use LZ4
+and larger ones select Zstd level 1 when AVX2 is available.
+Levels can be tuned with `--zstd_level` (1-5) or `--lz4_level` (`fast` or `hc`).
+
 CLI:
 
 ```sh
-lvmsync --compress zstd --compress-level 5 /dev/vg0/snap0 /dev/vg0/data
+lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85 /dev/vg0/snap0 /dev/vg0/data
 ```
 
 Environment:
 
 ```sh
-LVMSYNC_COMPRESS=zstd LVMSYNC_ZSTD_LEVEL=5 lvmsync /dev/vg0/snap0 /dev/vg0/data
+LVMSYNC_COMPRESS=auto LVMSYNC_ZSTD_LEVEL=2 LVMSYNC_COMPRESS_THRESHOLD=0.85 lvmsync /dev/vg0/snap0 /dev/vg0/data
 ```
 
 YAML:
 
 ```yaml
-compress: zstd
-zstd_level: 5
+compress: auto
+zstd_level: 2
+compress_threshold: 0.85
 ```
 
 #### LVM

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -160,6 +160,40 @@ func TestCompressChunkThreshold(t *testing.T) {
 	}
 }
 
+// TestCompressChunkAutoSelects verifies that automatic compression selects the
+// expected algorithm based on chunk size and CPU capabilities.
+func TestCompressChunkAutoSelects(t *testing.T) {
+	orig := hasAVX2
+	defer func() { hasAVX2 = orig }()
+
+	small := bytes.Repeat([]byte("a"), 64*1024)
+	large := bytes.Repeat([]byte("a"), 300*1024)
+
+	cases := []struct {
+		name   string
+		data   []byte
+		avx2   bool
+		expect string
+	}{
+		{"smallAvx2", small, true, compressionLZ4},
+		{"largeAvx2", large, true, compressionZSTD},
+		{"largeNoAvx2", large, false, compressionLZ4},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hasAVX2 = func() bool { return tc.avx2 }
+			_, algo, err := CompressChunk(tc.data, StrategyAuto, 0, 1, 1.0)
+			if err != nil {
+				t.Fatalf("compress chunk: %v", err)
+			}
+			if algo != tc.expect {
+				t.Fatalf("expected %s, got %s", tc.expect, algo)
+			}
+		})
+	}
+}
+
 func TestSelectAlgorithm(t *testing.T) {
 	orig := hasAVX2
 	defer func() { hasAVX2 = orig }()


### PR DESCRIPTION
## Summary
- document compression policy and configuration flags
- add test covering auto compression algorithm selection
- update README examples

## Testing
- `golangci-lint run`
- `go test -cover ./transfer`


------
https://chatgpt.com/codex/tasks/task_e_68988c0c55348323bbfbafad1c0b8333