### PR TITLE
fix(serve): log stream close errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ incoming client. The server listens on `--serve_listen` (default `:9000`) and
 expects the client to present matching `--serve_protocol`, `--serve_algorithm`,
 and optional `--serve_test_space` values. A mismatched value aborts the
 connection. Transfers proceed only when `--serve_policy` is `accept` (the
-default). The server closes the stream, QUIC connection, and listener when the transfer completes and exits gracefully when it receives `SIGINT` or `SIGTERM`.
+default). The server closes the stream, QUIC connection, and listener when the transfer completes, logging any shutdown errors at `warn` level, and exits gracefully when it receives `SIGINT` or `SIGTERM`.
 
 ```sh
 lvmsync --serve --serve_listen :9000

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -14,7 +14,8 @@ import (
 )
 
 // acceptFunc allows tests to override the listener and stream acceptance logic.
-// The provided context controls cancellation for listener and stream accepts.
+// The context controls cancellation for both the listener and the stream accepts
+// and must be honored by implementations.
 var acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteCloser, error) {
 	tlsConf, err := qn.NewTLSConfig(qn.Config{
 		TLSCert:       cfg.TLSCert,
@@ -43,8 +44,8 @@ var acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteClos
 	return &quicStream{ReadWriteCloser: stream, conn: conn, listener: l}, nil
 }
 
-// quicStream wraps a QUIC stream and ensures the connection and listener are
-// closed when the stream is closed.
+// quicStream wraps a QUIC stream and ensures the QUIC connection and listener
+// are closed when the stream is closed.
 type connCloser interface {
 	CloseWithError(code q.ApplicationErrorCode, msg string) error
 }
@@ -59,7 +60,8 @@ type quicStream struct {
 	listener listenerCloser
 }
 
-// Close closes the stream, connection, and listener, ignoring connection errors.
+// Close closes the stream, connection, and listener, ignoring connection
+// errors so shutdown paths can proceed.
 func (qs *quicStream) Close() error {
 	_ = qs.conn.CloseWithError(0, "")
 	_ = qs.listener.Close()
@@ -73,7 +75,11 @@ func Run(ctx context.Context, cfg *config.Config, logger *zap.Logger) error {
 	if err != nil {
 		return err
 	}
-	defer stream.Close()
+	defer func() {
+		if cerr := stream.Close(); cerr != nil {
+			logger.Warn("serve: stream close", zap.Error(cerr))
+		}
+	}()
 
 	expected := qn.Negotiation{
 		Protocol:  cfg.ServeProtocol,

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -12,6 +13,7 @@ import (
 	q "github.com/quic-go/quic-go"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/config"
 	qn "lvmsync_go/quic"
@@ -104,6 +106,40 @@ func TestRunRejectsPolicy(t *testing.T) {
 	client.Close()
 	if err := <-errCh; err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+type errCloseConn struct{ net.Conn }
+
+func (e errCloseConn) Close() error { return fmt.Errorf("close fail") }
+
+func TestRunLogsStreamCloseError(t *testing.T) {
+	server, client := net.Pipe()
+	orig := acceptFunc
+	acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteCloser, error) {
+		return errCloseConn{server}, nil
+	}
+	defer func() { acceptFunc = orig }()
+
+	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "accept"}
+	core, logs := observer.New(zap.WarnLevel)
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run(context.Background(), cfg, zap.New(core)) }()
+
+	hs := qn.Negotiation{Protocol: "proto", Algorithm: "alg", TestSpace: "ts"}
+	if err := qn.WriteNegotiation(client, hs); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	if _, err := qn.ReadNegotiation(bufio.NewReader(client)); err != nil {
+		t.Fatalf("read negotiation: %v", err)
+	}
+	client.Close()
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if logs.FilterMessage("serve: stream close").Len() != 1 {
+		t.Fatalf("expected stream close warning log")
 	}
 }
 


### PR DESCRIPTION
## Summary
- log stream close failures in `serve` command
- document QUIC server shutdown behavior
- cover close error logging in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b04a185548323b36e7286fad2f178