### PR TITLE
test(privesc): skip EnsureRootAlreadyRoot when not root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 
  - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.
 - [ ] Implement real transports for QUIC, HTTP/2, TCP+TLS, and SSH; replace placeholders with functional backends and tests.
-- [ ] Add privilege escalation (`privesc`) tests covering success and error paths.
+- [ ] Add privilege escalation (`privesc`) tests covering success and error paths (tests require root; skipped otherwise).
 - [ ] Expand coverage for configuration precedence across flags, environment variables, and config files.
 - [ ] Keep README configuration examples and precedence tests in sync.
  - [ ] Keep modules single-purpose; maintain the `transfer` package decomposition (`progress.go`, `handshake.go`, `block_writer.go`).

--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,8 @@ go test -coverprofile=coverage.out ./...
 go tool cover -func=coverage.out
 ```
 
+Some tests, such as those in `internal/privesc`, require root privileges and are skipped when run unprivileged.
+
 The workflow enforces a minimum of 50% total coverage.
 
 ## License

--- a/internal/privesc/privesc_test.go
+++ b/internal/privesc/privesc_test.go
@@ -25,6 +25,9 @@ func dropPriv(t *testing.T) func() {
 }
 
 func TestEnsureRootAlreadyRoot(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root")
+	}
 	called := false
 	err := EnsureRoot("sudo -n", func(argv0 string, argv []string, envv []string) error {
 		called = true


### PR DESCRIPTION
## Summary
- skip `TestEnsureRootAlreadyRoot` when not running as root
- document root requirement for privesc tests in README and AGENTS TODO

## Testing
- `sudo -u nobody env GOROOT=/usr/lib/go-1.22 GOMODCACHE=/tmp/gomodcache GOCACHE=/tmp/gocache GOPATH=/tmp/gopath go test -run TestEnsureRootAlreadyRoot -v ./internal/privesc`
- `go test -run TestEnsureRootAlreadyRoot -v ./internal/privesc`
- `go test ./internal/privesc`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899195988dc8323be36891992f91740