### PR TITLE
feat(remote): add context to SSH dial retries

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -61,7 +61,7 @@ func NewSSHClient(
 		Timeout:         timeout,
 	}
 	addr := fmt.Sprintf("%s:%d", host, port)
-	client, err := dialWithRetry(logger, addr, config, host, port, retries)
+	client, err := dialWithRetry(ctx, logger, addr, config, host, port, retries)
 	if err != nil {
 		return nil, err
 	}
@@ -118,10 +118,13 @@ func setupHostKeyCallback(_ bool, knownHostsPath string) (ssh.HostKeyCallback, e
 	return hostKeyCallback, nil
 }
 
-func dialWithRetry(logger *zap.Logger, addr string, config *ssh.ClientConfig, host string, port, retries int) (*ssh.Client, error) {
+func dialWithRetry(ctx context.Context, logger *zap.Logger, addr string, config *ssh.ClientConfig, host string, port, retries int) (*ssh.Client, error) {
 	var client *ssh.Client
 	var err error
 	for attempt := 0; attempt <= retries; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		client, err = ssh.Dial("tcp", addr, config)
 		if err == nil {
 			return client, nil
@@ -133,10 +136,17 @@ func dialWithRetry(logger *zap.Logger, addr string, config *ssh.ClientConfig, ho
 			zap.Error(err))
 		if attempt < retries {
 			backoff := time.Duration(1<<attempt) * time.Second
-			time.Sleep(backoff)
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 		}
 	}
 	logger.Error("Unable to establish SSH connection", zap.String("host", host), zap.Int("port", port), zap.Error(err))
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	return nil, fmt.Errorf("failed to dial SSH after %d attempts: %w", retries+1, err)
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -2,12 +2,14 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
 
 	remotetest "lvmsync_go/remote/testutil"
 )
@@ -48,5 +50,20 @@ func TestNewSSHClientNoAuth(t *testing.T) {
 	_, err := NewSSHClient(context.Background(), "localhost", "root", "", 22, knownHosts, true, time.Second, time.Second, 0, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "no SSH authentication methods configured") {
 		t.Fatalf("expected error for missing auth methods, got %v", err)
+	}
+}
+
+func TestDialWithRetryContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	config := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Millisecond,
+	}
+	cancel()
+	_, err := dialWithRetry(ctx, zap.NewNop(), "127.0.0.1:22", config, "127.0.0.1", 22, 3)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- pass context through `dialWithRetry` to allow cancellation during retries
- abort SSH dial backoff when context is done and return the cancellation error
- test context cancellation behavior

## Testing
- `go build ./... && echo build-ok`
- `go test -coverprofile=coverage.out ./...` (fails: cmd/serve/flag_test.go: not enough arguments in call to config.LoadConfig)
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b8fda3c108323a568cc38b342dce5