### PR TITLE
feat: integrate token bucket limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85 /dev/vg0/snap0 
 
 #### Rate Limiting
 
+Transfers can be throttled using a token bucket accurate to ±3% of the target.
 Limit the transfer speed to 50MB/s:
 
 ```sh

--- a/docs/privilege_escalation.md
+++ b/docs/privilege_escalation.md
@@ -1,0 +1,25 @@
+# Privilege Escalation Setup
+
+LVMSync operates on block devices and prefers Linux capabilities over sudo.
+
+## Capabilities
+
+Grant required capabilities to the binary:
+
+```sh
+setcap cap_sys_admin,cap_sys_rawio,cap_dac_override+ep /usr/local/bin/lvmsync
+```
+
+## sudoers Fallback
+
+When capabilities are unavailable, provide a minimal sudoers entry:
+
+```
+lvmsync ALL=(root) NOPASSWD:/usr/local/bin/lvmsync
+```
+
+Verify escalation availability:
+
+```sh
+lvmsync --check-escalation
+```

--- a/internal/limiter/token.go
+++ b/internal/limiter/token.go
@@ -1,5 +1,10 @@
 // Package limiter provides a token-bucket rate limiter used to cap outgoing
 // bandwidth based on post-compression bytes.
+//
+// Example:
+//
+//	tb := limiter.New(1<<20, 1<<20, nil) // 1 MiB/s
+//	tb.Allow(len(p))                     // block until tokens are available
 package limiter
 
 import (

--- a/internal/limiter/token_test.go
+++ b/internal/limiter/token_test.go
@@ -1,24 +1,32 @@
+// Package limiter tests verify token bucket accuracy.
+//
+// Example:
+//
+//	tb := New(1024, 1024, clk)
+//	tb.Allow(512)
 package limiter
 
 import (
+	"math"
 	"testing"
 	"time"
 )
 
-type fakeClock struct{ now time.Time }
+type stubClock struct{ now time.Time }
 
-func (f *fakeClock) Now() time.Time        { return f.now }
-func (f *fakeClock) Sleep(d time.Duration) { f.now = f.now.Add(d) }
+func (s *stubClock) Now() time.Time        { return s.now }
+func (s *stubClock) Sleep(d time.Duration) { s.now = s.now.Add(d) }
 
-func TestAllow(t *testing.T) {
-	fc := &fakeClock{now: time.Unix(0, 0)}
-	tb := New(1000, 1000, fc)
-	tb.Allow(1000)
-	if fc.now != time.Unix(0, 0) {
-		t.Fatalf("unexpected advance")
-	}
-	tb.Allow(1000)
-	if fc.now.Sub(time.Unix(0, 0)) < time.Second {
-		t.Fatalf("expected at least 1s wait")
+func TestTokenBucketAccuracy(t *testing.T) {
+	clk := &stubClock{now: time.Unix(0, 0)}
+	rate := 1024
+	tb := New(rate, rate, clk)
+	tb.Allow(rate)
+	start := clk.Now()
+	tb.Allow(rate)
+	elapsed := clk.Now().Sub(start)
+	expected := time.Second
+	if math.Abs(float64(elapsed-expected)) > float64(expected)*0.03 {
+		t.Fatalf("elapsed %v outside ±3%% of %v", elapsed, expected)
 	}
 }

--- a/transfer/utils.go
+++ b/transfer/utils.go
@@ -1,31 +1,34 @@
-// transfer/utils.go
+// Package transfer contains helpers for the data path.
+// WrapRateLimitedWriter returns a writer capped to speedLimit bytes per second.
+//
+// Example:
+//
+//	w := WrapRateLimitedWriter(dst, 1<<20) // 1 MiB/s
+//	w.Write(p)
 package transfer
 
 import (
-	"context"
 	"io"
 	"sync"
 
-	"golang.org/x/time/rate"
+	"lvmsync_go/internal/limiter"
 )
 
-// rateLimitedWriter wraps an io.Writer and throttles write throughput to a
-// specified number of bytes per second using a shared rate limiter.
+// rateLimitedWriter wraps an io.Writer with a token bucket limiter.
 type rateLimitedWriter struct {
-	w       io.Writer
-	limiter *rate.Limiter
+	w   io.Writer
+	tb  limiter.Limiter
+	max int
 }
 
 func (rlw *rateLimitedWriter) Write(p []byte) (int, error) {
 	written := 0
 	for len(p) > 0 {
 		chunk := len(p)
-		if burst := rlw.limiter.Burst(); chunk > burst {
-			chunk = burst
+		if chunk > rlw.max {
+			chunk = rlw.max
 		}
-		if err := rlw.limiter.WaitN(context.Background(), chunk); err != nil {
-			return written, err
-		}
+		rlw.tb.Allow(chunk)
 		n, err := rlw.w.Write(p[:chunk])
 		written += n
 		if err != nil {
@@ -37,26 +40,24 @@ func (rlw *rateLimitedWriter) Write(p []byte) (int, error) {
 }
 
 var (
-	rateLimiterCache     *rate.Limiter
+	rateLimiterCache     limiter.Limiter
 	lastSpeedLimit       int
 	rateLimiterCacheLock sync.Mutex
 )
 
-// WrapRateLimitedWriter returns an io.Writer that limits the write throughput
-// to the specified speedLimit in bytes per second. The limiter instance is
-// cached to avoid unnecessary allocations when the limit remains unchanged.
+// WrapRateLimitedWriter returns an io.Writer that limits throughput to
+// speedLimit bytes per second. The limiter instance is cached for reuse.
 func WrapRateLimitedWriter(w io.Writer, speedLimit int) io.Writer {
 	if speedLimit <= 0 {
 		return w
 	}
 
 	rateLimiterCacheLock.Lock()
-	defer rateLimiterCacheLock.Unlock()
-
 	if rateLimiterCache == nil || lastSpeedLimit != speedLimit {
-		rateLimiterCache = rate.NewLimiter(rate.Limit(speedLimit), speedLimit)
+		rateLimiterCache = limiter.New(speedLimit, speedLimit, nil)
 		lastSpeedLimit = speedLimit
 	}
-
-	return &rateLimitedWriter{w: w, limiter: rateLimiterCache}
+	rlw := &rateLimitedWriter{w: w, tb: rateLimiterCache, max: speedLimit}
+	rateLimiterCacheLock.Unlock()
+	return rlw
 }

--- a/transfer/utils_test.go
+++ b/transfer/utils_test.go
@@ -1,0 +1,41 @@
+// Package transfer tests rate-limited writer behavior.
+//
+// Example:
+//
+//	w := &rateLimitedWriter{w: dst, tb: limiter.New(1024, 1024, clk), max: 1024}
+//	w.Write(p)
+package transfer
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"time"
+
+	"lvmsync_go/internal/limiter"
+)
+
+type stubClock struct{ now time.Time }
+
+func (s *stubClock) Now() time.Time        { return s.now }
+func (s *stubClock) Sleep(d time.Duration) { s.now = s.now.Add(d) }
+
+func TestRateLimitedWriterAccuracy(t *testing.T) {
+	clk := &stubClock{now: time.Unix(0, 0)}
+	l := limiter.New(1024, 1024, clk)
+	buf := &bytes.Buffer{}
+	w := &rateLimitedWriter{w: buf, tb: l, max: 1024}
+	data := make([]byte, 2048)
+	start := clk.Now()
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	elapsed := clk.Now().Sub(start)
+	expected := time.Second
+	if math.Abs(float64(elapsed-expected)) > float64(expected)*0.03 {
+		t.Fatalf("elapsed %v outside ±3%% of %v", elapsed, expected)
+	}
+	if buf.Len() != len(data) {
+		t.Fatalf("wrote %d bytes want %d", buf.Len(), len(data))
+	}
+}


### PR DESCRIPTION
## Summary
- replace rate limiter with internal token-bucket implementation
- document privilege escalation capabilities
- add unit tests for limiter accuracy

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689a5620c2dc8323b4e2fca3d706b955