### PR TITLE
Add tests for transport selection, CDC dedup, gRPC client, and compression threshold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - Run `go test -cover ./...` to generate coverage statistics.
 - For a file `coverage.out`, view details with `go tool cover -func=coverage.out`.
 - Enforce a minimum threshold by failing the build when the total coverage is below the desired percentage.
+- Maintain overall coverage of at least 50% as reported by `go test -cover ./...`.
 
 ## Unit Tests
 

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"math/big"
 	"net"
 	"testing"
@@ -66,6 +67,220 @@ func TestHandshakeAndAck(t *testing.T) {
 	}
 	if _, err := stream.Recv(); err != nil {
 		t.Fatalf("recv: %v", err)
+	}
+}
+
+func TestDial(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	srv, err := servers.New(servers.Config{AllowInsecure: true}, nil)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	cases := []struct {
+		name    string
+		conf    Config
+		wantErr bool
+	}{
+		{"insecure", Config{AllowInsecure: true}, false},
+		{"missingCert", Config{TLSCert: "nope", TLSKey: "nope", CACert: "nope"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := []grpc.DialOption{}
+			if !tc.wantErr {
+				opts = append(opts, grpc.WithContextDialer(bufDialer(lis)))
+			}
+			conn, err := Dial("bufnet", tc.conf, opts...)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Dial: %v", err)
+			}
+			conn.Close()
+		})
+	}
+}
+
+type fakeSessionClient struct {
+	stubClient
+	resp *proto.SessionResponse
+	err  error
+}
+
+func (f *fakeSessionClient) CreateSession(ctx context.Context, _ *proto.SessionRequest, _ ...grpc.CallOption) (*proto.SessionResponse, error) {
+	return f.resp, f.err
+}
+
+func TestCreateSession(t *testing.T) {
+	goodCert := dummyCert(t)
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{
+			name:   "success",
+			client: &fakeSessionClient{resp: &proto.SessionResponse{SessionId: "s", Psk: []byte{1}, ServerCert: goodCert}},
+		},
+		{
+			name:    "badCert",
+			client:  &fakeSessionClient{resp: &proto.SessionResponse{SessionId: "s", Psk: []byte{1}, ServerCert: []byte("bad")}},
+			wantErr: true,
+		},
+		{
+			name:    "missingPSK",
+			client:  &fakeSessionClient{resp: &proto.SessionResponse{SessionId: "s", ServerCert: goodCert}},
+			wantErr: true,
+		},
+		{
+			name:    "rpcError",
+			client:  &fakeSessionClient{err: errors.New("fail")},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CreateSession(context.Background(), tc.client, "vol", "dev")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+type fakeManifestClient struct {
+	stubClient
+	resp *proto.StatusResponse
+	err  error
+}
+
+func (f *fakeManifestClient) SendFinalManifest(ctx context.Context, _ *proto.ManifestMessage, _ ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return f.resp, f.err
+}
+
+func TestSendFinalManifest(t *testing.T) {
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{
+			name:   "success",
+			client: &fakeManifestClient{resp: &proto.StatusResponse{Ok: true}},
+		},
+		{
+			name:    "rpcError",
+			client:  &fakeManifestClient{err: errors.New("fail")},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := SendFinalManifest(context.Background(), tc.client, "sess", []byte("{}"))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type fakeAckClient struct{ stubClient }
+
+func (fakeAckClient) AckStream(context.Context, ...grpc.CallOption) (proto.Replication_AckStreamClient, error) {
+	return nil, errors.New("fail")
+}
+
+func TestAckStreamError(t *testing.T) {
+	c := fakeAckClient{}
+	if _, err := AckStream(context.Background(), c, "sess"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+type fakeHandshakeClient struct{ stubClient }
+
+type stubClient struct{}
+
+func (stubClient) LockVolume(context.Context, *proto.LockRequest, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) GetVolumeMetadata(context.Context, *proto.LockRequest, ...grpc.CallOption) (*proto.VolumeMetadata, error) {
+	return nil, nil
+}
+
+func (stubClient) SendVolumeMetadata(context.Context, *proto.VolumeMetadata, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) StartTransferSession(context.Context, *proto.LockRequest, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) FinalizeSync(context.Context, *proto.LockRequest, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) GetStatus(context.Context, *proto.LockRequest, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) Ping(context.Context, *proto.Empty, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) Handshake(context.Context, *proto.HandshakeRequest, ...grpc.CallOption) (*proto.HandshakeResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) CreateSession(context.Context, *proto.SessionRequest, ...grpc.CallOption) (*proto.SessionResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) SendResumeBitmap(context.Context, ...grpc.CallOption) (proto.Replication_SendResumeBitmapClient, error) {
+	return nil, nil
+}
+
+func (stubClient) SendFinalManifest(context.Context, *proto.ManifestMessage, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) Finalize(context.Context, *proto.FinalizeRequest, ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return nil, nil
+}
+
+func (stubClient) AckStream(context.Context, ...grpc.CallOption) (proto.Replication_AckStreamClient, error) {
+	return nil, nil
+}
+
+func (fakeHandshakeClient) Handshake(context.Context, *proto.HandshakeRequest, ...grpc.CallOption) (*proto.HandshakeResponse, error) {
+	return nil, errors.New("fail")
+}
+
+func TestHandshakeError(t *testing.T) {
+	c := fakeHandshakeClient{}
+	if _, err := Handshake(context.Background(), c, &proto.HandshakeRequest{}); err == nil {
+		t.Fatalf("expected error")
 	}
 }
 

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -19,16 +19,45 @@ func TestRegistryLookup(t *testing.T) {
 	}
 }
 
-func TestSelectFallback(t *testing.T) {
+func TestSelectOrder(t *testing.T) {
 	fail := func(*config.Config) (Sender, Receiver, error) { return nil, nil, errors.New("fail") }
 	ok := func(*config.Config) (Sender, Receiver, error) { return NopSender{}, NopReceiver{}, nil }
-	Register("fail", fail)
-	Register("ok", ok)
-	_, _, name, err := Select(&config.Config{}, []string{"fail", "ok"})
-	if err != nil {
-		t.Fatalf("select returned error: %v", err)
+
+	tests := []struct {
+		name    string
+		order   []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "fallback",
+			order: []string{"fail", "ok"},
+			want:  "ok",
+		},
+		{
+			name:    "allfail",
+			order:   []string{"fail"},
+			wantErr: true,
+		},
 	}
-	if name != "ok" {
-		t.Fatalf("expected ok, got %s", name)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Register("fail", fail)
+			Register("ok", ok)
+			_, _, name, err := Select(&config.Config{}, tt.order)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("select returned error: %v", err)
+			}
+			if name != tt.want {
+				t.Fatalf("expected %s, got %s", tt.want, name)
+			}
+		})
 	}
 }

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -135,28 +135,37 @@ func TestNewCompressionWriterAutoDetects(t *testing.T) {
 }
 
 func TestCompressChunkThreshold(t *testing.T) {
-	data := bytes.Repeat([]byte("a"), 64*1024)
-	compressed, algo, err := CompressChunk(data, StrategyAuto, 0, 1, 0.9)
-	if err != nil {
-		t.Fatalf("compress chunk: %v", err)
-	}
-	if algo == "none" || len(compressed) >= len(data) {
-		t.Fatalf("expected data to be compressed")
-	}
-
 	rnd := make([]byte, 64*1024)
 	if _, err := rand.Read(rnd); err != nil {
 		t.Fatalf("rand: %v", err)
 	}
-	out, algo, err := CompressChunk(rnd, StrategyAuto, 0, 1, 0.9)
-	if err != nil {
-		t.Fatalf("compress chunk random: %v", err)
+	data := bytes.Repeat([]byte("a"), 64*1024)
+
+	cases := []struct {
+		name             string
+		input            []byte
+		expectCompressed bool
+	}{
+		{"compressible", data, true},
+		{"random", rnd, false},
 	}
-	if algo != "none" {
-		t.Fatalf("expected compression to be skipped")
-	}
-	if !bytes.Equal(out, rnd) {
-		t.Fatalf("data altered when compression skipped")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, algo, err := CompressChunk(tc.input, StrategyAuto, 0, 1, 0.9)
+			if err != nil {
+				t.Fatalf("compress chunk: %v", err)
+			}
+			if tc.expectCompressed {
+				if algo == "none" || len(out) >= len(tc.input) {
+					t.Fatalf("expected data to be compressed")
+				}
+			} else {
+				if algo != "none" || !bytes.Equal(out, tc.input) {
+					t.Fatalf("expected compression to be skipped")
+				}
+			}
+		})
 	}
 }
 

--- a/transfer/dedup_cdc_test.go
+++ b/transfer/dedup_cdc_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bytes"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -44,6 +45,50 @@ func TestCDCDedupChunkAndHash(t *testing.T) {
 	}
 }
 
