### PR TITLE
feat(config): add ssh host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
 | `--checksum_algorithm` | `LVMSYNC_CHECKSUM_ALGORITHM` | `checksum_algorithm` | Checksum algorithm: `sha256`, `blake3`, or `blake3-512` |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
+| `--ssh_host` | `LVMSYNC_SSH_HOST` | `ssh_host` | SSH host |
 | `--ssh_user` | `LVMSYNC_SSH_USER` | `ssh_user` | SSH username |
 | `--ssh_key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key or use agent |
 | `--ssh_port` | `LVMSYNC_SSH_PORT` | `ssh_port` | SSH port |
@@ -436,6 +437,7 @@ LVMSYNC_GRPC_CONNECT=localhost:9443 lvmsync /dev/vg0/snap0 /dev/vg0/data
 
 ```yaml
 parallel: 4               # General Options
+ssh_host: backup          # SSH Options
 ssh_user: backup          # SSH Options
 remote_pre_script: pre.sh # Remote Options
 dedup_strategy: bloom     # Deduplication Options
@@ -713,6 +715,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 
 | Option                    | Description                                                     | Default                  |
 | ------------------------- | --------------------------------------------------------------- | ------------------------ |
+| `--ssh_host`              | SSH host                                                        | `"localhost"`            |
 | `--ssh_user`              | SSH username                                                    | `"root"`                 |
 | `--ssh_key`               | Path to SSH private key or use the SSH agent                    | `""`                     |
 | `--ssh_port`              | SSH port number                                                 | `22`                     |
@@ -895,12 +898,13 @@ lvmsync --ssh-user backup --ssh-port 2222 /dev/vg0/snap0 backup:/dev/vg0/data
 Environment:
 
 ```sh
-LVMSYNC_SSH_USER=backup LVMSYNC_SSH_PORT=2222 lvmsync /dev/vg0/snap0 backup:/dev/vg0/data
+LVMSYNC_SSH_HOST=backup LVMSYNC_SSH_USER=backup LVMSYNC_SSH_PORT=2222 lvmsync /dev/vg0/snap0 /dev/vg0/data
 ```
 
 YAML:
 
 ```yaml
+ssh_host: backup
 ssh_user: backup
 ssh_port: 2222
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	NumaPin               bool          `mapstructure:"numa_pin"`
 	MaxRetries            int           `mapstructure:"max_retries"`
 	ResumeState           string        `mapstructure:"resume"`
+	SSHHost               string        `mapstructure:"ssh_host"`
 	SSHUser               string        `mapstructure:"ssh_user"`
 	SSHKeyPath            string        `mapstructure:"ssh_key"`
 	SSHPort               int           `mapstructure:"ssh_port"`
@@ -387,6 +388,7 @@ func DefaultConfig() (*Config, error) {
 		NumaPin:               false,
 		MaxRetries:            3,
 		ResumeState:           "",
+		SSHHost:               "localhost",
 		SSHUser:               "root",
 		SSHKeyPath:            "",
 		SSHPort:               22,
@@ -474,6 +476,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 
 func initSSHFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
+	fs.String("ssh_host", cfg.SSHHost, "SSH host")
 	fs.String("ssh_user", cfg.SSHUser, "SSH username")
 	fs.String("ssh_key", cfg.SSHKeyPath, "Path to SSH private key or use agent")
 	fs.Int("ssh_port", cfg.SSHPort, "SSH port")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -49,6 +49,7 @@ func TestInitSSHFlags(t *testing.T) {
 	}
 	fs := initSSHFlags(cfg)
 	cases := []struct{ name, want string }{
+		{"ssh_host", cfg.SSHHost},
 		{"ssh_user", cfg.SSHUser},
 		{"ssh_key", cfg.SSHKeyPath},
 		{"ssh_port", strconv.Itoa(cfg.SSHPort)},

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -156,3 +156,55 @@ func TestSSHUserEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("expected ssh_user env, got %s", conf.SSHUser)
 	}
 }
+
+func TestSSHHostCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "ssh_host: config\n")
+	resetFlags([]string{"--config", cfgPath, "--ssh_host", "cli"})
+	t.Setenv("LVMSYNC_SSH_HOST", "env")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	registerFlags(defaults)
+	pflag.Parse()
+
+	v, err := buildViper()
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.SSHHost != "cli" {
+		t.Fatalf("expected ssh_host cli, got %s", conf.SSHHost)
+	}
+}
+
+func TestSSHHostEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "ssh_host: config\n")
+	resetFlags([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_SSH_HOST", "env")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	registerFlags(defaults)
+	pflag.Parse()
+
+	v, err := buildViper()
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.SSHHost != "env" {
+		t.Fatalf("expected ssh_host env, got %s", conf.SSHHost)
+	}
+}

--- a/config/usage_test.go
+++ b/config/usage_test.go
@@ -18,7 +18,7 @@ func TestFlagSetUsage(t *testing.T) {
 		want string
 	}{
 		{initGeneralFlags(cfg), "--config"},
-		{initSSHFlags(cfg), "--ssh_user"},
+		{initSSHFlags(cfg), "--ssh_host"},
 		{initRemoteFlags(cfg), "--lvmsync_path"},
 		{initDedupFlags(cfg), "--dedup_strategy"},
 		{initCompressionFlags(cfg), "--compress"},

--- a/internal/transport/ssh/ssh.go
+++ b/internal/transport/ssh/ssh.go
@@ -34,7 +34,10 @@ func New(cfg *config.Config, logger *zap.Logger) (transport.Sender, transport.Re
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	host := "localhost"
+	host := cfg.SSHHost
+	if host == "" {
+		host = "localhost"
+	}
 	logger.Info("ssh connection attempt", zap.String("host", host), zap.Int("port", cfg.SSHPort))
 	client, err := remote.NewSSHClient(host, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)
 	if err != nil {
@@ -140,5 +143,4 @@ func (r *sshReceiver) Receive(ctx context.Context, w io.Writer) error {
 		r.logger.Info("ssh receive stream closed", zap.String("host", r.host), zap.Int("port", r.port), zap.Int64("bytes_transferred", n))
 	}
 	return copyErr
-
 }


### PR DESCRIPTION
## Summary
- add `ssh_host` configuration, flag, and docs
- allow SSH transport to connect to configurable host instead of localhost

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689a5e59d9e483239005c7cc0a620ba5