### PR TITLE
feat: add configurable LVM timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
 | `--lvm_escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands |
+| `--lvm_timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations |
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
 | `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
 | `--target_vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
@@ -769,15 +770,16 @@ sender, receiver, err := ssh.New(cfg, logger)
 
 #### LVM Options
 
-| Option                     | Description                                                                                                  | Default     |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
-| `--skip_snapshot_creation` | Skip automatic snapshot creation                                                                             | `false`     |
-| `--skip_disk_check`        | Skip disk space check before snapshot creation                                                               | `false`     |
-| `--snapshot_size`          | Snapshot size as an absolute value (e.g., `"20G"`) or as a percentage (e.g., `"20%"`)                        | `"20%"`     |
-| `--volume_group`           | Source volume group. Derived from the source device path when empty                                          | `""`        |
-| `--target_volume_group`    | Volume group name of the target LVM volume                                                                   | `""`        |
-| `--target_vgs`             | Candidate target volume groups for auto-selection                                                            | `[]`        |
-| `--lvm_escalation`         | Command used to re-execute the program with elevated privileges when not running as root (e.g., `"sudo -n"`) | `"sudo -n"` |
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| `--skip_snapshot_creation` | Skip automatic snapshot creation | `false` |
+| `--skip_disk_check` | Skip disk space check before snapshot creation | `false` |
+| `--snapshot_size` | Snapshot size as an absolute value (e.g., "20G") or as a percentage (e.g., "20%") | "20%" |
+| `--volume_group` | Source volume group. Derived from the source device path when empty | "" |
+| `--target_volume_group` | Volume group name of the target LVM volume | "" |
+| `--target_vgs` | Candidate target volume groups for auto-selection | [] |
+| `--lvm_escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n") | "sudo -n" |
+| `--lvm_timeout` | Timeout for LVM operations | 10s |
 
 #### gRPC Options
 

--- a/config.yaml
+++ b/config.yaml
@@ -82,6 +82,7 @@ target_vgs: [ ]  # Candidate target VGs for auto-selection
 # Command used to re-execute the program with elevated privileges
 # when required
 lvm_escalation: "sudo -n"
+lvm_timeout: 10s  # Timeout for LVM operations
 progress: true  # Enable progress display during transfer
 # Block size for LVM operations ('auto' or 0 for automatic detection)
 block_size: "auto"

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ type Config struct {
 	TargetVolumeGroup     string        `mapstructure:"target_volume_group"`
 	TargetVGCandidates    []string      `mapstructure:"target_vgs"`
 	LVMEscalation         string        `mapstructure:"lvm_escalation"`
+	LVMTimeout            time.Duration `mapstructure:"lvm_timeout"`
 	Progress              bool          `mapstructure:"progress"`
 	BlockSize             int           `mapstructure:"-"`
 	BlockSizeRaw          string        `mapstructure:"-"`
@@ -415,6 +416,7 @@ func DefaultConfig() (*Config, error) {
 		TargetVolumeGroup:     "",
 		TargetVGCandidates:    []string{},
 		LVMEscalation:         "sudo -n",
+		LVMTimeout:            10 * time.Second,
 		Progress:              true,
 		BlockSize:             0,
 		BlockSizeRaw:          Auto,
@@ -526,6 +528,7 @@ func initLVMFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("skip_disk_check", cfg.SkipDiskCheck, "Skip disk space check before snapshot creation")
 	fs.String("snapshot_size", cfg.SnapshotSize, "Snapshot size (e.g., '20G' or '20%')")
 	fs.String("lvm_escalation", cfg.LVMEscalation, "Command used to escalate privileges for LVM commands")
+	fs.Duration("lvm_timeout", cfg.LVMTimeout, "Timeout for LVM operations")
 	fs.String("volume_group", cfg.VolumeGroup, "Source volume group; derived from the source device path when empty")
 	fs.String("target_volume_group", cfg.TargetVolumeGroup, "Volume group name of the target LVM volume")
 	fs.StringSlice("target_vgs", cfg.TargetVGCandidates, "Candidate target volume groups for auto-selection")
@@ -673,12 +676,16 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("ssh keepalive interval must be > 0")
 	}
 	if c.VolumeGroup != "" {
-		if _, err := lvm.GetVolumeGroupFreeSpace(context.Background(), c.VolumeGroup); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), c.LVMTimeout)
+		defer cancel()
+		if _, err := lvm.GetVolumeGroupFreeSpace(ctx, c.VolumeGroup); err != nil {
 			return fmt.Errorf("volume group %q does not exist or is inaccessible: %w", c.VolumeGroup, err)
 		}
 	}
 	if c.TargetVolumeGroup != "" {
-		if _, err := lvm.GetVolumeGroupFreeSpace(context.Background(), c.TargetVolumeGroup); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), c.LVMTimeout)
+		defer cancel()
+		if _, err := lvm.GetVolumeGroupFreeSpace(ctx, c.TargetVolumeGroup); err != nil {
 			return fmt.Errorf("target volume group %q does not exist or is inaccessible: %w", c.TargetVolumeGroup, err)
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -45,6 +45,23 @@ func (f *fakeBackend) ListVolumeGroups(_ context.Context, candidates []string) (
 	return res, nil
 }
 
+type timeoutBackend struct{}
+
+func (timeoutBackend) CreateSnapshot(context.Context, string, string, string) error { return nil }
+func (timeoutBackend) RemoveSnapshot(context.Context, string) error                 { return nil }
+func (timeoutBackend) GetSnapshotUsage(context.Context, string) (float64, error)    { return 0, nil }
+func (timeoutBackend) GetVolumeGroupFreeSpace(ctx context.Context, _ string) (uint64, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-time.After(10 * time.Millisecond):
+		return 0, nil
+	}
+}
+func (timeoutBackend) ListVolumeGroups(context.Context, []string) ([]lvm.VolumeGroup, error) {
+	return nil, nil
+}
+
 func TestDefaultConfigCompress(t *testing.T) {
 	cfg, err := DefaultConfig()
 	if err != nil {
@@ -284,7 +301,7 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second}
+		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second}
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -296,7 +313,7 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second}
+		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -306,6 +323,17 @@ func TestConfigValidate(t *testing.T) {
 		cfg := &Config{SSHKeepAliveInterval: 0}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		restore := lvm.SetBackend(timeoutBackend{})
+		defer restore()
+		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
+		defer restorePriv()
+		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Millisecond}
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected timeout error")
 		}
 	})
 }

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -155,6 +155,7 @@ func TestInitLVMFlags(t *testing.T) {
 		{"skip_disk_check", strconv.FormatBool(cfg.SkipDiskCheck)},
 		{"snapshot_size", cfg.SnapshotSize},
 		{"lvm_escalation", cfg.LVMEscalation},
+		{"lvm_timeout", cfg.LVMTimeout.String()},
 		{"volume_group", cfg.VolumeGroup},
 		{"target_volume_group", cfg.TargetVolumeGroup},
 		{"target_vgs", "[]"},


### PR DESCRIPTION
## Summary
- add `lvm_timeout` option and flag for LVM operations
- enforce timeout when validating volume groups
- document new timeout setting in README and sample config

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b74f2bf808323a7b8cc1663399e7c