### PR TITLE
fix: handle rolling hash pool type mismatch

### DIFF
--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -221,22 +221,27 @@ func (c *ChecksumDedup) loadState() error {
 	return nil
 }
 
-func (r *RollingHashDedup) computeHash(data []byte) uint64 {
+func (r *RollingHashDedup) computeHash(data []byte) (uint64, error) {
 	hAny := rollingHashPool.Get()
 	h, ok := hAny.(*maphash.Hash)
 	if !ok {
-		panic("unexpected type from rollingHashPool")
+		rollingHashPool.Put(hAny)
+		return 0, fmt.Errorf("unexpected type %T from rollingHashPool", hAny)
 	}
 	h.Reset()
 	h.SetSeed(r.seed)
 	h.Write(data)
 	sum := h.Sum64()
 	rollingHashPool.Put(h)
-	return sum
+	return sum, nil
 }
 
 func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
-	h := r.computeHash(data)
+	h, err := r.computeHash(data)
+	if err != nil {
+		zap.L().Error("compute hash failed", zap.Error(err))
+		return true
+	}
 
 	r.mu.RLock()
 	prev, exists := r.hashes[offset]
@@ -246,7 +251,11 @@ func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
 }
 
 func (r *RollingHashDedup) RecordTransfer(offset int64, data []byte) {
-	h := r.computeHash(data)
+	h, err := r.computeHash(data)
+	if err != nil {
+		zap.L().Error("compute hash failed", zap.Error(err))
+		return
+	}
 
 	r.mu.Lock()
 	r.hashes[offset] = h

--- a/transfer/dedup_compute_hash_test.go
+++ b/transfer/dedup_compute_hash_test.go
@@ -1,0 +1,19 @@
+package transfer
+
+import (
+	"hash/maphash"
+	"sync"
+	"testing"
+)
+
+func TestRollingHashDedupComputeHashTypeMismatch(t *testing.T) {
+	t.Cleanup(func() {
+		rollingHashPool = sync.Pool{New: func() any { return new(maphash.Hash) }}
+	})
+	var wrong int
+	rollingHashPool.Put(&wrong)
+	r := &RollingHashDedup{seed: maphash.MakeSeed()}
+	if _, err := r.computeHash([]byte("data")); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- avoid panic when rolling hash pool contains unexpected type
- add regression test for rolling hash pool type mismatch

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898ad9d18fc832395ffec4086ac6542