### PR TITLE
ci: add pre-merge checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,13 +78,14 @@ jobs:
           git diff --exit-code -- go.mod go.sum || {
             echo "go.mod/go.sum changed after tidy. Commit the changes."; exit 1; }
 
-      - name: Build project
-        run: go build -v ./...
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
-      - name: Run tests
-        run: |
-          go test -coverprofile=coverage.out ./...
-          go tool cover -func=coverage.out | tail -n 1
+      - name: Build, test, and lint
+        run: make verify
+
+      - name: Show coverage
+        run: go tool cover -func=coverage.out | tail -n 1
 
       - name: Enforce coverage threshold
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,15 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 - Follow the guidelines in `CONTRIBUTING.md`.
 - Commit messages must follow the Conventional Commits format: `type(scope): description`.
 
+## Pre-Merge Checklist
+
+Run these commands locally before opening a pull request:
+
+- `go build ./...`
+- `go test -coverprofile=coverage.out ./...`
+- `golangci-lint run`
+- `go tool cover -func=coverage.out` and ensure total coverage is at least 50%
+
 ## Production Readiness Checklist
 
 - Use `zap` for all structured logging and call `logger.Sync()` on shutdown.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: proto build test
+.PHONY: proto build test lint verify
 
 proto:
 	protoc --go_out=. --go-grpc_out=. --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative proto/replication.proto
@@ -9,4 +9,12 @@ build:
 	go build -o bin/grpcd ./cmd/grpcd
 
 test:
-	go test ./...
+	go test -coverprofile=coverage.out ./...
+
+lint:
+	golangci-lint run
+
+verify:
+	go build ./...
+	go test -coverprofile=coverage.out ./...
+	golangci-lint run


### PR DESCRIPTION
## Summary
- document build, test, lint, and coverage steps in `AGENTS.md`
- add `verify` target to run go build, go test with coverage, and golangci-lint
- ensure CI runs verification target and enforces coverage

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: expected Serve true)*
- `golangci-lint run` *(fails: can't load config: sort-results should be 'true' to use sort-order)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6899ced469088323a358e1d0fbb0f450