### PR TITLE
fix(dedup): propagate hasher init errors

### DIFF
--- a/dedup/benchmarks_test.go
+++ b/dedup/benchmarks_test.go
@@ -11,7 +11,10 @@ import (
 func BenchmarkReplicator(b *testing.B) {
 	data := bytes.Repeat([]byte("abcde12345"), 1<<15) // ~1MB
 	ch := NewChunker(64, 256, 1024)
-	h := NewHasher(nil)
+	h, err := NewHasher(nil)
+	if err != nil {
+		b.Fatalf("new hasher: %v", err)
+	}
 	bloom := NewBloom(1<<20, 0.001)
 	for i := 0; i < b.N; i++ {
 		r := bytes.NewReader(data)

--- a/dedup/hash.go
+++ b/dedup/hash.go
@@ -13,21 +13,22 @@ type Hasher struct {
 }
 
 // NewHasher returns a hasher. When key is nil an unkeyed hash is used,
-// otherwise BLAKE3 is initialised in keyed mode.
-func NewHasher(key []byte) *Hasher {
+// otherwise BLAKE3 is initialised in keyed mode. Any initialisation error is
+// returned to the caller instead of panicking.
+func NewHasher(key []byte) (*Hasher, error) {
 	var h *blake3.Hasher
+	var err error
 	if key != nil {
 		var k [32]byte
 		copy(k[:], key)
-		var err error
 		h, err = blake3.NewKeyed(k[:])
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	} else {
 		h = blake3.New()
 	}
-	return &Hasher{h: h}
+	return &Hasher{h: h}, nil
 }
 
 // Reset resets the underlying hasher to start a new digest.

--- a/dedup/unit_test.go
+++ b/dedup/unit_test.go
@@ -8,9 +8,12 @@ import (
 )
 
 func TestHasher(t *testing.T) {
-	h := NewHasher(nil)
+	h, err := NewHasher(nil)
+	if err != nil {
+		t.Fatalf("new hasher: %v", err)
+	}
 	msg := []byte("hello world")
-	if _, err := h.Write(msg); err != nil {
+	if _, err = h.Write(msg); err != nil {
 		t.Fatalf("write failed: %v", err)
 	}
 	sum := h.Sum256()
@@ -20,8 +23,11 @@ func TestHasher(t *testing.T) {
 	}
 
 	key := []byte("0123456789abcdef0123456789abcdef")
-	h = NewHasher(key)
-	if _, err := h.Write(msg); err != nil {
+	h, err = NewHasher(key)
+	if err != nil {
+		t.Fatalf("new hasher: %v", err)
+	}
+	if _, err = h.Write(msg); err != nil {
 		t.Fatalf("write failed: %v", err)
 	}
 	sum2 := h.Sum256()


### PR DESCRIPTION
## Summary
- return an error from dedup.NewHasher instead of panicking on initialization failure
- handle NewHasher errors in dedup benchmarks and unit tests

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898abc2a078832390e8d21f6b3824ad