### PR TITLE
feat: add quic serve command with negotiation

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -11,6 +11,7 @@ import (
 	"lvmsync_go/app"
 	applycmd "lvmsync_go/cmd/apply"
 	dumpcmd "lvmsync_go/cmd/dump"
+	servecmd "lvmsync_go/cmd/serve"
 	"lvmsync_go/config"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privesc"
@@ -26,6 +27,7 @@ var (
 	executeClientFn   = clientpkg.ExecuteClient
 	selectTransport   = dumpcmd.SelectTransport
 	runDump           = dumpcmd.Run
+	runServe          = servecmd.Run
 )
 
 // SyncLogger flushes buffered log entries and logs if syncing fails.
@@ -97,6 +99,10 @@ func ExecuteClient(cfg *config.Config, snapshotPath, destPath string, sigErrCh, 
 
 // Run orchestrates the command execution.
 func Run(cfg *config.Config, logger *zap.Logger) error {
+	if cfg.Serve {
+		return runServe(cfg, logger)
+	}
+
 	defer lvm.Cleanup()
 
 	if err := selectTransport(cfg, logger); err != nil {

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -1,0 +1,63 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"go.uber.org/zap"
+
+	q "github.com/quic-go/quic-go"
+
+	"lvmsync_go/config"
+	qn "lvmsync_go/quic"
+)
+
+// acceptFunc allows tests to override the listener and stream acceptance logic.
+var acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) {
+	tlsConf, err := qn.NewTLSConfig(qn.Config{
+		TLSCert:       cfg.TLSCert,
+		TLSKey:        cfg.TLSKey,
+		CACert:        cfg.CACert,
+		AllowInsecure: cfg.AllowInsecure,
+	}, true)
+	if err != nil {
+		return nil, err
+	}
+	l, err := q.ListenAddr(cfg.ServeListen, tlsConf, qn.NewQUICConfig())
+	if err != nil {
+		return nil, err
+	}
+	conn, err := l.Accept(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	stream, err := conn.AcceptStream(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return stream, nil
+}
+
+// Run starts the QUIC server, negotiates parameters, and enforces the transfer policy.
+func Run(cfg *config.Config, logger *zap.Logger) error {
+	stream, err := acceptFunc(cfg)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+
+	expected := qn.Negotiation{
+		Protocol:  cfg.ServeProtocol,
+		Algorithm: cfg.ServeAlgorithm,
+		TestSpace: cfg.ServeTestSpace,
+	}
+	if err := qn.Negotiate(stream, expected); err != nil {
+		return err
+	}
+	if cfg.ServePolicy != "" && cfg.ServePolicy != "accept" {
+		return fmt.Errorf("transfer policy %s not accepted", cfg.ServePolicy)
+	}
+	logger.Info("serve: negotiation complete")
+	return nil
+}

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -1,0 +1,36 @@
+package serve
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+	qn "lvmsync_go/quic"
+)
+
+func TestRunAcceptsTransfer(t *testing.T) {
+	server, client := net.Pipe()
+	orig := acceptFunc
+	acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
+	defer func() { acceptFunc = orig }()
+
+	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "accept"}
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run(cfg, zap.NewNop()) }()
+
+	hs := qn.Negotiation{Protocol: "proto", Algorithm: "alg", TestSpace: "ts"}
+	if err := qn.WriteNegotiation(client, hs); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	if got, err := qn.ReadNegotiation(bufio.NewReader(client)); err != nil || got != hs {
+		t.Fatalf("unexpected ack: %v %v", got, err)
+	}
+	client.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ var (
 	lvmFlags         *pflag.FlagSet
 	grpcFlags        *pflag.FlagSet
 	transportFlags   *pflag.FlagSet
+	serveFlags       *pflag.FlagSet
 )
 
 var getEuid = os.Geteuid
@@ -117,6 +118,13 @@ type Config struct {
 	CheckpointInterval    time.Duration `mapstructure:"checkpoint_interval"`
 	QUICCongestionControl string        `mapstructure:"quic_cc"`
 	SyncIntervalBytes     int           `mapstructure:"-"`
+
+	Serve          bool   `mapstructure:"serve"`
+	ServeListen    string `mapstructure:"serve_listen"`
+	ServeProtocol  string `mapstructure:"serve_protocol"`
+	ServeAlgorithm string `mapstructure:"serve_algorithm"`
+	ServeTestSpace string `mapstructure:"serve_test_space"`
+	ServePolicy    string `mapstructure:"serve_policy"`
 }
 
 func FormatBlockSize(blockSize int) (string, error) {
@@ -438,6 +446,12 @@ func DefaultConfig() (*Config, error) {
 		CheckpointInterval:    0,
 		QUICCongestionControl: "",
 		SyncIntervalBytes:     1000000000,
+		Serve:                 false,
+		ServeListen:           ":9000",
+		ServeProtocol:         "lvmsync",
+		ServeAlgorithm:        "sha256",
+		ServeTestSpace:        "",
+		ServePolicy:           "accept",
 	}, nil
 }
 
@@ -543,6 +557,17 @@ func initTransportFlags(cfg *Config) *pflag.FlagSet {
 	return fs
 }
 
+func initServeFlags(cfg *Config) *pflag.FlagSet {
+	fs := pflag.NewFlagSet("Serve Options", pflag.ExitOnError)
+	fs.Bool("serve", cfg.Serve, "Run in serve mode")
+	fs.String("serve_listen", cfg.ServeListen, "QUIC listen address")
+	fs.String("serve_protocol", cfg.ServeProtocol, "Protocol to negotiate")
+	fs.String("serve_algorithm", cfg.ServeAlgorithm, "Algorithm to negotiate")
+	fs.String("serve_test_space", cfg.ServeTestSpace, "Test-space option")
+	fs.String("serve_policy", cfg.ServePolicy, "Transfer policy")
+	return fs
+}
+
 func initFlagSets(defaultCfg *Config) {
 	generalFlags = initGeneralFlags(defaultCfg)
 	sshFlags = initSSHFlags(defaultCfg)
@@ -552,6 +577,7 @@ func initFlagSets(defaultCfg *Config) {
 	lvmFlags = initLVMFlags(defaultCfg)
 	grpcFlags = initGRPCFlags(defaultCfg)
 	transportFlags = initTransportFlags(defaultCfg)
+	serveFlags = initServeFlags(defaultCfg)
 }
 
 func printFlagSetUsage(out io.Writer, fs *pflag.FlagSet) {
@@ -575,6 +601,7 @@ func registerFlags(defaultCfg *Config) {
 		lvmFlags,
 		grpcFlags,
 		transportFlags,
+		serveFlags,
 	}
 	for _, fs := range flagSets {
 		pflag.CommandLine.AddFlagSet(fs)

--- a/config/serve_flags_test.go
+++ b/config/serve_flags_test.go
@@ -1,0 +1,17 @@
+package config
+
+import "testing"
+
+func TestServeFlagParsing(t *testing.T) {
+	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.Serve {
+		t.Fatalf("expected Serve true")
+	}
+	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" {
+		t.Fatalf("unexpected serve config: %+v", cfg)
+	}
+}

--- a/quic/handshake.go
+++ b/quic/handshake.go
@@ -1,0 +1,67 @@
+package quic
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Negotiation describes parameters exchanged during a QUIC handshake.
+type Negotiation struct {
+	Protocol  string
+	Algorithm string
+	TestSpace string
+}
+
+// WriteNegotiation serializes n to w.
+func WriteNegotiation(w io.Writer, n Negotiation) error {
+	tokens := []string{n.Protocol}
+	if n.Algorithm != "" {
+		tokens = append(tokens, "algo:"+n.Algorithm)
+	}
+	if n.TestSpace != "" {
+		tokens = append(tokens, "test:"+n.TestSpace)
+	}
+	if _, err := fmt.Fprintln(w, strings.Join(tokens, " ")); err != nil {
+		return fmt.Errorf("write negotiation: %w", err)
+	}
+	return nil
+}
+
+// ReadNegotiation parses a negotiation from r.
+func ReadNegotiation(r *bufio.Reader) (Negotiation, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return Negotiation{}, fmt.Errorf("read negotiation: %w", err)
+	}
+	parts := strings.Fields(strings.TrimSpace(line))
+	if len(parts) == 0 {
+		return Negotiation{}, fmt.Errorf("empty negotiation")
+	}
+	n := Negotiation{Protocol: parts[0]}
+	for _, p := range parts[1:] {
+		switch {
+		case strings.HasPrefix(p, "algo:"):
+			n.Algorithm = strings.TrimPrefix(p, "algo:")
+		case strings.HasPrefix(p, "test:"):
+			n.TestSpace = strings.TrimPrefix(p, "test:")
+		default:
+			return Negotiation{}, fmt.Errorf("unexpected token %s", p)
+		}
+	}
+	return n, nil
+}
+
+// Negotiate performs a negotiation on rw and echoes the parameters back.
+func Negotiate(rw io.ReadWriter, expected Negotiation) error {
+	br := bufio.NewReader(rw)
+	n, err := ReadNegotiation(br)
+	if err != nil {
+		return err
+	}
+	if n.Protocol != expected.Protocol || n.Algorithm != expected.Algorithm || n.TestSpace != expected.TestSpace {
+		return fmt.Errorf("negotiation mismatch")
+	}
+	return WriteNegotiation(rw, expected)
+}

--- a/quic/handshake_test.go
+++ b/quic/handshake_test.go
@@ -1,0 +1,47 @@
+package quic
+
+import (
+	"bufio"
+	"net"
+	"testing"
+)
+
+func TestNegotiate(t *testing.T) {
+	server, client := net.Pipe()
+	expected := Negotiation{Protocol: "proto", Algorithm: "alg", TestSpace: "ts"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Negotiate(server, expected)
+		server.Close()
+	}()
+	if err := WriteNegotiation(client, expected); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	got, err := ReadNegotiation(bufio.NewReader(client))
+	if err != nil {
+		t.Fatalf("read negotiation: %v", err)
+	}
+	if got != expected {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("negotiate error: %v", err)
+	}
+}
+
+func TestNegotiateMismatch(t *testing.T) {
+	server, client := net.Pipe()
+	expected := Negotiation{Protocol: "proto", Algorithm: "alg", TestSpace: "ts"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Negotiate(server, expected)
+		server.Close()
+	}()
+	if err := WriteNegotiation(client, Negotiation{Protocol: "proto", Algorithm: "other", TestSpace: "ts"}); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	_ = client.Close()
+	if err := <-errCh; err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add `serve` command for QUIC listening and transfer policy
- bind serve flags to config and integrate with root command
- implement handshake negotiation for protocol/algorithm/test-space

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899c941694c8323acc94e89825f6ced