### PR TITLE
feat: propagate context through snapshot preparation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -185,6 +185,6 @@ func SetupSignalHandling(cfg *config.Config, snapshotPath *string, logger *zap.L
 }
 
 // PrepareSnapshot wraps the snapshot preparation logic.
-func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
-	return prepareSnapshot(cfg, originalVolume, logger)
+func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+	return prepareSnapshot(ctx, cfg, originalVolume, logger)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -330,10 +330,10 @@ func TestPrepareSnapshot(t *testing.T) {
 	logger := zap.NewNop()
 	orig := prepareSnapshot
 	defer func() { prepareSnapshot = orig }()
-	prepareSnapshot = func(c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+	prepareSnapshot = func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil
 	}
-	snap, ch, cleanup, err := PrepareSnapshot(cfg, "vol", logger)
+	snap, ch, cleanup, err := PrepareSnapshot(context.Background(), cfg, "vol", logger)
 	if err != nil || snap != "snap" || ch != nil || cleanup == nil {
 		t.Fatalf("unexpected result")
 	}
@@ -344,10 +344,10 @@ func TestPrepareSnapshotError(t *testing.T) {
 	logger := zap.NewNop()
 	orig := prepareSnapshot
 	defer func() { prepareSnapshot = orig }()
-	prepareSnapshot = func(c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+	prepareSnapshot = func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
 		return "", nil, nil, errors.New("fail")
 	}
-	if _, _, _, err := PrepareSnapshot(cfg, "vol", logger); err == nil {
+	if _, _, _, err := PrepareSnapshot(context.Background(), cfg, "vol", logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -107,8 +107,8 @@ func SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (fun
 }
 
 // PrepareSnapshot wraps snapshot preparation.
-func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
-	return prepareSnapshotFn(cfg, originalVolume, logger)
+func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+	return prepareSnapshotFn(ctx, cfg, originalVolume, logger)
 }
 
 // ExecuteClient runs the client transfer logic.
@@ -174,7 +174,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	}
 
 	var monitorErrCh chan error
-	snapshotPath, monitorErrCh, cleanup, err := PrepareSnapshot(cfg, originalVolume, logger)
+	snapshotPath, monitorErrCh, cleanup, err := PrepareSnapshot(ctx, cfg, originalVolume, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -142,10 +142,10 @@ func TestPrepareSnapshot(t *testing.T) {
 	logger := zap.NewNop()
 	orig := prepareSnapshotFn
 	defer func() { prepareSnapshotFn = orig }()
-	prepareSnapshotFn = func(c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+	prepareSnapshotFn = func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil
 	}
-	snap, ch, cleanup, err := PrepareSnapshot(cfg, "vol", logger)
+	snap, ch, cleanup, err := PrepareSnapshot(context.Background(), cfg, "vol", logger)
 	if err != nil || snap != "snap" || ch != nil || cleanup == nil {
 		t.Fatalf("unexpected result")
 	}
@@ -207,7 +207,9 @@ func TestRunHeartbeatError(t *testing.T) {
 	hbErrCh <- errors.New("hb fail")
 
 	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
-		return func() {}, make(chan error), nil
+		errCh := make(chan error, 1)
+		close(errCh)
+		return func() {}, errCh, nil
 	}
 	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
@@ -218,7 +220,7 @@ func TestRunHeartbeatError(t *testing.T) {
 	setupSignalHandle = func(*config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
 		return nil, sigErrCh
 	}
-	prepareSnapshotFn = func(*config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+	prepareSnapshotFn = func(ctx context.Context, _ *config.Config, _ string, _ *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil
 	}
 	executeClientFn = func(ctx context.Context, f func(context.Context, string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {

--- a/cmd/serve/flag_test.go
+++ b/cmd/serve/flag_test.go
@@ -15,7 +15,9 @@ import (
 
 func TestServeFlagBindingSuccess(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
-	cfg, err := config.LoadConfig()
+	defaults, _ := config.DefaultConfig()
+	flagSets := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(flagSets, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -48,7 +50,9 @@ func TestServeFlagBindingSuccess(t *testing.T) {
 
 func TestServeFlagBindingInvalidPolicy(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "deny"})
-	cfg, err := config.LoadConfig()
+	defaults, _ := config.DefaultConfig()
+	flagSets := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(flagSets, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -429,7 +429,7 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second}
+	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second}
 	if err := cfg.ValidateWith(geteuid); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -66,13 +66,13 @@ func SetRemoveSnapshotForTest(f func(context.Context, string) error) func() {
 
 // PrepareSnapshot sets up a snapshot for the given original volume. It returns the snapshot path,
 // an optional monitor error channel, a cleanup function, and any error encountered.
-func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
 	snapshotBytes, err := calculateSnapshotSize(cfg, originalVolume)
 	if err != nil {
 		return "", nil, nil, err
 	}
 
-	if err := ensureVolumeGroups(cfg, originalVolume, logger); err != nil {
+	if err := ensureVolumeGroups(ctx, cfg, originalVolume, logger); err != nil {
 		return "", nil, nil, err
 	}
 
@@ -80,7 +80,7 @@ func PrepareSnapshot(cfg *config.Config, originalVolume string, logger *zap.Logg
 		return "", nil, nil, err
 	}
 
-	return createSnapshotIfNeeded(cfg, originalVolume, snapshotBytes, logger)
+	return createSnapshotIfNeeded(ctx, cfg, originalVolume, snapshotBytes, logger)
 }
 
 func calculateSnapshotSize(cfg *config.Config, originalVolume string) (uint64, error) {
@@ -91,7 +91,7 @@ func calculateSnapshotSize(cfg *config.Config, originalVolume string) (uint64, e
 	return snapshotBytes, nil
 }
 
-func ensureVolumeGroups(cfg *config.Config, originalVolume string, logger *zap.Logger) error {
+func ensureVolumeGroups(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) error {
 	if cfg.VolumeGroup == "" {
 		vg, err := getVolumeGroupName(originalVolume)
 		if err != nil {
@@ -106,7 +106,7 @@ func ensureVolumeGroups(cfg *config.Config, originalVolume string, logger *zap.L
 		if err != nil {
 			return fmt.Errorf("failed to determine volume size: %w", err)
 		}
-		vg, err := selectVolumeGroupForSize(context.Background(), cfg.TargetVGCandidates, lvSize)
+		vg, err := selectVolumeGroupForSize(ctx, cfg.TargetVGCandidates, lvSize)
 		if err != nil {
 			return fmt.Errorf("failed to select target volume group: %w", err)
 		}
@@ -131,7 +131,7 @@ func checkDiskSpaceForSnapshot(cfg *config.Config, snapshotBytes uint64, logger 
 	return nil
 }
 
-func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotBytes uint64, logger *zap.Logger) (string, chan error, func(), error) {
+func createSnapshotIfNeeded(ctx context.Context, cfg *config.Config, originalVolume string, snapshotBytes uint64, logger *zap.Logger) (string, chan error, func(), error) {
 	snapshotPath := originalVolume
 	var monitorErrCh chan error
 	cleanup := func() {}
@@ -142,13 +142,13 @@ func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotB
 
 	monitorErrCh = make(chan error, 1)
 	snapshotName := fmt.Sprintf("snap-%d", time.Now().Unix())
-	if err := createSnapshot(context.Background(), originalVolume, snapshotName, strconv.FormatUint(snapshotBytes, 10)); err != nil {
+	if err := createSnapshot(ctx, originalVolume, snapshotName, strconv.FormatUint(snapshotBytes, 10)); err != nil {
 		return "", nil, nil, fmt.Errorf("snapshot creation failed: %w", err)
 	}
 	snapshotPath = getSnapshotDevicePath(snapshotName, cfg.VolumeGroup)
 	logger.Info("Snapshot created", zap.String("snapshot", snapshotPath))
 
-	monitorCtx, cancel := context.WithCancel(context.Background())
+	monitorCtx, cancel := context.WithCancel(ctx)
 	mon := monitorSnapshot
 	go func() {
 		defer close(monitorErrCh)
@@ -163,7 +163,9 @@ func createSnapshotIfNeeded(cfg *config.Config, originalVolume string, snapshotB
 
 	cleanup = func() {
 		cancel()
-		if err := removeSnapshot(context.Background(), snapshotPath); err != nil {
+		removeCtx, removeCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer removeCancel()
+		if err := removeSnapshot(removeCtx, snapshotPath); err != nil {
 			logger.Warn("Failed to remove snapshot", zap.Error(err))
 		} else {
 			logger.Info("Snapshot removed", zap.String("snapshot", snapshotPath))

--- a/internal/client/snapshot_helpers_test.go
+++ b/internal/client/snapshot_helpers_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"math"
 	"testing"
@@ -43,7 +44,7 @@ func TestEnsureVolumeGroups(t *testing.T) {
 
 	t.Run("sets missing volume group", func(t *testing.T) {
 		cfg := &config.Config{}
-		if err := ensureVolumeGroups(cfg, "/dev/sourcevg/lv1", logger); err != nil {
+		if err := ensureVolumeGroups(context.Background(), cfg, "/dev/sourcevg/lv1", logger); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.VolumeGroup != "sourcevg" {
@@ -53,7 +54,7 @@ func TestEnsureVolumeGroups(t *testing.T) {
 
 	t.Run("preserves existing volume group", func(t *testing.T) {
 		cfg := &config.Config{VolumeGroup: "existing"}
-		if err := ensureVolumeGroups(cfg, "/dev/othervg/lv", logger); err != nil {
+		if err := ensureVolumeGroups(context.Background(), cfg, "/dev/othervg/lv", logger); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.VolumeGroup != "existing" {

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -27,7 +27,7 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 	defer restore()
 
 	logger := zap.NewNop()
-	snap, monitorCh, cleanup, err := client.PrepareSnapshot(cfg, "/dev/vg/orig", logger)
+	snap, monitorCh, cleanup, err := client.PrepareSnapshot(context.Background(), cfg, "/dev/vg/orig", logger)
 	if err != nil {
 		t.Fatalf("Prepare returned error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
 	defer restoreRemove()
 
 	logger := zap.NewNop()
-	snap, monitorCh, cleanup, err := client.PrepareSnapshot(cfg, "/dev/vg/orig", logger)
+	snap, monitorCh, cleanup, err := client.PrepareSnapshot(context.Background(), cfg, "/dev/vg/orig", logger)
 	if err != nil {
 		t.Fatalf("PrepareSnapshot error: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestCreateSnapshotCleanupNoPanic(t *testing.T) {
 	defer restoreRemove()
 
 	logger := zap.NewNop()
-	_, monitorCh, cleanup, err := client.PrepareSnapshot(cfg, "/dev/vg/orig", logger)
+	_, monitorCh, cleanup, err := client.PrepareSnapshot(context.Background(), cfg, "/dev/vg/orig", logger)
 	if err != nil {
 		t.Fatalf("PrepareSnapshot error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- accept context in snapshot preparation helpers
- pass context from app and root callers
- update tests and config

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b8f7407208323a14b1cbce9bef0b5