### PR TITLE
fix(grpc): propagate serve errors

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -56,32 +56,38 @@ type ackStreamClient interface {
 	CloseSend() error
 }
 
-// StartGRPCServer starts the gRPC server if configured and returns a cleanup function.
-func StartGRPCServer(cfg *config.Config, logger *zap.Logger) (func(), error) {
+// StartGRPCServer starts the gRPC server if configured and returns a cleanup function and error channel.
+func StartGRPCServer(cfg *config.Config, logger *zap.Logger) (func(), chan error, error) {
+	errCh := make(chan error, 1)
 	if cfg.GRPCListen == "" {
-		return func() {}, nil
+		close(errCh)
+		return func() {}, errCh, nil
 	}
 
 	srvCfg := grpcserver.Config{TLSCert: cfg.TLSCert, TLSKey: cfg.TLSKey, CACert: cfg.CACert, AllowInsecure: cfg.AllowInsecure}
 	ln, err := listen("tcp", cfg.GRPCListen)
 	if err != nil {
-		return nil, fmt.Errorf("gRPC listen: %w", err)
+		close(errCh)
+		return nil, nil, fmt.Errorf("gRPC listen: %w", err)
 	}
 	srv, err := newServer(srvCfg, nil)
 	if err != nil {
 		ln.Close()
-		return nil, fmt.Errorf("gRPC server: %w", err)
+		close(errCh)
+		return nil, nil, fmt.Errorf("gRPC server: %w", err)
 	}
 	go func() {
 		if err := srv.Serve(ln); err != nil {
 			logger.Error("grpc server", zap.Error(err))
+			errCh <- err
 		}
 	}()
 	cleanup := func() {
 		srv.GracefulStop()
 		ln.Close()
+		close(errCh)
 	}
-	return cleanup, nil
+	return cleanup, errCh, nil
 }
 
 // ClientHandshake performs the gRPC client handshake and returns a cleanup function and heartbeat error channel.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -46,7 +46,7 @@ func TestStartGRPCServerSuccess(t *testing.T) {
 	srv := &fakeServer{}
 	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) { return srv, nil }
 
