### PR TITLE
feat: add context cancellation to client execution

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -88,7 +88,7 @@ func TestStartGRPCServerServeError(t *testing.T) {
 	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
 		return &failingServer{err: srvErr}, nil
 	}
-	cleanup, errCh, err := StartGRPCServer(cfg, logger)
+	cleanup, errCh, err := StartGRPCServer(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -107,8 +107,8 @@ func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logg
 }
 
 // ExecuteClient runs the client transfer logic.
-func ExecuteClient(cfg *config.Config, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
-	return executeClientFn(func(snapshot, dest string) error {
+func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
+	return executeClientFn(ctx, func(ctx context.Context, snapshot, dest string) error {
 		return runDump(cfg, snapshot, dest, logger)
 	}, snapshotPath, destPath, sigErrCh, monitorErrCh)
 }
@@ -175,7 +175,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	}
 	defer cleanup()
 
-	return ExecuteClient(cfg, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
+	return ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
 }
 
 // Execute is a helper that configures and runs the root command.

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -52,7 +52,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 	srvErrCh <- nil
 	<-done
 	cleanupClient()
-	if errCh == nil {
+	if hbErrCh == nil {
 		t.Fatalf("expected error channel")
 	}
 	if !srvCleanCalled || !clientCleanCalled {
@@ -120,7 +120,7 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 		startGRPCServer = origStart
 		clientHandshake = origClient
 	}()
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		ch := make(chan error, 1)
 		ch <- errors.New("serve boom")
 		return func() { srvCleanupCalled = true; close(ch) }, ch, nil
@@ -129,7 +129,7 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 		t.Fatalf("client handshake should not be called")
 		return nil, nil, nil
 	}
-	if _, _, _, err := SetupGRPC(cfg, logger); err == nil {
+	if _, _, _, err := SetupGRPC(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error from serve failure")
 	}
 	if !srvCleanupCalled {
@@ -161,12 +161,12 @@ func TestExecuteClient(t *testing.T) {
 		executeClientFn = origExec
 		runDump = origRunDump
 	}()
-	executeClientFn = func(f func(string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
+	executeClientFn = func(ctx context.Context, f func(context.Context, string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
 		called = true
 		if snap != "s" || dest != "d" {
 			t.Fatalf("unexpected args")
 		}
-		return f(snap, dest)
+		return f(ctx, snap, dest)
 	}
 	runDump = func(_ *config.Config, snap, dest string, _ *zap.Logger) error {
 		if snap != "s" || dest != "d" {
@@ -174,7 +174,9 @@ func TestExecuteClient(t *testing.T) {
 		}
 		return nil
 	}
-	if err := ExecuteClient(cfg, "s", "d", nil, nil, logger); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := ExecuteClient(ctx, cfg, "s", "d", nil, nil, logger); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !called {
@@ -204,7 +206,9 @@ func TestRunHeartbeatError(t *testing.T) {
 	hbErrCh := make(chan error, 1)
 	hbErrCh <- errors.New("hb fail")
 
-	startGRPCServer = func(*config.Config, *zap.Logger) (func(), error) { return func() {}, nil }
+	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
+		return func() {}, make(chan error), nil
+	}
 	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
 	}
@@ -217,7 +221,7 @@ func TestRunHeartbeatError(t *testing.T) {
 	prepareSnapshotFn = func(*config.Config, string, *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil
 	}
-	executeClientFn = func(f func(string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
+	executeClientFn = func(ctx context.Context, f func(context.Context, string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
 		return <-sigErrCh
 	}
 

--- a/internal/client/execute.go
+++ b/internal/client/execute.go
@@ -1,12 +1,15 @@
 package client
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // ExecuteClient runs the client transfer logic and handles signal and monitor errors.
-func ExecuteClient(runClient func(string, string) error, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error) error {
+func ExecuteClient(ctx context.Context, runClient func(context.Context, string, string) error, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error) error {
 	clientErrCh := make(chan error, 1)
 	go func() {
-		clientErrCh <- runClient(snapshotPath, destPath)
+		clientErrCh <- runClient(ctx, snapshotPath, destPath)
 	}()
 
 	select {
@@ -16,12 +19,22 @@ func ExecuteClient(runClient func(string, string) error, snapshotPath, destPath 
 		}
 	case err := <-sigErrCh:
 		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
 	if monitorErrCh != nil {
-		for err := range monitorErrCh {
-			if err != nil {
-				return fmt.Errorf("snapshot monitor error: %w", err)
+		for {
+			select {
+			case err, ok := <-monitorErrCh:
+				if !ok {
+					return nil
+				}
+				if err != nil {
+					return fmt.Errorf("snapshot monitor error: %w", err)
+				}
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 	}

--- a/internal/client/execute_test.go
+++ b/internal/client/execute_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -8,9 +9,11 @@ import (
 )
 
 func TestExecuteRunError(t *testing.T) {
-	runClient := func(string, string) error { return errors.New("run") }
+	runClient := func(context.Context, string, string) error { return errors.New("run") }
 	sigCh := make(chan error, 1)
-	err := ExecuteClient(runClient, "snap", "dest", sigCh, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, nil)
 	if err == nil || !strings.Contains(err.Error(), "copy operation failed") {
 		t.Fatalf("expected copy failure, got %v", err)
 	}
@@ -18,16 +21,18 @@ func TestExecuteRunError(t *testing.T) {
 
 func TestExecuteSignal(t *testing.T) {
 	block := make(chan struct{})
-	runClient := func(string, string) error {
+	runClient := func(context.Context, string, string) error {
 		<-block
 		return nil
 	}
 	sigCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
 		time.Sleep(10 * time.Millisecond)
 		sigCh <- errors.New("signal")
 	}()
-	err := ExecuteClient(runClient, "snap", "dest", sigCh, nil)
+	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, nil)
 	close(block)
 	if err == nil || !strings.Contains(err.Error(), "signal") {
 		t.Fatalf("expected signal error, got %v", err)
@@ -35,12 +40,14 @@ func TestExecuteSignal(t *testing.T) {
 }
 
 func TestExecuteMonitorError(t *testing.T) {
-	runClient := func(string, string) error { return nil }
+	runClient := func(context.Context, string, string) error { return nil }
 	sigCh := make(chan error, 1)
 	monitorCh := make(chan error, 1)
 	monitorCh <- errors.New("monitor")
 	close(monitorCh)
-	err := ExecuteClient(runClient, "snap", "dest", sigCh, monitorCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, monitorCh)
 	if err == nil || !strings.Contains(err.Error(), "snapshot monitor error") {
 		t.Fatalf("expected monitor error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- accept context in ExecuteClient and respect cancellation
- propagate cancellable context from root command
- update tests for context-aware ExecuteClient

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b82fafa1083239573fb5f520749e1