### PR TITLE
refactor: inject flag sets and remove globals

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -88,7 +88,7 @@ func TestStartGRPCServerServeError(t *testing.T) {
 	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
 		return &failingServer{err: srvErr}, nil
 	}
-	cleanup, errCh, err := StartGRPCServer(cfg, logger)
+	cleanup, errCh, err := StartGRPCServer(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -41,7 +41,12 @@ func SyncLogger(logger *zap.Logger) {
 
 // Configure loads configuration, ensures privileges, validates, and sets up logging.
 func Configure() (*config.Config, *zap.Logger, error) {
-	cfg, err := config.LoadConfig()
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("configuration error: %w", err)
+	}
+	flagSets := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(flagSets, defaults)
 	if err != nil {
 		return nil, nil, fmt.Errorf("configuration error: %w", err)
 	}

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -52,7 +52,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 	srvErrCh <- nil
 	<-done
 	cleanupClient()
-	if errCh == nil {
+	if hbErrCh == nil {
 		t.Fatalf("expected error channel")
 	}
 	if !srvCleanCalled || !clientCleanCalled {
@@ -120,7 +120,7 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 		startGRPCServer = origStart
 		clientHandshake = origClient
 	}()
-	startGRPCServer = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		ch := make(chan error, 1)
 		ch <- errors.New("serve boom")
 		return func() { srvCleanupCalled = true; close(ch) }, ch, nil
@@ -129,7 +129,7 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 		t.Fatalf("client handshake should not be called")
 		return nil, nil, nil
 	}
-	if _, _, _, err := SetupGRPC(cfg, logger); err == nil {
+	if _, _, _, err := SetupGRPC(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error from serve failure")
 	}
 	if !srvCleanupCalled {
@@ -204,7 +204,10 @@ func TestRunHeartbeatError(t *testing.T) {
 	hbErrCh := make(chan error, 1)
 	hbErrCh <- errors.New("hb fail")
 
-	startGRPCServer = func(*config.Config, *zap.Logger) (func(), error) { return func() {}, nil }
+	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
+		ch := make(chan error)
+		return func() { close(ch) }, ch, nil
+	}
 	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
 	}

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -55,7 +55,12 @@ func resetFlags(args []string) {
 
 func TestServeFlagParsing(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--allow_insecure"})
-	cfg, err := config.LoadConfig()
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(fs, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -35,19 +35,48 @@ var (
 	SupportedChecksumAlgorithms = []string{"sha256", "blake3", "blake3-512"}
 )
 
-var (
-	generalFlags     *pflag.FlagSet
-	sshFlags         *pflag.FlagSet
-	remoteFlags      *pflag.FlagSet
-	dedupFlags       *pflag.FlagSet
-	compressionFlags *pflag.FlagSet
-	lvmFlags         *pflag.FlagSet
-	grpcFlags        *pflag.FlagSet
-	transportFlags   *pflag.FlagSet
-	serveFlags       *pflag.FlagSet
-)
+// FlagSets groups the flag sets for different configuration areas.
+type FlagSets struct {
+	General     *pflag.FlagSet
+	SSH         *pflag.FlagSet
+	Remote      *pflag.FlagSet
+	Dedup       *pflag.FlagSet
+	Compression *pflag.FlagSet
+	LVM         *pflag.FlagSet
+	GRPC        *pflag.FlagSet
+	Transport   *pflag.FlagSet
+	Serve       *pflag.FlagSet
+}
 
-var getEuid = os.Geteuid
+// NewFlagSets constructs grouped flag sets using the provided defaults.
+func NewFlagSets(cfg *Config) *FlagSets {
+	return &FlagSets{
+		General:     initGeneralFlags(cfg),
+		SSH:         initSSHFlags(cfg),
+		Remote:      initRemoteFlags(cfg),
+		Dedup:       initDedupFlags(cfg),
+		Compression: initCompressionFlags(cfg),
+		LVM:         initLVMFlags(cfg),
+		GRPC:        initGRPCFlags(cfg),
+		Transport:   initTransportFlags(cfg),
+		Serve:       initServeFlags(cfg),
+	}
+}
+
+// All returns all flag sets in a stable order.
+func (f *FlagSets) All() []*pflag.FlagSet {
+	return []*pflag.FlagSet{
+		f.General,
+		f.SSH,
+		f.Remote,
+		f.Dedup,
+		f.Compression,
+		f.LVM,
+		f.GRPC,
+		f.Transport,
+		f.Serve,
+	}
+}
 
 type Config struct {
 	ConfigFile            string        `mapstructure:"config"`
@@ -573,18 +602,6 @@ func initServeFlags(cfg *Config) *pflag.FlagSet {
 	return fs
 }
 
-func initFlagSets(defaultCfg *Config) {
-	generalFlags = initGeneralFlags(defaultCfg)
-	sshFlags = initSSHFlags(defaultCfg)
-	remoteFlags = initRemoteFlags(defaultCfg)
-	dedupFlags = initDedupFlags(defaultCfg)
-	compressionFlags = initCompressionFlags(defaultCfg)
-	lvmFlags = initLVMFlags(defaultCfg)
-	grpcFlags = initGRPCFlags(defaultCfg)
-	transportFlags = initTransportFlags(defaultCfg)
-	serveFlags = initServeFlags(defaultCfg)
-}
-
 func printFlagSetUsage(out io.Writer, fs *pflag.FlagSet) {
 	if fs == nil {
 		return
@@ -595,38 +612,22 @@ func printFlagSetUsage(out io.Writer, fs *pflag.FlagSet) {
 	fmt.Fprintln(out)
 }
 
-func registerFlags(defaultCfg *Config) {
-	initFlagSets(defaultCfg)
-	flagSets := allFlagSets()
-	for _, fs := range flagSets {
+func registerFlags(flagSets *FlagSets) {
+	for _, fs := range flagSets.All() {
 		pflag.CommandLine.AddFlagSet(fs)
 	}
 	pflag.CommandLine.Usage = func() {
 		out := pflag.CommandLine.Output()
 		fmt.Fprintln(out, "Usage of", os.Args[0]+":")
 		fmt.Fprintln(out)
-		for _, fs := range flagSets {
+		for _, fs := range flagSets.All() {
 			printFlagSetUsage(out, fs)
 		}
 	}
 	pflag.Usage = pflag.CommandLine.Usage
 }
 
-func allFlagSets() []*pflag.FlagSet {
-	return []*pflag.FlagSet{
-		generalFlags,
-		sshFlags,
-		remoteFlags,
-		dedupFlags,
-		compressionFlags,
-		lvmFlags,
-		grpcFlags,
-		transportFlags,
-		serveFlags,
-	}
-}
-
-func buildViper() (*viper.Viper, error) {
+func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")
@@ -635,7 +636,7 @@ func buildViper() (*viper.Viper, error) {
 	v.SetEnvPrefix("LVMSYNC")
 	v.AutomaticEnv()
 
-	for _, fs := range allFlagSets() {
+	for _, fs := range flagSets.All() {
 		if err := v.BindPFlags(fs); err != nil {
 			return nil, err
 		}
@@ -649,22 +650,18 @@ func buildViper() (*viper.Viper, error) {
 	return v, nil
 }
 
-func LoadConfig() (*Config, error) {
-	defaultCfg, err := DefaultConfig()
-	if err != nil {
-		return nil, err
-	}
-	registerFlags(defaultCfg)
+func LoadConfig(flagSets *FlagSets, defaults *Config) (*Config, error) {
+	registerFlags(flagSets)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(flagSets)
 	if err != nil {
 		return nil, err
 	}
 
 	builder := &Builder{
 		v:        v,
-		defaults: defaultCfg,
+		defaults: defaults,
 	}
 	conf, err := builder.Build()
 	if err != nil {
@@ -674,7 +671,11 @@ func LoadConfig() (*Config, error) {
 	return conf, nil
 }
 
-func (c *Config) Validate() error {
+// Validate verifies configuration values using the real OS euid.
+func (c *Config) Validate() error { return c.ValidateWith(os.Geteuid) }
+
+// ValidateWith verifies configuration values using the provided geteuid function.
+func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.SSHKeepAliveInterval <= 0 {
 		return fmt.Errorf("ssh keepalive interval must be > 0")
 	}
@@ -695,7 +696,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("target volume group %q does not exist or is inaccessible: %w", c.TargetVolumeGroup, err)
 		}
 	}
-	if getEuid() != 0 {
+	if geteuid() != 0 {
 		parts := strings.Fields(c.LVMEscalation)
 		if len(parts) == 0 {
 			return fmt.Errorf("lvm escalation command is empty")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -391,9 +391,7 @@ func TestApplyThroughputMode(t *testing.T) {
 }
 
 func TestValidateEscalationCommandPath(t *testing.T) {
-	oldEuid := getEuid
-	getEuid = func() int { return 1000 }
-	defer func() { getEuid = oldEuid }()
+	geteuid := func() int { return 1000 }
 
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
@@ -406,12 +404,12 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	os.Setenv("PATH", dir)
 
 	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second}
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.ValidateWith(geteuid); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	os.Setenv("PATH", "")
-	if err := cfg.Validate(); err == nil {
+	if err := cfg.ValidateWith(geteuid); err == nil {
 		t.Fatalf("expected error when command missing")
 	}
 }
@@ -647,8 +645,12 @@ func TestLoadConfigPrecedence(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
 	t.Setenv("LVMSYNC_PARALLEL", "2")
-
-	conf, err := LoadConfig()
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	conf, err := LoadConfig(fs, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -661,7 +663,12 @@ func TestLoadConfigInvalidPath(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing.yaml")
 	resetFlags([]string{"--config", missing})
 
-	if _, err := LoadConfig(); err == nil || !strings.Contains(err.Error(), "error reading config file") {
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	if _, err := LoadConfig(fs, defaults); err == nil || !strings.Contains(err.Error(), "error reading config file") {
 		t.Fatalf("expected config file error, got %v", err)
 	}
 }

--- a/config/loadconfig_test.go
+++ b/config/loadconfig_test.go
@@ -34,7 +34,8 @@ func TestRegisterFlags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(cfg)
+	fs := NewFlagSets(cfg)
+	registerFlags(fs)
 	names := []string{"parallel", "ssh_user", "grpc_port"}
 	for _, name := range names {
 		if f := pflag.CommandLine.Lookup(name); f == nil {
@@ -52,9 +53,10 @@ func TestBuildViperPrecedence(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
 		}
-		registerFlags(cfg)
+		fs := NewFlagSets(cfg)
+		registerFlags(fs)
 		pflag.Parse()
-		v, err := buildViper()
+		v, err := buildViper(fs)
 		if err != nil {
 			t.Fatalf("buildViper: %v", err)
 		}
@@ -70,9 +72,10 @@ func TestBuildViperPrecedence(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
 		}
-		registerFlags(cfg)
+		fs := NewFlagSets(cfg)
+		registerFlags(fs)
 		pflag.Parse()
-		v, err := buildViper()
+		v, err := buildViper(fs)
 		if err != nil {
 			t.Fatalf("buildViper: %v", err)
 		}
@@ -88,9 +91,10 @@ func TestBuildViperPrecedence(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
 		}
-		registerFlags(cfg)
+		fs := NewFlagSets(cfg)
+		registerFlags(fs)
 		pflag.Parse()
-		v, err := buildViper()
+		v, err := buildViper(fs)
 		if err != nil {
 			t.Fatalf("buildViper: %v", err)
 		}
@@ -106,7 +110,8 @@ func TestUsageOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(cfg)
+	fs := NewFlagSets(cfg)
+	registerFlags(fs)
 	buf := &bytes.Buffer{}
 	pflag.CommandLine.SetOutput(buf)
 	pflag.Usage()

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -15,10 +15,11 @@ func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(defaults)
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(fs)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}
@@ -41,10 +42,11 @@ func TestEnvOverridesConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(defaults)
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(fs)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}
@@ -74,10 +76,11 @@ func TestFlagSetsBindToViper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(defaults)
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(fs)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}
@@ -114,10 +117,11 @@ func TestSSHUserCLIOverridesEnvAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(defaults)
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(fs)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}
@@ -140,10 +144,11 @@ func TestSSHUserEnvOverridesConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(defaults)
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(fs)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}
@@ -166,10 +171,11 @@ func TestSSHHostCLIOverridesEnvAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(defaults)
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(fs)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}
@@ -192,10 +198,11 @@ func TestSSHHostEnvOverridesConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	registerFlags(defaults)
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
 	pflag.Parse()
 
-	v, err := buildViper()
+	v, err := buildViper(fs)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}

--- a/config/serve_flags_test.go
+++ b/config/serve_flags_test.go
@@ -4,7 +4,12 @@ import "testing"
 
 func TestServeFlagParsing(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
-	cfg, err := LoadConfig()
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	cfg, err := LoadConfig(fs, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}


### PR DESCRIPTION
## Summary
- replace package flag-set globals with `NewFlagSets` constructor
- inject flag sets into configuration loading and remove mutable globals
- add `ValidateWith` helper and update tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b82fd88a883239b3af08cd327c8a6