### PR TITLE
fix(ssh): repair tests and constructor

### DIFF
--- a/internal/transport/ssh/ssh.go
+++ b/internal/transport/ssh/ssh.go
@@ -11,15 +11,6 @@ import (
 	"lvmsync_go/remote"
 )
 
-var logger = zap.NewNop()
-
-// SetLogger assigns the package-wide logger.
-func SetLogger(l *zap.Logger) {
-	if l != nil {
-		logger = l
-	}
-}
-
 func init() {
 	transport.Register("ssh", New)
 }
@@ -39,7 +30,10 @@ type sshReceiver struct {
 }
 
 // New wraps the existing SSH client as a transport.
-func New(cfg *config.Config) (transport.Sender, transport.Receiver, error) {
+func New(cfg *config.Config, logger *zap.Logger) (transport.Sender, transport.Receiver, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	host := "localhost"
 	logger.Info("ssh connection attempt", zap.String("host", host), zap.Int("port", cfg.SSHPort))
 	client, err := remote.NewSSHClient(host, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)

--- a/internal/transport/ssh/ssh_test.go
+++ b/internal/transport/ssh/ssh_test.go
@@ -157,7 +157,7 @@ func setupTransport(t *testing.T, srv *mockServer) (transport.Sender, transport.
 		SSHKeepAliveInterval: time.Second,
 		KnownHosts:           srv.knownHostsFile(t),
 	}
-	s, r, err := New(cfg)
+	s, r, err := New(cfg, zap.NewNop())
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -179,6 +179,11 @@ func TestSSHSendReceive(t *testing.T) {
 	var buf bytes.Buffer
 	if err := r.Receive(context.Background(), &buf); err != nil {
 		t.Fatalf("receive: %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), payload) {
+		t.Fatalf("got %q want %q", buf.Bytes(), payload)
+	}
+}
 
 func TestSSHRegistered(t *testing.T) {
 	if _, ok := transport.Get("ssh"); !ok {
@@ -187,11 +192,26 @@ func TestSSHRegistered(t *testing.T) {
 }
 
 func TestSSHNew(t *testing.T) {
-	if _, _, err := New(&config.Config{}, zap.NewNop()); err != nil {
-		t.Fatalf("New: %v", err)
+	srv := newMockServer(t, nil)
+	defer srv.Close()
+	_, portStr, err := net.SplitHostPort(srv.addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
 	}
-	if !bytes.Equal(buf.Bytes(), payload) {
-		t.Fatalf("got %q want %q", buf.Bytes(), payload)
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+	_, _, err = New(&config.Config{
+		SSHUser:              "test",
+		SSHKeyPath:           remotetest.CreateTempKey(t),
+		SSHPort:              port,
+		SSHTimeout:           time.Second,
+		SSHKeepAliveInterval: time.Second,
+		KnownHosts:           srv.knownHostsFile(t),
+	}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure TestSSHSendReceive closes properly and tests are top-level
- align SSH transport constructor with transport.Factory by accepting a logger

## Testing
- `go test ./internal/transport/ssh`


------
https://chatgpt.com/codex/tasks/task_e_68990d66ce0083239a4c88ab65672a1f