### PR TITLE
docs: document transport configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - Document every CLI flag, environment variable, and configuration option in `README.md`.
 - Update examples and default values to match new options.
 - Deduplication modes (`fixed`, `cdc`, `hybrid`) expose tunables `--cdc-min`, `--cdc-avg`, `--cdc-max`, and Bloom filter sizing with `--bloom-mbits` for the mmap-backed index.
+- Keep transport sections and flag-to-env tables (QUIC, HTTP/2, TCP+TLS, SSH) in sync with code changes.
 
 ## Release Workflow
 
@@ -217,6 +218,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).
 - [ ] Document gRPC daemon configuration sources (flags, env vars, config file) and precedence.
 - [ ] Keep `README` configuration documentation current with code changes.
+- [ ] Keep transport documentation and configuration references (flags and env vars) up to date.
 - [ ] Track decomposition of large files like `transfer/transfer.go`.
 - [ ] Ensure progress logging uses `zap` exclusively.
 - [ ] Add a dedicated unit test for every new function.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Recent refactors added several configuration options:
 
 - `--transport` selects the ordered list of transports to try.
 - `--quic_listen` and `--quic_connect` configure QUIC addresses.
-- `--tcp_port` and `--h2_port` expose TCP+TLS and HTTP/2 endpoints.
+- `--tcp_port`, `--h2_port`, and `--ssh_port` expose TCP+TLS, HTTP/2, and SSH endpoints.
 - `--sync_interval` controls how many bytes are written between `fdatasync` calls.
 - `--block_size` sets the transfer block size (use `auto` for detection).
 
@@ -389,30 +389,49 @@ lvmsync --config config.yaml /dev/vg0/snap0 /mnt/backup
 
 Transports are pluggable and selected in order using the `--transport` flag. LVMSync tries each transport until one succeeds.
 
-Each transport exposes its own tuning flags:
+### Flags and environment variables
 
-- `--quic-listen` / `--quic-connect`
-- `--h2-port` for HTTP/2
-- `--tcp-port` for TCP+TLS
-- `--ssh-port` for SSH
+| Flag | Environment variable | Description |
+|------|----------------------|-------------|
+| `--transport` | `LVMSYNC_TRANSPORT` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) |
+| `--quic-listen` | `LVMSYNC_QUIC_LISTEN` | QUIC listen address |
+| `--quic-connect` | `LVMSYNC_QUIC_CONNECT` | QUIC connect address |
+| `--h2-port` | `LVMSYNC_H2_PORT` | HTTP/2 TLS port |
+| `--tcp-port` | `LVMSYNC_TCP_PORT` | TCP+TLS port |
+| `--ssh-port` | `LVMSYNC_SSH_PORT` | SSH port |
 
-CLI:
+### Usage examples
+
+**QUIC**
 
 ```sh
-lvmsync --transport quic,h2,tcp+tls,ssh --quic-listen :9000 --tcp-port 9443 /dev/vg0/snap0 /mnt/backup
+lvmsync --transport quic --quic-listen :9000
+# or
+LVMSYNC_TRANSPORT=quic LVMSYNC_QUIC_LISTEN=:9000 lvmsync
 ```
 
-Environment:
+**HTTP/2**
 
 ```sh
-LVMSYNC_TRANSPORT=quic,h2,tcp+tls,ssh lvmsync /dev/vg0/snap0 /mnt/backup
+lvmsync --transport h2 --h2-port 9443
+# or
+LVMSYNC_TRANSPORT=h2 LVMSYNC_H2_PORT=9443 lvmsync
 ```
 
-YAML:
+**TCP+TLS**
 
-```yaml
-transport: quic,h2,tcp+tls,ssh
-tcp-port: 9443
+```sh
+lvmsync --transport tcp+tls --tcp-port 9443
+# or
+LVMSYNC_TRANSPORT=tcp+tls LVMSYNC_TCP_PORT=9443 lvmsync
+```
+
+**SSH**
+
+```sh
+lvmsync --transport ssh backup@host:/dev/vg1/target --ssh-port 2222
+# or
+LVMSYNC_TRANSPORT=ssh LVMSYNC_SSH_PORT=2222 lvmsync backup@host:/dev/vg1/target
 ```
 
 ## Hybrid Deduplication and Adaptive Compression


### PR DESCRIPTION
## Summary
- document QUIC, HTTP/2, TCP+TLS, and SSH transport flags and environment variables
- add contributor reminders to keep transport docs and config references updated

## Testing
- `go test -cover ./...` *(fails: not enough arguments in call to privesc.EnsureRoot)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6898ff708fd48323a18cfbb14e659ad6