### PR TITLE
feat(config): add throughput mode presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,18 @@ lvmsync --transport quic,h2,tcp+tls,ssh --quic-connect host:9000 --tcp-port 9443
 BDP-based autotuning keeps roughly one to two times the bandwidth–delay product
 in flight. Override the autotuned value with `--concurrency`.
 
+## Throughput Mode
+
+The `throughput` preset favors maximal transfer rates:
+
+- transport order `quic,h2,tcp+tls`
+- concurrency `8`
+- hybrid dedup with 2 MiB fixed chunks and CDC range 256 KiB–8 MiB
+- compression `auto`
+- enables `--odirect`
+- `--sync-interval=1 GiB`, `--checkpoint-bytes=1 GiB`, `--checkpoint-interval=10s`
+- QUIC congestion control `bbr`
+
 ## Compression Policy
 
 - Sample 8 KiB from each chunk to estimate the compression ratio.

--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ LVMSync exposes a `--mode` flag to apply preset configurations.
 
 - `default` – standard behavior.
 - `throughput` – tunes defaults for maximum throughput:
-  - transport order `quic,h2,tcp+tls,ssh`
+  - transport order `quic,h2,tcp+tls`
   - concurrency `8`
-  - deduplication mode `hybrid`
+  - deduplication mode `hybrid` with 2 MiB fixed chunks and CDC range 256 KiB–8 MiB
   - compression `auto`
   - enables `--odirect`
-  - large sync and checkpoint intervals
+  - `--sync-interval=1 GiB`, `--checkpoint-bytes=1 GiB`, `--checkpoint-interval=10s`
   - QUIC congestion control `bbr`
 
 ```go

--- a/config/config.go
+++ b/config/config.go
@@ -234,14 +234,30 @@ func (b *Builder) applyDefaults(conf *Config) error {
 }
 
 func (b *Builder) applyThroughput(conf *Config) {
-	if conf.Transport == "" {
-		conf.Transport = "quic,h2,tcp+tls,ssh"
+	if !b.v.IsSet("transport") {
+		conf.Transport = "quic,h2,tcp+tls"
 	}
 	if !b.v.IsSet("parallel") {
 		conf.Parallel = 8
 	}
+	if !b.v.IsSet("concurrency") {
+		conf.Concurrency = 8
+	}
 	if !b.v.IsSet("dedup") {
 		conf.DedupMode = "hybrid"
+	}
+	if !b.v.IsSet("block_size") {
+		conf.BlockSize = 2 * 1024 * 1024
+		conf.BlockSizeRaw = "2097152"
+	}
+	if !b.v.IsSet("cdc_min") {
+		conf.CDCMin = 256 * 1024
+	}
+	if !b.v.IsSet("cdc_avg") {
+		conf.CDCAvg = 2 * 1024 * 1024
+	}
+	if !b.v.IsSet("cdc_max") {
+		conf.CDCMax = 8 * 1024 * 1024
 	}
 	if !b.v.IsSet("compress") {
 		conf.Compress = Auto
@@ -249,11 +265,12 @@ func (b *Builder) applyThroughput(conf *Config) {
 	if !b.v.IsSet("odirect") {
 		conf.ODirect = true
 	}
-	if conf.SyncInterval == "" {
-		conf.SyncInterval = "10MB"
+	if !b.v.IsSet("sync_interval") {
+		conf.SyncInterval = "1GB"
+		conf.SyncIntervalBytes = 1000000000
 	}
-	if conf.CheckpointInterval == 0 {
-		conf.CheckpointInterval = 30 * time.Minute
+	if !b.v.IsSet("checkpoint_interval") && conf.CheckpointInterval == 0 {
+		conf.CheckpointInterval = 10 * time.Second
 	}
 	if conf.QUICCongestionControl == "" {
 		conf.QUICCongestionControl = "bbr"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -288,23 +289,38 @@ func TestApplyThroughputMode(t *testing.T) {
 	if err := b.applyDefaults(conf); err != nil {
 		t.Fatalf("applyDefaults returned error: %v", err)
 	}
-	if conf.Transport != "quic,h2,tcp+tls,ssh" {
+	if conf.Transport != "quic,h2,tcp+tls" {
 		t.Fatalf("transport order %s", conf.Transport)
 	}
 	if conf.Parallel != 8 {
 		t.Fatalf("parallel %d", conf.Parallel)
 	}
+	if conf.Concurrency != 8 {
+		t.Fatalf("concurrency %d", conf.Concurrency)
+	}
 	if conf.DedupMode != "hybrid" {
 		t.Fatalf("dedup mode %s", conf.DedupMode)
+	}
+	if conf.BlockSize != 2*1024*1024 {
+		t.Fatalf("block size %d", conf.BlockSize)
+	}
+	if conf.CDCMin != 256*1024 || conf.CDCAvg != 2*1024*1024 || conf.CDCMax != 8*1024*1024 {
+		t.Fatalf("cdc ranges %d %d %d", conf.CDCMin, conf.CDCAvg, conf.CDCMax)
+	}
+	if conf.Compress != Auto {
+		t.Fatalf("compress %s", conf.Compress)
 	}
 	if !conf.ODirect {
 		t.Fatalf("expected odirect enabled")
 	}
+	if conf.SyncIntervalBytes != 1000000000 {
+		t.Fatalf("sync interval bytes %d", conf.SyncIntervalBytes)
+	}
+	if conf.CheckpointInterval != 10*time.Second {
+		t.Fatalf("checkpoint interval %v", conf.CheckpointInterval)
+	}
 	if conf.QUICCongestionControl != "bbr" {
 		t.Fatalf("quic cc %s", conf.QUICCongestionControl)
-	}
-	if conf.SyncInterval == "" || conf.CheckpointInterval == 0 {
-		t.Fatalf("expected non-zero intervals")
 	}
 }
 


### PR DESCRIPTION
## Summary
- apply throughput mode presets for transport order, concurrency, dedup chunking, compression, and IO tuning
- test throughput mode defaults
- document throughput preset behaviour

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898ac67860883239bfba5b60dd0395e