### PR TITLE
fix(remote): add timeout for ssh agent dial

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -78,8 +78,10 @@ func selectAuthMethods(logger *zap.Logger, keyPath string) ([]ssh.AuthMethod, er
 	} else {
 		sshAgentSock := os.Getenv("SSH_AUTH_SOCK")
 		if sshAgentSock != "" {
-			conn, err := net.Dial("unix", sshAgentSock)
-			if err == nil {
+			conn, err := net.DialTimeout("unix", sshAgentSock, 5*time.Second)
+			if err != nil {
+				logger.Warn("ssh agent dial failed", zap.String("sock", sshAgentSock), zap.Error(err))
+			} else {
 				agentClient := agent.NewClient(conn)
 				authMethods = append(authMethods, ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {
 					defer func() {


### PR DESCRIPTION
## Summary
- use net.DialTimeout when connecting to ssh-agent
- warn when SSH agent connection fails for easier diagnostics

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b6ff5f1888323a55970e3c5687862