### PR TITLE
test(config,grpcd): verify flag binding and precedence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
   golangci-lint run
   ```
 
-- [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s.
+ - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.
 - [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).
 - [ ] Document gRPC daemon configuration sources (flags, env vars, config file) and precedence.
 - [ ] Keep `README` configuration documentation current with code changes.

--- a/README.md
+++ b/README.md
@@ -835,6 +835,26 @@ volume_group: vg_data
 
 `lvmsync-grpcd` accepts configuration via flags, environment variables prefixed with `LVMSYNC_GRPC_`, or a YAML file. Values are resolved in the following order: flags override environment variables, which override the config file.
 
+| Flag | Environment variable | Config key | Description |
+|------|----------------------|------------|-------------|
+| `--grpc-port` | `LVMSYNC_GRPC_GRPC_PORT` | `grpc-port` | gRPC port to listen on |
+| `--tls-cert` | `LVMSYNC_GRPC_TLS_CERT` | `tls-cert` | TLS certificate file |
+| `--tls-key` | `LVMSYNC_GRPC_TLS_KEY` | `tls-key` | TLS key file |
+| `--ca-cert` | `LVMSYNC_GRPC_CA_CERT` | `ca-cert` | CA certificate file |
+| `--allow-insecure` | `LVMSYNC_GRPC_ALLOW_INSECURE` | `allow-insecure` | Allow insecure (no TLS) |
+| `--config` | `LVMSYNC_GRPC_CONFIG` | `config` | Path to config YAML file |
+
+Precedence example:
+
+```sh
+cat >grpcd.yaml <<'EOF'
+grpc-port: 1111
+EOF
+export LVMSYNC_GRPC_GRPC_PORT=2222
+lvmsync-grpcd --config grpcd.yaml --grpc-port 3333
+# effective port: 3333
+```
+
 CLI:
 
 ```sh

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -86,3 +86,31 @@ func TestInitConfigPrecedence(t *testing.T) {
 		}
 	})
 }
+
+func TestFlagSetsBindToViper(t *testing.T) {
+	v, err := initConfig([]string{
+		"--grpc-port", "9999",
+		"--tls-cert", "cert.pem",
+		"--tls-key", "key.pem",
+		"--ca-cert", "ca.pem",
+		"--allow-insecure",
+	})
+	if err != nil {
+		t.Fatalf("initConfig: %v", err)
+	}
+	if port := v.GetInt("grpc-port"); port != 9999 {
+		t.Fatalf("expected grpc-port 9999, got %d", port)
+	}
+	if cert := v.GetString("tls-cert"); cert != "cert.pem" {
+		t.Fatalf("expected tls-cert cert.pem, got %q", cert)
+	}
+	if key := v.GetString("tls-key"); key != "key.pem" {
+		t.Fatalf("expected tls-key key.pem, got %q", key)
+	}
+	if ca := v.GetString("ca-cert"); ca != "ca.pem" {
+		t.Fatalf("expected ca-cert ca.pem, got %q", ca)
+	}
+	if insecure := v.GetBool("allow-insecure"); !insecure {
+		t.Fatalf("expected allow-insecure true")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -596,7 +596,7 @@ func buildViper() (*viper.Viper, error) {
 	v.SetConfigType("yaml")
 	v.AddConfigPath(".")
 	v.AutomaticEnv()
-	v.SetEnvKeyReplacer(strings.NewReplacer("_", "."))
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.SetEnvPrefix("LVMSYNC")
 
 	if err := v.BindPFlags(pflag.CommandLine); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -579,7 +579,7 @@ func TestDefaultCDCTunables(t *testing.T) {
 func TestLoadConfigPrecedence(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
-	t.Setenv("LVMSYNC.PARALLEL", "2")
+	t.Setenv("LVMSYNC_PARALLEL", "2")
 
 	conf, err := LoadConfig()
 	if err != nil {

--- a/config/loadconfig_test.go
+++ b/config/loadconfig_test.go
@@ -65,7 +65,7 @@ func TestBuildViperPrecedence(t *testing.T) {
 
 	t.Run("env_overrides_config", func(t *testing.T) {
 		resetFlags([]string{"--config", cfgPath})
-		t.Setenv("LVMSYNC.PARALLEL", "2")
+		t.Setenv("LVMSYNC_PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
@@ -83,7 +83,7 @@ func TestBuildViperPrecedence(t *testing.T) {
 
 	t.Run("flags_override_env", func(t *testing.T) {
 		resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
-		t.Setenv("LVMSYNC.PARALLEL", "2")
+		t.Setenv("LVMSYNC_PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -9,7 +9,7 @@ import (
 func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
-	t.Setenv("LVMSYNC.PARALLEL", "2")
+	t.Setenv("LVMSYNC_PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -35,7 +35,7 @@ func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 func TestEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	resetFlags([]string{"--config", cfgPath})
-	t.Setenv("LVMSYNC.PARALLEL", "2")
+	t.Setenv("LVMSYNC_PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary
- ensure config binds `LVMSYNC_*` environment variables by default
- test gRPC flag sets bind correctly to viper and confirm precedence
- document gRPC flag/env/config mapping with precedence example

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898d7c98a8483238fa64436cb1c1d11