### PR TITLE
refactor(privesc): inject exec func and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,9 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 
 - Add a dedicated unit test for every new function.
 - Cover both successful and failing paths to verify correctness.
+- Where external commands would normally execute, inject test hooks (e.g.,
+  `privesc.EnsureRoot` accepts an `exec` function) to stub side effects during
+  tests.
 
 ## Modularity and Single Responsibility
 

--- a/README.md
+++ b/README.md
@@ -934,6 +934,16 @@ Keep functions and packages focused on a single task to simplify maintenance and
 
 Decouple modules by injecting dependencies through interfaces or constructor parameters. This approach makes components easier to test and swap during refactoring.
 
+For example, `internal/privesc.EnsureRoot` accepts an `exec` function so tests
+can stub the `unix.Exec` call:
+
+```go
+err := privesc.EnsureRoot("sudo -n", func(argv0 string, argv, envv []string) error {
+    // record arguments or return a controlled error
+    return nil
+})
+```
+
 ### Test Coverage
 
 Every change should include unit tests. Run `go test -cover ./...` to ensure coverage remains high and regressions are caught early.

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"golang.org/x/sys/unix"
+
 	"lvmsync_go/internal/privesc"
 	lvmlib "lvmsync_go/lvm"
 )
@@ -57,7 +59,7 @@ func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error) Agent 
 			if cmd == "" {
 				cmd = "sudo -n"
 			}
-			return privesc.EnsureRoot(cmd)
+			return privesc.EnsureRoot(cmd, unix.Exec)
 		}
 	}
 	return &sudoAgent{sudoPath: sudoPath, lvm: api, ensureRoot: ensureRoot}

--- a/internal/privesc/privesc.go
+++ b/internal/privesc/privesc.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
-// EnsureRoot verifies that the current process has root privileges.
-// If not, it attempts to re-exec the process using the provided
-// escalation command (e.g. "sudo -n"). The current process will be
-// replaced on success.
-func EnsureRoot(escalationCmd string) error {
+// ExecFunc models the signature of unix.Exec and allows tests to stub the
+// exec call.
+type ExecFunc func(argv0 string, argv, envv []string) error
+
+// EnsureRoot verifies that the current process has root privileges. If not, it
+// attempts to re-exec the process using the provided escalation command (e.g.
+// "sudo -n"). The current process will be replaced on success. The execFunc
+// parameter is injected to facilitate testing and typically wraps unix.Exec.
+func EnsureRoot(escalationCmd string, execFunc ExecFunc) error {
 	if os.Geteuid() == 0 {
 		return nil
 	}
@@ -21,7 +23,7 @@ func EnsureRoot(escalationCmd string) error {
 	}
 	parts := strings.Fields(escalationCmd)
 	argv := append(append([]string{}, parts...), os.Args...)
-	if err := unix.Exec(parts[0], argv, os.Environ()); err != nil {
+	if err := execFunc(parts[0], argv, os.Environ()); err != nil {
 		return fmt.Errorf("failed to exec %s: %w", parts[0], err)
 	}
 	return nil

--- a/internal/privesc/privesc_test.go
+++ b/internal/privesc/privesc_test.go
@@ -1,0 +1,72 @@
+package privesc
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// dropPriv changes the effective UID for the duration of the test. It skips the
+// test if privileges cannot be adjusted.
+func dropPriv(t *testing.T) func() {
+	t.Helper()
+	orig := os.Geteuid()
+	if orig != 0 {
+		t.Skip("test requires root")
+	}
+	if err := unix.Setresuid(-1, 1000, -1); err != nil {
+		t.Skipf("unable to drop privileges: %v", err)
+	}
+	return func() {
+		_ = unix.Setresuid(-1, orig, -1)
+	}
+}
+
+func TestEnsureRootAlreadyRoot(t *testing.T) {
+	called := false
+	err := EnsureRoot("sudo -n", func(argv0 string, argv []string, envv []string) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if called {
+		t.Fatal("exec function should not be called when already root")
+	}
+}
+
+func TestEnsureRootMissingCommand(t *testing.T) {
+	restore := dropPriv(t)
+	defer restore()
+
+	called := false
+	err := EnsureRoot("", func(argv0 string, argv []string, envv []string) error {
+		called = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error for missing command")
+	}
+	if called {
+		t.Fatal("exec function should not be called when command is missing")
+	}
+}
+
+func TestEnsureRootExecFailure(t *testing.T) {
+	restore := dropPriv(t)
+	defer restore()
+
+	boom := errors.New("boom")
+	err := EnsureRoot("sudo -n", func(argv0 string, argv []string, envv []string) error {
+		return boom
+	})
+	if err == nil {
+		t.Fatal("expected exec failure")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected wrapped boom error, got %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"lvmsync_go/app"
 	applycmd "lvmsync_go/cmd/apply"
@@ -36,7 +37,7 @@ func configure() (*config.Config, *zap.Logger, error) {
 		return nil, nil, fmt.Errorf("configuration error: %w", err)
 	}
 
-	if err = privesc.EnsureRoot(cfg.LVMEscalation); err != nil {
+	if err = privesc.EnsureRoot(cfg.LVMEscalation, unix.Exec); err != nil {
 		return nil, nil, fmt.Errorf("privilege escalation error: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- allow `privesc.EnsureRoot` to accept an injected exec function
- cover EnsureRoot behavior for root, missing command, and exec failure scenarios
- document new test hooks in AGENTS and README

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898ed13a948832388e9d0d3bd5439c5