### PR TITLE
feat(config): add gRPC heartbeat settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--grpc_connect` | `LVMSYNC_GRPC_CONNECT` | `grpc_connect` | gRPC server address to connect to |
 | `--grpc_port` | `LVMSYNC_GRPC_PORT` | `grpc_port` | gRPC port to listen on |
 | `--grpc_dial_timeout` | `LVMSYNC_GRPC_DIAL_TIMEOUT` | `grpc_dial_timeout` | gRPC dial timeout |
+| `--grpc_heartbeat_interval` | `LVMSYNC_GRPC_HEARTBEAT_INTERVAL` | `grpc_heartbeat_interval` | gRPC heartbeat interval |
+| `--grpc_heartbeat_send_timeout` | `LVMSYNC_GRPC_HEARTBEAT_SEND_TIMEOUT` | `grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout |
 | `--tls_cert` | `LVMSYNC_TLS_CERT` | `tls_cert` | TLS certificate file |
 | `--tls_key` | `LVMSYNC_TLS_KEY` | `tls_key` | TLS key file |
 | `--ca_cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
@@ -799,6 +801,8 @@ sender, receiver, err := ssh.New(cfg, logger)
 | ------------------ | ---------------------------- | --------------- |
 | `--grpc_port`      | gRPC port to listen on       | `8443`          |
 | `--grpc_dial_timeout` | gRPC dial timeout          | `5s`            |
+| `--grpc_heartbeat_interval` | gRPC heartbeat interval | `30s`          |
+| `--grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout | `5s` |
 | `--tls_cert`       | TLS certificate file         | `""`            |
 | `--tls_key`        | TLS key file                 | `""`            |
 | `--ca_cert`        | CA certificate file          | `""`            |

