### PR TITLE
feat: implement tcp tls transport

### DIFF
--- a/internal/transport/tcp/tcp.go
+++ b/internal/transport/tcp/tcp.go
@@ -1,18 +1,166 @@
 package tcp
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"time"
+
+	"go.uber.org/zap"
 
 	"lvmsync_go/config"
 	"lvmsync_go/internal/transport"
 )
 
+var logger = zap.NewNop()
+
+// SetLogger assigns the package-wide logger for TCP transport.
+func SetLogger(l *zap.Logger) {
+	if l != nil {
+		logger = l
+	}
+}
+
 func init() {
 	transport.Register("tcp+tls", New)
 }
 
-// New returns no-op TCP+TLS transport implementations.
+// tcpSender establishes a TLS connection to the configured address and
+// streams bytes from an io.Reader.
+type tcpSender struct {
+	addr    string
+	tlsConf *tls.Config
+	logger  *zap.Logger
+}
+
+// Send implements the transport.Sender interface.
+func (s *tcpSender) Send(ctx context.Context, r io.Reader) error {
+	d := &net.Dialer{}
+	conn, err := tls.DialWithDialer(d, "tcp", s.addr, s.tlsConf)
+	if err != nil {
+		s.logger.Error("tcp dial error", zap.String("remote_addr", s.addr), zap.Error(err))
+		return err
+	}
+	s.logger.Info("tcp connection opened", zap.String("remote_addr", conn.RemoteAddr().String()))
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+	n, copyErr := io.Copy(conn, r)
+	if closeErr := conn.Close(); closeErr != nil && copyErr == nil {
+		copyErr = closeErr
+	}
+	close(done)
+	if copyErr != nil {
+		s.logger.Error("tcp send error", zap.String("remote_addr", s.addr), zap.Error(copyErr), zap.Int64("bytes_transferred", n))
+		return copyErr
+	}
+	s.logger.Info("tcp connection closed", zap.String("remote_addr", s.addr), zap.Int64("bytes_transferred", n))
+	return nil
+}
+
+// tcpReceiver listens for an incoming TLS connection and writes bytes to an io.Writer.
+type tcpReceiver struct {
+	ln     net.Listener
+	logger *zap.Logger
+}
+
+// Receive implements the transport.Receiver interface.
+func (r *tcpReceiver) Receive(ctx context.Context, w io.Writer) error {
+	connCh := make(chan net.Conn, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		c, err := r.ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		connCh <- c
+	}()
+	var conn net.Conn
+	select {
+	case <-ctx.Done():
+		_ = r.ln.Close()
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	case conn = <-connCh:
+	}
+	r.logger.Info("tcp connection opened", zap.String("remote_addr", conn.RemoteAddr().String()))
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+	n, copyErr := io.Copy(w, conn)
+	if closeErr := conn.Close(); closeErr != nil && copyErr == nil {
+		copyErr = closeErr
+	}
+	close(done)
+	if copyErr != nil {
+		r.logger.Error("tcp receive error", zap.Error(copyErr), zap.Int64("bytes_transferred", n))
+		return copyErr
+	}
+	r.logger.Info("tcp connection closed", zap.Int64("bytes_transferred", n))
+	return nil
+}
+
+// Close releases the listener associated with the receiver.
+func (r *tcpReceiver) Close() error {
+	if r.ln != nil {
+		return r.ln.Close()
+	}
+	return nil
+}
+
+// New initializes a TCP+TLS sender and receiver bound to cfg.TCPPort.
 func New(cfg *config.Config) (transport.Sender, transport.Receiver, error) {
-	_ = tls.Config{}
-	return transport.NopSender{}, transport.NopReceiver{}, nil
+	cert, err := generateCert()
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate cert: %w", err)
+	}
+	ln, err := tls.Listen("tcp", fmt.Sprintf(":%d", cfg.TCPPort), &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		return nil, nil, err
+	}
+	addr := ln.Addr().String()
+	sender := &tcpSender{addr: addr, tlsConf: &tls.Config{InsecureSkipVerify: true}, logger: logger}
+	receiver := &tcpReceiver{ln: ln, logger: logger}
+	return sender, receiver, nil
+}
+
+func generateCert() (tls.Certificate, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	return tls.X509KeyPair(certPEM, keyPEM)
 }

--- a/internal/transport/tcp/tcp_test.go
+++ b/internal/transport/tcp/tcp_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"sync"
 	"testing"
 
 	"lvmsync_go/config"
@@ -11,18 +12,58 @@ import (
 )
 
 func TestTCPRegistered(t *testing.T) {
-	f, ok := transport.Get("tcp+tls")
-	if !ok {
+	if _, ok := transport.Get("tcp+tls"); !ok {
 		t.Fatalf("tcp+tls transport not registered")
 	}
-	s, r, err := f(&config.Config{})
+}
+
+func TestTCPSendReceive(t *testing.T) {
+	s, r, err := New(&config.Config{TCPPort: 0})
 	if err != nil {
-		t.Fatalf("factory error: %v", err)
+		t.Fatalf("New: %v", err)
 	}
-	if err := s.Send(context.Background(), bytes.NewReader(nil)); err != nil {
+	defer r.(*tcpReceiver).Close()
+
+	data := []byte("hello world")
+	var buf bytes.Buffer
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := r.Receive(ctx, &buf); err != nil {
+			t.Errorf("receive: %v", err)
+		}
+	}()
+	if err := s.Send(ctx, bytes.NewReader(data)); err != nil {
 		t.Fatalf("send: %v", err)
 	}
-	if err := r.Receive(context.Background(), io.Discard); err != nil {
-		t.Fatalf("receive: %v", err)
+	wg.Wait()
+	if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatalf("got %q want %q", buf.Bytes(), data)
 	}
+}
+
+func TestTCPSendError(t *testing.T) {
+	s, r, err := New(&config.Config{TCPPort: 0})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	r.(*tcpReceiver).Close()
+	if err := s.Send(context.Background(), bytes.NewReader([]byte("x"))); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestTCPReceiveCanceled(t *testing.T) {
+	_, r, err := New(&config.Config{TCPPort: 0})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := r.Receive(ctx, io.Discard); err == nil {
+		t.Fatalf("expected error")
+	}
+	r.(*tcpReceiver).Close()
 }


### PR DESCRIPTION
## Summary
- implement real TCP+TLS sender and receiver with logging
- add unit tests for send/receive and error paths

## Testing
- `go test ./...` *(fails: cmd/root/root.go:43:30: not enough arguments in call to privesc.EnsureRoot)*

------
https://chatgpt.com/codex/tasks/task_e_6898fcac29748323bfbed9b49fc53642