### PR TITLE
refactor(quic): unify constructor and document transport usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit (block size logs now use `size_bytes`).
 - [ ] Remove stray `fmt.Print*` calls in favor of structured logs.
 - [ ] Monitor elimination of `fmt.Print*` calls to keep progress logging fully structured.
+- [ ] Review QUIC constructor refactor and expand tests for sender/receiver coverage.
 - [x] Refactor `cmd/grpcd` to defer `syncLogger` for structured log flushing.
 - [x] Expand unit test coverage for remote execution and client signal handling, and run coverage reports (transports coverage ≥50%).
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ Recent refactors added several configuration options:
 - `--sync_interval` controls how many bytes are written between `fdatasync` calls.
 - `--block_size` sets the transfer block size (use `auto` for detection).
 
+### QUIC transport
+
+Include `quic` in the `--transport` list or configuration to enable the QUIC data plane.
+Use `--quic_listen` (`LVMSYNC_QUIC_LISTEN` / `quic_listen`) to bind a listener and `--quic_connect`
+(`LVMSYNC_QUIC_CONNECT` / `quic_connect`) to dial a peer. Select the congestion control algorithm with
+`--quic_cc` or `LVMSYNC_QUIC_CC` (defaults to `bbr`).
+
+```sh
+lvmsync --transport quic --quic_listen :9000
+```
+
 ### I/O tuning
 
 - `--odirect` uses O_DIRECT with block-size aligned buffers.

--- a/internal/transport/quic/quic.go
+++ b/internal/transport/quic/quic.go
@@ -19,15 +19,6 @@ import (
 	"lvmsync_go/internal/transport"
 )
 
-var logger = zap.NewNop()
-
-// SetLogger assigns the package-wide logger for QUIC transport.
-func SetLogger(l *zap.Logger) {
-	if l != nil {
-		logger = l
-	}
-}
-
 func init() {
 	transport.Register("quic", New)
 }
@@ -124,7 +115,7 @@ func (r *quicReceiver) Close() error {
 }
 
 // New initializes QUIC sender and receiver according to configuration.
-func New(cfg *config.Config) (transport.Sender, transport.Receiver, error) {
+func New(cfg *config.Config, logger *zap.Logger) (transport.Sender, transport.Receiver, error) {
 	tlsConf := &tls.Config{InsecureSkipVerify: true, NextProtos: []string{"lvmsync"}}
 	quicConf := &q.Config{Allow0RTT: false}
 
@@ -169,11 +160,4 @@ func generateCert() (tls.Certificate, error) {
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
 	return tls.X509KeyPair(certPEM, keyPEM)
-
-// New returns no-op QUIC transport implementations.
-func New(cfg *config.Config, logger *zap.Logger) (transport.Sender, transport.Receiver, error) {
-	_ = logger
-	var _ quic.VersionNumber
-	return transport.NopSender{}, transport.NopReceiver{}, nil
-
 }

--- a/internal/transport/quic/quic_test.go
+++ b/internal/transport/quic/quic_test.go
@@ -1,6 +1,11 @@
 package quic
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
 	"testing"
 
 	"go.uber.org/zap"
@@ -15,9 +20,10 @@ func newPair(t *testing.T) (transport.Sender, transport.Receiver) {
 	if !ok {
 		t.Fatalf("quic transport not registered")
 	}
+	logger := zap.NewNop()
 	// Create receiver first to determine listening address.
 	cfgR := &config.Config{QUICListen: "127.0.0.1:0"}
-	_, rcv, err := f(cfgR)
+	_, rcv, err := f(cfgR, logger)
 	if err != nil {
 		t.Fatalf("receiver factory error: %v", err)
 	}
@@ -26,7 +32,7 @@ func newPair(t *testing.T) (transport.Sender, transport.Receiver) {
 		t.Fatalf("unexpected receiver type")
 	}
 	cfgS := &config.Config{QUICConnect: qr.ln.Addr().String()}
-	snd, _, err := f(cfgS)
+	snd, _, err := f(cfgS, logger)
 	if err != nil {
 		t.Fatalf("sender factory error: %v", err)
 	}
@@ -116,4 +122,3 @@ func TestQUICNew(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 }
-


### PR DESCRIPTION
## Summary
- refactor QUIC transport into a single `New(cfg, logger)` constructor
- update QUIC tests for new constructor and required imports
- document QUIC transport configuration in README and track follow-up TODO

## Testing
- `golangci-lint run`
- `go test -cover ./internal/transport/quic`
- `go test -cover ./...` *(fails: internal/transport/ssh/ssh_test.go:183:6: expected '(')*

------
https://chatgpt.com/codex/tasks/task_e_68990d4eedc88323b15ec3ca02b61229