+func TestCDCDedupChunkBoundaries(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	// Use small CDC sizes for predictable chunking.
+	cfg.CDCMin = 64
+	cfg.CDCAvg = 64
+	cfg.CDCMax = 128
+
+	cases := []struct {
+		name string
+		size int
+	}{
+		{"ltMin", 32},
+		{"eqMin", 64},
+		{"gtMax", 256},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewCDCDedup(cfg)
+			data := bytes.Repeat([]byte("a"), tc.size)
+			chunks, _, err := d.ChunkAndHash(data)
+			if err != nil {
+				t.Fatalf("ChunkAndHash: %v", err)
+			}
+			var total int
+			for i, ch := range chunks {
+				total += ch.Length
+				if ch.Length > cfg.CDCMax {
+					t.Fatalf("chunk %d exceeded max", i)
+				}
+				if i < len(chunks)-1 && ch.Length < cfg.CDCMin {
+					t.Fatalf("chunk %d below min", i)
+				}
+			}
+			if total != tc.size {
+				t.Fatalf("total %d != size %d", total, tc.size)
+			}
+		})
+	}
+}
+
 func TestCDCDedupSaveStateWriteFailure(t *testing.T) {
 	cfg, err := config.DefaultConfig()
 	if err != nil {
@@ -70,5 +115,24 @@ func TestCDCDedupMmapIndex(t *testing.T) {
 	expected := 1 << (cfg.BloomMBits - 3)
 	if len(d.index) != expected {
 		t.Fatalf("unexpected index size %d want %d", len(d.index), expected)
+	}
+}
+
+func TestCDCDedupSaveState(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.DedupStateFile = filepath.Join(t.TempDir(), "state")
+	d := NewCDCDedup(cfg)
+	if err := d.SaveState(); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	info, err := os.Stat(cfg.DedupStateFile)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("expected non-empty state file")
 	}
 }


### PR DESCRIPTION
## Summary
- add table-driven tests for transport fallback and missing transports
- extend CDC dedup tests with chunk boundary and save-state coverage
- cover gRPC client Dial, CreateSession, SendFinalManifest, and error cases
- convert compression threshold check to table-driven test
- document 50% coverage floor in AGENTS.md

## Testing
- `go test -cover ./...`

------
https://chatgpt.com/codex/tasks/task_e_6898af9a15e4832399273929fc40ad56