### PR TITLE
test(root): rename hbErrCh variable

### DIFF
--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -35,7 +35,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 		return func() { clientCleanCalled = true }, make(chan error), nil
 	}
 
-	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(context.Background(), cfg, logger)
+	cleanupSrv, cleanupClient, errCh, err := SetupGRPC(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 	srvErrCh <- nil
 	<-done
 	cleanupClient()
-	if hbErrCh == nil {
+	if errCh == nil {
 		t.Fatalf("expected error channel")
 	}
 	if !srvCleanCalled || !clientCleanCalled {


### PR DESCRIPTION
## Summary
- use errCh instead of hbErrCh in `TestSetupGRPCSuccess`

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: cmd/serve build failed; config TestValidateEscalationCommandPath error)*
- `golangci-lint run`
- `go test ./cmd/root`


------
https://chatgpt.com/codex/tasks/task_e_689b89533b4083238aeed125c7ca8e4c