### PR TITLE
docs: expand configuration examples and add sync todo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - [ ] Implement real transports for QUIC, HTTP/2, TCP+TLS, and SSH; replace placeholders with functional backends and tests.
 - [ ] Add privilege escalation (`privesc`) tests covering success and error paths.
 - [ ] Expand coverage for configuration precedence across flags, environment variables, and config files.
+- [ ] Keep README configuration examples and precedence tests in sync.
  - [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).
 - [ ] Document gRPC daemon configuration sources (flags, env vars, config file) and precedence.
 - [ ] Keep `README` configuration documentation current with code changes.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ Logger.Warn("Zero-copy transfer failed",
 LVMSync uses [`pflag`](https://github.com/spf13/pflag) and [`viper`](https://github.com/spf13/viper) to accept options from
 flags, environment variables, and a YAML file.
 
+### Examples
+
+Set the `parallel` worker count using any configuration source:
+
+CLI flag:
+
+```sh
+lvmsync --parallel 16
+```
+
+Environment variable:
+
+```sh
+LVMSYNC_PARALLEL=16 lvmsync
+```
+
+`config.yaml`:
+
+```yaml
+parallel: 16
+```
+
 ### Flag groups
 
 Flags are grouped in the CLI help:


### PR DESCRIPTION
## Summary
- document flag, env var, and config file examples in the Configuration section
- add TODO to keep README examples and precedence tests synchronized

## Testing
- `go test -cover ./...` (fails: TestHandshakeAndAck timed out)
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689911ec397c832388532135644c384a