### PR TITLE
Add function tests and enforce coverage threshold

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -94,4 +94,4 @@ jobs:
       - name: Enforce coverage threshold
         run: |
           pct=$(go tool cover -func=coverage.out | tail -n 1 | awk '{print $3}' | tr -d '%')
-          awk -v p="$pct" 'BEGIN { if (p < 40) { printf("coverage %.2f%% is below 40%%\n", p); exit 1 } }'
+          awk -v p="$pct" 'BEGIN { if (p < 50) { printf("coverage %.2f%% is below 50%%\n", p); exit 1 } }'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 
 - Run `go test -cover ./...` to generate coverage statistics.
 - For a file `coverage.out`, view details with `go tool cover -func=coverage.out`.
-- Enforce a minimum threshold by failing the build when the total coverage is below the desired percentage.
-- Maintain overall coverage of at least 50% as reported by `go test -cover ./...`.
+- Ensure overall test coverage remains at or above 50%; CI enforces this threshold and fails if the total coverage falls below it.
 
 ## Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -922,16 +922,16 @@ Run the linter locally to mirror CI:
 golangci-lint run ./...
 ```
 
-To run the tests and static checks locally:
+### Testing
+
+Run unit tests with coverage:
 
 ```sh
-go fmt ./...
-go vet ./...
-go test ./...
-go test -cover ./config
+go test -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out
 ```
 
-The last command generates a coverage report for the `config` package. The same steps run in GitHub Actions under `.github/workflows/go.yml`.
+The workflow enforces a minimum of 50% total coverage.
 
 ## License
 

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -114,3 +114,21 @@ func TestFlagSetsBindToViper(t *testing.T) {
 		t.Fatalf("expected allow-insecure true")
 	}
 }
+
+func TestInitConfigUnknownFlag(t *testing.T) {
+	if _, err := initConfig([]string{"--unknown"}); err == nil {
+		t.Fatalf("expected error for unknown flag")
+	}
+}
+
+func TestInitConfigInvalidConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "grpcd.yaml")
+	// Write malformed YAML
+	if err := os.WriteFile(cfgFile, []byte(":-bad"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := initConfig([]string{"--config", cfgFile}); err == nil {
+		t.Fatalf("expected error for malformed config")
+	}
+}

--- a/config/builder_build_test.go
+++ b/config/builder_build_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestBuilderBuildSuccess verifies that Build returns a config using defaults
+// when no explicit settings are provided.
+func TestBuilderBuildSuccess(t *testing.T) {
+	v := viper.New()
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	b := &Builder{v: v, defaults: defaults}
+	cfg, err := b.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if cfg.Transport == "" {
+		t.Fatalf("expected Transport to be set")
+	}
+}
+
+// TestBuilderBuildUnsupportedCompression verifies that Build fails when an
+// unsupported compression algorithm is specified.
+func TestBuilderBuildUnsupportedCompression(t *testing.T) {
+	v := viper.New()
+	v.Set("compress_threshold", 2.0)
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	b := &Builder{v: v, defaults: defaults}
+	if _, err := b.Build(); err == nil {
+		t.Fatalf("expected error for invalid compression threshold")
+	}
+}


### PR DESCRIPTION
## Summary
- add explicit tests for `Builder.Build` and `grpcd`'s `initConfig`
- enforce a 50% coverage minimum in CI
- document testing guidance and coverage target

## Testing
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6898e1eff5408323b33ec7214a0f4daa