### PR TITLE
docs: expand contributor guidelines and TODOs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This project maintains a set of conventions to keep contributions consistent and
 ## Logging
 
 - Use [zap](https://github.com/uber-go/zap) for structured logging.
+- Zap is the sole logging backend; avoid `log` or `fmt.Print*` for progress output.
 - Always call `Sync()` (e.g., `defer logger.Sync()`) before program exit to flush buffers.
 
 ### Field Naming
@@ -37,6 +38,7 @@ logger.Info("snapshot complete",
 - Prefer [`pflag`](https://github.com/spf13/pflag) for flag parsing.
 - Bind flags to [`viper`](https://github.com/spf13/viper) to support configuration from flags, config files, and environment variables.
 - Group related options into `FlagSet`s to share common configuration across commands.
+- Define flags within `pflag.FlagSet`s and bind them to `viper`; the standard library `flag` package is not used.
 - Expose configuration via both config files and environment variables for easy automation.
 
 ### Flag Grouping Example
@@ -159,7 +161,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 
 ## Unit Tests
 
-- Add a dedicated unit test for every new function.
+- Every function must have a dedicated unit test.
 - Cover both successful and failing paths to verify correctness.
 - Where external commands would normally execute, inject test hooks (e.g.,
   `privesc.EnsureRoot` accepts an `exec` function) to stub side effects during
@@ -215,13 +217,16 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
   ```
 
  - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.
-- [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).
+- [ ] Implement real transports for QUIC, HTTP/2, TCP+TLS, and SSH; replace placeholders with functional backends and tests.
+- [ ] Add privilege escalation (`privesc`) tests covering success and error paths.
+- [ ] Expand coverage for configuration precedence across flags, environment variables, and config files.
+ - [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).
 - [ ] Document gRPC daemon configuration sources (flags, env vars, config file) and precedence.
 - [ ] Keep `README` configuration documentation current with code changes.
 - [ ] Keep transport documentation and configuration references (flags and env vars) up to date.
 - [ ] Track decomposition of large files like `transfer/transfer.go`.
 - [ ] Ensure progress logging uses `zap` exclusively.
-- [ ] Add a dedicated unit test for every new function.
+ - [ ] Ensure every function has a dedicated unit test.
 - [ ] Maintain tests for compression detection, ensuring benchmark and cache logic remain correct.
 - [ ] Maintain tests for buffer alignment, hole punching, and NUMA pinning.
 - [ ] Enforce modular, single-responsibility design across packages.

--- a/README.md
+++ b/README.md
@@ -964,7 +964,7 @@ LVMSync is written in Go by Ofer Chen, inspired by [mpalmer/lvmsync](https://git
 
 ## Contributing
 
-Contributions are welcome. Please follow the project's coding guidelines, include appropriate logging and error handling, and update documentation as needed.
+Contributions are welcome. See [AGENTS.md](AGENTS.md) for detailed contributor instructions and open TODO items. Please follow the project's coding guidelines, include appropriate logging and error handling, and update documentation as needed.
 
 ### Single-Responsibility Functions
 


### PR DESCRIPTION
## Summary
- clarify zap-only logging and FlagSet/viper requirements
- document unit-test-per-function policy
- add TODOs for transports, privesc tests, and configuration precedence

## Testing
- `golangci-lint run`
- `go test -cover ./...` *(fails: internal/transport tests do not compile)*

------
https://chatgpt.com/codex/tasks/task_e_689904cea32883238fb5b1e8f36e363e