### PR TITLE
refactor(dedup): remove syslog and log sync errors

### DIFF
--- a/dedup/logger.go
+++ b/dedup/logger.go
@@ -1,0 +1,10 @@
+package dedup
+
+import "go.uber.org/zap"
+
+// syncLogger flushes any buffered log entries and logs if the sync fails.
+func syncLogger(logger *zap.Logger) {
+	if err := logger.Sync(); err != nil {
+		logger.Error("Logger sync error", zap.Error(err))
+	}
+}

--- a/dedup/manifest.go
+++ b/dedup/manifest.go
@@ -2,7 +2,6 @@ package dedup
 
 import (
 	"encoding/json"
-	"log/syslog"
 
 	"go.uber.org/zap"
 )
@@ -25,8 +24,10 @@ func (m *Manifest) Append(hash [32]byte, offset int64, length int) {
 }
 
 // Marshal returns the JSON representation of the manifest.
+var jsonMarshal = json.Marshal
+
 func (m *Manifest) Marshal() ([]byte, error) {
-	return json.Marshal(m)
+	return jsonMarshal(m)
 }
 
 // UnmarshalManifest decodes a manifest from JSON data.
@@ -36,7 +37,7 @@ func UnmarshalManifest(b []byte) (Manifest, error) {
 	return m, err
 }
 
-// AuditLog writes the manifest to syslog and the provided zap logger using snake_case fields.
+// AuditLog writes the manifest using the provided zap logger with snake_case fields.
 func (m *Manifest) AuditLog(logger *zap.Logger) {
 	if logger == nil {
 		logger = zap.NewNop()
@@ -44,13 +45,9 @@ func (m *Manifest) AuditLog(logger *zap.Logger) {
 	b, err := m.Marshal()
 	if err != nil {
 		logger.Error("manifest_marshal_error", zap.Error(err))
-		_ = logger.Sync()
+		syncLogger(logger)
 		return
 	}
-	if w, err := syslog.New(syslog.LOG_INFO|syslog.LOG_USER, "lvmsync"); err == nil {
-		_, _ = w.Write(b)
-		_ = w.Close()
-	}
 	logger.Info("session_manifest", zap.ByteString("manifest_json", b))
-	_ = logger.Sync()
+	syncLogger(logger)
 }

--- a/dedup/manifest_test.go
+++ b/dedup/manifest_test.go
@@ -1,26 +1,69 @@
 package dedup
 
 import (
+	"errors"
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestManifestAuditLog(t *testing.T) {
+type failingSyncCore struct {
+	zapcore.Core
+	err error
+}
+
+func (c *failingSyncCore) Sync() error {
+	return c.err
+}
+
+func TestAuditLogSuccessSyncError(t *testing.T) {
 	m := &Manifest{}
 	m.Append([32]byte{}, 0, 1)
-	core, logs := observer.New(zap.InfoLevel)
-	logger := zap.New(core)
+	core, observed := observer.New(zap.InfoLevel)
+	syncErr := errors.New("sync fail")
+	logger := zap.New(&failingSyncCore{Core: core, err: syncErr})
 	m.AuditLog(logger)
-	if logs.Len() != 1 {
-		t.Fatalf("expected one log, got %d", logs.Len())
+	entries := observed.All()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(entries))
 	}
-	entry := logs.All()[0]
-	if entry.Message != "session_manifest" {
-		t.Fatalf("unexpected message %s", entry.Message)
+	if entries[0].Message != "session_manifest" {
+		t.Fatalf("unexpected first log message %q", entries[0].Message)
 	}
-	if _, ok := entry.ContextMap()["manifest_json"]; !ok {
-		t.Fatalf("missing manifest_json field")
+	if entries[1].Message != "Logger sync error" {
+		t.Fatalf("unexpected second log message %q", entries[1].Message)
+	}
+	if errStr, ok := entries[1].ContextMap()["error"].(string); !ok || errStr != syncErr.Error() {
+		t.Fatalf("expected sync error %q, got %v", syncErr.Error(), entries[1].ContextMap()["error"])
+	}
+}
+
+func TestAuditLogMarshalErrorSyncError(t *testing.T) {
+	m := &Manifest{}
+	original := jsonMarshal
+	marshalErr := errors.New("marshal fail")
+	jsonMarshal = func(v any) ([]byte, error) { return nil, marshalErr }
+	defer func() { jsonMarshal = original }()
+	core, observed := observer.New(zap.InfoLevel)
+	syncErr := errors.New("sync fail")
+	logger := zap.New(&failingSyncCore{Core: core, err: syncErr})
+	m.AuditLog(logger)
+	entries := observed.All()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(entries))
+	}
+	if entries[0].Message != "manifest_marshal_error" {
+		t.Fatalf("unexpected first log message %q", entries[0].Message)
+	}
+	if errStr, ok := entries[0].ContextMap()["error"].(string); !ok || errStr != marshalErr.Error() {
+		t.Fatalf("expected marshal error %q, got %v", marshalErr.Error(), entries[0].ContextMap()["error"])
+	}
+	if entries[1].Message != "Logger sync error" {
+		t.Fatalf("unexpected second log message %q", entries[1].Message)
+	}
+	if errStr, ok := entries[1].ContextMap()["error"].(string); !ok || errStr != syncErr.Error() {
+		t.Fatalf("expected sync error %q, got %v", syncErr.Error(), entries[1].ContextMap()["error"])
 	}
 }


### PR DESCRIPTION
## Summary
- remove syslog dependency from manifest audit logging
- add syncLogger helper to capture logger sync errors
- test audit logging success and marshal failure paths

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898eb4dd1088323b9de97e53d95a03b