### PR TITLE
refactor(logging): use syncLogger and document conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit.
 - [ ] Remove stray `fmt.Print*` calls in favor of structured logs.
 - [ ] Monitor elimination of `fmt.Print*` calls to keep progress logging fully structured.
+- [x] Refactor `cmd/grpcd` to defer `syncLogger` for structured log flushing.
 - [ ] Expand unit test coverage for remote execution and client signal handling, and run coverage reports.
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ structured log entries, allowing external tooling to track transfer completion.
 
 ### Expectations
 
-- Use `zap` for all logging.
+- Use `zap` for all logging and avoid `fmt.Print*` or `log.*` calls.
 - Log field keys in `snake_case` and include units where relevant (for example, `duration_ms`).
-- Always call `logger.Sync()` before exit and log if the sync fails.
+- Always defer `syncLogger(logger)` to flush buffers and log if the sync fails.
 
 The example below demonstrates these conventions:
 
 ```go
 logger, _ := zap.NewProduction()
-defer logger.Sync()
+defer syncLogger(logger)
 start := time.Now()
 
 logger.Info("snapshot complete",

--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -28,7 +28,7 @@ func main() {
 		exitFunc(1)
 	}
 	zap.ReplaceGlobals(logger)
-	defer syncAndExit(logger)
+	defer syncLogger(logger)
 
 	v, err := initConfig(os.Args[1:])
 	if err != nil {
@@ -61,10 +61,10 @@ func main() {
 	}
 }
 
-func syncAndExit(logger *zap.Logger) {
-	if syncErr := logger.Sync(); syncErr != nil {
-		logger.Error("failed to sync logger", zap.Error(syncErr))
-		exitFunc(1)
+// syncLogger flushes any buffered log entries and logs if the sync fails.
+func syncLogger(logger *zap.Logger) {
+	if err := logger.Sync(); err != nil {
+		logger.Error("Logger sync error", zap.Error(err))
 	}
 }
 

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -8,30 +8,30 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
-type failCore struct{}
-
-func (failCore) Enabled(zapcore.Level) bool        { return false }
-func (failCore) With([]zapcore.Field) zapcore.Core { return failCore{} }
-func (failCore) Check(zapcore.Entry, *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	return nil
+type failingSyncCore struct {
+	zapcore.Core
+	err error
 }
-func (failCore) Write(zapcore.Entry, []zapcore.Field) error { return nil }
-func (failCore) Sync() error                                { return errors.New("sync failure") }
 
-func TestSyncAndExitLogsError(t *testing.T) {
-	logger := zap.New(failCore{})
+func (c *failingSyncCore) Sync() error { return c.err }
 
-	oldExit := exitFunc
-	defer func() { exitFunc = oldExit }()
-
-	var code int
-	exitFunc = func(c int) { code = c }
-
-	syncAndExit(logger)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
+func TestSyncLoggerLogsError(t *testing.T) {
+	syncErr := errors.New("sync failure")
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(&failingSyncCore{Core: core, err: syncErr})
+	syncLogger(logger)
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+	if entries[0].Message != "Logger sync error" {
+		t.Fatalf("unexpected log message %q", entries[0].Message)
+	}
+	if got := entries[0].ContextMap()["error"]; got != syncErr.Error() {
+		t.Fatalf("expected error %q, got %v", syncErr.Error(), got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- defer `syncLogger` in `cmd/grpcd` and log sync failures through zap
- add unit test for grpcd logger sync errors
- document zap logging conventions and `syncLogger` usage in README
- track grpcd logging refactor in `AGENTS.md`

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898caff4cd88323abe66f9b42b80dd9