### PR TITLE
Add serve flag parsing and QUIC negotiation tests

### DIFF
--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"os"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
@@ -32,5 +34,68 @@ func TestRunAcceptsTransfer(t *testing.T) {
 	client.Close()
 	if err := <-errCh; err != nil {
 		t.Fatalf("Run error: %v", err)
+	}
+}
+
+// resetFlags replaces the global command line flags and sets os.Args.
+func resetFlags(args []string) {
+	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
+	pflag.CommandLine.SetOutput(io.Discard)
+	os.Args = append([]string{"test"}, args...)
+}
+
+func TestServeFlagParsing(t *testing.T) {
+	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.Serve {
+		t.Fatalf("expected Serve true")
+	}
+	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" {
+		t.Fatalf("unexpected serve config: %+v", cfg)
+	}
+}
+
+func TestRunNegotiationMismatch(t *testing.T) {
+	server, client := net.Pipe()
+	orig := acceptFunc
+	acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
+	defer func() { acceptFunc = orig }()
+
+	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "accept"}
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run(cfg, zap.NewNop()) }()
+
+	if err := qn.WriteNegotiation(client, qn.Negotiation{Protocol: "proto", Algorithm: "other", TestSpace: "ts"}); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	client.Close()
+	if err := <-errCh; err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRunRejectsPolicy(t *testing.T) {
+	server, client := net.Pipe()
+	orig := acceptFunc
+	acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
+	defer func() { acceptFunc = orig }()
+
+	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "deny"}
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run(cfg, zap.NewNop()) }()
+
+	hs := qn.Negotiation{Protocol: "proto", Algorithm: "alg", TestSpace: "ts"}
+	if err := qn.WriteNegotiation(client, hs); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	if _, err := qn.ReadNegotiation(bufio.NewReader(client)); err != nil {
+		t.Fatalf("read negotiation: %v", err)
+	}
+	client.Close()
+	if err := <-errCh; err == nil {
+		t.Fatalf("expected error")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -611,6 +611,7 @@ func allFlagSets() []*pflag.FlagSet {
 		lvmFlags,
 		grpcFlags,
 		transportFlags,
+		serveFlags,
 	}
 }
 

--- a/quic/handshake_test.go
+++ b/quic/handshake_test.go
@@ -3,6 +3,7 @@ package quic
 import (
 	"bufio"
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -42,6 +43,20 @@ func TestNegotiateMismatch(t *testing.T) {
 	}
 	_ = client.Close()
 	if err := <-errCh; err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReadNegotiationEmpty(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("\n"))
+	if _, err := ReadNegotiation(r); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReadNegotiationUnexpectedToken(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("proto extra\n"))
+	if _, err := ReadNegotiation(r); err == nil {
 		t.Fatalf("expected error")
 	}
 }


### PR DESCRIPTION
## Summary
- ensure serve flags are registered with configuration loading
- add cmd/serve tests for flag parsing, negotiation mismatch, and policy rejection
- cover empty and invalid QUIC negotiation tokens

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899cea254f88323bc585a7eb78e9efe