### PR TITLE
feat: add foundational privilege, device, hash, compression, frame, limiter packages

### DIFF
--- a/internal/compress/auto.go
+++ b/internal/compress/auto.go
@@ -1,0 +1,29 @@
+// Package compress includes an auto codec that picks LZ4 for smaller inputs and
+// Zstd for larger ones, returning the original data when compression is not
+// beneficial.
+package compress
+
+// Auto selects a codec based on input size.
+type Auto struct {
+	lz4  Codec
+	zstd Codec
+}
+
+// NewAuto returns an auto-selecting codec.
+func NewAuto() Codec { return &Auto{lz4: NewLZ4(), zstd: NewZstd()} }
+
+// Compress chooses LZ4 for inputs <256KiB otherwise Zstd.
+func (a *Auto) Compress(in []byte) ([]byte, bool, error) {
+	if len(in) < 256<<10 {
+		return a.lz4.Compress(in)
+	}
+	return a.zstd.Compress(in)
+}
+
+// Decompress tries Zstd first then falls back to LZ4.
+func (a *Auto) Decompress(in []byte) ([]byte, error) {
+	if out, err := a.zstd.Decompress(in); err == nil {
+		return out, nil
+	}
+	return a.lz4.Decompress(in)
+}

--- a/internal/compress/codec.go
+++ b/internal/compress/codec.go
@@ -1,0 +1,9 @@
+// Package compress provides pluggable compression codecs with an auto mode that
+// selects between LZ4 and Zstd based on input size.
+package compress
+
+// Codec compresses and decompresses byte slices.
+type Codec interface {
+	Compress(in []byte) (out []byte, used bool, err error)
+	Decompress(in []byte) ([]byte, error)
+}

--- a/internal/compress/compress_test.go
+++ b/internal/compress/compress_test.go
@@ -1,0 +1,54 @@
+package compress
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestLZ4RoundTrip(t *testing.T) {
+	c := NewLZ4()
+	in := bytes.Repeat([]byte{1}, 1024)
+	out, used, err := c.Compress(in)
+	if err != nil || !used {
+		t.Fatalf("compress: %v", err)
+	}
+	dec, err := c.Decompress(out)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if !bytes.Equal(in, dec) {
+		t.Fatalf("mismatch")
+	}
+}
+
+func TestZstdRoundTrip(t *testing.T) {
+	c := NewZstd()
+	in := bytes.Repeat([]byte{2}, 1024)
+	out, used, err := c.Compress(in)
+	if err != nil || !used {
+		t.Fatalf("compress: %v", err)
+	}
+	dec, err := c.Decompress(out)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if !bytes.Equal(in, dec) {
+		t.Fatalf("mismatch")
+	}
+}
+
+func TestAuto(t *testing.T) {
+	c := NewAuto()
+	in := bytes.Repeat([]byte{3}, 1024)
+	out, used, err := c.Compress(in)
+	if err != nil || !used {
+		t.Fatalf("compress: %v", err)
+	}
+	dec, err := c.Decompress(out)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if !bytes.Equal(in, dec) {
+		t.Fatalf("mismatch")
+	}
+}

--- a/internal/compress/lz4.go
+++ b/internal/compress/lz4.go
@@ -1,0 +1,38 @@
+// Package compress offers an LZ4 codec using pierrec/lz4.
+package compress
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+// LZ4 implements the Codec interface.
+type LZ4 struct{}
+
+// NewLZ4 returns an LZ4 codec.
+func NewLZ4() Codec { return LZ4{} }
+
+// Compress encodes data with LZ4 using the framed format.
+func (LZ4) Compress(in []byte) ([]byte, bool, error) {
+	var buf bytes.Buffer
+	w := lz4.NewWriter(&buf)
+	if _, err := w.Write(in); err != nil {
+		return nil, false, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, false, err
+	}
+	out := buf.Bytes()
+	if len(out) >= len(in) {
+		return in, false, nil
+	}
+	return out, true, nil
+}
+
+// Decompress decodes LZ4 framed data.
+func (LZ4) Decompress(in []byte) ([]byte, error) {
+	r := lz4.NewReader(bytes.NewReader(in))
+	return io.ReadAll(r)
+}

