### PR TITLE
fix: inject logger for signal handling and update grpc client

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -142,11 +142,11 @@ func ClientHandshake(cfg *config.Config, logger *zap.Logger) (func(), error) {
 }
 
 // SetupSignalHandling configures signal handling and returns the signal and error channels.
-func SetupSignalHandling(cfg *config.Config, snapshotPath *string) (chan os.Signal, chan error) {
+func SetupSignalHandling(cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	sigErrCh := make(chan error, 1)
-	go handleSignals(cfg, signals, snapshotPath, sigErrCh)
+	go handleSignals(cfg, logger, signals, snapshotPath, sigErrCh)
 	return signals, sigErrCh
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -142,12 +142,13 @@ func TestSetupSignalHandling(t *testing.T) {
 	called := make(chan struct{})
 	origHandle := handleSignals
 	defer func() { handleSignals = origHandle }()
-	handleSignals = func(cfg *config.Config, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	handleSignals = func(cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		<-sigs
 		*p = "set"
 		close(called)
 	}
-	signals, sigErrCh := SetupSignalHandling(cfg, &path)
+	logger := zap.NewNop()
+	signals, sigErrCh := SetupSignalHandling(cfg, &path, logger)
 	signals <- os.Interrupt
 	select {
 	case <-called:
@@ -172,10 +173,11 @@ func TestSetupSignalHandlingError(t *testing.T) {
 	var path string
 	origHandle := handleSignals
 	defer func() { handleSignals = origHandle }()
-	handleSignals = func(cfg *config.Config, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	handleSignals = func(cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		errCh <- errors.New("boom")
 	}
-	_, sigErrCh := SetupSignalHandling(cfg, &path)
+	logger := zap.NewNop()
+	_, sigErrCh := SetupSignalHandling(cfg, &path, logger)
 	if err := <-sigErrCh; err == nil {
 		t.Fatalf("expected error")
 	}

--- a/cmd/lvmsync/signals/signals.go
+++ b/cmd/lvmsync/signals/signals.go
@@ -14,15 +14,16 @@ import (
 
 var removeSnapshot = lvm.RemoveSnapshot
 
-// Handle waits for an OS signal and performs cleanup.
-func Handle(cfg *config.Config, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error) {
+// Handle waits for an OS signal, logs it, and removes the snapshot when
+// necessary.
+func Handle(cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error) {
 	sig := <-signals
-	zap.L().Info("Received signal, aborting", zap.String("signal", sig.String()))
+	logger.Info("received signal, aborting", zap.String("signal", sig.String()))
 	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
 		if err := removeSnapshot(context.Background(), *snapshotPath); err != nil {
-			zap.L().Warn("Failed to remove snapshot on shutdown", zap.Error(err))
+			logger.Warn("failed to remove snapshot on shutdown", zap.Error(err))
 		} else {
-			zap.L().Info("Snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))
+			logger.Info("snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))
 		}
 	}
 	errCh <- fmt.Errorf("received signal: %s", sig)

--- a/cmd/lvmsync/signals/signals_test.go
+++ b/cmd/lvmsync/signals/signals_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/config"
 )
 
@@ -13,7 +15,8 @@ func TestHandle(t *testing.T) {
 	sigCh := make(chan os.Signal, 1)
 	errCh := make(chan error, 1)
 	var snap string
-	go Handle(cfg, sigCh, &snap, errCh)
+	logger := zap.NewNop()
+	go Handle(cfg, logger, sigCh, &snap, errCh)
 	sigCh <- os.Interrupt
 	err := <-errCh
 	if err == nil || !strings.Contains(err.Error(), "received signal") {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -122,7 +122,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	defer cleanupClient()
 
 	var snapshotPath string
-	signals, sigErrCh := setupSignalHandle(cfg, &snapshotPath)
+	signals, sigErrCh := setupSignalHandle(cfg, &snapshotPath, logger)
 	defer signal.Stop(signals)
 
 	if cfg.ApplyMode != "" {

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -17,6 +17,10 @@ import (
 	qn "lvmsync_go/quic"
 )
 
+type nopRWCloser struct{ io.ReadCloser }
+
+func (nopRWCloser) Write(p []byte) (int, error) { return len(p), nil }
+
 func TestRunAcceptsTransfer(t *testing.T) {
 	server, client := net.Pipe()
 	orig := acceptFunc
@@ -119,7 +123,7 @@ func (f *fakeListener) Close() error {
 
 func TestQuicStreamCloseClosesResources(t *testing.T) {
 	qs := &quicStream{
-		ReadWriteCloser: io.NopCloser(strings.NewReader("")),
+		ReadWriteCloser: nopRWCloser{io.NopCloser(strings.NewReader(""))},
 		conn:            &fakeConn{},
 		listener:        &fakeListener{},
 	}

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -50,7 +51,11 @@ func Dial(addr string, conf Config, opts ...grpc.DialOption) (*grpc.ClientConn, 
 		}
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
 	}
-	return grpc.Dial(addr, opts...)
+	target := addr
+	if !strings.Contains(addr, "://") {
+		target = "passthrough:///" + addr
+	}
+	return grpc.NewClient(target, opts...)
 }
 
 func Handshake(ctx context.Context, c proto.ReplicationClient, hs *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -44,15 +44,24 @@ type agent struct {
 	lvm lvmAPI
 }
 
-// NewSudoAgent returns an Agent implementation that ensures root privileges
-// before invoking LVM commands. An optional ensureRoot function can be provided
-// (primarily for tests). When nil, privilege.New().Ensure is used.
-func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error) Agent {
-	api, _ := l.(lvmAPI)
-	if ensureRoot == nil {
-		ensureRoot = privilege.New().Ensure
+// NewAgent constructs an Agent that delegates LVM operations to the provided
+// lvmAPI and ensures privileges using the given Escalator. When esc is nil,
+// privilege.New() supplies a default implementation.
+func NewAgent(lvm lvmAPI, esc privilege.Escalator) Agent {
+	if esc == nil {
+		esc = privilege.New()
 	}
-	return &agent{esc: esc, lvm: api}
+	return &agent{esc: esc, lvm: lvm}
+}
+
+// NewSudoAgent wraps the public LVM API with a privilege-enforcing Agent. The
+// sudoPath and ensureRoot parameters are retained for compatibility but are
+// currently unused.
+func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error) Agent { //nolint:revive // sudoPath kept for future use
+	_ = sudoPath
+	_ = ensureRoot
+	api, _ := l.(lvmAPI)
+	return NewAgent(api, nil)
 }
 
 func (a *agent) Lock(ctx context.Context, volume, requester string) error {


### PR DESCRIPTION
## Summary
- remove global zap logger usage by injecting logger into signal handling
- add generic LVM agent constructor and replace deprecated gRPC dial
- update tests and switch to grpc.NewClient with passthrough target

## Testing
- `go build ./...`
- `go test -cover ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_689afdb07c608323a0fd51284638a903