### PR TITLE
feat: aligned buffers and NUMA pinning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - [ ] Ensure progress logging uses `zap` exclusively.
 - [ ] Add a dedicated unit test for every new function.
 - [ ] Maintain tests for compression detection, ensuring benchmark and cache logic remain correct.
+- [ ] Maintain tests for buffer alignment, hole punching, and NUMA pinning.
 - [ ] Enforce modular, single-responsibility design across packages.
 - [ ] Document each new CLI flag, environment variable, and configuration option in `README.md`.
 - [ ] Refactor `main.go` into smaller modules.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or a Bloom filter with optional FastCDC content-defined chunking and mmap-backed index.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers.
+- **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it.
+- **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to the device's NUMA node.
 - **LVM Snapshot Management**:
   - Automatic snapshot creation and removal.
   - Configurable snapshot size (absolute or percentage-based).
@@ -156,6 +158,12 @@ The overall loading flow works in three stages:
 2. `buildViper()` binds flags, `LVMSYNC_*` environment variables, and an optional `config.yaml` into a single configuration source.
 3. `LoadConfig()` merges those values with built-in defaults and validates the result.
 
+### I/O tuning
+
+- `--odirect` uses O_DIRECT with block-size aligned buffers.
+- `--sync_interval` sets how many bytes are written between `fdatasync` calls.
+- `--numa_pin` pins worker goroutines to CPUs local to the source device's NUMA node.
+
 ### Precedence and environment variables
 
 LVMSync uses [`pflag`](https://github.com/spf13/pflag) and [`viper`](https://github.com/spf13/viper) so every option can be
@@ -187,9 +195,12 @@ because flags override environment variables, which override the config file.
 | `--stdout` | `LVMSYNC_STDOUT` | `stdout` | Write change dump to STDOUT |
 | `--parallel` | `LVMSYNC_PARALLEL` | `parallel` | Number of concurrent workers |
 | `--zerocopy` | `LVMSYNC_ZEROCOPY` | `zerocopy` | Enable zero-copy transfers |
+| `--odirect` | `LVMSYNC_ODIRECT` | `odirect` | Use O_DIRECT for device I/O when possible |
+| `--numa_pin` | `LVMSYNC_NUMA_PIN` | `numa_pin` | Pin worker goroutines to device NUMA node |
 | `--max_retries` | `LVMSYNC_MAX_RETRIES` | `max_retries` | Maximum number of retries per block |
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file |
 | `--speed` | `LVMSYNC_SPEED` | `speed` | Transfer speed limit |
+| `--sync_interval` | `LVMSYNC_SYNC_INTERVAL` | `sync_interval` | Bytes between fdatasync calls |
 | `--block_size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
 | `--verbose` | `LVMSYNC_VERBOSE` | `verbose` | Verbosity level |
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	Parallel              int           `mapstructure:"parallel"`
 	ZeroCopy              bool          `mapstructure:"zerocopy"`
 	ODirect               bool          `mapstructure:"odirect"`
+	NumaPin               bool          `mapstructure:"numa_pin"`
 	MaxRetries            int           `mapstructure:"max_retries"`
 	ResumeState           string        `mapstructure:"resume"`
 	SSHUser               string        `mapstructure:"ssh_user"`
@@ -175,6 +176,9 @@ func (b *Builder) applyDefaults(conf *Config) error {
 	}
 	if !b.v.IsSet("allow_insecure") {
 		conf.AllowInsecure = b.defaults.AllowInsecure
+	}
+	if !b.v.IsSet("numa_pin") {
+		conf.NumaPin = b.defaults.NumaPin
 	}
 	if conf.GRPCPort == 0 {
 		conf.GRPCPort = b.defaults.GRPCPort
@@ -356,6 +360,8 @@ func DefaultConfig() (*Config, error) {
 		StdoutMode:            false,
 		Parallel:              4,
 		ZeroCopy:              false,
+		ODirect:               false,
+		NumaPin:               false,
 		MaxRetries:            3,
 		ResumeState:           "",
 		SSHUser:               "root",
@@ -425,6 +431,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Int("parallel", cfg.Parallel, "Number of concurrent workers")
 	fs.Bool("zerocopy", cfg.ZeroCopy, "Enable zero-copy transfers")
 	fs.Bool("odirect", cfg.ODirect, "Use O_DIRECT for device I/O when possible")
+	fs.Bool("numa_pin", cfg.NumaPin, "Pin worker goroutines to device NUMA node")
 	fs.Int("max_retries", cfg.MaxRetries, "Maximum number of retries per block")
 	fs.String("resume", cfg.ResumeState, "Path to resume state file")
 	fs.String("speed", cfg.Speed, "Transfer speed limit")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -20,6 +20,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"parallel", strconv.Itoa(cfg.Parallel)},
 		{"zerocopy", strconv.FormatBool(cfg.ZeroCopy)},
 		{"odirect", strconv.FormatBool(cfg.ODirect)},
+		{"numa_pin", strconv.FormatBool(cfg.NumaPin)},
 		{"max_retries", strconv.Itoa(cfg.MaxRetries)},
 		{"resume", cfg.ResumeState},
 		{"speed", cfg.Speed},
@@ -29,7 +30,6 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"verify_checksum", strconv.FormatBool(cfg.VerifyChecksum)},
 		{"checksum_algorithm", cfg.ChecksumAlgorithm},
 		{"progress", strconv.FormatBool(cfg.Progress)},
-		{"odirect", strconv.FormatBool(cfg.ODirect)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)

--- a/transfer/aligned_linux_test.go
+++ b/transfer/aligned_linux_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package transfer
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"unsafe"
+)
+
+func TestGetAlignedBlockBuffer(t *testing.T) {
+	buf := getAlignedBlockBuffer(4096)
+	if uintptr(unsafe.Pointer(&buf[0]))%4096 != 0 {
+		t.Fatalf("buffer not aligned to 4096: %v", buf)
+	}
+	putAlignedBlockBuffer(buf)
+}
+
+func TestPunchHole(t *testing.T) {
+	f, err := os.CreateTemp("", "hole")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	data := bytes.Repeat([]byte{1}, 4096*2)
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := punchHole(f, 4096, 4096); err != nil {
+		t.Skipf("punchHole unsupported: %v", err)
+	}
+	out := make([]byte, 4096)
+	if _, err := f.ReadAt(out, 4096); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !isAllZero(out) {
+		t.Fatalf("expected zeros after punchHole")
+	}
+}

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -136,6 +136,8 @@ func processParallelResults(cfg *config.Config, results <-chan *BlockResult, buf
 
 func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
 	defer workerWG.Done()
+	unlock := pinWorkerToDevice(cfg, srcFile)
+	defer unlock()
 	for task := range tasks {
 		offset, blockSize, err := validateOffsetAndSize(task.R.Start, cfg.BlockSize)
 		if err != nil {

--- a/transfer/numa_linux.go
+++ b/transfer/numa_linux.go
@@ -1,0 +1,100 @@
+//go:build linux
+
+package transfer
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"lvmsync_go/config"
+)
+
+// pinCurrentThreadToDevice pins the current OS thread to CPUs local to the
+// NUMA node of the provided device file.
+func pinCurrentThreadToDevice(f *os.File) error {
+	st, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat device: %w", err)
+	}
+	sys, ok := st.Sys().(*unix.Stat_t)
+	if !ok {
+		return fmt.Errorf("unexpected stat type")
+	}
+	major := unix.Major(uint64(sys.Rdev))
+	minor := unix.Minor(uint64(sys.Rdev))
+	nodePath := fmt.Sprintf("/sys/dev/block/%d:%d/numa_node", major, minor)
+	b, err := os.ReadFile(nodePath)
+	if err != nil {
+		return err
+	}
+	node, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || node < 0 {
+		return fmt.Errorf("invalid numa node")
+	}
+	cpuListPath := fmt.Sprintf("/sys/devices/system/node/node%d/cpulist", node)
+	cpulist, err := os.ReadFile(cpuListPath)
+	if err != nil {
+		return err
+	}
+	cpus := parseCPUList(strings.TrimSpace(string(cpulist)))
+	if len(cpus) == 0 {
+		return fmt.Errorf("no cpus for node %d", node)
+	}
+	var mask unix.CPUSet
+	for _, cpu := range cpus {
+		mask.Set(cpu)
+	}
+	if err := unix.SchedSetaffinity(0, &mask); err != nil {
+		return fmt.Errorf("set affinity: %w", err)
+	}
+	return nil
+}
+
+func parseCPUList(list string) []int {
+	var cpus []int
+	for _, part := range strings.Split(list, ",") {
+		if part == "" {
+			continue
+		}
+		if strings.Contains(part, "-") {
+			bounds := strings.SplitN(part, "-", 2)
+			start, err1 := strconv.Atoi(bounds[0])
+			end, err2 := strconv.Atoi(bounds[1])
+			if err1 != nil || err2 != nil {
+				continue
+			}
+			for i := start; i <= end; i++ {
+				cpus = append(cpus, i)
+			}
+		} else {
+			v, err := strconv.Atoi(part)
+			if err != nil {
+				continue
+			}
+			cpus = append(cpus, v)
+		}
+	}
+	return cpus
+}
+
+// pinWorkerToDevice pins the current goroutine to the NUMA node associated
+// with the source device when cfg.NumaPin is true. The returned function must
+// be deferred to release the thread lock.
+func pinWorkerToDevice(cfg *config.Config, src *os.File) func() {
+	if cfg == nil || !cfg.NumaPin {
+		return func() {}
+	}
+	runtime.LockOSThread()
+	if err := pinCurrentThreadToDevice(src); err != nil {
+		if Logger != nil {
+			Logger.Warn("numa pin failed", zap.Error(err))
+		}
+	}
+	return runtime.UnlockOSThread
+}

--- a/transfer/numa_stub.go
+++ b/transfer/numa_stub.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package transfer
+
+import (
+	"os"
+
+	"lvmsync_go/config"
+)
+
+func pinWorkerToDevice(cfg *config.Config, src *os.File) func() {
+	return func() {}
+}


### PR DESCRIPTION
## Summary
- add `numa_pin` flag and NUMA-aware worker pinning
- allocate block-size aligned buffers with zero-run hole punching tests
- document `--odirect`, `--sync_interval`, and NUMA pinning options

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898a6440bac8323a3d1d1294bb3a1a6