### PR TITLE
fix(client): close monitor channel after goroutine exits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,9 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - Where external commands would normally execute, inject test hooks (e.g.,
   `privesc.EnsureRoot` accepts an `exec` function) to stub side effects during
   tests.
+- The snapshot monitoring goroutine closes its error channel on exit; cleanup
+  must only cancel monitoring. `TestCreateSnapshotCleanupNoPanic` verifies this
+  behavior.
 
 ## Modularity and Single Responsibility
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
   - Auto-selection of target volume groups with sufficient free space.
   - Automatic privilege escalation (defaulting to `sudo -n`).
   - Snapshot health monitoring that fails fast if usage exceeds a threshold.
+  - Snapshot monitor goroutine closes its error channel on exit; cleanup only
+    cancels monitoring, avoiding send-on-closed-channel panics (see
+    `TestCreateSnapshotCleanupNoPanic`).
 - **Graceful Shutdown**: Signal handling ensures snapshots are cleaned up on interruption.
 - **Flexible Configuration**: Flags, environment variables, or `config.yaml`. See [Configuration](#configuration).
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -150,6 +150,7 @@ func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotB
 
 	monitorCtx, cancel := context.WithCancel(context.Background())
 	go func() {
+		defer close(monitorErrCh)
 		if err := monitorSnapshot(monitorCtx, snapshotPath, 80.0, 10*time.Second); err != nil && err != context.Canceled {
 			logger.Error("Snapshot monitor error", zap.Error(err))
 			select {
@@ -161,9 +162,6 @@ func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotB
 
 	cleanup = func() {
 		cancel()
-		if monitorErrCh != nil {
-			close(monitorErrCh)
-		}
 		if err := removeSnapshot(context.Background(), snapshotPath); err != nil {
 			logger.Warn("Failed to remove snapshot", zap.Error(err))
 		} else {

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -96,5 +97,60 @@ func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
 	cleanup()
 	if removedPath != snap {
 		t.Fatalf("removeSnapshot called with %q, expected %q", removedPath, snap)
+	}
+}
+
+func TestCreateSnapshotCleanupNoPanic(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.SkipDiskCheck = true
+	cfg.VolumeGroup = "vg"
+	cfg.TargetVolumeGroup = "vg2"
+
+	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string) (uint64, error) { return 1024, nil })
+	defer restoreParse()
+
+	restoreCreate := client.SetCreateSnapshotForTest(func(context.Context, string, string, string) error { return nil })
+	defer restoreCreate()
+
+	restorePath := client.SetGetSnapshotDevicePathForTest(func(name, vg string) string { return "/dev/" + vg + "/" + name })
+	defer restorePath()
+
+	ready := make(chan struct{}, 1)
+	restoreMonitor := client.SetMonitorSnapshotForTest(func(ctx context.Context, path string, threshold float64, interval time.Duration) error {
+		ready <- struct{}{}
+		<-ctx.Done()
+		return errors.New("monitor error")
+	})
+	defer restoreMonitor()
+
+	restoreRemove := client.SetRemoveSnapshotForTest(func(context.Context, string) error { return nil })
+	defer restoreRemove()
+
+	logger := zap.NewNop()
+	_, monitorCh, cleanup, err := client.PrepareSnapshot(cfg, "/dev/vg/orig", logger)
+	if err != nil {
+		t.Fatalf("PrepareSnapshot error: %v", err)
+	}
+
+	<-ready
+	cleanup()
+
+	select {
+	case err, ok := <-monitorCh:
+		if !ok {
+			t.Fatalf("expected monitor error")
+		}
+		if err == nil {
+			t.Fatalf("expected error from monitor, got nil")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timeout waiting for monitor error")
+	}
+
+	if _, ok := <-monitorCh; ok {
+		t.Fatalf("expected closed monitor channel")
 	}
 }


### PR DESCRIPTION
## Summary
- ensure snapshot monitor goroutine closes its error channel and remove cleanup close
- add TestCreateSnapshotCleanupNoPanic to verify monitor channel closes without panic
- document channel closing behavior in AGENTS.md and README

## Testing
- `go build ./...`
- `go test ./internal/client`


------
https://chatgpt.com/codex/tasks/task_e_6899135b743c8323869afc28c45aab92