### PR TITLE
chore: align tooling to Go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.24]
+        go-version: [1.23]
     permissions:
       contents: write
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module lvmsync_go
 
-go 1.24.5
+go 1.23.0
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.0

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.24.5
+go 1.23.0
 
 use (
-    .
-    ./internal/multierr
+	.
+	./internal/multierr
 )

--- a/internal/multierr/go.mod
+++ b/internal/multierr/go.mod
@@ -1,4 +1,3 @@
 module go.uber.org/multierr
 
-go 1.24.3
-
+go 1.23


### PR DESCRIPTION
## Summary
- use Go 1.23 across go.mod, go.work, and internal module
- run Go 1.23 in CI workflow

## Testing
- `GOTOOLCHAIN=go1.23.0 go mod tidy`
- `GOTOOLCHAIN=go1.23.0 go work sync`
- `GOTOOLCHAIN=go1.23.0 go build ./...` *(fails: not enough arguments in call to privesc.EnsureRoot)*
- `GOTOOLCHAIN=go1.23.0 go test -cover ./...` *(fails: not enough arguments in call to privesc.EnsureRoot)*
- `GOVERSION=1.23 GOTOOLCHAIN=go1.23.0 golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_6898f3649d888323933b40c84ff7b57c