### PR TITLE
fix(root): monitor heartbeat errors

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -127,11 +127,17 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	}
 	defer cleanupSrv()
 	defer cleanupClient()
-	_ = hbErrCh
 
 	var snapshotPath string
 	signals, sigErrCh := setupSignalHandle(cfg, &snapshotPath, logger)
 	defer signal.Stop(signals)
+
+	go func() {
+		if err := <-hbErrCh; err != nil {
+			logger.Error("heartbeat error", zap.Error(err))
+			sigErrCh <- err
+		}
+	}()
 
 	args := pflag.Args()
 	if (cfg.StdoutMode && len(args) < 1) || (!cfg.StdoutMode && len(args) < 2) {

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -2,8 +2,10 @@ package root
 
 import (
 	"errors"
+	"os"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"lvmsync_go/config"
 
 	"go.uber.org/zap"
@@ -122,5 +124,53 @@ func TestExecuteClient(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("executeClientFn not called")
+	}
+}
+
+func TestRunHeartbeatError(t *testing.T) {
+	cfg := &config.Config{StdoutMode: true}
+	logger := zap.NewNop()
+
+	origStart := startGRPCServer
+	origClient := clientHandshake
+	origSetup := setupSignalHandle
+	origPrepare := prepareSnapshotFn
+	origExec := executeClientFn
+	origSelect := selectTransport
+	defer func() {
+		startGRPCServer = origStart
+		clientHandshake = origClient
+		setupSignalHandle = origSetup
+		prepareSnapshotFn = origPrepare
+		executeClientFn = origExec
+		selectTransport = origSelect
+	}()
+
+	hbErrCh := make(chan error, 1)
+	hbErrCh <- errors.New("hb fail")
+
+	startGRPCServer = func(*config.Config, *zap.Logger) (func(), error) { return func() {}, nil }
+	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
+		return func() {}, hbErrCh, nil
+	}
+	selectTransport = func(*config.Config, *zap.Logger) error { return nil }
+
+	sigErrCh := make(chan error, 1)
+	setupSignalHandle = func(*config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+		return nil, sigErrCh
+	}
+	prepareSnapshotFn = func(*config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+		return "snap", nil, func() {}, nil
+	}
+	executeClientFn = func(f func(string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
+		return <-sigErrCh
+	}
+
+	pflag.CommandLine = pflag.NewFlagSet("test", pflag.ContinueOnError)
+	pflag.CommandLine.Parse([]string{"vol"})
+
+	err := Run(cfg, logger)
+	if err == nil || err.Error() != "hb fail" {
+		t.Fatalf("expected heartbeat error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- handle heartbeat channel errors in root Run
- add test ensuring heartbeat error terminates Run

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b7cceb2a483239399eed0991d5c3b