### PR TITLE
docs: add roadmap and contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,13 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - [ ] Refactor `main.go` into smaller modules.
 - [ ] Verify configuration precedence.
 - [ ] Document feature changes in `README.md`.
+## Roadmap
+
+- [ ] Implement gRPC control plane with mTLS and port configurability.
+- [ ] Introduce pluggable data plane with transport registry supporting QUIC, HTTP/2, TLS/TCP, and SSH.
+- [ ] Add hybrid deduplication combining fixed-size and content-defined chunking (FastCDC).
+- [ ] Implement adaptive compression with CPU feature detection and per-chunk sampling.
+- [ ] Optimize transfer pipeline for concurrency autotuning, large in-flight windows, and efficient I/O paths.
+- [ ] Provide `FlagSet`-grouped CLI options bound to Viper, with parity across flags, environment variables, and config files.
+- [ ] Ensure each new function includes unit tests and documentation updates in README.md.
+- [ ] Maintain modular, single-responsibility design to ease future maintenance.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Flexible Configuration**: Flags, environment variables, or `config.yaml`. See [Configuration](#configuration).
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.
 
+## Roadmap
+
+- gRPC control plane with mTLS and configurable ports
+- Pluggable data plane: QUIC, HTTP/2, TLS/TCP, SSH
+- Hybrid fixed + CDC deduplication with Bloom filter index
+- Adaptive compression using LZ4 or Zstd with per-chunk sampling
+- Throughput mode presets for high-bandwidth links
+
+See AGENTS.md for contributor tasks and design guidelines.
+
 ## Architecture
 
 LVMSync is organized into modular packages to keep concerns separated:


### PR DESCRIPTION
## Summary
- document future roadmap for gRPC control plane, pluggable transports, dedup, compression, and throughput mode
- add contributor checklist with viper+pflag usage, zap logging, and testing expectations
- reference AGENTS.md in README for developer guidance

## Testing
- `go test ./common`
- `golangci-lint run` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_689890359ae483238f3ef0a7502d14d9