-	cleanup, err := StartGRPCServer(cfg, logger)
+	cleanup, errCh, err := StartGRPCServer(cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,6 +58,9 @@ func TestStartGRPCServerSuccess(t *testing.T) {
 	if !srv.stopped.Load() {
 		t.Fatalf("server not stopped")
 	}
+	if _, ok := <-errCh; ok {
+		t.Fatalf("expected closed channel")
+	}
 }
 
 func TestStartGRPCServerListenError(t *testing.T) {
@@ -67,10 +70,41 @@ func TestStartGRPCServerListenError(t *testing.T) {
 	defer func() { listen = origListen }()
 	listen = func(network, addr string) (net.Listener, error) { return nil, errors.New("boom") }
 
-	if _, err := StartGRPCServer(cfg, logger); err == nil {
+	if _, _, err := StartGRPCServer(cfg, logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestStartGRPCServerServeError(t *testing.T) {
+	cfg := &config.Config{GRPCListen: "127.0.0.1:0"}
+	logger := zap.NewNop()
+	origListen := listen
+	origNewServer := newServer
+	defer func() { listen = origListen; newServer = origNewServer }()
+	listen = func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil }
+	srvErr := errors.New("serve boom")
+	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
+		return &failingServer{err: srvErr}, nil
+	}
+	cleanup, errCh, err := StartGRPCServer(cfg, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, srvErr) {
+			t.Fatalf("unexpected serve error: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout waiting for serve error")
+	}
+}
+
+type failingServer struct{ err error }
+
+func (f *failingServer) Serve(net.Listener) error { return f.err }
+func (f *failingServer) GracefulStop()            {}
 
 // ClientHandshake tests
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -76,16 +76,52 @@ func Configure() (*config.Config, *zap.Logger, error) {
 
 // SetupGRPC starts the server and performs client handshake returning cleanup functions and heartbeat error channel.
 func SetupGRPC(cfg *config.Config, logger *zap.Logger) (func(), func(), chan error, error) {
-	cleanupSrv, err := startGRPCServer(cfg, logger)
+	cleanupSrv, srvErrCh, err := startGRPCServer(cfg, logger)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+	select {
+	case err, ok := <-srvErrCh:
+		if ok && err != nil {
+			cleanupSrv()
+			return nil, nil, nil, fmt.Errorf("gRPC serve: %w", err)
+		}
+	default:
 	}
 	cleanupClient, hbErrCh, err := clientHandshake(cfg, logger)
 	if err != nil {
 		cleanupSrv()
 		return nil, nil, nil, err
 	}
-	return cleanupSrv, cleanupClient, hbErrCh, nil
+
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		for srvErrCh != nil || hbErrCh != nil {
+			select {
+			case err, ok := <-srvErrCh:
+				if !ok {
+					srvErrCh = nil
+					continue
+				}
+				if err != nil {
+					errCh <- err
+					return
+				}
+			case err, ok := <-hbErrCh:
+				if !ok {
+					hbErrCh = nil
+					continue
+				}
+				if err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}
+	}()
+
+	return cleanupSrv, cleanupClient, errCh, nil
 }
 
 // PrepareSnapshot wraps snapshot preparation.

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -22,21 +22,22 @@ func TestSetupGRPCSuccess(t *testing.T) {
 		clientHandshake = origClient
 	}()
 
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
-		return func() { srvCleanCalled = true }, nil
+	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+		ch := make(chan error)
+		return func() { srvCleanCalled = true; close(ch) }, ch, nil
 	}
 	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return func() { clientCleanCalled = true }, make(chan error), nil
 	}
 
-	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(cfg, logger)
+	cleanupSrv, cleanupClient, errCh, err := SetupGRPC(cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cleanupSrv()
 	cleanupClient()
-	if hbErrCh == nil {
-		t.Fatalf("expected heartbeat channel")
+	if errCh == nil {
+		t.Fatalf("expected error channel")
 	}
 	if !srvCleanCalled || !clientCleanCalled {
 		t.Fatalf("cleanup functions not called")
@@ -48,8 +49,8 @@ func TestSetupGRPCServerError(t *testing.T) {
 	logger := zap.NewNop()
 	origStart := startGRPCServer
 	defer func() { startGRPCServer = origStart }()
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
-		return nil, errors.New("srv fail")
+	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+		return nil, nil, errors.New("srv fail")
 	}
 	if _, _, _, err := SetupGRPC(cfg, logger); err == nil {
 		t.Fatalf("expected error")
@@ -66,8 +67,9 @@ func TestSetupGRPCClientError(t *testing.T) {
 		startGRPCServer = origStart
 		clientHandshake = origClient
 	}()
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
-		return func() { srvCleanupCalled = true }, nil
+	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+		ch := make(chan error)
+		return func() { srvCleanupCalled = true; close(ch) }, ch, nil
 	}
 	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return nil, nil, errors.New("client fail")
@@ -77,6 +79,33 @@ func TestSetupGRPCClientError(t *testing.T) {
 	}
 	if !srvCleanupCalled {
 		t.Fatalf("server cleanup not called on error")
+	}
+}
+
+func TestSetupGRPCServeFailurePropagation(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	srvCleanupCalled := false
+	origStart := startGRPCServer
+	origClient := clientHandshake
+	defer func() {
+		startGRPCServer = origStart
+		clientHandshake = origClient
+	}()
+	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+		ch := make(chan error, 1)
+		ch <- errors.New("serve boom")
+		return func() { srvCleanupCalled = true; close(ch) }, ch, nil
+	}
+	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+		t.Fatalf("client handshake should not be called")
+		return nil, nil, nil
+	}
+	if _, _, _, err := SetupGRPC(cfg, logger); err == nil {
+		t.Fatalf("expected error from serve failure")
+	}
+	if !srvCleanupCalled {
+		t.Fatalf("server cleanup not called on serve failure")
 	}
 }
 


### PR DESCRIPTION
## Summary
- capture gRPC `Serve` errors with a dedicated channel and close it during cleanup
- forward server errors in `SetupGRPC` so immediate failures abort startup
- extend gRPC tests for serve failure propagation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b7cf0386c83239060867864fe4f34