### PR TITLE
refactor(cmd): modularize main into root and dump packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,8 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - [ ] Enforce modular, single-responsibility design across packages.
 - [ ] Document each new CLI flag, environment variable, and configuration option in `README.md`.
 - [x] Refactor `main.go` into smaller modules.
-- `cmd/client` handles snapshot dumping and transport selection, receiving configuration and loggers explicitly.
+- `cmd/dump` handles snapshot dumping and transport selection, receiving configuration and loggers explicitly.
+- `cmd/root` configures the application and wires `cmd/dump` and `cmd/apply`.
 - `cmd/apply` streams incoming data to destination devices and also accepts explicit configuration and loggers.
 - [ ] Verify configuration precedence.
 - [ ] Document feature changes in `README.md`.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ LVMSync is organized into modular packages to keep concerns separated:
 - `grpc` – provides the gRPC server and authentication helpers used by the remote daemon.
 - `common` and `internal` – shared helpers and internal utilities such as multi-error handling.
 - `internal/client` – coordinates snapshot preparation and client transfer execution.
-- `cmd/client` – handles snapshot dumping and transport selection.
+- `cmd/dump` – handles snapshot dumping and transport selection.
+- `cmd/root` – configures the application and routes to subcommands.
 - `cmd/apply` – applies streamed data to destination devices.
 - `cmd/lvmsync` – CLI orchestrator with a `signals` subpackage for signal handling and cleanup.
 - `cmd/grpcd` – standalone gRPC daemon exposing LVMSync operations remotely.
@@ -64,7 +65,7 @@ This structure allows individual packages to be developed and tested in isolatio
 
 - Snapshot preparation helpers (`ensureVolumeGroups`, `checkDiskSpaceForSnapshot`, `createSnapshotIfNeeded`, `PrepareSnapshot`) and client execution logic are consolidated under `internal/client`.
 - These helpers no longer rely on global variables; configuration and loggers are passed explicitly.
-- `main.go` now orchestrates operations through the `cmd/client` and `cmd/apply` packages.
+- `main.go` now delegates to `cmd/root`, which wires together `cmd/dump` and `cmd/apply`.
 
 ## Logging
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"errors"

--- a/cmd/dump/dump_test.go
+++ b/cmd/dump/dump_test.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"io"

