### PR TITLE
refactor(config): drop redundant sudo path flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--ssh_timeout` | `LVMSYNC_SSH_TIMEOUT` | `ssh_timeout` | SSH connection timeout |
 | `--ssh_keepalive` | `LVMSYNC_SSH_KEEPALIVE` | `ssh_keepalive` | SSH keepalive interval |
 | `--known_hosts` | `LVMSYNC_KNOWN_HOSTS` | `known_hosts` | Path to known_hosts file |
-| `--stricthostkeychecking` | `LVMSYNC_STRICTHOSTKEYCHECKING` | `strict_host_key_checking` | Enable SSH StrictHostKeyChecking |
+| `--strict_host_key_checking` | `LVMSYNC_STRICT_HOST_KEY_CHECKING` | `strict_host_key_checking` | Require host keys to be present in `known_hosts` |
 | `--lvmsync_path` | `LVMSYNC_LVMSYNC_PATH` | `lvmsync_path` | Remote command to run |
 | `--remote_pre_script` | `LVMSYNC_REMOTE_PRE_SCRIPT` | `remote_pre_script` | Remote script to run before transfer |
 | `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer |
@@ -315,7 +315,6 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--tls_key` | `LVMSYNC_TLS_KEY` | `tls_key` | TLS key file |
 | `--ca_cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
 | `--allow_insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
-| `--sudo_path` | `LVMSYNC_SUDO_PATH` | `sudo_path` | Path to sudo executable |
 
 ### Common deployment scenarios
 
@@ -673,7 +672,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--ssh_key`               | Path to SSH private key or use the SSH agent                    | `""`                     |
 | `--ssh_port`              | SSH port number                                                 | `22`                     |
 | `--known_hosts`           | Path to known_hosts file (defaults to `$HOME/.ssh/known_hosts`) | `$HOME/.ssh/known_hosts` |
-| `--stricthostkeychecking` | Enable SSH StrictHostKeyChecking                                | `true`                   |
+| `--strict_host_key_checking` | Require host keys to be present in `known_hosts`            | `true`                   |
 
 Programmatic use of the SSH transport requires a configuration populated with
 fields like `SSHUser`, `SSHKeyPath`, `SSHPort`, `KnownHosts`,
@@ -739,7 +738,6 @@ sender, receiver, err := ssh.New(cfg, logger)
 | `--tls-key`        | TLS key file                 | `""`            |
 | `--ca-cert`        | CA certificate file          | `""`            |
 | `--allow-insecure` | Allow insecure (disable TLS) | `false`         |
-| `--sudo_path`      | Path to sudo executable      | `/usr/bin/sudo` |
 
 ### Examples
 

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,6 @@ tls_cert: ""  # TLS certificate file
 tls_key: ""  # TLS key file
 ca_cert: ""  # CA certificate file
 allow_insecure: true  # Allow running without TLS
-sudo_path: "/usr/bin/sudo"  # Path to sudo executable
 
 # Deduplication Options
 # Strategy: "none", "auto", "checksum", "rolling_hash", or "bloom"