--- a/app/app.go
+++ b/app/app.go
@@ -35,11 +35,9 @@ var (
 	ackStream     = func(ctx context.Context, c proto.ReplicationClient, id string) (ackStreamClient, error) {
 		return grpcclient.AckStream(ctx, c, id)
 	}
-	handleSignals        = signalspkg.Handle
-	prepareSnapshot      = clientpkg.PrepareSnapshot
-	newTicker            = time.NewTicker
-	heartbeatInterval    = 30 * time.Second
-	heartbeatSendTimeout = 5 * time.Second
+	handleSignals   = signalspkg.Handle
+	prepareSnapshot = clientpkg.PrepareSnapshot
+	newTicker       = time.NewTicker
 )
 
 type grpcServer interface {
@@ -137,14 +135,14 @@ func ClientHandshake(cfg *config.Config, logger *zap.Logger) (func(), chan error
 	}
 	hbErrCh := make(chan error, 1)
 	go func(id string) {
-		ticker := newTicker(heartbeatInterval)
+		ticker := newTicker(cfg.HeartbeatInterval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				sendCtx, sendCancel := context.WithTimeout(ctx, heartbeatSendTimeout)
+				sendCtx, sendCancel := context.WithTimeout(ctx, cfg.HeartbeatSendTimeout)
 				errCh := make(chan error, 1)
 				go func() {
 					errCh <- stream.Send(&proto.Ack{SessionId: id, Ok: true, Message: "ping"})

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -88,7 +88,7 @@ func TestStartGRPCServerServeError(t *testing.T) {
 	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
 		return &failingServer{err: srvErr}, nil
 	}
-	cleanup, errCh, err := StartGRPCServer(cfg, logger)
+	cleanup, errCh, err := StartGRPCServer(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,7 +124,7 @@ func (f *fakeStream) Send(*proto.Ack) error { return nil }
 func (f *fakeStream) CloseSend() error      { f.closed = true; return nil }
 
 func TestClientHandshakeSuccess(t *testing.T) {
-	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1, GRPCDialTimeout: time.Second}
+	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second}
 	logger := zap.NewNop()
 
 	fc := &fakeConn{}
@@ -162,7 +162,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 }
 
 func TestClientHandshakeDialError(t *testing.T) {
-	cfg := &config.Config{GRPCConnect: "addr", GRPCDialTimeout: time.Second}
+	cfg := &config.Config{GRPCConnect: "addr", GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second}
 	logger := zap.NewNop()
 	origDial := dial
 	defer func() { dial = origDial }()
@@ -176,7 +176,7 @@ func TestClientHandshakeDialError(t *testing.T) {
 }
 
 func TestClientHandshakeHeartbeatFailure(t *testing.T) {
-	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1}
+	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1, HeartbeatInterval: 10 * time.Millisecond, HeartbeatSendTimeout: time.Second}
 	logger := zap.NewNop()
 
 	fc := &fakeConn{}
@@ -185,13 +185,11 @@ func TestClientHandshakeHeartbeatFailure(t *testing.T) {
 	origHandshake := handshake
 	origCreateSession := createSession
 	origAckStream := ackStream
-	origInterval := heartbeatInterval
 	defer func() {
 		dial = origDial
 		handshake = origHandshake
 		createSession = origCreateSession
 		ackStream = origAckStream
-		heartbeatInterval = origInterval
 	}()
 	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
 		return fc, nil
@@ -203,7 +201,6 @@ func TestClientHandshakeHeartbeatFailure(t *testing.T) {
 		return &proto.SessionResponse{SessionId: "id"}, nil
 	}
 	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
-	heartbeatInterval = 10 * time.Millisecond
 
 	cleanup, hbErrCh, err := ClientHandshake(cfg, logger)
 	if err != nil {
@@ -221,7 +218,7 @@ func TestClientHandshakeHeartbeatFailure(t *testing.T) {
 }
 
 func TestClientHandshakeHeartbeatTimeout(t *testing.T) {
-	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1}
+	cfg := &config.Config{GRPCConnect: "addr", Parallel: 1, HeartbeatInterval: 10 * time.Millisecond, HeartbeatSendTimeout: 20 * time.Millisecond}
 	logger := zap.NewNop()
 
 	fc := &fakeConn{}
@@ -231,15 +228,11 @@ func TestClientHandshakeHeartbeatTimeout(t *testing.T) {
 	origHandshake := handshake
 	origCreateSession := createSession
 	origAckStream := ackStream
-	origInterval := heartbeatInterval
-	origTimeout := heartbeatSendTimeout
 	defer func() {
 		dial = origDial
 		handshake = origHandshake
 		createSession = origCreateSession
 		ackStream = origAckStream
-		heartbeatInterval = origInterval
-		heartbeatSendTimeout = origTimeout
 	}()
 	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
 		return fc, nil
@@ -251,8 +244,6 @@ func TestClientHandshakeHeartbeatTimeout(t *testing.T) {
 		return &proto.SessionResponse{SessionId: "id"}, nil
 	}
 	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
-	heartbeatInterval = 10 * time.Millisecond
-	heartbeatSendTimeout = 20 * time.Millisecond
 
 	cleanup, hbErrCh, err := ClientHandshake(cfg, logger)
 	if err != nil {

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -52,7 +52,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 	srvErrCh <- nil
 	<-done
 	cleanupClient()
-	if errCh == nil {
+	if hbErrCh == nil {
 		t.Fatalf("expected error channel")
 	}
 	if !srvCleanCalled || !clientCleanCalled {
@@ -120,7 +120,7 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 		startGRPCServer = origStart
 		clientHandshake = origClient
 	}()
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		ch := make(chan error, 1)
 		ch <- errors.New("serve boom")
 		return func() { srvCleanupCalled = true; close(ch) }, ch, nil
@@ -129,7 +129,7 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 		t.Fatalf("client handshake should not be called")
 		return nil, nil, nil
 	}
-	if _, _, _, err := SetupGRPC(cfg, logger); err == nil {
+	if _, _, _, err := SetupGRPC(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error from serve failure")
 	}
 	if !srvCleanupCalled {
@@ -204,7 +204,11 @@ func TestRunHeartbeatError(t *testing.T) {
 	hbErrCh := make(chan error, 1)
 	hbErrCh <- errors.New("hb fail")
 
-	startGRPCServer = func(*config.Config, *zap.Logger) (func(), error) { return func() {}, nil }
+	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
+		ch := make(chan error, 1)
+		close(ch)
+		return func() {}, ch, nil
+	}
 	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,9 @@ sync_interval: "1GB"  # Bytes between fdatasync calls
 
 # gRPC Options
 grpc_port: 8443  # gRPC port to listen on
+grpc_dial_timeout: 5s  # gRPC dial timeout
+grpc_heartbeat_interval: 30s  # gRPC heartbeat interval
+grpc_heartbeat_send_timeout: 5s  # gRPC heartbeat send timeout
 tls_cert: ""  # TLS certificate file
 tls_key: ""  # TLS key file
 ca_cert: ""  # CA certificate file

--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,8 @@ type Config struct {
 	GRPCListen            string        `mapstructure:"grpc_listen"`
 	GRPCConnect           string        `mapstructure:"grpc_connect"`
 	GRPCDialTimeout       time.Duration `mapstructure:"grpc_dial_timeout"` // gRPC dial timeout
+	HeartbeatInterval     time.Duration `mapstructure:"grpc_heartbeat_interval"`
+	HeartbeatSendTimeout  time.Duration `mapstructure:"grpc_heartbeat_send_timeout"`
 	TLSCert               string        `mapstructure:"tls_cert"`
 	TLSKey                string        `mapstructure:"tls_key"`
 	CACert                string        `mapstructure:"ca_cert"`
@@ -434,6 +436,8 @@ func DefaultConfig() (*Config, error) {
 		GRPCListen:            "",
 		GRPCConnect:           "",
 		GRPCDialTimeout:       5 * time.Second,
+		HeartbeatInterval:     30 * time.Second,
+		HeartbeatSendTimeout:  5 * time.Second,
 		TLSCert:               "",
 		TLSKey:                "",
 		CACert:                "",
@@ -543,6 +547,8 @@ func initGRPCFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("grpc_listen", cfg.GRPCListen, "gRPC listen address")
 	fs.String("grpc_connect", cfg.GRPCConnect, "gRPC server address to connect to")
 	fs.Duration("grpc_dial_timeout", cfg.GRPCDialTimeout, "gRPC dial timeout")
+	fs.Duration("grpc_heartbeat_interval", cfg.HeartbeatInterval, "gRPC heartbeat interval")
+	fs.Duration("grpc_heartbeat_send_timeout", cfg.HeartbeatSendTimeout, "gRPC heartbeat send timeout")
 	fs.String("tls_cert", cfg.TLSCert, "TLS certificate file")
 	fs.String("tls_key", cfg.TLSKey, "TLS key file")
 	fs.String("ca_cert", cfg.CACert, "CA certificate file")
@@ -680,6 +686,12 @@ func (c *Config) Validate() error {
 	}
 	if c.GRPCDialTimeout <= 0 {
 		return fmt.Errorf("grpc dial timeout must be > 0")
+	}
+	if c.HeartbeatInterval <= 0 {
+		return fmt.Errorf("grpc heartbeat interval must be > 0")
+	}
+	if c.HeartbeatSendTimeout <= 0 {
+		return fmt.Errorf("grpc heartbeat send timeout must be > 0")
 	}
 	if c.VolumeGroup != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), c.LVMTimeout)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -92,6 +92,16 @@ func TestDefaultConfigStrictHostKeyCheck(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigHeartbeat(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	if cfg.HeartbeatInterval != 30*time.Second || cfg.HeartbeatSendTimeout != 5*time.Second {
+		t.Fatalf("unexpected heartbeat defaults %v %v", cfg.HeartbeatInterval, cfg.HeartbeatSendTimeout)
+	}
+}
+
 func TestHumanBlockSize(t *testing.T) {
 	c := &Config{BlockSize: 0}
 	if c.HumanBlockSize() != Auto {
@@ -307,6 +317,8 @@ func TestConfigValidate(t *testing.T) {
 			SSHKeepAliveInterval: time.Second,
 			LVMTimeout:           time.Second,
 			GRPCDialTimeout:      time.Second,
+			HeartbeatInterval:    time.Second,
+			HeartbeatSendTimeout: time.Second,
 		}
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -326,7 +338,21 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalidKeepalive", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second}
+		cfg := &Config{SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second}
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("invalidHeartbeatInterval", func(t *testing.T) {
+		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second}
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("invalidHeartbeatSendTimeout", func(t *testing.T) {
+		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -405,7 +431,7 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second}
+	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -182,6 +182,8 @@ func TestInitGRPCFlags(t *testing.T) {
 		{"grpc_listen", cfg.GRPCListen},
 		{"grpc_connect", cfg.GRPCConnect},
 		{"grpc_dial_timeout", cfg.GRPCDialTimeout.String()},
+		{"grpc_heartbeat_interval", cfg.HeartbeatInterval.String()},
+		{"grpc_heartbeat_send_timeout", cfg.HeartbeatSendTimeout.String()},
 		{"tls_cert", cfg.TLSCert},
 		{"tls_key", cfg.TLSKey},
 		{"ca_cert", cfg.CACert},

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -67,6 +68,8 @@ func TestFlagSetsBindToViper(t *testing.T) {
 		"--compress", "lz4",
 		"--skip_snapshot_creation=true",
 		"--grpc_port", "9999",
+		"--grpc_heartbeat_interval", "2s",
+		"--grpc_heartbeat_send_timeout", "1s",
 	}
 	resetFlags(args)
 
@@ -102,6 +105,12 @@ func TestFlagSetsBindToViper(t *testing.T) {
 	}
 	if got := v.GetInt("grpc_port"); got != 9999 {
 		t.Fatalf("grpc_port got %d want 9999", got)
+	}
+	if got := v.GetDuration("grpc_heartbeat_interval"); got != 2*time.Second {
+		t.Fatalf("grpc_heartbeat_interval got %v want 2s", got)
+	}
+	if got := v.GetDuration("grpc_heartbeat_send_timeout"); got != time.Second {
+		t.Fatalf("grpc_heartbeat_send_timeout got %v want 1s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add configurable gRPC heartbeat interval and timeout
- document and expose heartbeat options via CLI and config
- use heartbeat values during client handshake

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b83008ad48323a4cbdd794bf7e2b0