### PR TITLE
fix(remote): sanitize remote command validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--ssh_keepalive` | `LVMSYNC_SSH_KEEPALIVE` | `ssh_keepalive` | SSH keepalive interval |
 | `--known_hosts` | `LVMSYNC_KNOWN_HOSTS` | `known_hosts` | Path to known_hosts file |
 | `--strict_host_key_checking` | `LVMSYNC_STRICT_HOST_KEY_CHECKING` | `strict_host_key_checking` | Require host keys to be present in `known_hosts` |
-| `--lvmsync_path` | `LVMSYNC_LVMSYNC_PATH` | `lvmsync_path` | Remote command to run |
+| `--lvmsync_path` | `LVMSYNC_LVMSYNC_PATH` | `lvmsync_path` | Remote command to run (basename sanitized; only `[a-zA-Z0-9._-]+` allowed) |
 | `--remote_pre_script` | `LVMSYNC_REMOTE_PRE_SCRIPT` | `remote_pre_script` | Remote script to run before transfer |
 | `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer |
 | `--dedup_strategy` | `LVMSYNC_DEDUP_STRATEGY` | `dedup_strategy` | Deduplication strategy: `none`, `auto`, `checksum`, `rolling_hash`, or `bloom` |
@@ -755,9 +755,12 @@ sender, receiver, err := ssh.New(cfg, logger)
 
 #### Remote Options
 
+The `--lvmsync_path` value is sanitized to its basename and must match
+`[a-zA-Z0-9._-]+` to prevent shell injection.
+
 | Option                 | Description                                       | Default     |
 | ---------------------- | ------------------------------------------------- | ----------- |
-| `--lvmsync_path`       | Remote command to run (e.g., `"lvmsync"`)         | `"lvmsync"` |
+| `--lvmsync_path`       | Remote command to run (sanitized basename)         | `"lvmsync"` |
 | `--remote_pre_script`  | Remote script to run before starting the transfer | `""`        |
 | `--remote_post_script` | Remote script to run after finishing the transfer | `""`        |
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -141,14 +143,26 @@ func dialWithRetry(logger *zap.Logger, addr string, config *ssh.ClientConfig, ho
 }
 
 // ValidateRemoteCommand ensures that the provided command exists and is
-// executable on the remote host by attempting to run it with a --version flag.
-// It returns an error if the command is missing or cannot be executed.
+// executable on the remote host by running `<cmd> --version`.
+//
+// The command is sanitized before execution: only the basename is used and it
+// must match `^[a-zA-Z0-9._-]+$`. Any shell metacharacters in the original
+// string cause validation to fail to prevent injection.
+//
+// It returns an error if the command is empty, contains disallowed characters,
+// or cannot be executed on the remote host.
 func (c *SSHClient) ValidateRemoteCommand(remoteCmd string) error {
+	if strings.ContainsAny(remoteCmd, "&|;<>$`\"'!*") {
+		return fmt.Errorf("remote command contains shell metacharacters")
+	}
 	tokens := strings.Fields(remoteCmd)
 	if len(tokens) == 0 {
 		return fmt.Errorf("remote command is empty")
 	}
-	cmd := tokens[0]
+	cmd := filepath.Base(tokens[0])
+	if !regexp.MustCompile(`^[a-zA-Z0-9._-]+$`).MatchString(cmd) {
+		return fmt.Errorf("remote command %s contains invalid characters", cmd)
+	}
 	session, err := c.NewSession()
 	if err != nil {
 		return fmt.Errorf("failed to create SSH session for validation: %w", err)

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -20,11 +20,27 @@ func TestValidateRemoteCommand(t *testing.T) {
 	})
 
 	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
-	if err := client.ValidateRemoteCommand("echo"); err != nil {
-		t.Fatalf("expected success, got %v", err)
+	tests := []struct {
+		name    string
+		cmd     string
+		wantErr bool
+	}{
+		{"valid", "echo", false},
+		{"path sanitized", "/usr/bin/echo", false},
+		{"missing", "nonexistent", true},
+		{"metacharacters", "echo; rm -rf /", true},
 	}
-	if err := client.ValidateRemoteCommand("nonexistent"); err == nil {
-		t.Fatalf("expected error for nonexistent command")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := client.ValidateRemoteCommand(tt.cmd)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error for %q", tt.cmd)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.cmd, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- restrict remote command validation to basename and allowed characters
- document remote command sanitization in README
- add tests covering sanitized paths and metacharacter rejection

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: not enough arguments in call to config.LoadConfig in cmd/serve)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689b8fbaab64832383b2765125257d81