--- a/cmd/dump/local_dump_test.go
+++ b/cmd/dump/local_dump_test.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"errors"

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"io"

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"errors"

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"io"

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"io"

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -1,4 +1,4 @@
-package client
+package dump
 
 import (
 	"io"

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,0 +1,157 @@
+package root
+
+import (
+	"fmt"
+	"os/signal"
+
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+
+	"lvmsync_go/app"
+	applycmd "lvmsync_go/cmd/apply"
+	dumpcmd "lvmsync_go/cmd/dump"
+	"lvmsync_go/config"
+	clientpkg "lvmsync_go/internal/client"
+	"lvmsync_go/internal/privesc"
+	"lvmsync_go/lvm"
+)
+
+// function variables for testing
+var (
+	startGRPCServer   = app.StartGRPCServer
+	clientHandshake   = app.ClientHandshake
+	setupSignalHandle = app.SetupSignalHandling
+	prepareSnapshotFn = app.PrepareSnapshot
+	executeClientFn   = clientpkg.ExecuteClient
+	selectTransport   = dumpcmd.SelectTransport
+	runDump           = dumpcmd.Run
+)
+
+// SyncLogger flushes buffered log entries and logs if syncing fails.
+func SyncLogger(logger *zap.Logger) {
+	if err := logger.Sync(); err != nil {
+		logger.Error("Logger sync error", zap.Error(err))
+	}
+}
+
+// Configure loads configuration, ensures privileges, validates, and sets up logging.
+func Configure() (*config.Config, *zap.Logger, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("configuration error: %w", err)
+	}
+	if err = privesc.EnsureRoot(cfg.LVMEscalation); err != nil {
+		return nil, nil, fmt.Errorf("privilege escalation error: %w", err)
+	}
+	if err = cfg.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("configuration validation error: %w", err)
+	}
+	logger, err := zap.NewProduction()
+	if err != nil {
+		return nil, nil, fmt.Errorf("logger initialization error: %w", err)
+	}
+	logger.Info("Effective configuration",
+		zap.String("block_size", cfg.HumanBlockSize()),
+		zap.Int("parallel", cfg.Parallel),
+		zap.String("dedup_strategy", cfg.DedupStrategy),
+		zap.String("compress", cfg.Compress),
+		zap.Int("compress_level", cfg.CompressLevel),
+		zap.Int("compress_concurrency", cfg.CompressConcurrency),
+		zap.String("snapshot_size", cfg.SnapshotSize),
+		zap.String("volume_group", cfg.VolumeGroup),
+		zap.String("target_volume_group", cfg.TargetVolumeGroup),
+		zap.Bool("stdout_mode", cfg.StdoutMode),
+		zap.String("lvmsync_path", cfg.LVMSyncPath),
+		zap.String("grpc_listen", cfg.GRPCListen),
+		zap.String("grpc_connect", cfg.GRPCConnect),
+	)
+	return cfg, logger, nil
+}
+
+// SetupGRPC starts the server and performs client handshake returning cleanup functions.
+func SetupGRPC(cfg *config.Config, logger *zap.Logger) (func(), func(), error) {
+	cleanupSrv, err := startGRPCServer(cfg, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanupClient, err := clientHandshake(cfg, logger)
+	if err != nil {
+		cleanupSrv()
+		return nil, nil, err
+	}
+	return cleanupSrv, cleanupClient, nil
+}
+
+// PrepareSnapshot wraps snapshot preparation.
+func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+	return prepareSnapshotFn(cfg, originalVolume, logger)
+}
+
+// ExecuteClient runs the client transfer logic.
+func ExecuteClient(cfg *config.Config, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
+	return executeClientFn(func(snapshot, dest string) error {
+		return runDump(cfg, snapshot, dest, logger)
+	}, snapshotPath, destPath, sigErrCh, monitorErrCh)
+}
+
+// Run orchestrates the command execution.
+func Run(cfg *config.Config, logger *zap.Logger) error {
+	defer lvm.Cleanup()
+
+	if err := selectTransport(cfg, logger); err != nil {
+		return err
+	}
+
+	cleanupSrv, cleanupClient, err := SetupGRPC(cfg, logger)
+	if err != nil {
+		return err
+	}
+	defer cleanupSrv()
+	defer cleanupClient()
+
+	var snapshotPath string
+	signals, sigErrCh := setupSignalHandle(cfg, &snapshotPath)
+	defer signal.Stop(signals)
+
+	if cfg.ApplyMode != "" {
+		if err = applycmd.Run(cfg, cfg.ApplyMode, pflag.Args()); err != nil {
+			return fmt.Errorf("apply operation failed: %w", err)
+		}
+		return nil
+	}
+
+	args := pflag.Args()
+	if (cfg.StdoutMode && len(args) < 1) || (!cfg.StdoutMode && len(args) < 2) {
+		pflag.Usage()
+		return fmt.Errorf("invalid arguments")
+	}
+	originalVolume := args[0]
+	destPath := ""
+	if !cfg.StdoutMode {
+		destPath = args[1]
+	}
+
+	var monitorErrCh chan error
+	snapshotPath, monitorErrCh, cleanup, err := PrepareSnapshot(cfg, originalVolume, logger)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return ExecuteClient(cfg, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
+}
+
+// Execute is a helper that configures and runs the root command.
+func Execute() error {
+	cfg, logger, err := Configure()
+	if err != nil {
+		return err
+	}
+	if err := Run(cfg, logger); err != nil {
+		logger.Error("run failed", zap.Error(err))
+		SyncLogger(logger)
+		return err
+	}
+	SyncLogger(logger)
+	return nil
+}

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -1,0 +1,122 @@
+package root
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"lvmsync_go/config"
+)
+
+func TestSetupGRPCSuccess(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	srvCleanCalled := false
+	clientCleanCalled := false
+
+	origStart := startGRPCServer
+	origClient := clientHandshake
+	defer func() {
+		startGRPCServer = origStart
+		clientHandshake = origClient
+	}()
+
+	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
+		return func() { srvCleanCalled = true }, nil
+	}
+	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), error) {
+		return func() { clientCleanCalled = true }, nil
+	}
+
+	cleanupSrv, cleanupClient, err := SetupGRPC(cfg, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cleanupSrv()
+	cleanupClient()
+	if !srvCleanCalled || !clientCleanCalled {
+		t.Fatalf("cleanup functions not called")
+	}
+}
+
+func TestSetupGRPCServerError(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	origStart := startGRPCServer
+	defer func() { startGRPCServer = origStart }()
+	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
+		return nil, errors.New("srv fail")
+	}
+	if _, _, err := SetupGRPC(cfg, logger); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSetupGRPCClientError(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	srvCleanupCalled := false
+	origStart := startGRPCServer
+	origClient := clientHandshake
+	defer func() {
+		startGRPCServer = origStart
+		clientHandshake = origClient
+	}()
+	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
+		return func() { srvCleanupCalled = true }, nil
+	}
+	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), error) {
+		return nil, errors.New("client fail")
+	}
+	if _, _, err := SetupGRPC(cfg, logger); err == nil {
+		t.Fatalf("expected error")
+	}
+	if !srvCleanupCalled {
+		t.Fatalf("server cleanup not called on error")
+	}
+}
+
+func TestPrepareSnapshot(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	orig := prepareSnapshotFn
+	defer func() { prepareSnapshotFn = orig }()
+	prepareSnapshotFn = func(c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+		return "snap", nil, func() {}, nil
+	}
+	snap, ch, cleanup, err := PrepareSnapshot(cfg, "vol", logger)
+	if err != nil || snap != "snap" || ch != nil || cleanup == nil {
+		t.Fatalf("unexpected result")
+	}
+}
+
+func TestExecuteClient(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	called := false
+	origExec := executeClientFn
+	origRunDump := runDump
+	defer func() {
+		executeClientFn = origExec
+		runDump = origRunDump
+	}()
+	executeClientFn = func(f func(string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
+		called = true
+		if snap != "s" || dest != "d" {
+			t.Fatalf("unexpected args")
+		}
+		return f(snap, dest)
+	}
+	runDump = func(_ *config.Config, snap, dest string, _ *zap.Logger) error {
+		if snap != "s" || dest != "d" {
+			t.Fatalf("unexpected dump args")
+		}
+		return nil
+	}
+	if err := ExecuteClient(cfg, "s", "d", nil, nil, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatalf("executeClientFn not called")
+	}
+}

--- a/error_handling_test.go
+++ b/error_handling_test.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
-	clientcmd "lvmsync_go/cmd/client"
+	dumpcmd "lvmsync_go/cmd/dump"
 )
 
 type failingSyncCore struct {
@@ -23,7 +23,7 @@ func (c *failingSyncCore) Sync() error {
 
 func TestCopyPipeAsyncError(t *testing.T) {
 	r, w := io.Pipe()
-	errCh := clientcmd.CopyPipeAsync(io.Discard, r)
+	errCh := dumpcmd.CopyPipeAsync(io.Discard, r)
 	expected := errors.New("copy fail")
 	w.CloseWithError(expected)
 	if err := <-errCh; !errors.Is(err, expected) {

--- a/main.go
+++ b/main.go
@@ -3,129 +3,26 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/signal"
 
-	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 
-	"lvmsync_go/app"
-	applycmd "lvmsync_go/cmd/apply"
-	clientcmd "lvmsync_go/cmd/client"
-	"lvmsync_go/config"
-	clientpkg "lvmsync_go/internal/client"
-	"lvmsync_go/internal/privesc"
-	"lvmsync_go/lvm"
+	rootcmd "lvmsync_go/cmd/root"
 )
 
 var (
-	configureFunc = configure
-	runFunc       = run
-	exitFunc      = os.Exit
+	configureFunc  = rootcmd.Configure
+	runFunc        = rootcmd.Run
+	syncLoggerFunc = rootcmd.SyncLogger
+	exitFunc       = os.Exit
 )
 
-// syncLogger flushes any buffered log entries and logs if the sync fails.
-func syncLogger(logger *zap.Logger) {
-	if err := logger.Sync(); err != nil {
-		logger.Error("Logger sync error", zap.Error(err))
-	}
-}
-
-func configure() (*config.Config, *zap.Logger, error) {
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return nil, nil, fmt.Errorf("configuration error: %w", err)
-	}
-
-	if err = privesc.EnsureRoot(cfg.LVMEscalation); err != nil {
-		return nil, nil, fmt.Errorf("privilege escalation error: %w", err)
-	}
-
-	if err = cfg.Validate(); err != nil {
-		return nil, nil, fmt.Errorf("configuration validation error: %w", err)
-	}
-
-	logger, err := zap.NewProduction()
-	if err != nil {
-		return nil, nil, fmt.Errorf("logger initialization error: %w", err)
-	}
-
-	logger.Info("Effective configuration",
-		zap.String("block_size", cfg.HumanBlockSize()),
-		zap.Int("parallel", cfg.Parallel),
-		zap.String("dedup_strategy", cfg.DedupStrategy),
-		zap.String("compress", cfg.Compress),
-		zap.Int("compress_level", cfg.CompressLevel),
-		zap.Int("compress_concurrency", cfg.CompressConcurrency),
-		zap.String("snapshot_size", cfg.SnapshotSize),
-		zap.String("volume_group", cfg.VolumeGroup),
-		zap.String("target_volume_group", cfg.TargetVolumeGroup),
-		zap.Bool("stdout_mode", cfg.StdoutMode),
-		zap.String("lvmsync_path", cfg.LVMSyncPath),
-		zap.String("grpc_listen", cfg.GRPCListen),
-		zap.String("grpc_connect", cfg.GRPCConnect),
-	)
-
-	return cfg, logger, nil
-}
-
-func run(cfg *config.Config, logger *zap.Logger) error {
-	defer lvm.Cleanup()
-
-	if err := clientcmd.SelectTransport(cfg, logger); err != nil {
-		return err
-	}
-
-	cleanupSrv, err := app.StartGRPCServer(cfg, logger)
-	if err != nil {
-		return err
-	}
-	defer cleanupSrv()
-
-	cleanupClient, err := app.ClientHandshake(cfg, logger)
-	if err != nil {
-		return err
-	}
-	defer cleanupClient()
-
-	var snapshotPath string
-	signals, sigErrCh := app.SetupSignalHandling(cfg, &snapshotPath)
-	defer signal.Stop(signals)
-
-	if cfg.ApplyMode != "" {
-		if err = applycmd.Run(cfg, cfg.ApplyMode, pflag.Args()); err != nil {
-			return fmt.Errorf("apply operation failed: %w", err)
-		}
-		return nil
-	}
-
-	args := pflag.Args()
-	if (cfg.StdoutMode && len(args) < 1) || (!cfg.StdoutMode && len(args) < 2) {
-		pflag.Usage()
-		return fmt.Errorf("invalid arguments")
-	}
-	originalVolume := args[0]
-	destPath := ""
-	if !cfg.StdoutMode {
-		destPath = args[1]
-	}
-
-	var monitorErrCh chan error
-	snapshotPath, monitorErrCh, cleanup, err := app.PrepareSnapshot(cfg, originalVolume, logger)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
-	return clientpkg.ExecuteClient(func(snapshot, dest string) error {
-		return clientcmd.Run(cfg, snapshot, dest, logger)
-	}, snapshotPath, destPath, sigErrCh, monitorErrCh)
-}
+func syncLogger(logger *zap.Logger) { syncLoggerFunc(logger) }
 
 func main() {
 	cfg, logger, err := configureFunc()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "configuration failed: %v\n", err)
-		os.Exit(1)
+		exitFunc(1)
 	}
 	if err := runFunc(cfg, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))


### PR DESCRIPTION
## Summary
- split `main.go` into new `cmd/root` package and renamed `cmd/client` to `cmd/dump`
- expose testable helpers for gRPC setup, snapshot prep, and client execution
- document new module structure in README and AGENTS

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898ed5b8f948323a68b8e98e9f765e1