### PR TITLE
feat(config): bind flag sets with env prefix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -566,16 +566,7 @@ func printFlagSetUsage(out io.Writer, fs *pflag.FlagSet) {
 
 func registerFlags(defaultCfg *Config) {
 	initFlagSets(defaultCfg)
-	flagSets := []*pflag.FlagSet{
-		generalFlags,
-		sshFlags,
-		remoteFlags,
-		dedupFlags,
-		compressionFlags,
-		lvmFlags,
-		grpcFlags,
-		transportFlags,
-	}
+	flagSets := allFlagSets()
 	for _, fs := range flagSets {
 		pflag.CommandLine.AddFlagSet(fs)
 	}
@@ -590,17 +581,32 @@ func registerFlags(defaultCfg *Config) {
 	pflag.Usage = pflag.CommandLine.Usage
 }
 
+func allFlagSets() []*pflag.FlagSet {
+	return []*pflag.FlagSet{
+		generalFlags,
+		sshFlags,
+		remoteFlags,
+		dedupFlags,
+		compressionFlags,
+		lvmFlags,
+		grpcFlags,
+		transportFlags,
+	}
+}
+
 func buildViper() (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")
 	v.AddConfigPath(".")
-	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.SetEnvPrefix("LVMSYNC")
+	v.AutomaticEnv()
 
-	if err := v.BindPFlags(pflag.CommandLine); err != nil {
-		return nil, err
+	for _, fs := range allFlagSets() {
+		if err := v.BindPFlags(fs); err != nil {
+			return nil, err
+		}
 	}
 	if cfgFile := v.GetString("config"); cfgFile != "" {
 		v.SetConfigFile(cfgFile)

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -104,3 +104,55 @@ func TestFlagSetsBindToViper(t *testing.T) {
 		t.Fatalf("grpc_port got %d want 9999", got)
 	}
 }
+
+func TestSSHUserCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "ssh_user: config\n")
+	resetFlags([]string{"--config", cfgPath, "--ssh_user", "cli"})
+	t.Setenv("LVMSYNC_SSH_USER", "env")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	registerFlags(defaults)
+	pflag.Parse()
+
+	v, err := buildViper()
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.SSHUser != "cli" {
+		t.Fatalf("expected ssh_user cli, got %s", conf.SSHUser)
+	}
+}
+
+func TestSSHUserEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "ssh_user: config\n")
+	resetFlags([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_SSH_USER", "env")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	registerFlags(defaults)
+	pflag.Parse()
+
+	v, err := buildViper()
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.SSHUser != "env" {
+		t.Fatalf("expected ssh_user env, got %s", conf.SSHUser)
+	}
+}


### PR DESCRIPTION
## Summary
- bind each FlagSet to viper and enable `LVMSYNC` env prefix
- add tests verifying CLI, environment, and config precedence for ssh flags

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899ca3338bc8323a4c66d5e14bb393d