### PR TITLE
fix(client): drain monitor channel

### DIFF
--- a/internal/client/execute.go
+++ b/internal/client/execute.go
@@ -19,12 +19,10 @@ func ExecuteClient(runClient func(string, string) error, snapshotPath, destPath 
 	}
 
 	if monitorErrCh != nil {
-		select {
-		case err := <-monitorErrCh:
+		for err := range monitorErrCh {
 			if err != nil {
 				return fmt.Errorf("snapshot monitor error: %w", err)
 			}
-		default:
 		}
 	}
 

--- a/internal/client/execute_test.go
+++ b/internal/client/execute_test.go
@@ -39,6 +39,7 @@ func TestExecuteMonitorError(t *testing.T) {
 	sigCh := make(chan error, 1)
 	monitorCh := make(chan error, 1)
 	monitorCh <- errors.New("monitor")
+	close(monitorCh)
 	err := ExecuteClient(runClient, "snap", "dest", sigCh, monitorCh)
 	if err == nil || !strings.Contains(err.Error(), "snapshot monitor error") {
 		t.Fatalf("expected monitor error, got %v", err)

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -152,12 +152,18 @@ func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotB
 	go func() {
 		if err := monitorSnapshot(monitorCtx, snapshotPath, 80.0, 10*time.Second); err != nil && err != context.Canceled {
 			logger.Error("Snapshot monitor error", zap.Error(err))
-			monitorErrCh <- err
+			select {
+			case monitorErrCh <- err:
+			default:
+			}
 		}
 	}()
 
 	cleanup = func() {
 		cancel()
+		if monitorErrCh != nil {
+			close(monitorErrCh)
+		}
 		if err := removeSnapshot(context.Background(), snapshotPath); err != nil {
 			logger.Warn("Failed to remove snapshot", zap.Error(err))
 		} else {


### PR DESCRIPTION
## Summary
- avoid blocking snapshot monitor by non-blocking send and closing monitor channel on cleanup
- drain monitor error channel until closed
- adjust tests for closed monitor channel

## Testing
- `go test ./...` *(fails: TestHandshakeAndAck timeout in grpc/client)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898a6a6fc7483239cd1e46ef40cd1aa