### PR TITLE
feat(device): add readahead helper

### DIFF
--- a/internal/device/io_test.go
+++ b/internal/device/io_test.go
@@ -62,3 +62,15 @@ func TestFileWriter(t *testing.T) {
 	}
 	f.Close()
 }
+
+func TestSetReadAhead(t *testing.T) {
+	f, err := os.CreateTemp("", "ra")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	if err := SetReadAhead(f, 128*1024); err != nil {
+		t.Fatalf("readahead: %v", err)
+	}
+}

--- a/internal/device/readahead.go
+++ b/internal/device/readahead.go
@@ -1,0 +1,30 @@
+// Package device includes a helper to configure kernel readahead hints for
+// block devices.
+package device
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// SetReadAhead adjusts the kernel readahead window for the provided file. The
+// size is specified in bytes and rounded down to a 512-byte sector. On systems
+// where the ioctl is unsupported or the file is not a block device, the call
+// succeeds with a nil error.
+func SetReadAhead(f *os.File, size int) error {
+	if size <= 0 {
+		return nil
+	}
+	sectors := size / 512
+	if sectors == 0 {
+		sectors = 1
+	}
+	if err := unix.IoctlSetInt(int(f.Fd()), unix.BLKRASET, sectors); err != nil {
+		if err == unix.ENOTTY || err == unix.EOPNOTSUPP || err == unix.EINVAL {
+			return nil
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add SetReadAhead helper to device package
- test readahead configuration

## Testing
- `go build ./...`
- `go test ./...`
- `golangci-lint run`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689a4489a63c8323b5f7fa516fdbcf24