### PR TITLE
refactor(app): modularize startup logic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	signalspkg "lvmsync_go/cmd/lvmsync/signals"
+	"lvmsync_go/config"
+	grpcclient "lvmsync_go/grpc/client"
+	grpcserver "lvmsync_go/grpc/server"
+	clientpkg "lvmsync_go/internal/client"
+	lvmlib "lvmsync_go/internal/lvm"
+	"lvmsync_go/proto"
+)
+
+// Wrappers for external dependencies to enable test stubbing.
+var (
+	listen    = net.Listen
+	newServer = func(cfg grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
+		return grpcserver.New(cfg, agent)
+	}
+	dial = func(addr string, conf grpcclient.Config) (closeableConn, error) {
+		return grpcclient.Dial(addr, conf)
+	}
+	handshake     = grpcclient.Handshake
+	createSession = grpcclient.CreateSession
+	ackStream     = func(ctx context.Context, c proto.ReplicationClient, id string) (ackStreamClient, error) {
+		return grpcclient.AckStream(ctx, c, id)
+	}
+	handleSignals   = signalspkg.Handle
+	prepareSnapshot = clientpkg.PrepareSnapshot
+)
+
+type grpcServer interface {
+	Serve(net.Listener) error
+	GracefulStop()
+}
+
+type closeableConn interface {
+	grpc.ClientConnInterface
+	Close() error
+}
+
+type ackStreamClient interface {
+	Send(*proto.Ack) error
+	CloseSend() error
+}
+
+// StartGRPCServer starts the gRPC server if configured and returns a cleanup function.
+func StartGRPCServer(cfg *config.Config, logger *zap.Logger) (func(), error) {
+	if cfg.GRPCListen == "" {
+		return func() {}, nil
+	}
+
+	srvCfg := grpcserver.Config{TLSCert: cfg.TLSCert, TLSKey: cfg.TLSKey, CACert: cfg.CACert, AllowInsecure: cfg.AllowInsecure}
+	ln, err := listen("tcp", cfg.GRPCListen)
+	if err != nil {
+		return nil, fmt.Errorf("gRPC listen: %w", err)
+	}
+	srv, err := newServer(srvCfg, nil)
+	if err != nil {
+		ln.Close()
+		return nil, fmt.Errorf("gRPC server: %w", err)
+	}
+	go func() {
+		if err := srv.Serve(ln); err != nil {
+			logger.Error("grpc server", zap.Error(err))
+		}
+	}()
+	cleanup := func() {
+		srv.GracefulStop()
+		ln.Close()
+	}
+	return cleanup, nil
+}
+
+// ClientHandshake performs the gRPC client handshake and returns a cleanup function.
+func ClientHandshake(cfg *config.Config, logger *zap.Logger) (func(), error) {
+	if cfg.GRPCConnect == "" {
+		return func() {}, nil
+	}
+	conn, err := dial(cfg.GRPCConnect, grpcclient.Config{
+		TLSCert:       cfg.TLSCert,
+		TLSKey:        cfg.TLSKey,
+		CACert:        cfg.CACert,
+		AllowInsecure: cfg.AllowInsecure,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gRPC dial: %w", err)
+	}
+	c := proto.NewReplicationClient(conn)
+	hs := &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: uint32(cfg.Parallel), DedupSupported: true, CompressionSupported: true}
+	if _, err := handshake(context.Background(), c, hs); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("handshake failed: %w", err)
+	}
+	sess, err := createSession(context.Background(), c, "vol", "dev")
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+	stream, err := ackStream(context.Background(), c, sess.GetSessionId())
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ack stream: %w", err)
+	}
+	go func(id string) {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			if err := stream.Send(&proto.Ack{SessionId: id, Ok: true, Message: "ping"}); err != nil {
+				return
+			}
+		}
+	}(sess.GetSessionId())
+	cleanup := func() {
+		stream.CloseSend()
+		conn.Close()
+	}
+	return cleanup, nil
+}
+
+// SetupSignalHandling configures signal handling and returns the signal and error channels.
+func SetupSignalHandling(cfg *config.Config, snapshotPath *string) (chan os.Signal, chan error) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	sigErrCh := make(chan error, 1)
+	go handleSignals(cfg, signals, snapshotPath, sigErrCh)
+	return signals, sigErrCh
+}
+
+// PrepareSnapshot wraps the snapshot preparation logic.
+func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+	return prepareSnapshot(cfg, originalVolume, logger)
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,210 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"os/signal"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"lvmsync_go/config"
+	grpcclient "lvmsync_go/grpc/client"
+	grpcserver "lvmsync_go/grpc/server"
+	lvmlib "lvmsync_go/internal/lvm"
+	"lvmsync_go/proto"
+)
+
+// fake implementations for testing
+
+type fakeListener struct{}
+
+func (f *fakeListener) Accept() (net.Conn, error) { return nil, errors.New("accept not implemented") }
+func (f *fakeListener) Close() error              { return nil }
+func (f *fakeListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
+type fakeServer struct {
+	served  bool
+	stopped bool
+}
+
+func (f *fakeServer) Serve(net.Listener) error { f.served = true; return nil }
+func (f *fakeServer) GracefulStop()            { f.stopped = true }
+
+func TestStartGRPCServerSuccess(t *testing.T) {
+	cfg := &config.Config{GRPCListen: "127.0.0.1:0"}
+	logger := zap.NewNop()
+	origListen := listen
+	origNewServer := newServer
+	defer func() { listen = origListen; newServer = origNewServer }()
+	listen = func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil }
+	srv := &fakeServer{}
+	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) { return srv, nil }
+
+	cleanup, err := StartGRPCServer(cfg, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if !srv.served {
+		t.Fatalf("server not started")
+	}
+	cleanup()
+	if !srv.stopped {
+		t.Fatalf("server not stopped")
+	}
+}
+
+func TestStartGRPCServerListenError(t *testing.T) {
+	cfg := &config.Config{GRPCListen: "bad"}
+	logger := zap.NewNop()
+	origListen := listen
+	defer func() { listen = origListen }()
+	listen = func(network, addr string) (net.Listener, error) { return nil, errors.New("boom") }
+
+	if _, err := StartGRPCServer(cfg, logger); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+// ClientHandshake tests
+
+type fakeConn struct{ closed bool }
+
+func (f *fakeConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error { return nil }
+func (f *fakeConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, nil
+}
+func (f *fakeConn) Close() error { f.closed = true; return nil }
+
+type fakeStream struct{ closed bool }
+
+func (f *fakeStream) Send(*proto.Ack) error { return nil }
+func (f *fakeStream) CloseSend() error      { f.closed = true; return nil }
+
+func TestClientHandshakeSuccess(t *testing.T) {
+	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1}
+	logger := zap.NewNop()
+
+	fc := &fakeConn{}
+	fs := &fakeStream{}
+	origDial := dial
+	origHandshake := handshake
+	origCreateSession := createSession
+	origAckStream := ackStream
+	defer func() {
+		dial = origDial
+		handshake = origHandshake
+		createSession = origCreateSession
+		ackStream = origAckStream
+	}()
+	dial = func(addr string, conf grpcclient.Config) (closeableConn, error) { return fc, nil }
+	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+		return &proto.HandshakeResponse{}, nil
+	}
+	createSession = func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
+		return &proto.SessionResponse{SessionId: "id"}, nil
+	}
+	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
+
+	cleanup, err := ClientHandshake(cfg, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cleanup()
+	if !fc.closed || !fs.closed {
+		t.Fatalf("cleanup did not close resources")
+	}
+}
+
+func TestClientHandshakeDialError(t *testing.T) {
+	cfg := &config.Config{GRPCConnect: "addr"}
+	logger := zap.NewNop()
+	origDial := dial
+	defer func() { dial = origDial }()
+	dial = func(string, grpcclient.Config) (closeableConn, error) { return nil, errors.New("dial fail") }
+
+	if _, err := ClientHandshake(cfg, logger); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+// SetupSignalHandling tests
+
+func TestSetupSignalHandling(t *testing.T) {
+	cfg := &config.Config{}
+	var path string
+	called := make(chan struct{})
+	origHandle := handleSignals
+	defer func() { handleSignals = origHandle }()
+	handleSignals = func(cfg *config.Config, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+		<-sigs
+		*p = "set"
+		close(called)
+	}
+	signals, sigErrCh := SetupSignalHandling(cfg, &path)
+	signals <- os.Interrupt
+	select {
+	case <-called:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("handler not invoked")
+	}
+	if path != "set" {
+		t.Fatalf("path not set")
+	}
+	select {
+	case err := <-sigErrCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	default:
+	}
+	signal.Stop(signals)
+}
+
+func TestSetupSignalHandlingError(t *testing.T) {
+	cfg := &config.Config{}
+	var path string
+	origHandle := handleSignals
+	defer func() { handleSignals = origHandle }()
+	handleSignals = func(cfg *config.Config, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+		errCh <- errors.New("boom")
+	}
+	_, sigErrCh := SetupSignalHandling(cfg, &path)
+	if err := <-sigErrCh; err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+// PrepareSnapshot tests
+
+func TestPrepareSnapshot(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	orig := prepareSnapshot
+	defer func() { prepareSnapshot = orig }()
+	prepareSnapshot = func(c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+		return "snap", nil, func() {}, nil
+	}
+	snap, ch, cleanup, err := PrepareSnapshot(cfg, "vol", logger)
+	if err != nil || snap != "snap" || ch != nil || cleanup == nil {
+		t.Fatalf("unexpected result")
+	}
+}
+
+func TestPrepareSnapshotError(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	orig := prepareSnapshot
+	defer func() { prepareSnapshot = orig }()
+	prepareSnapshot = func(c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+		return "", nil, nil, errors.New("fail")
+	}
+	if _, _, _, err := PrepareSnapshot(cfg, "vol", logger); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,31 +2,24 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/signal"
 	"strings"
-	"syscall"
-	"time"
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 
-	signalspkg "lvmsync_go/cmd/lvmsync/signals"
+	"lvmsync_go/app"
 	"lvmsync_go/common"
 	"lvmsync_go/config"
-	grpcclient "lvmsync_go/grpc/client"
-	grpcserver "lvmsync_go/grpc/server"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privesc"
 	"lvmsync_go/internal/transport"
 	"lvmsync_go/lvm"
-	"lvmsync_go/proto"
 	"lvmsync_go/remote"
 	"lvmsync_go/transfer"
 )
@@ -313,68 +306,21 @@ func run() error {
 		logger.Info("selected transport", zap.String("transport", name))
 	}
 
-	if cfg.GRPCListen != "" {
-		srvCfg := grpcserver.Config{TLSCert: cfg.TLSCert, TLSKey: cfg.TLSKey, CACert: cfg.CACert, AllowInsecure: cfg.AllowInsecure}
-		ln, err := net.Listen("tcp", cfg.GRPCListen)
-		if err != nil {
-			return fmt.Errorf("gRPC listen: %w", err)
-		}
-		srv, err := grpcserver.New(srvCfg, nil)
-		if err != nil {
-			return fmt.Errorf("gRPC server: %w", err)
-		}
-		go func() {
-			if err := srv.Serve(ln); err != nil {
-				zap.L().Error("grpc server", zap.Error(err))
-			}
-		}()
-		defer srv.GracefulStop()
+	cleanupSrv, err := app.StartGRPCServer(cfg, logger)
+	if err != nil {
+		return err
 	}
+	defer cleanupSrv()
 
-	if cfg.GRPCConnect != "" {
-		conn, err := grpcclient.Dial(cfg.GRPCConnect, grpcclient.Config{
-			TLSCert:       cfg.TLSCert,
-			TLSKey:        cfg.TLSKey,
-			CACert:        cfg.CACert,
-			AllowInsecure: cfg.AllowInsecure,
-		})
-		if err != nil {
-			return fmt.Errorf("gRPC dial: %w", err)
-		}
-		c := proto.NewReplicationClient(conn)
-		hs := &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: uint32(cfg.Parallel), DedupSupported: true, CompressionSupported: true}
-		if _, err := grpcclient.Handshake(context.Background(), c, hs); err != nil {
-			conn.Close()
-			return fmt.Errorf("handshake failed: %w", err)
-		}
-		sess, err := grpcclient.CreateSession(context.Background(), c, "vol", "dev")
-		if err != nil {
-			conn.Close()
-			return fmt.Errorf("create session: %w", err)
-		}
-		stream, err := grpcclient.AckStream(context.Background(), c, sess.GetSessionId())
-		if err != nil {
-			conn.Close()
-			return fmt.Errorf("ack stream: %w", err)
-		}
-		go func(id string) {
-			ticker := time.NewTicker(30 * time.Second)
-			defer ticker.Stop()
-			for range ticker.C {
-				if err := stream.Send(&proto.Ack{SessionId: id, Ok: true, Message: "ping"}); err != nil {
-					return
-				}
-			}
-		}(sess.GetSessionId())
-		defer stream.CloseSend()
-		defer conn.Close()
+	cleanupClient, err := app.ClientHandshake(cfg, logger)
+	if err != nil {
+		return err
 	}
+	defer cleanupClient()
 
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	var snapshotPath string
-	sigErrCh := make(chan error, 1)
-	go signalspkg.Handle(cfg, signals, &snapshotPath, sigErrCh)
+	signals, sigErrCh := app.SetupSignalHandling(cfg, &snapshotPath)
+	defer signal.Stop(signals)
 
 	if cfg.ApplyMode != "" {
 		if err = runApplyMode(cfg.ApplyMode); err != nil {
@@ -395,7 +341,7 @@ func run() error {
 	}
 
 	var monitorErrCh chan error
-	snapshotPath, monitorErrCh, cleanup, err := clientpkg.PrepareSnapshot(cfg, originalVolume, logger)
+	snapshotPath, monitorErrCh, cleanup, err := app.PrepareSnapshot(cfg, originalVolume, logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- extract gRPC server startup, client handshake, signal handling, and snapshot preparation into new app package
- pass config and logger explicitly and streamline run coordinator
- add unit tests for new app functions covering success and failure cases

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898b4100e7883239d60f21f88a5a97c