### PR TITLE
fix(main): log configuration errors with zap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ This structure allows individual packages to be developed and tested in isolatio
 
 LVMSync emits structured logs using [zap](https://github.com/uber-go/zap). Errors are logged with
 structured fields instead of being written to stderr, and the logger is flushed on shutdown to
-ensure all entries are persisted. When `--progress` is enabled, progress updates are emitted as
-structured log entries, allowing external tooling to track transfer completion.
+ensure all entries are persisted. Even configuration failures during startup are reported through a
+temporary zap logger for uniform structured output. When `--progress` is enabled, progress updates
+are emitted as structured log entries, allowing external tooling to track transfer completion.
 
 ### Expectations
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -10,10 +9,11 @@ import (
 )
 
 var (
-	configureFunc  = rootcmd.Configure
-	runFunc        = rootcmd.Run
-	syncLoggerFunc = rootcmd.SyncLogger
-	exitFunc       = os.Exit
+	configureFunc     = rootcmd.Configure
+	runFunc           = rootcmd.Run
+	syncLoggerFunc    = rootcmd.SyncLogger
+	exitFunc          = os.Exit
+	exampleLoggerFunc = func() *zap.Logger { return zap.NewExample() }
 )
 
 func syncLogger(logger *zap.Logger) { syncLoggerFunc(logger) }
@@ -21,13 +21,17 @@ func syncLogger(logger *zap.Logger) { syncLoggerFunc(logger) }
 func main() {
 	cfg, logger, err := configureFunc()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "configuration failed: %v\n", err)
+		tmpLogger := exampleLoggerFunc()
+		tmpLogger.Error("configuration failed", zap.Error(err))
+		_ = tmpLogger.Sync()
 		exitFunc(1)
+		return
 	}
 	if err := runFunc(cfg, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
 		syncLogger(logger)
 		exitFunc(1)
+		return
 	}
 	syncLogger(logger)
 }

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -56,3 +56,39 @@ func TestMainLogsStructuredError(t *testing.T) {
 		t.Fatalf("logger was not synced")
 	}
 }
+
+func TestMainLogsConfigError(t *testing.T) {
+	// stub configure to return an error
+	oldConfigure := configureFunc
+	configureFunc = func() (*config.Config, *zap.Logger, error) { return nil, nil, errors.New("cfg fail") }
+	defer func() { configureFunc = oldConfigure }()
+
+	// capture exit code
+	oldExit := exitFunc
+	var code int
+	exitFunc = func(c int) { code = c }
+	defer func() { exitFunc = oldExit }()
+
+	core, logs := observer.New(zap.ErrorLevel)
+	synced := false
+	tmpLogger := zap.New(&syncCheckCore{Core: core, synced: &synced})
+
+	oldExample := exampleLoggerFunc
+	exampleLoggerFunc = func() *zap.Logger { return tmpLogger }
+	defer func() { exampleLoggerFunc = oldExample }()
+
+	main()
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+
+	entries := logs.FilterMessage("configuration failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+
+	if !synced {
+		t.Fatalf("logger was not synced")
+	}
+}


### PR DESCRIPTION
## Summary
- replace `fmt.Fprintf` with a temporary `zap.Logger` for startup configuration failures
- add unit test covering configuration error logging
- note in README that even startup errors use zap for consistent structured logs

## Testing
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689911de17348323ace8a57ce1907f35