### PR TITLE
Validate dedup config precedence and document options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - Dedup strategies should expose pure functions and persist state deterministically.
 - Provide tests for Bloom filter sizing and CDC window boundaries.
 - Document tunables `--cdc-min`, `--cdc-avg`, `--cdc-max`, and `--bloom-mbits`.
+- Verify configuration precedence (flags > env vars > config file) and handle invalid YAML or value parse errors.
 
 ### Compression
 
@@ -224,6 +225,8 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - `cmd/client` handles snapshot dumping and transport selection, receiving configuration and loggers explicitly.
 - `cmd/apply` streams incoming data to destination devices and also accepts explicit configuration and loggers.
 - [ ] Verify configuration precedence.
+- [ ] Maintain tests for dedup configuration precedence and error paths (invalid YAML, parse errors).
+- [ ] Keep README dedup configuration options in sync with code.
 - [ ] Document feature changes in `README.md`.
 - [x] Implement full transport registry with working QUIC, HTTP/2, TCP+TLS, and SSH backends and accompanying tests.
 - [x] Finalize hybrid deduplication and document CDC tuning knobs.

--- a/README.md
+++ b/README.md
@@ -457,6 +457,26 @@ compress: auto
 compress_threshold: 0.85
 ```
 
+### Dedup configuration
+
+The `dedup` package exposes a `LoadConfig` helper that reads tuning parameters
+from flags, `LVMSYNC_*` environment variables, or keys in a YAML file. Values
+are resolved with the following precedence (highest first):
+
+1. Command-line flags
+2. `LVMSYNC_*` environment variables
+3. `config.yaml`
+4. Built-in defaults
+
+| Flag | Environment variable | Config key | Description | Default |
+|------|----------------------|------------|-------------|---------|
+| `--min_chunk_size` | `LVMSYNC_MIN_CHUNK_SIZE` | `min_chunk_size` | Minimum chunk size in bytes | `4096` |
+| `--max_chunk_size` | `LVMSYNC_MAX_CHUNK_SIZE` | `max_chunk_size` | Maximum chunk size in bytes | `1048576` |
+| `--false_positive_rate` | `LVMSYNC_FALSE_POSITIVE_RATE` | `false_positive_rate` | Bloom filter false positive rate | `0.001` |
+| `--ram_bytes` | `LVMSYNC_RAM_BYTES` | `ram_bytes` | RAM budget for the Bloom filter | `1073741824` |
+| `--volume_size` | `LVMSYNC_VOLUME_SIZE` | `volume_size` | Size of the volume being processed | `0` |
+| `--hash_key` | `LVMSYNC_HASH_KEY` | `hash_key` | Optional hex-encoded key for BLAKE3 hashing | `""` |
+
 ## Throughput Mode Presets
 
 `--mode throughput` applies a set of options tuned for high-bandwidth links:

--- a/dedup/config_test.go
+++ b/dedup/config_test.go
@@ -1,0 +1,58 @@
+package dedup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfigPrecedence(t *testing.T) {
+	cfgPath := writeTempConfig(t, "min_chunk_size: 4096\nmax_chunk_size: 8192\n")
+
+	t.Run("env_overrides_config", func(t *testing.T) {
+		t.Setenv("LVMSYNC_MAX_CHUNK_SIZE", "16384")
+		cfg, err := LoadConfig(cfgPath, nil)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.MaxChunkSize != 16384 {
+			t.Fatalf("expected max_chunk_size 16384, got %d", cfg.MaxChunkSize)
+		}
+	})
+
+	t.Run("flags_override_env", func(t *testing.T) {
+		t.Setenv("LVMSYNC_MIN_CHUNK_SIZE", "2048")
+		cfg, err := LoadConfig(cfgPath, []string{"--min_chunk_size", "1024"})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.MinChunkSize != 1024 {
+			t.Fatalf("expected min_chunk_size 1024, got %d", cfg.MinChunkSize)
+		}
+	})
+}
+
+func TestLoadConfigFailures(t *testing.T) {
+	t.Run("invalid_yaml", func(t *testing.T) {
+		cfgPath := writeTempConfig(t, ":\n")
+		if _, err := LoadConfig(cfgPath, nil); err == nil {
+			t.Fatalf("expected error for invalid YAML")
+		}
+	})
+
+	t.Run("parse_error", func(t *testing.T) {
+		if _, err := LoadConfig("", []string{"--min_chunk_size", "abc"}); err == nil {
+			t.Fatalf("expected parse error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add tests for dedup.LoadConfig precedence and error paths
- document dedup configuration options and precedence
- note dedup config guidelines and TODOs

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898ed398acc8323bb9fa85434279fcf