### PR TITLE
refactor(logging): add size_bytes field for block operations

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Changed
+- Log block sizes with `size_bytes` field for clarity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 
 ## TODO
 
-- [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit.
+- [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit (block size logs now use `size_bytes`).
 - [ ] Remove stray `fmt.Print*` calls in favor of structured logs.
 - [ ] Monitor elimination of `fmt.Print*` calls to keep progress logging fully structured.
 - [x] Refactor `cmd/grpcd` to defer `syncLogger` for structured log flushing.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ logger.Info("snapshot complete",
 )
 ```
 
+Errors during block operations log the byte offset and block size explicitly:
+
+```go
+Logger.Warn("Zero-copy transfer failed",
+    zap.Int64("offset", offset),
+    zap.Int("size_bytes", blockSize),
+    zap.Int("attempt", attempt+1),
+    zap.Error(err),
+)
+```
+
+| Field | Description |
+|-------|-------------|
+| `offset` | Byte offset from the start of the device |
+| `size_bytes` | Size of the block being processed |
+| `attempt` | Current retry attempt |
+
 ## Configuration
 
 LVMSync uses [`pflag`](https://github.com/spf13/pflag) and [`viper`](https://github.com/spf13/viper) to accept options from

--- a/transfer/block_common.go
+++ b/transfer/block_common.go
@@ -77,7 +77,7 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 
 		Logger.Warn("Zero-copy transfer failed",
 			zap.Int64("offset", offset),
-			zap.Int("size", blockSize),
+			zap.Int("size_bytes", blockSize),
 			zap.Int("attempt", attempt+1),
 			zap.Error(err))
 
@@ -126,7 +126,7 @@ func retryRead(cfg *config.Config, src *os.File, offset int64) ([]byte, error) {
 
 		Logger.Warn("Failed to read block",
 			zap.Int64("offset", offset),
-			zap.Int("size", blockSize),
+			zap.Int("size_bytes", blockSize),
 			zap.Int("attempt", attempt+1),
 			zap.Error(err))
 


### PR DESCRIPTION
## Summary
- log block sizes using `size_bytes` for unit clarity
- document block size logging in README with examples and table
- note logging update in AGENTS and changelog

## Testing
- `go test -cover ./...`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_6898e6748e148323817483f024299a99