### PR TITLE
ci: run super-linter across codebase

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -55,8 +55,8 @@ jobs:
           # Core
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          # Validate all code on PRs; changed files only on direct pushes
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          # Validate entire codebase
+          VALIDATE_ALL_CODEBASE: "true"
           FILTER_REGEX_INCLUDE: ""
 
           # Go: pass ONLY the package pattern (NO "run")


### PR DESCRIPTION
## Summary
- force Super-Linter to check the entire codebase

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898b6aa094c83238f640050704ecca2