### PR TITLE
fix: resolve data races in gRPC and snapshot handling

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,12 +29,12 @@ func (f *fakeListener) Close() error              { return nil }
 func (f *fakeListener) Addr() net.Addr            { return &net.TCPAddr{} }
 
 type fakeServer struct {
-	served  bool
-	stopped bool
+	served  atomic.Bool
+	stopped atomic.Bool
 }
 
-func (f *fakeServer) Serve(net.Listener) error { f.served = true; return nil }
-func (f *fakeServer) GracefulStop()            { f.stopped = true }
+func (f *fakeServer) Serve(net.Listener) error { f.served.Store(true); return nil }
+func (f *fakeServer) GracefulStop()            { f.stopped.Store(true) }
 
 func TestStartGRPCServerSuccess(t *testing.T) {
 	cfg := &config.Config{GRPCListen: "127.0.0.1:0"}
@@ -50,11 +51,11 @@ func TestStartGRPCServerSuccess(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	time.Sleep(10 * time.Millisecond)
-	if !srv.served {
+	if !srv.served.Load() {
 		t.Fatalf("server not started")
 	}
 	cleanup()
-	if !srv.stopped {
+	if !srv.stopped.Load() {
 		t.Fatalf("server not stopped")
 	}
 }

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -85,14 +85,10 @@ func AckStream(ctx context.Context, c proto.ReplicationClient, sessionID string)
 	if err != nil {
 		return nil, err
 	}
-	go func() {
-		for {
-			if _, err := stream.Recv(); err != nil {
-				return
-			}
-		}
-	}()
 	if err := stream.Send(&proto.Ack{SessionId: sessionID, Ok: true, Message: "init"}); err != nil {
+		return nil, err
+	}
+	if _, err := stream.Recv(); err != nil {
 		return nil, err
 	}
 	return stream, nil

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -149,9 +149,10 @@ func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotB
 	logger.Info("Snapshot created", zap.String("snapshot", snapshotPath))
 
 	monitorCtx, cancel := context.WithCancel(context.Background())
+	mon := monitorSnapshot
 	go func() {
 		defer close(monitorErrCh)
-		if err := monitorSnapshot(monitorCtx, snapshotPath, 80.0, 10*time.Second); err != nil && err != context.Canceled {
+		if err := mon(monitorCtx, snapshotPath, 80.0, 10*time.Second); err != nil && err != context.Canceled {
 			logger.Error("Snapshot monitor error", zap.Error(err))
 			select {
 			case monitorErrCh <- err:


### PR DESCRIPTION
## Summary
- make test server state concurrency-safe
- remove background receiver from AckStream and wait for initial ack
- capture snapshot monitor function to avoid races when overridden

## Testing
- `go test -race ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689926feae148323b8366621d7dbe392