--- a/internal/compress/zstd.go
+++ b/internal/compress/zstd.go
@@ -1,0 +1,32 @@
+// Package compress offers a Zstd codec using klauspost/compress.
+package compress
+
+import "github.com/klauspost/compress/zstd"
+
+// Zstd implements the Codec interface.
+type Zstd struct{}
+
+// NewZstd returns a Zstd codec.
+func NewZstd() Codec { return Zstd{} }
+
+// Compress encodes data with Zstd at level 1.
+func (Zstd) Compress(in []byte) ([]byte, bool, error) {
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		return nil, false, err
+	}
+	out := enc.EncodeAll(in, make([]byte, 0, len(in)))
+	if len(out) >= len(in) {
+		return in, false, nil
+	}
+	return out, true, nil
+}
+
+// Decompress decodes Zstd data.
+func (Zstd) Decompress(in []byte) ([]byte, error) {
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		return nil, err
+	}
+	return dec.DecodeAll(in, nil)
+}

--- a/internal/device/align.go
+++ b/internal/device/align.go
@@ -1,0 +1,8 @@
+// Package device includes alignment helpers for block operations.
+package device
+
+// AlignDown returns x rounded down to the nearest multiple of a.
+func AlignDown(x, a uint64) uint64 { return x & ^(a - 1) }
+
+// AlignUp returns x rounded up to the nearest multiple of a.
+func AlignUp(x, a uint64) uint64 { return (x + a - 1) & ^(a - 1) }

