### PR TITLE
docs: add supported platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Flexible Configuration**: Flags, environment variables, or `config.yaml`. See [Configuration](#configuration).
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.
 
+## Supported Platforms
+
+LVMSync targets Linux systems only. Builds are tested on the `amd64` and `arm64` architectures.
+
 ## Roadmap
 
 - gRPC control plane with mTLS and configurable ports

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,6 +4,10 @@
 
 LVMSync provides high-performance block-level replication for LVM snapshots on 64-bit Linux systems. The repository already includes Go modules, basic tests and CI, but still needs improved coverage, error handling and developer documentation. This PRD outlines remaining capabilities, coding standards and tasks for future development.
 
+## Supported Platforms
+
+LVMSync runs on Linux only and is validated on the `amd64` and `arm64` architectures.
+
 ## Goals
 
 - Reliable incremental replication of LVM snapshots across hosts.

--- a/packaging/systemd/lvmsync-grpcd.service
+++ b/packaging/systemd/lvmsync-grpcd.service
@@ -1,4 +1,6 @@
 [Unit]
+# LVMSync gRPC daemon service
+# Supported Platforms: Linux only, tested on amd64 and arm64
 Description=LVMSync gRPC daemon
 
 [Service]


### PR DESCRIPTION
## Summary
- document Linux-only support and tested amd64/arm64 architectures
- note supported platforms in docs/PRD and systemd service

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b74f47bac83239bad99159f388336