### PR TITLE
fix(serve): support context cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ incoming client. The server listens on `--serve_listen` (default `:9000`) and
 expects the client to present matching `--serve_protocol`, `--serve_algorithm`,
 and optional `--serve_test_space` values. A mismatched value aborts the
 connection. Transfers proceed only when `--serve_policy` is `accept` (the
-default).
+default). The server exits gracefully when it receives `SIGINT` or `SIGTERM`.
 
 ```sh
 lvmsync --serve --serve_listen :9000

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,8 +1,11 @@
 package root
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -100,7 +103,9 @@ func ExecuteClient(cfg *config.Config, snapshotPath, destPath string, sigErrCh, 
 // Run orchestrates the command execution.
 func Run(cfg *config.Config, logger *zap.Logger) error {
 	if cfg.Serve {
-		return runServe(cfg, logger)
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		return runServe(ctx, cfg, logger)
 	}
 
 	defer lvm.Cleanup()

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -14,7 +14,8 @@ import (
 )
 
 // acceptFunc allows tests to override the listener and stream acceptance logic.
-var acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) {
+// The provided context controls cancellation for listener and stream accepts.
+var acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteCloser, error) {
 	tlsConf, err := qn.NewTLSConfig(qn.Config{
 		TLSCert:       cfg.TLSCert,
 		TLSKey:        cfg.TLSKey,
@@ -28,11 +29,11 @@ var acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := l.Accept(context.Background())
+	conn, err := l.Accept(ctx)
 	if err != nil {
 		return nil, err
 	}
-	stream, err := conn.AcceptStream(context.Background())
+	stream, err := conn.AcceptStream(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +41,9 @@ var acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) {
 }
 
 // Run starts the QUIC server, negotiates parameters, and enforces the transfer policy.
-func Run(cfg *config.Config, logger *zap.Logger) error {
-	stream, err := acceptFunc(cfg)
+// The context allows callers to cancel pending accept operations and shut down gracefully.
+func Run(ctx context.Context, cfg *config.Config, logger *zap.Logger) error {
+	stream, err := acceptFunc(ctx, cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 	"os"
@@ -17,12 +18,12 @@ import (
 func TestRunAcceptsTransfer(t *testing.T) {
 	server, client := net.Pipe()
 	orig := acceptFunc
-	acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
+	acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
 	defer func() { acceptFunc = orig }()
 
 	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "accept"}
 	errCh := make(chan error, 1)
-	go func() { errCh <- Run(cfg, zap.NewNop()) }()
+	go func() { errCh <- Run(context.Background(), cfg, zap.NewNop()) }()
 
 	hs := qn.Negotiation{Protocol: "proto", Algorithm: "alg", TestSpace: "ts"}
 	if err := qn.WriteNegotiation(client, hs); err != nil {
@@ -61,12 +62,12 @@ func TestServeFlagParsing(t *testing.T) {
 func TestRunNegotiationMismatch(t *testing.T) {
 	server, client := net.Pipe()
 	orig := acceptFunc
-	acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
+	acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
 	defer func() { acceptFunc = orig }()
 
 	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "accept"}
 	errCh := make(chan error, 1)
-	go func() { errCh <- Run(cfg, zap.NewNop()) }()
+	go func() { errCh <- Run(context.Background(), cfg, zap.NewNop()) }()
 
 	if err := qn.WriteNegotiation(client, qn.Negotiation{Protocol: "proto", Algorithm: "other", TestSpace: "ts"}); err != nil {
 		t.Fatalf("write negotiation: %v", err)
@@ -80,12 +81,12 @@ func TestRunNegotiationMismatch(t *testing.T) {
 func TestRunRejectsPolicy(t *testing.T) {
 	server, client := net.Pipe()
 	orig := acceptFunc
-	acceptFunc = func(cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
+	acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteCloser, error) { return server, nil }
 	defer func() { acceptFunc = orig }()
 
 	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "deny"}
 	errCh := make(chan error, 1)
-	go func() { errCh <- Run(cfg, zap.NewNop()) }()
+	go func() { errCh <- Run(context.Background(), cfg, zap.NewNop()) }()
 
 	hs := qn.Negotiation{Protocol: "proto", Algorithm: "alg", TestSpace: "ts"}
 	if err := qn.WriteNegotiation(client, hs); err != nil {


### PR DESCRIPTION
## Summary
- allow serve command to accept context for listener and stream
- root command propagates signal-aware context to serve
- document graceful shutdown

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689aed8dde5083238d9fd266f8867fac