--- a/config/config.go
+++ b/config/config.go
@@ -107,7 +107,6 @@ type Config struct {
 	TLSKey                string        `mapstructure:"tls_key"`
 	CACert                string        `mapstructure:"ca_cert"`
 	AllowInsecure         bool          `mapstructure:"allow_insecure"`
-	SudoPath              string        `mapstructure:"sudo_path"`
 	Transport             string        `mapstructure:"transport"`
 	QUICListen            string        `mapstructure:"quic_listen"`
 	QUICConnect           string        `mapstructure:"quic_connect"`
@@ -183,9 +182,6 @@ func (b *Builder) applyDefaults(conf *Config) error {
 	}
 	if conf.GRPCPort == 0 {
 		conf.GRPCPort = b.defaults.GRPCPort
-	}
-	if conf.SudoPath == "" {
-		conf.SudoPath = b.defaults.SudoPath
 	}
 	if conf.Transport == "" {
 		conf.Transport = b.defaults.Transport
@@ -428,7 +424,6 @@ func DefaultConfig() (*Config, error) {
 		TLSKey:                "",
 		CACert:                "",
 		AllowInsecure:         true,
-		SudoPath:              "/usr/bin/sudo",
 		Transport:             "quic,h2,tcp+tls,ssh",
 		QUICListen:            "",
 		QUICConnect:           "",
@@ -471,7 +466,7 @@ func initSSHFlags(cfg *Config) *pflag.FlagSet {
 	fs.Duration("ssh_timeout", cfg.SSHTimeout, "SSH connection timeout")
 	fs.Duration("ssh_keepalive", cfg.SSHKeepAliveInterval, "SSH keepalive interval")
 	fs.String("known_hosts", cfg.KnownHosts, "Path to known_hosts file")
-	fs.Bool("stricthostkeychecking", cfg.StrictHostKeyCheck, "Enable SSH StrictHostKeyChecking")
+	fs.Bool("strict_host_key_checking", cfg.StrictHostKeyCheck, "Require host keys to be present in known_hosts")
 	return fs
 }
 
@@ -528,7 +523,6 @@ func initGRPCFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("tls_key", cfg.TLSKey, "TLS key file")
 	fs.String("ca_cert", cfg.CACert, "CA certificate file")
 	fs.Bool("allow_insecure", cfg.AllowInsecure, "Allow insecure (no TLS)")
-	fs.String("sudo_path", cfg.SudoPath, "Path to sudo executable")
 	return fs
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,6 +65,16 @@ func TestDefaultConfigBlockSize(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigStrictHostKeyCheck(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	if !cfg.StrictHostKeyCheck {
+		t.Fatalf("expected StrictHostKeyCheck to default to true")
+	}
+}
+
 func TestHumanBlockSize(t *testing.T) {
 	c := &Config{BlockSize: 0}
 	if c.HumanBlockSize() != Auto {
@@ -187,6 +197,20 @@ func TestBuilderValidateCompression(t *testing.T) {
 
 	t.Run(Zstd+"Invalid", func(t *testing.T) {
 		conf := &Config{Compress: Zstd, ZstdLevel: 6, CompressThreshold: 0.9}
+		if err := b.validateCompression(conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("invalidThresholdTooHigh", func(t *testing.T) {
+		conf := &Config{Compress: Zstd, ZstdLevel: 3, CompressThreshold: 1.1}
+		if err := b.validateCompression(conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("invalidThresholdNonPositive", func(t *testing.T) {
+		conf := &Config{Compress: Zstd, ZstdLevel: 3, CompressThreshold: 0}
 		if err := b.validateCompression(conf); err == nil {
 			t.Fatalf("expected error")
 		}

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -55,7 +55,7 @@ func TestInitSSHFlags(t *testing.T) {
 		{"ssh_timeout", cfg.SSHTimeout.String()},
 		{"ssh_keepalive", cfg.SSHKeepAliveInterval.String()},
 		{"known_hosts", cfg.KnownHosts},
-		{"stricthostkeychecking", strconv.FormatBool(cfg.StrictHostKeyCheck)},
+		{"strict_host_key_checking", strconv.FormatBool(cfg.StrictHostKeyCheck)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)
@@ -182,7 +182,6 @@ func TestInitGRPCFlags(t *testing.T) {
 		{"tls_key", cfg.TLSKey},
 		{"ca_cert", cfg.CACert},
 		{"allow_insecure", strconv.FormatBool(cfg.AllowInsecure)},
-		{"sudo_path", cfg.SudoPath},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)


### PR DESCRIPTION
## Summary
- remove unused `sudo_path` configuration option
- rename SSH flag to `--strict_host_key_checking`
- document simplified flag set and add tests for defaults and compression threshold errors

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899c9fc3d2c8323a552d0baef84bf44