### PR TITLE
feat(grpc): add dial timeout and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--grpc_listen` | `LVMSYNC_GRPC_LISTEN` | `grpc_listen` | gRPC listen address |
 | `--grpc_connect` | `LVMSYNC_GRPC_CONNECT` | `grpc_connect` | gRPC server address to connect to |
 | `--grpc_port` | `LVMSYNC_GRPC_PORT` | `grpc_port` | gRPC port to listen on |
+| `--grpc_dial_timeout` | `LVMSYNC_GRPC_DIAL_TIMEOUT` | `grpc_dial_timeout` | gRPC dial timeout |
 | `--tls_cert` | `LVMSYNC_TLS_CERT` | `tls_cert` | TLS certificate file |
 | `--tls_key` | `LVMSYNC_TLS_KEY` | `tls_key` | TLS key file |
 | `--ca_cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
@@ -784,6 +785,7 @@ sender, receiver, err := ssh.New(cfg, logger)
 | Option             | Description                  | Default         |
 | ------------------ | ---------------------------- | --------------- |
 | `--grpc_port`      | gRPC port to listen on       | `8443`          |
+| `--grpc_dial_timeout` | gRPC dial timeout          | `5s`            |
 | `--tls_cert`       | TLS certificate file         | `""`            |
 | `--tls_key`        | TLS key file                 | `""`            |
 | `--ca_cert`        | CA certificate file          | `""`            |

--- a/app/app.go
+++ b/app/app.go
@@ -27,8 +27,8 @@ var (
 	newServer = func(cfg grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
 		return grpcserver.New(cfg, agent)
 	}
-	dial = func(addr string, conf grpcclient.Config) (closeableConn, error) {
-		return grpcclient.Dial(addr, conf)
+	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
+		return grpcclient.Dial(ctx, addr, conf)
 	}
 	handshake     = grpcclient.Handshake
 	createSession = grpcclient.CreateSession
@@ -87,18 +87,20 @@ func ClientHandshake(cfg *config.Config, logger *zap.Logger) (func(), error) {
 	if cfg.GRPCConnect == "" {
 		return func() {}, nil
 	}
-	conn, err := dial(cfg.GRPCConnect, grpcclient.Config{
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, err := dial(ctx, cfg.GRPCConnect, grpcclient.Config{
 		TLSCert:       cfg.TLSCert,
 		TLSKey:        cfg.TLSKey,
 		CACert:        cfg.CACert,
 		AllowInsecure: cfg.AllowInsecure,
+		DialTimeout:   cfg.GRPCDialTimeout,
 	})
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("gRPC dial: %w", err)
 	}
 	c := proto.NewReplicationClient(conn)
 	hs := &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: uint32(cfg.Parallel), DedupSupported: true, CompressionSupported: true}
-	ctx, cancel := context.WithCancel(context.Background())
 	hsCtx, hsCancel := context.WithTimeout(ctx, 10*time.Second)
 	if _, err := handshake(hsCtx, c, hs); err != nil {
 		hsCancel()

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -88,7 +88,7 @@ func (f *fakeStream) Send(*proto.Ack) error { return nil }
 func (f *fakeStream) CloseSend() error      { f.closed = true; return nil }
 
 func TestClientHandshakeSuccess(t *testing.T) {
-	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1}
+	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1, GRPCDialTimeout: time.Second}
 	logger := zap.NewNop()
 
 	fc := &fakeConn{}
@@ -103,7 +103,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 		createSession = origCreateSession
 		ackStream = origAckStream
 	}()
-	dial = func(addr string, conf grpcclient.Config) (closeableConn, error) { return fc, nil }
+	dial = func(context.Context, string, grpcclient.Config) (closeableConn, error) { return fc, nil }
 	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
 		return &proto.HandshakeResponse{}, nil
 	}
