### PR TITLE
fix(app): add heartbeat send timeout

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -35,10 +35,11 @@ var (
 	ackStream     = func(ctx context.Context, c proto.ReplicationClient, id string) (ackStreamClient, error) {
 		return grpcclient.AckStream(ctx, c, id)
 	}
-	handleSignals     = signalspkg.Handle
-	prepareSnapshot   = clientpkg.PrepareSnapshot
-	newTicker         = time.NewTicker
-	heartbeatInterval = 30 * time.Second
+	handleSignals        = signalspkg.Handle
+	prepareSnapshot      = clientpkg.PrepareSnapshot
+	newTicker            = time.NewTicker
+	heartbeatInterval    = 30 * time.Second
+	heartbeatSendTimeout = 5 * time.Second
 )
 
 type grpcServer interface {
@@ -132,9 +133,24 @@ func ClientHandshake(cfg *config.Config, logger *zap.Logger) (func(), chan error
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := stream.Send(&proto.Ack{SessionId: id, Ok: true, Message: "ping"}); err != nil {
-					logger.Error("heartbeat send failed", zap.Error(err))
-					hbErrCh <- err
+				sendCtx, sendCancel := context.WithTimeout(ctx, heartbeatSendTimeout)
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- stream.Send(&proto.Ack{SessionId: id, Ok: true, Message: "ping"})
+				}()
+				select {
+				case err := <-errCh:
+					sendCancel()
+					if err != nil {
+						logger.Error("heartbeat send failed", zap.Error(err))
+						hbErrCh <- err
+						cancel()
+						return
+					}
+				case <-sendCtx.Done():
+					sendCancel()
+					logger.Error("heartbeat send timeout", zap.Error(sendCtx.Err()))
+					hbErrCh <- sendCtx.Err()
 					cancel()
 					return
 				}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -184,10 +184,68 @@ func TestClientHandshakeHeartbeatFailure(t *testing.T) {
 	}
 }
 
+func TestClientHandshakeHeartbeatTimeout(t *testing.T) {
+	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1}
+	logger := zap.NewNop()
+
+	fc := &fakeConn{}
+	block := make(chan struct{})
+	fs := &blockingStream{block: block}
+	origDial := dial
+	origHandshake := handshake
+	origCreateSession := createSession
+	origAckStream := ackStream
+	origInterval := heartbeatInterval
+	origTimeout := heartbeatSendTimeout
+	defer func() {
+		dial = origDial
+		handshake = origHandshake
+		createSession = origCreateSession
+		ackStream = origAckStream
+		heartbeatInterval = origInterval
+		heartbeatSendTimeout = origTimeout
+	}()
+	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
+		return fc, nil
+	}
+	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+		return &proto.HandshakeResponse{}, nil
+	}
+	createSession = func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
+		return &proto.SessionResponse{SessionId: "id"}, nil
+	}
+	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
+	heartbeatInterval = 10 * time.Millisecond
+	heartbeatSendTimeout = 20 * time.Millisecond
+
+	cleanup, hbErrCh, err := ClientHandshake(cfg, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	select {
+	case err := <-hbErrCh:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected deadline exceeded, got %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("timeout waiting for heartbeat error")
+	}
+	close(block)
+}
+
 type failingStream struct{ closed bool }
 
 func (f *failingStream) Send(*proto.Ack) error { return errors.New("send fail") }
 func (f *failingStream) CloseSend() error      { f.closed = true; return nil }
+
+type blockingStream struct {
+	closed bool
+	block  chan struct{}
+}
+
+func (b *blockingStream) Send(*proto.Ack) error { <-b.block; return nil }
+func (b *blockingStream) CloseSend() error      { b.closed = true; return nil }
 
 // SetupSignalHandling tests
 


### PR DESCRIPTION
## Summary
- add per-send timeout for client heartbeat stream
- simulate blocked send to verify heartbeat timeout

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b7ce5ac788323b1859ccb26acad59