### PR TITLE
feat(grpc): add context-aware server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ serve_listen: ":9900"
 
 The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel.
 
+`StartGRPCServer` accepts a `context.Context` and runs the server in a goroutine, returning a buffered error channel. Cancel the context or invoke the cleanup function to stop the server and wait on the channel during shutdown to surface any serve errors.
+
 1. **Handshake** – clients advertise `sector_size`, `alignment`, `max_concurrency`, and whether deduplication and compression are supported.
 2. **Session Creation** – the client sends an ephemeral certificate and receives a session ID, server certificate, and pre-shared key.
 3. **Resume Bitmap** – dirty block bitmaps are streamed with the session ID to resume interrupted transfers, and final manifests carrying SHA-256 digests validate completion.

--- a/app/app.go
+++ b/app/app.go
@@ -56,32 +56,42 @@ type ackStreamClient interface {
 	CloseSend() error
 }
 
-// StartGRPCServer starts the gRPC server if configured and returns a cleanup function.
-func StartGRPCServer(cfg *config.Config, logger *zap.Logger) (func(), error) {
+// StartGRPCServer starts the gRPC server if configured and returns a cleanup function and error channel.
+func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), <-chan error, error) {
+	errCh := make(chan error, 1)
 	if cfg.GRPCListen == "" {
-		return func() {}, nil
+		close(errCh)
+		return func() {}, errCh, nil
 	}
 
 	srvCfg := grpcserver.Config{TLSCert: cfg.TLSCert, TLSKey: cfg.TLSKey, CACert: cfg.CACert, AllowInsecure: cfg.AllowInsecure}
 	ln, err := listen("tcp", cfg.GRPCListen)
 	if err != nil {
-		return nil, fmt.Errorf("gRPC listen: %w", err)
+		return nil, nil, fmt.Errorf("gRPC listen: %w", err)
 	}
 	srv, err := newServer(srvCfg, nil)
 	if err != nil {
 		ln.Close()
-		return nil, fmt.Errorf("gRPC server: %w", err)
+		return nil, nil, fmt.Errorf("gRPC server: %w", err)
 	}
 	go func() {
-		if err := srv.Serve(ln); err != nil {
-			logger.Error("grpc server", zap.Error(err))
+		serveErrCh := make(chan error, 1)
+		go func() { serveErrCh <- srv.Serve(ln) }()
+		var serveErr error
+		select {
+		case serveErr = <-serveErrCh:
+		case <-ctx.Done():
+			srv.GracefulStop()
+			ln.Close()
+			serveErr = <-serveErrCh
 		}
+		errCh <- serveErr
 	}()
 	cleanup := func() {
 		srv.GracefulStop()
 		ln.Close()
 	}
-	return cleanup, nil
+	return cleanup, errCh, nil
 }
 
 // ClientHandshake performs the gRPC client handshake and returns a cleanup function and heartbeat error channel.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -46,7 +46,8 @@ func TestStartGRPCServerSuccess(t *testing.T) {
 	srv := &fakeServer{}
 	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) { return srv, nil }
 
