### PR TITLE
docs: document serve command and add todos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,17 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
   golangci-lint run
   ```
 
- - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.
+- [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.
+- [ ] Implement QUIC `serve` command with minimal flags and `zap`-only logging.
+- [ ] Audit `serve` and related CLI flags for simplification and consistency.
+- [ ] Update `README` and configuration docs for `serve` mode and flag changes.
+- [ ] Add unit tests for the `serve` command and flag parsing.
+
+  ```sh
+  go build ./...
+  go test -cover ./...
+  golangci-lint run
+  ```
 - [ ] Implement real transports for QUIC, HTTP/2, TCP+TLS, and SSH; replace placeholders with functional backends and tests.
 - [ ] Add privilege escalation (`privesc`) tests covering success and error paths (tests require root; skipped otherwise).
 - [ ] Expand coverage for configuration precedence across flags, environment variables, and config files.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -10,6 +10,10 @@ LVMSync provides high-performance block-level replication for LVM snapshots on 6
 - Resume and deduplicate transfers to minimize bandwidth usage.
 - Easy to operate locally or over SSH with configurable options.
 
+## Serve Command and Logging
+
+The planned `serve` subcommand will expose a QUIC listener for incoming replication requests. It follows an argument simplification philosophy, surfacing only essential flags while relying on configuration binding for advanced tuning. All logging for this command must use the structured `zap` logger.
+
 ## Identified Gaps
 
 1. **Deduplication State Loading** – deduplication strategies save state but never load existing state files on startup.
@@ -46,6 +50,28 @@ LVMSync provides high-performance block-level replication for LVM snapshots on 6
 5. **Extended Documentation**
    - Document package architecture and developer guidelines.
    - Explain how to run tests and CI locally.
+
+6. **Implement QUIC Serve Command**
+   - Build the `serve` subcommand with a minimal flag surface.
+   - Enforce `zap` for structured logging.
+
+7. **Audit Flag Surface**
+   - Review existing CLI flags for redundancy and simplification.
+   - Keep documentation and configuration options consistent.
+
+8. **Update Serve Documentation**
+   - Document `serve` usage in `README` and configuration examples.
+
+9. **Add Serve Tests**
+   - Provide unit tests covering command behavior and flag parsing.
+
+Contributors tackling these tasks must run:
+
+```sh
+go build ./...
+go test -cover ./...
+golangci-lint run
+```
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- document planned QUIC `serve` command and logging philosophy
- add TODO items for serve command implementation, flag audit, documentation, and tests
- note required build, test, and lint checks for these areas

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestServeFlagParsing expected Serve true)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_6899ce9a0f98832392defb53b090df50