### PR TITLE
test(config): add config precedence and invalid path tests

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -572,5 +573,28 @@ func TestDefaultCDCTunables(t *testing.T) {
 	}
 	if cfg.BloomMBits != 0 {
 		t.Fatalf("expected bloom mbits 0, got %d", cfg.BloomMBits)
+	}
+}
+
+func TestLoadConfigPrecedence(t *testing.T) {
+	cfgPath := writeTempConfig(t, "parallel: 1\n")
+	resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
+	t.Setenv("LVMSYNC.PARALLEL", "2")
+
+	conf, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if conf.Parallel != 3 {
+		t.Fatalf("expected parallel 3, got %d", conf.Parallel)
+	}
+}
+
+func TestLoadConfigInvalidPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+	resetFlags([]string{"--config", missing})
+
+	if _, err := LoadConfig(); err == nil || !strings.Contains(err.Error(), "error reading config file") {
+		t.Fatalf("expected config file error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add tests verifying flags override env vars and YAML
- add test for error on missing config path

## Testing
- `go test -short -cover ./...` *(hangs on grpc/client; partial output)*
- `go test -cover ./config`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898c082b1fc8323ab613d8d286f1dcc