--- a/internal/device/io.go
+++ b/internal/device/io.go
@@ -1,0 +1,50 @@
+// Package device contains low-level helpers for opening block devices with
+// direct I/O and aligned read/write primitives.
+package device
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Reader wraps the ReadAt method of an io.ReaderAt compatible type.
+type Reader interface {
+	ReadAt(p []byte, off int64) (int, error)
+}
+
+// Writer writes at arbitrary offsets and supports syncing and optional discard.
+type Writer interface {
+	WriteAt(p []byte, off int64) (int, error)
+	Sync() error
+	Discard(off, length int64) error
+}
+
+// OpenDirect opens path using O_DIRECT for minimal caching. The file must be
+// closed by the caller.
+func OpenDirect(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_DIRECT, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// FileWriter provides aligned writes and optional discard support.
+type FileWriter struct{ *os.File }
+
+// WriteAt writes bytes at the given offset.
+func (w *FileWriter) WriteAt(p []byte, off int64) (int, error) { return w.File.WriteAt(p, off) }
+
+// Sync flushes the underlying file.
+func (w *FileWriter) Sync() error { return w.File.Sync() }
+
+// Discard punches a hole in the file when supported. A nil error is returned
+// if the operation is unsupported.
+func (w *FileWriter) Discard(off, length int64) error {
+	err := unix.Fallocate(int(w.File.Fd()), unix.FALLOC_FL_PUNCH_HOLE|unix.FALLOC_FL_KEEP_SIZE, off, length)
+	if err == unix.EOPNOTSUPP || err == unix.ENOSYS { // syscall may be missing
+		return nil
+	}
+	return err
+}

--- a/internal/device/io_test.go
+++ b/internal/device/io_test.go
@@ -1,0 +1,63 @@
+package device
+
+import (
+	"errors"
+	"golang.org/x/sys/unix"
+	"os"
+	"testing"
+)
+
+func TestAlign(t *testing.T) {
+	if AlignDown(4097, 4096) != 4096 {
+		t.Fatalf("algin down")
+	}
+	if AlignUp(4097, 4096) != 8192 {
+		t.Fatalf("align up")
+	}
+}
+
+func TestBlockSizes(t *testing.T) {
+	f, err := os.CreateTemp("", "blk")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	l, p, err := BlockSizes(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l <= 0 || p <= 0 {
+		t.Fatalf("invalid sizes")
+	}
+}
+
+func TestOpenDirect(t *testing.T) {
+	f, err := OpenDirect("/dev/zero")
+	if err != nil {
+		if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
+			t.Skip("O_DIRECT unsupported")
+		}
+		t.Fatalf("open direct: %v", err)
+	}
+	f.Close()
+}
+
+func TestFileWriter(t *testing.T) {
+	f, err := os.CreateTemp("", "w")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	w := &FileWriter{f}
+	if _, err := w.WriteAt([]byte("hi"), 0); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if err := w.Discard(0, 2); err != nil {
+		t.Fatalf("discard: %v", err)
+	}
+	f.Close()
+}

--- a/internal/device/probe.go
+++ b/internal/device/probe.go
@@ -1,0 +1,23 @@
+// Package device exposes helpers to determine logical and physical block sizes
+// for an opened file descriptor. Regular files default to 4096 bytes when the
+// ioctl is unsupported.
+package device
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// BlockSizes returns logical and physical block sizes in bytes.
+func BlockSizes(f *os.File) (logical, physical int, err error) {
+	l, err := unix.IoctlGetInt(int(f.Fd()), unix.BLKSSZGET)
+	if err != nil {
+		l = 4096
+	}
+	p, err := unix.IoctlGetInt(int(f.Fd()), unix.BLKPBSZGET)
+	if err != nil {
+		p = l
+	}
+	return l, p, nil
+}

--- a/internal/frame/binary.go
+++ b/internal/frame/binary.go
@@ -1,0 +1,45 @@
+// Package frame provides a simple binary implementation of the Framer
+// interface using little-endian encoding.
+package frame
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const headerSize = 52
+
+// Binary implements Framer with a fixed-size header followed by payload.
+type Binary struct{}
+
+// NewBinary returns a Framer that uses binary encoding.
+func NewBinary() Framer { return Binary{} }
+
+// Encode serializes h and appends payload.
+func (Binary) Encode(h Header, payload []byte) ([]byte, error) {
+	buf := make([]byte, headerSize+len(payload))
+	binary.LittleEndian.PutUint16(buf[0:2], h.Version)
+	binary.LittleEndian.PutUint16(buf[2:4], h.Flags)
+	binary.LittleEndian.PutUint64(buf[4:12], h.Offset)
+	binary.LittleEndian.PutUint32(buf[12:16], h.Length)
+	binary.LittleEndian.PutUint32(buf[16:20], h.CmpLen)
+	copy(buf[20:52], h.Hash[:])
+	copy(buf[headerSize:], payload)
+	return buf, nil
+}
+
+// Decode parses a frame into its header and payload.
+func (Binary) Decode(buf []byte) (Header, []byte, error) {
+	if len(buf) < headerSize {
+		return Header{}, nil, fmt.Errorf("short frame")
+	}
+	h := Header{
+		Version: binary.LittleEndian.Uint16(buf[0:2]),
+		Flags:   binary.LittleEndian.Uint16(buf[2:4]),
+		Offset:  binary.LittleEndian.Uint64(buf[4:12]),
+		Length:  binary.LittleEndian.Uint32(buf[12:16]),
+		CmpLen:  binary.LittleEndian.Uint32(buf[16:20]),
+	}
+	copy(h.Hash[:], buf[20:52])
+	return h, buf[headerSize:], nil
+}

--- a/internal/frame/frame_test.go
+++ b/internal/frame/frame_test.go
@@ -1,0 +1,28 @@
+package frame
+
+import "testing"
+
+func TestRoundTrip(t *testing.T) {
+	f := NewBinary()
+	hdr := Header{Version: 1, Flags: 2, Offset: 3, Length: 4, CmpLen: 5}
+	copy(hdr.Hash[:], []byte("hashhashhashhashhashhashhashhash"))
+	payload := []byte("payload")
+	buf, err := f.Encode(hdr, payload)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	h2, p2, err := f.Decode(buf)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if h2 != hdr || string(p2) != string(payload) {
+		t.Fatalf("mismatch")
+	}
+}
+
+func TestDecodeShort(t *testing.T) {
+	f := NewBinary()
+	if _, _, err := f.Decode([]byte{1, 2, 3}); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/frame/wire.go
+++ b/internal/frame/wire.go
@@ -1,0 +1,18 @@
+// Package frame defines the on-wire representation for transferred chunks.
+package frame
+
+// Header precedes each payload and is encoded in little-endian order.
+type Header struct {
+	Version uint16
+	Flags   uint16
+	Offset  uint64
+	Length  uint32
+	CmpLen  uint32
+	Hash    [32]byte
+}
+
+// Framer encodes and decodes frames.
+type Framer interface {
+	Encode(h Header, payload []byte) ([]byte, error)
+	Decode(buf []byte) (Header, []byte, error)
+}

--- a/internal/hash/api.go
+++ b/internal/hash/api.go
@@ -1,0 +1,8 @@
+// Package hash provides pluggable hashing algorithms used throughout the
+// transfer pipeline.
+package hash
+
+// Hasher sums a byte slice into a 32-byte digest.
+type Hasher interface {
+	Sum(b []byte) [32]byte
+}

--- a/internal/hash/blake3.go
+++ b/internal/hash/blake3.go
@@ -1,0 +1,14 @@
+// Package hash exposes a BLAKE3 implementation leveraging the zeebo/blake3
+// library, which performs SIMD auto-detection internally.
+package hash
+
+import "github.com/zeebo/blake3"
+
+// Blake3 returns a Hasher using the BLAKE3 algorithm.
+type Blake3 struct{}
+
+// NewBlake3 creates a new BLAKE3 hasher.
+func NewBlake3() Hasher { return Blake3{} }
+
+// Sum computes a 32-byte digest of the provided data.
+func (Blake3) Sum(b []byte) [32]byte { return blake3.Sum256(b) }

--- a/internal/hash/detect.go
+++ b/internal/hash/detect.go
@@ -1,0 +1,22 @@
+// Package hash exposes CPU feature detection to allow callers to log chosen
+// SIMD paths or make algorithm decisions.
+package hash
+
+import "github.com/klauspost/cpuid/v2"
+
+// SIMD reports available SIMD extensions.
+type SIMD struct {
+	AVX512 bool
+	AVX2   bool
+	SSE41  bool
+}
+
+// Detect returns SIMD capabilities of the current CPU.
+func Detect() SIMD {
+	cpu := cpuid.CPU
+	return SIMD{
+		AVX512: cpu.Supports(cpuid.AVX512F),
+		AVX2:   cpu.Supports(cpuid.AVX2),
+		SSE41:  cpu.Supports(cpuid.SSE4),
+	}
+}

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -1,0 +1,28 @@
+package hash
+
+import "testing"
+
+func TestBlake3Determinism(t *testing.T) {
+	h := NewBlake3()
+	a := h.Sum([]byte("hello"))
+	b := h.Sum([]byte("hello"))
+	if a != b {
+		t.Fatalf("inconsistent")
+	}
+}
+
+func TestSHA256Determinism(t *testing.T) {
+	h := NewSHA256()
+	a := h.Sum([]byte("world"))
+	b := h.Sum([]byte("world"))
+	if a != b {
+		t.Fatalf("inconsistent")
+	}
+}
+
+func TestDetect(t *testing.T) {
+	d := Detect()
+	if !d.AVX2 && !d.SSE41 && !d.AVX512 { // ensure at least detection ran
+		t.Log("no SIMD, but detect executed")
+	}
+}

--- a/internal/hash/sha256.go
+++ b/internal/hash/sha256.go
@@ -1,0 +1,13 @@
+// Package hash also offers a SHA-256 implementation as a portability fallback.
+package hash
+
+import "crypto/sha256"
+
+// SHA256 provides the SHA-256 hashing algorithm.
+type SHA256 struct{}
+
+// NewSHA256 creates a new SHA-256 hasher.
+func NewSHA256() Hasher { return SHA256{} }
+
+// Sum computes the SHA-256 digest of b.
+func (SHA256) Sum(b []byte) [32]byte { return sha256.Sum256(b) }

--- a/internal/limiter/token.go
+++ b/internal/limiter/token.go
@@ -1,0 +1,71 @@
+// Package limiter provides a token-bucket rate limiter used to cap outgoing
+// bandwidth based on post-compression bytes.
+package limiter
+
+import (
+	"sync"
+	"time"
+)
+
+// Limiter throttles data transfers.
+type Limiter interface {
+	Allow(n int)
+}
+
+// Clock abstracts time for testability.
+type Clock interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+}
+
+// realClock implements Clock using the system clock.
+type realClock struct{}
+
+func (realClock) Now() time.Time        { return time.Now() }
+func (realClock) Sleep(d time.Duration) { time.Sleep(d) }
+
+// TokenBucket implements Limiter.
+type TokenBucket struct {
+	rate   float64
+	burst  float64
+	mu     sync.Mutex
+	tokens float64
+	last   time.Time
+	clk    Clock
+}
+
+// New creates a token bucket with rate bytes per second and burst capacity.
+func New(rate, burst int, clk Clock) *TokenBucket {
+	if clk == nil {
+		clk = realClock{}
+	}
+	return &TokenBucket{rate: float64(rate), burst: float64(burst), tokens: float64(burst), last: clk.Now(), clk: clk}
+}
+
+// Allow waits until n tokens are available.
+func (t *TokenBucket) Allow(n int) {
+	if t.rate <= 0 {
+		return
+	}
+	need := float64(n)
+	for {
+		t.mu.Lock()
+		now := t.clk.Now()
+		elapsed := now.Sub(t.last).Seconds()
+		if elapsed > 0 {
+			t.tokens += elapsed * t.rate
+			if t.tokens > t.burst {
+				t.tokens = t.burst
+			}
+			t.last = now
+		}
+		if t.tokens >= need {
+			t.tokens -= need
+			t.mu.Unlock()
+			return
+		}
+		wait := (need - t.tokens) / t.rate
+		t.mu.Unlock()
+		t.clk.Sleep(time.Duration(wait * float64(time.Second)))
+	}
+}

--- a/internal/limiter/token_test.go
+++ b/internal/limiter/token_test.go
@@ -1,0 +1,24 @@
+package limiter
+
+import (
+	"testing"
+	"time"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f *fakeClock) Now() time.Time        { return f.now }
+func (f *fakeClock) Sleep(d time.Duration) { f.now = f.now.Add(d) }
+
+func TestAllow(t *testing.T) {
+	fc := &fakeClock{now: time.Unix(0, 0)}
+	tb := New(1000, 1000, fc)
+	tb.Allow(1000)
+	if fc.now != time.Unix(0, 0) {
+		t.Fatalf("unexpected advance")
+	}
+	tb.Allow(1000)
+	if fc.now.Sub(time.Unix(0, 0)) < time.Second {
+		t.Fatalf("expected at least 1s wait")
+	}
+}

--- a/internal/privilege/caps.go
+++ b/internal/privilege/caps.go
@@ -1,0 +1,36 @@
+// Package privilege implements capability detection to avoid unnecessary sudo
+// usage. Only the capabilities required for LVM and direct I/O operations are
+// checked.
+package privilege
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+var hasCaps = realHasCaps
+
+// realHasCaps probes the kernel for effective capabilities.
+func realHasCaps() bool {
+	hdr := &unix.CapUserHeader{Version: unix.LINUX_CAPABILITY_VERSION_3}
+	data := &unix.CapUserData{}
+	if err := unix.Capget(hdr, data); err != nil {
+		return false
+	}
+	needed := []uint{unix.CAP_SYS_ADMIN, unix.CAP_SYS_RAWIO, unix.CAP_DAC_OVERRIDE}
+	for _, c := range needed {
+		if data.Effective&(1<<c) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// checkCaps ensures the required capabilities are present.
+func checkCaps() error {
+	if hasCaps() {
+		return nil
+	}
+	return fmt.Errorf("missing capabilities")
+}

--- a/internal/privilege/escalate.go
+++ b/internal/privilege/escalate.go
@@ -1,0 +1,24 @@
+// Package privilege provides helpers for validating and executing commands
+// with the required elevated permissions. It prefers Linux capabilities and
+// falls back to sudo when capabilities are missing.
+package privilege
+
+import "os/exec"
+
+// Escalator validates privilege requirements and executes commands with
+// escalation when needed.
+type Escalator interface {
+	// Ensure verifies that the required capabilities or sudo are available.
+	Ensure() error
+	// Command constructs an *exec.Cmd, adding sudo when capabilities are
+	// insufficient.
+	Command(name string, args ...string) *exec.Cmd
+}
+
+// sudoEscalator implements Escalator using Linux capabilities when present
+// and sudo -n as a fallback.
+type sudoEscalator struct{ useSudo bool }
+
+// New returns an Escalator. If the current process lacks the required
+// capabilities, commands will be executed via sudo -n.
+func New() Escalator { return &sudoEscalator{useSudo: !hasCaps()} }

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -1,0 +1,69 @@
+package privilege
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+// fakeLookPath stubs exec.LookPath.
+func fakeLookPath(err error) func(string) (string, error) {
+	return func(string) (string, error) { return "/usr/bin/sudo", err }
+}
+
+func TestEnsureWithCaps(t *testing.T) {
+	hasCaps = func() bool { return true }
+	esc := New().(*sudoEscalator)
+	if esc.useSudo {
+		t.Fatalf("expected capabilities to be used")
+	}
+	if err := esc.Ensure(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureWithSudo(t *testing.T) {
+	hasCaps = func() bool { return false }
+	lookPath = fakeLookPath(nil)
+	esc := New().(*sudoEscalator)
+	if !esc.useSudo {
+		t.Fatalf("expected sudo usage")
+	}
+	if err := esc.Ensure(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureNoSudo(t *testing.T) {
+	hasCaps = func() bool { return false }
+	lookPath = fakeLookPath(errors.New("missing"))
+	esc := New().(*sudoEscalator)
+	if err := esc.Ensure(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestCommand(t *testing.T) {
+	hasCaps = func() bool { return false }
+	esc := New()
+	cmd := esc.Command("echo", "hi")
+	if cmd.Args[0] != "sudo" {
+		t.Fatalf("expected sudo prefix")
+	}
+	hasCaps = func() bool { return true }
+	esc = New()
+	cmd = esc.Command("echo", "hi")
+	if cmd.Args[0] == "sudo" {
+		t.Fatalf("unexpected sudo prefix")
+	}
+}
+
+// Restore globals after tests.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	hasCaps = realHasCaps
+	lookPath = exec.LookPath
+	if code != 0 {
+		panic(code)
+	}
+}

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -1,0 +1,32 @@
+// Package privilege contains a sudo-based escalator used when capabilities are
+// unavailable.
+package privilege
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+var lookPath = exec.LookPath
+
+// Ensure verifies that either the required capabilities are present or that
+// sudo is available when escalation is necessary.
+func (s *sudoEscalator) Ensure() error {
+	if s.useSudo {
+		if _, err := lookPath("sudo"); err != nil {
+			return fmt.Errorf("sudo not found: %w", err)
+		}
+		return nil
+	}
+	return checkCaps()
+}
+
+// Command returns an *exec.Cmd that runs the given program. sudo -n is inserted
+// when capabilities are missing.
+func (s *sudoEscalator) Command(name string, args ...string) *exec.Cmd {
+	if s.useSudo {
+		all := append([]string{"-n", name}, args...)
+		return exec.Command("sudo", all...)
+	}
+	return exec.Command(name, args...)
+}


### PR DESCRIPTION
## Summary
- add privilege Escalator with capability detection and sudo fallback
- add direct I/O device helpers and discard support
- implement hashing (BLAKE3/SHA-256), LZ4/Zstd compression with auto selection
- add frame encoder/decoder and token-bucket rate limiter

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689a3446a190832393ac95b2198cab2a