@@ -123,11 +123,13 @@ func TestClientHandshakeSuccess(t *testing.T) {
 }
 
 func TestClientHandshakeDialError(t *testing.T) {
-	cfg := &config.Config{GRPCConnect: "addr"}
+	cfg := &config.Config{GRPCConnect: "addr", GRPCDialTimeout: time.Second}
 	logger := zap.NewNop()
 	origDial := dial
 	defer func() { dial = origDial }()
-	dial = func(string, grpcclient.Config) (closeableConn, error) { return nil, errors.New("dial fail") }
+	dial = func(context.Context, string, grpcclient.Config) (closeableConn, error) {
+		return nil, errors.New("dial fail")
+	}
 
 	if _, err := ClientHandshake(cfg, logger); err == nil {
 		t.Fatalf("expected error")

--- a/config/config.go
+++ b/config/config.go
@@ -105,6 +105,7 @@ type Config struct {
 	GRPCPort              int           `mapstructure:"grpc_port"`
 	GRPCListen            string        `mapstructure:"grpc_listen"`
 	GRPCConnect           string        `mapstructure:"grpc_connect"`
+	GRPCDialTimeout       time.Duration `mapstructure:"grpc_dial_timeout"` // gRPC dial timeout
 	TLSCert               string        `mapstructure:"tls_cert"`
 	TLSKey                string        `mapstructure:"tls_key"`
 	CACert                string        `mapstructure:"ca_cert"`
@@ -430,6 +431,7 @@ func DefaultConfig() (*Config, error) {
 		GRPCPort:              8443,
 		GRPCListen:            "",
 		GRPCConnect:           "",
+		GRPCDialTimeout:       5 * time.Second,
 		TLSCert:               "",
 		TLSKey:                "",
 		CACert:                "",
@@ -537,6 +539,7 @@ func initGRPCFlags(cfg *Config) *pflag.FlagSet {
 	fs.Int("grpc_port", cfg.GRPCPort, "gRPC port to listen on")
 	fs.String("grpc_listen", cfg.GRPCListen, "gRPC listen address")
 	fs.String("grpc_connect", cfg.GRPCConnect, "gRPC server address to connect to")
+	fs.Duration("grpc_dial_timeout", cfg.GRPCDialTimeout, "gRPC dial timeout")
 	fs.String("tls_cert", cfg.TLSCert, "TLS certificate file")
 	fs.String("tls_key", cfg.TLSKey, "TLS key file")
 	fs.String("ca_cert", cfg.CACert, "CA certificate file")
@@ -671,6 +674,9 @@ func LoadConfig() (*Config, error) {
 func (c *Config) Validate() error {
 	if c.SSHKeepAliveInterval <= 0 {
 		return fmt.Errorf("ssh keepalive interval must be > 0")
+	}
+	if c.GRPCDialTimeout <= 0 {
+		return fmt.Errorf("grpc dial timeout must be > 0")
 	}
 	if c.VolumeGroup != "" {
 		if _, err := lvm.GetVolumeGroupFreeSpace(context.Background(), c.VolumeGroup); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -284,7 +284,7 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second}
+		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second}
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -296,14 +296,14 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second}
+		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidKeepalive", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: 0}
+		cfg := &Config{SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -371,7 +371,7 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second}
+	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -180,6 +180,7 @@ func TestInitGRPCFlags(t *testing.T) {
 		{"grpc_port", strconv.Itoa(cfg.GRPCPort)},
 		{"grpc_listen", cfg.GRPCListen},
 		{"grpc_connect", cfg.GRPCConnect},
+		{"grpc_dial_timeout", cfg.GRPCDialTimeout.String()},
 		{"tls_cert", cfg.TLSCert},
 		{"tls_key", cfg.TLSKey},
 		{"ca_cert", cfg.CACert},

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -25,9 +25,10 @@ type Config struct {
 	TLSKey        string
 	CACert        string
 	AllowInsecure bool
+	DialTimeout   time.Duration
 }
 
-func Dial(addr string, conf Config, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func Dial(ctx context.Context, addr string, conf Config, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	if conf.AllowInsecure {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
@@ -55,7 +56,9 @@ func Dial(addr string, conf Config, opts ...grpc.DialOption) (*grpc.ClientConn, 
 	if !strings.Contains(addr, "://") {
 		target = "passthrough:///" + addr
 	}
-	return grpc.NewClient(target, opts...)
+	dctx, cancel := context.WithTimeout(ctx, conf.DialTimeout)
+	defer cancel()
+	return grpc.DialContext(dctx, target, opts...)
 }
 
 func Handshake(ctx context.Context, c proto.ReplicationClient, hs *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -36,11 +36,13 @@ func setupClient(t *testing.T) (proto.ReplicationClient, func()) {
 		t.Fatalf("server.New: %v", err)
 	}
 	go srv.Serve(lis)
-	conn, err := Dial("bufnet", Config{AllowInsecure: true}, grpc.WithContextDialer(bufDialer(lis)))
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, err := Dial(ctx, "bufnet", Config{AllowInsecure: true, DialTimeout: time.Second}, grpc.WithContextDialer(bufDialer(lis)))
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
 	cleanup := func() {
+		cancel()
 		conn.Close()
 		srv.Stop()
 	}
@@ -84,8 +86,8 @@ func TestDial(t *testing.T) {
 		conf    Config
 		wantErr bool
 	}{
-		{"insecure", Config{AllowInsecure: true}, false},
-		{"missingCert", Config{TLSCert: "nope", TLSKey: "nope", CACert: "nope"}, true},
+		{"insecure", Config{AllowInsecure: true, DialTimeout: time.Second}, false},
+		{"missingCert", Config{TLSCert: "nope", TLSKey: "nope", CACert: "nope", DialTimeout: time.Second}, true},
 	}
 
 	for _, tc := range cases {
@@ -94,7 +96,9 @@ func TestDial(t *testing.T) {
 			if !tc.wantErr {
 				opts = append(opts, grpc.WithContextDialer(bufDialer(lis)))
 			}
-			conn, err := Dial("bufnet", tc.conf, opts...)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			conn, err := Dial(ctx, "bufnet", tc.conf, opts...)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")


### PR DESCRIPTION
## Summary
- handle context cancellation and dial timeout for gRPC clients
- allow configuring gRPC dial timeout via flag/env/config
- update tests and documentation for new gRPC dial behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_689b74eaea0c8323b93526162c57f6a4