### PR TITLE
docs: clarify positional args

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,33 +55,32 @@ logger.Info("snapshot complete",
 ### Flag Grouping Example
 
 ```go
-func initConfig() *viper.Viper {
+func initConfig() (*viper.Viper, string, string) {
     v := viper.New()
-    syncFlags := pflag.NewFlagSet("sync", pflag.ExitOnError)
-    syncFlags.String("source", "", "snapshot device")
-    syncFlags.String("dest", "", "destination path")
-    pflag.CommandLine.AddFlagSet(syncFlags)
+    general := pflag.NewFlagSet("general", pflag.ExitOnError)
+    general.Bool("progress", true, "show progress")
+    pflag.CommandLine.AddFlagSet(general)
 
-    v.BindPFlags(syncFlags)
+    v.BindPFlags(pflag.CommandLine)
     v.SetConfigName("config")
     v.AddConfigPath(".")
     v.SetEnvPrefix("LVMSYNC")
     v.AutomaticEnv()
-    return v
+
+    pflag.Parse()
+    args := pflag.Args()
+    if len(args) < 2 {
+        pflag.Usage()
+        os.Exit(1)
+    }
+    return v, args[0], args[1]
 }
 ```
 
-Sample `config.yaml`:
-
-```yaml
-source: /dev/vg0/snap0
-dest: /mnt/backup
-```
-
-Environment override:
+Example invocation:
 
 ```sh
-LVMSYNC_SOURCE=/dev/vg0/snap1
+lvmsync /dev/vg0/snap0 /mnt/backup
 ```
 
 ## Transport Configuration

--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ Logger.Warn("Zero-copy transfer failed",
 ## Configuration
 
 LVMSync uses [`pflag`](https://github.com/spf13/pflag) and [`viper`](https://github.com/spf13/viper) to accept options from
-flags, environment variables, and a YAML file.
+flags, environment variables, and a YAML file. Source and destination paths are provided as positional arguments after any
+flags:
+
+```sh
+lvmsync [flags] <source> <dest>
+```
 
 ### Examples
 


### PR DESCRIPTION
## Summary
- update AGENTS guidelines to show positional source/dest arguments instead of syncFlags example
- clarify README that source and destination are positional arguments after flags

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b7d4cc4c8832386bc784298b64dce