### PR TITLE
refactor: delegate transport logging sync to caller

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -235,7 +235,6 @@ func SelectTransport(cfg *config.Config, logger *zap.Logger) error {
 	if cfg.Transport == "" {
 		return nil
 	}
-	defer logger.Sync()
 	order := strings.Split(cfg.Transport, ",")
 	_, _, name, err := transport.Select(cfg, order, logger)
 	if err != nil {

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -207,7 +207,9 @@ func TestRunHeartbeatError(t *testing.T) {
 	hbErrCh <- errors.New("hb fail")
 
 	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
-		return func() {}, make(chan error), nil
+		ch := make(chan error)
+		close(ch)
+		return func() {}, ch, nil
 	}
 	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
@@ -215,8 +217,9 @@ func TestRunHeartbeatError(t *testing.T) {
 	selectTransport = func(*config.Config, *zap.Logger) error { return nil }
 
 	sigErrCh := make(chan error, 1)
+	signalCh := make(chan os.Signal)
 	setupSignalHandle = func(*config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
-		return nil, sigErrCh
+		return signalCh, sigErrCh
 	}
 	prepareSnapshotFn = func(*config.Config, string, *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil

--- a/cmd/serve/flag_test.go
+++ b/cmd/serve/flag_test.go
@@ -15,7 +15,12 @@ import (
 
 func TestServeFlagBindingSuccess(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
-	cfg, err := config.LoadConfig()
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(fs, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -48,7 +53,12 @@ func TestServeFlagBindingSuccess(t *testing.T) {
 
 func TestServeFlagBindingInvalidPolicy(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "deny"})
-	cfg, err := config.LoadConfig()
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(fs, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -429,7 +429,7 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second}
+	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second}
 	if err := cfg.ValidateWith(geteuid); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove deferred logger sync from transport selection
- adjust tests for updated config loading and heartbeat validation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b8f8474488323aedc8468de7e1e93