-	cleanup, err := StartGRPCServer(cfg, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	cleanup, errCh, err := StartGRPCServer(ctx, cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,8 +56,12 @@ func TestStartGRPCServerSuccess(t *testing.T) {
 		t.Fatalf("server not started")
 	}
 	cleanup()
+	cancel()
 	if !srv.stopped.Load() {
 		t.Fatalf("server not stopped")
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("unexpected server error: %v", err)
 	}
 }
 
@@ -67,7 +72,7 @@ func TestStartGRPCServerListenError(t *testing.T) {
 	defer func() { listen = origListen }()
 	listen = func(network, addr string) (net.Listener, error) { return nil, errors.New("boom") }
 
-	if _, err := StartGRPCServer(cfg, logger); err == nil {
+	if _, _, err := StartGRPCServer(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -75,17 +75,22 @@ func Configure() (*config.Config, *zap.Logger, error) {
 }
 
 // SetupGRPC starts the server and performs client handshake returning cleanup functions and heartbeat error channel.
-func SetupGRPC(cfg *config.Config, logger *zap.Logger) (func(), func(), chan error, error) {
-	cleanupSrv, err := startGRPCServer(cfg, logger)
+func SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), func(), chan error, error) {
+	cleanupSrv, srvErrCh, err := startGRPCServer(ctx, cfg, logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	cleanupClient, hbErrCh, err := clientHandshake(cfg, logger)
 	if err != nil {
 		cleanupSrv()
+		<-srvErrCh
 		return nil, nil, nil, err
 	}
-	return cleanupSrv, cleanupClient, hbErrCh, nil
+	wrappedSrvCleanup := func() {
+		cleanupSrv()
+		<-srvErrCh
+	}
+	return wrappedSrvCleanup, cleanupClient, hbErrCh, nil
 }
 
 // PrepareSnapshot wraps snapshot preparation.
@@ -121,11 +126,16 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 		return err
 	}
 
-	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(cfg, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(ctx, cfg, logger)
 	if err != nil {
+		cancel()
 		return err
 	}
-	defer cleanupSrv()
+	defer func() {
+		cancel()
+		cleanupSrv()
+	}()
 	defer cleanupClient()
 	_ = hbErrCh
 

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -1,8 +1,10 @@
 package root
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"lvmsync_go/config"
 
@@ -22,18 +24,30 @@ func TestSetupGRPCSuccess(t *testing.T) {
 		clientHandshake = origClient
 	}()
 
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
-		return func() { srvCleanCalled = true }, nil
+	srvErrCh := make(chan error)
+	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+		return func() { srvCleanCalled = true }, srvErrCh, nil
 	}
 	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return func() { clientCleanCalled = true }, make(chan error), nil
 	}
 
-	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(cfg, logger)
+	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	cleanupSrv()
+	done := make(chan struct{})
+	go func() {
+		cleanupSrv()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatalf("cleanupSrv returned before errCh signal")
+	case <-time.After(10 * time.Millisecond):
+	}
+	srvErrCh <- nil
+	<-done
 	cleanupClient()
 	if hbErrCh == nil {
 		t.Fatalf("expected heartbeat channel")
@@ -48,10 +62,10 @@ func TestSetupGRPCServerError(t *testing.T) {
 	logger := zap.NewNop()
 	origStart := startGRPCServer
 	defer func() { startGRPCServer = origStart }()
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
-		return nil, errors.New("srv fail")
+	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+		return nil, nil, errors.New("srv fail")
 	}
-	if _, _, _, err := SetupGRPC(cfg, logger); err == nil {
+	if _, _, _, err := SetupGRPC(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -66,15 +80,28 @@ func TestSetupGRPCClientError(t *testing.T) {
 		startGRPCServer = origStart
 		clientHandshake = origClient
 	}()
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), error) {
-		return func() { srvCleanupCalled = true }, nil
+	srvErrCh := make(chan error)
+	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+		return func() { srvCleanupCalled = true }, srvErrCh, nil
 	}
 	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return nil, nil, errors.New("client fail")
 	}
-	if _, _, _, err := SetupGRPC(cfg, logger); err == nil {
-		t.Fatalf("expected error")
+	done := make(chan struct{})
+	go func() {
+		_, _, _, err := SetupGRPC(context.Background(), cfg, logger)
+		if err == nil {
+			t.Errorf("expected error")
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatalf("SetupGRPC returned before errCh signal")
+	case <-time.After(10 * time.Millisecond):
 	}
+	srvErrCh <- nil
+	<-done
 	if !srvCleanupCalled {
 		t.Fatalf("server cleanup not called on error")
 	}


### PR DESCRIPTION
## Summary
- allow StartGRPCServer to accept a context and expose serve errors via a channel
- propagate context into SetupGRPC and wait for server shutdown
- document context-aware gRPC server behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b7cdbb9b0832395050a5e61796a3e