### PR TITLE
feat(remote): add context-aware SSH keepalive

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -1,6 +1,7 @@
 package dump
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -77,12 +78,14 @@ func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string,
 }
 
 // SetupSSHClient creates an SSH client for remote operations.
-func SetupSSHClient(cfg *config.Config, destHost string, logger *zap.Logger) (*remote.SSHClient, error) {
-	client, err := newSSHClient(destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)
+func SetupSSHClient(cfg *config.Config, destHost string, logger *zap.Logger) (*remote.SSHClient, context.CancelFunc, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := newSSHClient(ctx, destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SSH client: %w", err)
+		cancel()
+		return nil, nil, fmt.Errorf("failed to create SSH client: %w", err)
 	}
-	return client, nil
+	return client, cancel, nil
 }
 
 func closeSession(session *ssh.Session, errp *error) {
@@ -192,11 +195,12 @@ func ExecuteRemoteCommand(cfg *config.Config, client *remote.SSHClient, destDevi
 func RunRemoteDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	parts := strings.SplitN(dest, ":", 2)
 	destHost, destDevice := parts[0], parts[1]
-	client, err := SetupSSHClient(cfg, destHost, logger)
+	client, cancel, err := SetupSSHClient(cfg, destHost, logger)
 	if err != nil {
 		return err
 	}
 	defer func() {
+		cancel()
 		if err2 := client.Close(); err2 != nil && !errors.Is(err2, io.EOF) {
 			if err == nil {
 				err = fmt.Errorf("failed to close SSH client: %w", err2)

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -1,6 +1,7 @@
 package dump
 
 import (
+	"context"
 	"errors"
 	"io"
 	"strings"
@@ -22,7 +23,7 @@ func TestSetupSSHClient(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		dummy := &remote.SSHClient{}
 		called := false
-		newSSHClient = func(host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
+		newSSHClient = func(ctx context.Context, host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
 			called = true
 			if host != "dest" {
 				t.Fatalf("unexpected host %s", host)
@@ -31,7 +32,7 @@ func TestSetupSSHClient(t *testing.T) {
 		}
 		defer func() { newSSHClient = remote.NewSSHClient }()
 
-		client, err := SetupSSHClient(cfg, "dest", zap.NewNop())
+		client, cancel, err := SetupSSHClient(cfg, "dest", zap.NewNop())
 		if err != nil {
 			t.Fatalf("SetupSSHClient returned error: %v", err)
 		}
@@ -41,15 +42,16 @@ func TestSetupSSHClient(t *testing.T) {
 		if !called {
 			t.Fatalf("newSSHClient was not called")
 		}
+		cancel()
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		newSSHClient = func(host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
+		newSSHClient = func(ctx context.Context, host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
 			return nil, errors.New("fail")
 		}
 		defer func() { newSSHClient = remote.NewSSHClient }()
 
-		_, err := SetupSSHClient(cfg, "dest", zap.NewNop())
+		_, _, err := SetupSSHClient(cfg, "dest", zap.NewNop())
 		if err == nil || !strings.Contains(err.Error(), "failed to create SSH client") {
 			t.Fatalf("expected wrapped error, got %v", err)
 		}

--- a/internal/transport/ssh/ssh.go
+++ b/internal/transport/ssh/ssh.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"context"
 	"io"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -15,15 +16,30 @@ func init() {
 	transport.Register("ssh", New)
 }
 
+type sshClientWrapper struct {
+	*remote.SSHClient
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (w *sshClientWrapper) Close() error {
+	var err error
+	w.once.Do(func() {
+		w.cancel()
+		err = w.SSHClient.Close()
+	})
+	return err
+}
+
 type sshSender struct {
-	client *remote.SSHClient
+	client *sshClientWrapper
 	host   string
 	port   int
 	logger *zap.Logger
 }
 
 type sshReceiver struct {
-	client *remote.SSHClient
+	client *sshClientWrapper
 	host   string
 	port   int
 	logger *zap.Logger
@@ -39,16 +55,35 @@ func New(cfg *config.Config, logger *zap.Logger) (transport.Sender, transport.Re
 		host = "localhost"
 	}
 	logger.Info("ssh connection attempt", zap.String("host", host), zap.Int("port", cfg.SSHPort))
-	client, err := remote.NewSSHClient(host, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := remote.NewSSHClient(
+		ctx,
+		host,
+		cfg.SSHUser,
+		cfg.SSHKeyPath,
+		cfg.SSHPort,
+		cfg.KnownHosts,
+		cfg.StrictHostKeyCheck,
+		cfg.SSHTimeout,
+		cfg.SSHKeepAliveInterval,
+		cfg.MaxRetries,
+		logger,
+	)
 	if err != nil {
+		cancel()
 		logger.Error("ssh authentication failed", zap.String("host", host), zap.Int("port", cfg.SSHPort), zap.Error(err))
 		return nil, nil, err
 	}
 	logger.Info("ssh connection established", zap.String("host", host), zap.Int("port", cfg.SSHPort))
-	sender := &sshSender{client: client, host: host, port: cfg.SSHPort, logger: logger}
-	receiver := &sshReceiver{client: client, host: host, port: cfg.SSHPort, logger: logger}
+	wrapper := &sshClientWrapper{SSHClient: client, cancel: cancel}
+	sender := &sshSender{client: wrapper, host: host, port: cfg.SSHPort, logger: logger}
+	receiver := &sshReceiver{client: wrapper, host: host, port: cfg.SSHPort, logger: logger}
 	return sender, receiver, nil
 }
+
+func (s *sshSender) Close() error { return s.client.Close() }
+
+func (r *sshReceiver) Close() error { return r.client.Close() }
 
 func (s *sshSender) Send(ctx context.Context, r io.Reader) error {
 	if err := ctx.Err(); err != nil {

--- a/internal/transport/ssh/ssh_test.go
+++ b/internal/transport/ssh/ssh_test.go
@@ -161,6 +161,10 @@ func setupTransport(t *testing.T, srv *mockServer) (transport.Sender, transport.
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	t.Cleanup(func() {
+		_ = s.(*sshSender).Close()
+		_ = r.(*sshReceiver).Close()
+	})
 	return s, r
 }
 
@@ -202,7 +206,7 @@ func TestSSHNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Atoi: %v", err)
 	}
-	_, _, err = New(&config.Config{
+	s, r, err := New(&config.Config{
 		SSHUser:              "test",
 		SSHKeyPath:           remotetest.CreateTempKey(t),
 		SSHPort:              port,
@@ -213,6 +217,8 @@ func TestSSHNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	_ = s.(*sshSender).Close()
+	_ = r.(*sshReceiver).Close()
 }
 
 func TestSSHContextCancel(t *testing.T) {

--- a/remote/keepalive.go
+++ b/remote/keepalive.go
@@ -2,18 +2,24 @@
 package remote
 
 import (
+	"context"
 	"time"
 
 	"go.uber.org/zap"
 )
 
-func (c *SSHClient) startKeepAlive(host string, interval time.Duration) {
+func (c *SSHClient) startKeepAlive(ctx context.Context, host string, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		if err := c.sendKeepAlive(host); err != nil {
-			break
+	for {
+		select {
+		case <-ticker.C:
+			if err := c.sendKeepAlive(host); err != nil {
+				return
+			}
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -2,6 +2,7 @@
 package remote
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +31,16 @@ type SSHClient struct {
 // private key or the local SSH agent for authentication. The connection is
 // configured with a keep-alive mechanism and host key verification based on the
 // provided known_hosts file.
-func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*SSHClient, error) {
+func NewSSHClient(
+	ctx context.Context,
+	host, user, keyPath string,
+	port int,
+	knownHostsPath string,
+	verify bool,
+	timeout, keepAliveInterval time.Duration,
+	retries int,
+	logger *zap.Logger,
+) (*SSHClient, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -57,7 +67,7 @@ func NewSSHClient(host, user, keyPath string, port int, knownHostsPath string, v
 	}
 
 	sshClient := &SSHClient{Client: client, Logger: logger}
-	go sshClient.startKeepAlive(host, keepAliveInterval)
+	go sshClient.startKeepAlive(ctx, host, keepAliveInterval)
 
 	return sshClient, nil
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -44,7 +45,7 @@ func TestNewSSHClientNoAuth(t *testing.T) {
 	}()
 
 	knownHosts := remotetest.CreateEmptyKnownHosts(t)
-	_, err := NewSSHClient("localhost", "root", "", 22, knownHosts, true, time.Second, time.Second, 0, zap.NewNop())
+	_, err := NewSSHClient(context.Background(), "localhost", "root", "", 22, knownHosts, true, time.Second, time.Second, 0, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "no SSH authentication methods configured") {
 		t.Fatalf("expected error for missing auth methods, got %v", err)
 	}

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -29,21 +30,22 @@ func TestStartKeepAlive(t *testing.T) {
 
 	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		client.startKeepAlive("host", 10*time.Millisecond)
+		client.startKeepAlive(ctx, "host", 10*time.Millisecond)
 		close(done)
 	}()
 
 	time.Sleep(30 * time.Millisecond)
-	if err := client.Close(); err != nil {
-		t.Fatalf("client.Close error: %v", err)
-	}
-
+	cancel()
 	select {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("startKeepAlive did not exit")
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close error: %v", err)
 	}
 
 	if len(server.GlobalRequests()) == 0 {
@@ -54,11 +56,13 @@ func TestStartKeepAlive(t *testing.T) {
 func TestNewSSHClient(t *testing.T) {
 	server, host, port, knownHosts := newSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	keyPath := remotetest.CreateTempKey(t)
-	client, err := NewSSHClient(host, "test", keyPath, port, knownHosts, true, time.Second, 10*time.Millisecond, 0, zap.NewNop())
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := NewSSHClient(ctx, host, "test", keyPath, port, knownHosts, true, time.Second, 10*time.Millisecond, 0, zap.NewNop())
 	if err != nil {
 		t.Fatalf("NewSSHClient error: %v", err)
 	}
 	time.Sleep(20 * time.Millisecond)
+	cancel()
 	if err := client.Close(); err != nil {
 		t.Fatalf("client.Close error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- manage SSH keepalive with context for clean shutdown
- expose cancelation from SSH client setup and transport

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b6ff025d083238c2094499cc78638