### PR TITLE
test(cmd): adjust grpc server stub

### DIFF
--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -207,8 +207,7 @@ func TestRunHeartbeatError(t *testing.T) {
 	hbErrCh <- errors.New("hb fail")
 
 	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
-		ch := make(chan error)
-		return func() { close(ch) }, ch, nil
+		return func() {}, make(chan error), nil
 	}
 	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil


### PR DESCRIPTION
## Summary
- modify gRPC server stub in root test to return no-op cancel and open error channel

## Testing
- `go build ./...`
- `go test ./cmd/root -count=1 -timeout 5s` *(fails: test timed out after 5s)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b8957459883238f6796cb8d897069