### PR TITLE
feat(remote): add context-aware remote command helpers

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -162,7 +162,7 @@ func WaitForRemoteCompletion(session waitSession, stdoutErrCh, stderrErrCh <-cha
 
 // ExecuteRemoteCommand runs the remote apply command over SSH.
 func ExecuteRemoteCommand(cfg *config.Config, client *remote.SSHClient, destDevice, snapshotDevice, originDevice string, logger *zap.Logger) (err error) {
-	if err = client.ValidateRemoteCommand(cfg.LVMSyncPath); err != nil {
+	if err = client.ValidateRemoteCommand(context.Background(), cfg.LVMSyncPath); err != nil {
 		return fmt.Errorf("remote command validation failed: %w", err)
 	}
 
@@ -210,14 +210,15 @@ func RunRemoteDump(cfg *config.Config, snapshotDevice, originDevice, dest string
 		}
 	}()
 
+	ctx := context.Background()
 	if cfg.RemotePreScript != "" {
-		if err = client.RunRemoteScript(cfg.RemotePreScript); err != nil {
+		if err = client.RunRemoteScript(ctx, cfg.RemotePreScript); err != nil {
 			return fmt.Errorf("remote pre-script failed: %w", err)
 		}
 	}
 	if cfg.RemotePostScript != "" {
 		defer func() {
-			if err2 := client.RunRemoteScript(cfg.RemotePostScript); err2 != nil {
+			if err2 := client.RunRemoteScript(ctx, cfg.RemotePostScript); err2 != nil {
 				if err == nil {
 					err = fmt.Errorf("remote post-script failed: %w", err2)
 				} else {

--- a/remote/logger_test.go
+++ b/remote/logger_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"testing"
 
 	"go.uber.org/zap"
@@ -27,7 +28,7 @@ func TestRunRemoteScriptNoLogger(t *testing.T) {
 	sshClient := &SSHClient{Client: client, Logger: zap.NewNop()}
 
 	script := "echo hi"
-	if scriptErr := sshClient.RunRemoteScript(script); scriptErr != nil {
+	if scriptErr := sshClient.RunRemoteScript(context.Background(), script); scriptErr != nil {
 		t.Fatalf("RunRemoteScript error: %v", scriptErr)
 	}
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -143,7 +143,7 @@ func dialWithRetry(logger *zap.Logger, addr string, config *ssh.ClientConfig, ho
 // ValidateRemoteCommand ensures that the provided command exists and is
 // executable on the remote host by attempting to run it with a --version flag.
 // It returns an error if the command is missing or cannot be executed.
-func (c *SSHClient) ValidateRemoteCommand(remoteCmd string) error {
+func (c *SSHClient) ValidateRemoteCommand(ctx context.Context, remoteCmd string) error {
 	tokens := strings.Fields(remoteCmd)
 	if len(tokens) == 0 {
 		return fmt.Errorf("remote command is empty")
@@ -160,21 +160,34 @@ func (c *SSHClient) ValidateRemoteCommand(remoteCmd string) error {
 	}()
 	session.Stdout = io.Discard
 	session.Stderr = io.Discard
-	if err := session.Run(fmt.Sprintf("%s --version", cmd)); err != nil {
-		if exitErr, ok := err.(*ssh.ExitError); ok {
-			status := exitErr.ExitStatus()
-			if status == 126 || status == 127 {
-				return fmt.Errorf("remote command %s not found or not executable: %w", cmd, err)
-			}
+	errCh := make(chan error, 1)
+	if err := session.Start(fmt.Sprintf("%s --version", cmd)); err != nil {
+		return fmt.Errorf("failed to start remote command %s: %w", cmd, err)
+	}
+	go func() { errCh <- session.Wait() }()
+	select {
+	case <-ctx.Done():
+		if sigErr := session.Signal(ssh.SIGKILL); sigErr != nil && !errors.Is(sigErr, io.EOF) {
+			c.Logger.Warn("session signal error", zap.Error(sigErr))
 		}
-		return fmt.Errorf("failed to run remote command %s: %w", cmd, err)
+		return ctx.Err()
+	case err := <-errCh:
+		if err != nil {
+			if exitErr, ok := err.(*ssh.ExitError); ok {
+				status := exitErr.ExitStatus()
+				if status == 126 || status == 127 {
+					return fmt.Errorf("remote command %s not found or not executable: %w", cmd, err)
+				}
+			}
+			return fmt.Errorf("failed to run remote command %s: %w", cmd, err)
+		}
 	}
 	return nil
 }
 
 // RunRemoteScript executes the provided shell script on the remote host using
 // the given SSH client.
-func (c *SSHClient) RunRemoteScript(script string) error {
+func (c *SSHClient) RunRemoteScript(ctx context.Context, script string) error {
 	session, err := c.NewSession()
 	if err != nil {
 		return fmt.Errorf("failed to create SSH session for script: %w", err)
@@ -185,5 +198,18 @@ func (c *SSHClient) RunRemoteScript(script string) error {
 		}
 	}()
 	c.Logger.Info("Running remote script", zap.String("script", script))
-	return session.Run(script)
+	errCh := make(chan error, 1)
+	if err := session.Start(script); err != nil {
+		return fmt.Errorf("failed to start remote script: %w", err)
+	}
+	go func() { errCh <- session.Wait() }()
+	select {
+	case <-ctx.Done():
+		if sigErr := session.Signal(ssh.SIGKILL); sigErr != nil && !errors.Is(sigErr, io.EOF) {
+			c.Logger.Warn("session signal error", zap.Error(sigErr))
+		}
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
 }

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -1,7 +1,10 @@
 package remote
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -20,10 +23,10 @@ func TestValidateRemoteCommand(t *testing.T) {
 	})
 
 	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
-	if err := client.ValidateRemoteCommand("echo"); err != nil {
+	if err := client.ValidateRemoteCommand(context.Background(), "echo"); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
-	if err := client.ValidateRemoteCommand("nonexistent"); err == nil {
+	if err := client.ValidateRemoteCommand(context.Background(), "nonexistent"); err == nil {
 		t.Fatalf("expected error for nonexistent command")
 	}
 }
@@ -38,7 +41,7 @@ func TestRunRemoteScript(t *testing.T) {
 	client := &SSHClient{Client: rawClient, Logger: logger}
 
 	script := "echo hi"
-	if err := client.RunRemoteScript(script); err != nil {
+	if err := client.RunRemoteScript(context.Background(), script); err != nil {
 		t.Fatalf("RunRemoteScript error: %v", err)
 	}
 
@@ -56,5 +59,31 @@ func TestRunRemoteScript(t *testing.T) {
 	}
 	if logs[0].ContextMap()["script"] != script {
 		t.Fatalf("expected script %q in log, got %v", script, logs[0].ContextMap()["script"])
+	}
+}
+
+func TestRunRemoteScriptCanceled(t *testing.T) {
+	_, rawClient := newSSHServerClient(t, func(cmd string) int {
+		time.Sleep(100 * time.Millisecond)
+		return 0
+	})
+	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := client.RunRemoteScript(ctx, "echo hi"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestValidateRemoteCommandCanceled(t *testing.T) {
+	_, rawClient := newSSHServerClient(t, func(cmd string) int {
+		time.Sleep(100 * time.Millisecond)
+		return 0
+	})
+	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := client.ValidateRemoteCommand(ctx, "echo"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- extend `RunRemoteScript` and `ValidateRemoteCommand` with `context.Context`
- enforce cancellation and timeouts using `session.Start` and context
- add coverage tests for cancellation scenarios and adjust callers

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/serve build failure; cmd/root TestRunHeartbeatError timeout; config TestValidateEscalationCommandPath)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689b8fd15f4883238216dfe8fdeed22e