### PR TITLE
refactor: encapsulate transfer state

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -2,13 +2,17 @@ package apply
 
 import (
 	"fmt"
+	"sync"
 
 	"lvmsync_go/config"
 	"lvmsync_go/transfer"
 )
 
 // applyFunc allows tests to override the apply implementation.
-var applyFunc = transfer.RunApply
+var applyFunc = func(cfg *config.Config, applyFile, destDevice string) error {
+	t := transfer.NewTransfer(transfer.Logger, &sync.WaitGroup{})
+	return t.RunApply(cfg, applyFile, destDevice)
+}
 
 // Run executes apply mode using the provided configuration and arguments.
 // args should contain the destination device as the first element.

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
@@ -19,11 +20,17 @@ import (
 )
 
 var (
-	dumpChangesSequential        = transfer.DumpChangesSequential
-	dumpChangesParallel          = transfer.DumpChangesParallel
-	dumpChangesWithDeduplication = transfer.DumpChangesWithDeduplication
-	newSSHClient                 = remote.NewSSHClient
-	openFile                     = os.OpenFile
+	dumpChangesSequential = func(t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
+		return t.DumpChangesSequential(cfg, snap, origin, out)
+	}
+	dumpChangesParallel = func(t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
+		return t.DumpChangesParallel(cfg, snap, origin, out)
+	}
+	dumpChangesWithDeduplication = func(t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
+		return t.DumpChangesWithDeduplication(cfg, snap, origin, out, d)
+	}
+	newSSHClient = remote.NewSSHClient
+	openFile     = os.OpenFile
 )
 
 // CopyPipeAsync copies data from src to dst in a new goroutine and returns a channel with the result.
@@ -38,6 +45,7 @@ func CopyPipeAsync(dst io.Writer, src io.Reader) <-chan error {
 
 // ExecuteDump selects the appropriate dump implementation based on configuration.
 func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io.Writer, logger *zap.Logger) error {
+	t := transfer.NewTransfer(logger, &sync.WaitGroup{})
 	dedup := transfer.NewDeduplicationStrategy(cfg)
 	if dedup != nil {
 		defer func() {
@@ -45,12 +53,12 @@ func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io
 				logger.Error("Failed to save dedup state", zap.Error(err))
 			}
 		}()
-		return dumpChangesWithDeduplication(cfg, snapshotDevice, originDevice, out, dedup)
+		return dumpChangesWithDeduplication(t, cfg, snapshotDevice, originDevice, out, dedup)
 	}
 	if cfg.Parallel <= 1 {
-		return dumpChangesSequential(cfg, snapshotDevice, originDevice, out)
+		return dumpChangesSequential(t, cfg, snapshotDevice, originDevice, out)
 	}
-	return dumpChangesParallel(cfg, snapshotDevice, originDevice, out)
+	return dumpChangesParallel(t, cfg, snapshotDevice, originDevice, out)
 }
 
 // Run executes client mode transferring data to dest.

--- a/cmd/dump/dump_test.go
+++ b/cmd/dump/dump_test.go
@@ -20,7 +20,7 @@ func TestExecuteDumpSequential(t *testing.T) {
 
 	called := false
 	original := dumpChangesSequential
-	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		called = true
 		return nil
 	}
@@ -43,7 +43,7 @@ func TestExecuteDumpParallel(t *testing.T) {
 
 	called := false
 	original := dumpChangesParallel
-	dumpChangesParallel = func(c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesParallel = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		called = true
 		return nil
 	}
@@ -66,7 +66,7 @@ func TestExecuteDumpWithDedup(t *testing.T) {
 
 	called := false
 	original := dumpChangesWithDeduplication
-	dumpChangesWithDeduplication = func(c *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
+	dumpChangesWithDeduplication = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
 		if d == nil {
 			t.Fatalf("deduplication strategy was nil")
 		}

--- a/cmd/dump/local_dump_test.go
+++ b/cmd/dump/local_dump_test.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/transfer"
 )
 
 func TestRunLocalDumpSuccess(t *testing.T) {
@@ -33,7 +34,7 @@ func TestRunLocalDumpSuccess(t *testing.T) {
 
 	originalDump := dumpChangesSequential
 	var dumpCalled bool
-	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		dumpCalled = true
 		if snap != "snap" || origin != "orig" {
 			t.Fatalf("unexpected devices: %s %s", snap, origin)
@@ -66,7 +67,7 @@ func TestRunLocalDumpOpenError(t *testing.T) {
 	defer func() { openFile = originalOpen }()
 
 	originalDump := dumpChangesSequential
-	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		t.Fatalf("dumpChangesSequential should not be called on open error")
 		return nil
 	}

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -11,6 +11,7 @@ import (
 
 	"lvmsync_go/config"
 	remotetest "lvmsync_go/remote/testutil"
+	"lvmsync_go/transfer"
 )
 
 // TestRunRemoteDump executes a remote apply command through SSH.
@@ -50,7 +51,7 @@ func TestRunRemoteDump(t *testing.T) {
 	cfg.Parallel = 1
 
 	origDump := dumpChangesSequential
-	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		if snap != "snap" || origin != "origin" {
 			t.Fatalf("unexpected devices: %s %s", snap, origin)
 		}
@@ -107,7 +108,7 @@ func TestRunRemoteDumpError(t *testing.T) {
 	cfg.Parallel = 1
 
 	origDump := dumpChangesSequential
-	dumpChangesSequential = func(c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		return nil
 	}
 	defer func() { dumpChangesSequential = origDump }()

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"lvmsync_go/config"
 	"lvmsync_go/remote"
+	"lvmsync_go/transfer"
 )
 
 func TestSetupSSHClient(t *testing.T) {
@@ -158,7 +159,7 @@ func TestStreamToRemote(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dumpChangesSequential = func(c *config.Config, snapshot, origin string, out io.Writer) error {
+			dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snapshot, origin string, out io.Writer) error {
 				return tc.dumpErr
 			}
 			remoteStdin := &mockWriteCloser{Writer: io.Discard, closeErr: tc.closeErr}

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -11,6 +11,7 @@ import (
 
 	"lvmsync_go/config"
 	remotetest "lvmsync_go/remote/testutil"
+	"lvmsync_go/transfer"
 )
 
 // Test that remote post script executes even when dumpChanges fails
@@ -41,7 +42,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 
 	original := dumpChangesSequential
-	dumpChangesSequential = func(c *config.Config, snapshot, source string, out io.Writer) error {
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
 		return io.ErrUnexpectedEOF
 	}
 	defer func() { dumpChangesSequential = original }()

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -24,7 +24,7 @@ func TestRunLogsSaveStateError(t *testing.T) {
 	cfg.MaxRetries = 1
 
 	original := dumpChangesWithDeduplication
-	dumpChangesWithDeduplication = func(c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
+	dumpChangesWithDeduplication = func(_ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
 		return nil
 	}
 	defer func() { dumpChangesWithDeduplication = original }()

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/transfer"
 )
 
 func TestRunStdout(t *testing.T) {
@@ -23,7 +24,7 @@ func TestRunStdout(t *testing.T) {
 	expected := "test output"
 
 	originalFunc := dumpChangesSequential
-	dumpChangesSequential = func(c *config.Config, snapshot, source string, out io.Writer) error {
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
 		_, writeErr := out.Write([]byte(expected))
 		return writeErr
 	}

--- a/cmd/serve/flag_test.go
+++ b/cmd/serve/flag_test.go
@@ -15,7 +15,8 @@ import (
 
 func TestServeFlagBindingSuccess(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
-	cfg, err := config.LoadConfig()
+	fs := config.NewFlagSets(&config.Config{})
+	cfg, err := config.LoadConfig(fs, &config.Config{})
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -48,7 +49,8 @@ func TestServeFlagBindingSuccess(t *testing.T) {
 
 func TestServeFlagBindingInvalidPolicy(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "deny"})
-	cfg, err := config.LoadConfig()
+	fs := config.NewFlagSets(&config.Config{})
+	cfg, err := config.LoadConfig(fs, &config.Config{})
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}

--- a/transfer/block_test.go
+++ b/transfer/block_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
-	SetLogger(zap.NewNop())
+	Logger = zap.NewNop()
 
 	blockSize := 4
 	data := []byte{1, 2, 3, 4}
@@ -44,7 +44,7 @@ func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
 }
 
 func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
-	SetLogger(zap.NewNop())
+	Logger = zap.NewNop()
 
 	blockSize := 4
 	data := []byte{1, 2, 3, 4}

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -143,8 +143,8 @@ func processParallelResults(cfg *config.Config, results <-chan *BlockResult, buf
 	return totalBytesTransferred, manifest, nil
 }
 
-func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult) {
-	defer workerWG.Done()
+func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult, wg *sync.WaitGroup) {
+	defer wg.Done()
 	unlock := pinWorkerToDevice(cfg, srcFile)
 	defer unlock()
 	for task := range tasks {

--- a/transfer/digest_verification_test.go
+++ b/transfer/digest_verification_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestIterateBlocksFinalSHA(t *testing.T) {
-	SetLogger(zap.NewNop())
+	Logger = zap.NewNop()
 	blockSize := int64(1024)
 	snapshot := "vg-lv"
 	_, src := createVolumeFiles(t, snapshot, blockSize, []int{0})

--- a/transfer/dumpchanges_benchmark_test.go
+++ b/transfer/dumpchanges_benchmark_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"lvmsync_go/config"
@@ -10,7 +11,7 @@ import (
 )
 
 func BenchmarkDumpChangesSequential(b *testing.B) {
-	SetLogger(zap.NewNop())
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
 	blockSize := int64(4096)
 	changed := []int{0, 1, 2, 3}
 	src, snapshot := createDumpTestFiles(b, blockSize, changed)
@@ -19,14 +20,14 @@ func BenchmarkDumpChangesSequential(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		if err := DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+		if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
 			b.Fatalf("DumpChangesSequential failed: %v", err)
 		}
 	}
 }
 
 func BenchmarkDumpChangesParallel(b *testing.B) {
-	SetLogger(zap.NewNop())
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
 	blockSize := int64(4096)
 	changed := []int{0, 1, 2, 3}
 	src, snapshot := createDumpTestFiles(b, blockSize, changed)
@@ -35,7 +36,7 @@ func BenchmarkDumpChangesParallel(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		if err := DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+		if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 			b.Fatalf("DumpChangesParallel failed: %v", err)
 		}
 	}

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"lvmsync_go/common"
@@ -49,14 +50,14 @@ func parseOffsetsNoHandshake(t *testing.T, r io.Reader) []int64 {
 }
 
 func TestDumpChangesSequential(t *testing.T) {
-	SetLogger(zap.NewNop())
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
 	blockSize := int64(1024)
 	changed := []int{0, 2}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", DedupStateFile: filepath.Join(t.TempDir(), "state"), DedupStrategy: "checksum", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesSequential failed: %v", err)
 	}
 	reader := bufio.NewReader(bytes.NewReader(buf.Bytes()))
@@ -81,7 +82,7 @@ func (d *dummyDedup) RecordTransfer(int64, []byte)      {}
 func (d *dummyDedup) SaveState() error                  { return nil }
 
 func TestDumpChangesWithDeduplication(t *testing.T) {
-	SetLogger(zap.NewNop())
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
 	blockSize := int64(1024)
 	changed := []int{1}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
@@ -89,7 +90,7 @@ func TestDumpChangesWithDeduplication(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
 	dedup := &dummyDedup{}
-	if err := DumpChangesWithDeduplication(cfg, snapshot, src, &buf, dedup); err != nil {
+	if err := tr.DumpChangesWithDeduplication(cfg, snapshot, src, &buf, dedup); err != nil {
 		t.Fatalf("DumpChangesWithDeduplication failed: %v", err)
 	}
 	reader := bufio.NewReader(bytes.NewReader(buf.Bytes()))
@@ -109,14 +110,14 @@ func TestDumpChangesWithDeduplication(t *testing.T) {
 
 func TestDumpChangesParallelProgress(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	SetLogger(zap.New(core))
+	tr := NewTransfer(zap.New(core), &sync.WaitGroup{})
 	blockSize := int64(1024)
 	changed := []int{0}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, MaxRetries: 1, Progress: true}
 	var buf bytes.Buffer
-	if err := DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	if logs.FilterMessage("transfer progress").Len() == 0 {
@@ -125,14 +126,14 @@ func TestDumpChangesParallelProgress(t *testing.T) {
 }
 
 func TestProcessDumpDataAutoDecompression(t *testing.T) {
-	SetLogger(zap.NewNop())
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
 	blockSize := int64(1024)
 	changed := []int{0}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
 
 	cfgDump := &config.Config{BlockSize: int(blockSize), Compress: "zstd", ZstdLevel: 1, CompressLevel: 1, VerifyChecksum: true, Parallel: 1, MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := DumpChangesParallel(cfgDump, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(cfgDump, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 
@@ -161,7 +162,7 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 	destFile.Close()
 
 	cfgProcess := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
-	if err = ProcessDumpData(cfgProcess, bytes.NewReader(data), dest); err != nil {
+	if err = tr.ProcessDumpData(cfgProcess, bytes.NewReader(data), dest); err != nil {
 		t.Fatalf("ProcessDumpData failed: %v", err)
 	}
 

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/zeebo/blake3"
@@ -16,7 +17,7 @@ import (
 
 func TestDumpChangesSequentialLogFields(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	SetLogger(zap.New(core))
+	tr := NewTransfer(zap.New(core), &sync.WaitGroup{})
 
 	blockSize := int64(1024)
 	changed := []int{0, 2}
@@ -24,7 +25,7 @@ func TestDumpChangesSequentialLogFields(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesSequential failed: %v", err)
 	}
 

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/zeebo/blake3"
@@ -68,14 +69,14 @@ func parseOffsets(t *testing.T, data []byte, blockSize int64) []int64 {
 }
 
 func TestResumeSequential(t *testing.T) {
-	SetLogger(zap.NewNop())
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4)
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1}
 
 	var buf bytes.Buffer
-	if err := DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	finalizeResumeState(cfg)
@@ -92,14 +93,14 @@ func TestResumeSequential(t *testing.T) {
 }
 
 func TestResumeParallel(t *testing.T) {
-	SetLogger(zap.NewNop())
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4)
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 2, ResumeState: resume, MaxRetries: 1}
 
 	var buf bytes.Buffer
-	if err := DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	finalizeResumeState(cfg)

--- a/transfer/save_state_error_test.go
+++ b/transfer/save_state_error_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bytes"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"lvmsync_go/config"
@@ -14,8 +15,7 @@ import (
 func TestDumpChangesLogsSaveStateError(t *testing.T) {
 	core, observed := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
-	SetLogger(logger)
-	defer SetLogger(nil)
+	tr := NewTransfer(logger, &sync.WaitGroup{})
 
 	blockSize := int64(1024)
 	changed := []int{0}
@@ -23,7 +23,7 @@ func TestDumpChangesLogsSaveStateError(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", DedupStrategy: "checksum", DedupStateFile: filepath.Join(t.TempDir(), "missing", "state"), MaxRetries: 1}
 	var buf bytes.Buffer
-	if dumpErr := DumpChanges(cfg, snapshot, src, &buf); dumpErr != nil {
+	if dumpErr := tr.DumpChanges(cfg, snapshot, src, &buf); dumpErr != nil {
 		t.Fatalf("DumpChanges failed: %v", dumpErr)
 	}
 	logs := observed.FilterMessage("Failed to save dedup state").All()

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -25,14 +25,23 @@ import (
 )
 
 // Logger holds the package-wide zap.Logger used for progress and error reporting.
-var (
+var Logger *zap.Logger
+
+// Transfer encapsulates transfer state shared across operations.
+type Transfer struct {
 	Logger   *zap.Logger
 	workerWG *sync.WaitGroup
-)
+}
 
-// SetLogger assigns Logger for package-wide logging and overrides any existing logger.
-func SetLogger(logger *zap.Logger) {
+// NewTransfer creates a Transfer with the provided logger and wait group.
+// When wg is nil, a new instance is allocated. The package-wide Logger is
+// set to the provided logger for internal helpers that rely on it.
+func NewTransfer(logger *zap.Logger, wg *sync.WaitGroup) *Transfer {
+	if wg == nil {
+		wg = &sync.WaitGroup{}
+	}
 	Logger = logger
+	return &Transfer{Logger: logger, workerWG: wg}
 }
 
 // ChecksumState stores block checksums and the algorithm used for deduplication.
@@ -200,7 +209,7 @@ func setupPipe(cfg *config.Config) ([2]int, func(), error) {
 	return pipeFds, cleanup, nil
 }
 
-func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
+func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
 	ranges, err := prepareRanges(cfg, snapshot, source)
 	if err != nil {
 		return err
@@ -253,7 +262,7 @@ func dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer,
 	return nil
 }
 
-func setupDedup(cfg *config.Config) (DeduplicationStrategy, func()) {
+func (t *Transfer) setupDedup(cfg *config.Config) (DeduplicationStrategy, func()) {
 	dedup := NewDeduplicationStrategy(cfg)
 	cleanup := func() {}
 	if dedup != nil {
@@ -267,29 +276,29 @@ func setupDedup(cfg *config.Config) (DeduplicationStrategy, func()) {
 }
 
 // DumpChangesSequential streams changed blocks from snapshot to out sequentially and saves dedup state if enabled.
-func DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.Writer) error {
-	dedup, cleanup := setupDedup(cfg)
+func (t *Transfer) DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.Writer) error {
+	dedup, cleanup := t.setupDedup(cfg)
 	if dedup != nil {
 		defer cleanup()
 	}
-	return dumpChangesCore(cfg, snapshot, source, out, dedup, "")
+	return t.dumpChangesCore(cfg, snapshot, source, out, dedup, "")
 }
 
 // DumpChangesWithDeduplication transfers changed blocks using the provided dedup strategy and a checksum-dedup handshake, updating the strategy's state.
-func DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy) error {
-	return dumpChangesCore(cfg, snapshot, source, out, dedup, "checksum-dedup")
+func (t *Transfer) DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy) error {
+	return t.dumpChangesCore(cfg, snapshot, source, out, dedup, "checksum-dedup")
 }
 
 // DumpChanges chooses an appropriate transfer mode and persists dedup state when a strategy is configured.
-func DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
-	dedup, cleanup := setupDedup(cfg)
+func (t *Transfer) DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
+	dedup, cleanup := t.setupDedup(cfg)
 	if dedup != nil {
 		defer cleanup()
 		Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
-		return DumpChangesWithDeduplication(cfg, snapshot, source, out, dedup)
+		return t.DumpChangesWithDeduplication(cfg, snapshot, source, out, dedup)
 	}
 	Logger.Info("Deduplication disabled, performing full block transfer")
-	return DumpChangesSequential(cfg, snapshot, source, out)
+	return t.DumpChangesSequential(cfg, snapshot, source, out)
 }
 
 var (
@@ -394,7 +403,7 @@ func calculateTotalDataSize(ranges []Range) int64 {
 	return int64(total)
 }
 
-func startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, resumeStart int) <-chan *BlockResult {
+func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, resumeStart int) <-chan *BlockResult {
 	numBlocks := len(ranges)
 	taskBuf := cfg.Parallel
 	if taskBuf < 1 {
@@ -402,10 +411,9 @@ func startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, 
 	}
 	tasks := make(chan BlockTask, taskBuf)
 	results := make(chan *BlockResult, taskBuf)
-	workerWG = &sync.WaitGroup{}
 	for i := 0; i < cfg.Parallel; i++ {
-		workerWG.Add(1)
-		go worker(cfg, srcFile, tasks, results)
+		t.workerWG.Add(1)
+		go worker(cfg, srcFile, tasks, results, t.workerWG)
 	}
 
 	go func() {
@@ -415,14 +423,14 @@ func startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, 
 		close(tasks)
 	}()
 
-	go finalizeResults(workerWG, results)
+	go finalizeResults(t.workerWG, results)
 	return results
 }
 
-func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
+func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
 	if cfg.ZeroCopy {
 		Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
-		return DumpChangesSequential(cfg, snapshot, source, out)
+		return t.DumpChangesSequential(cfg, snapshot, source, out)
 	}
 
 	ranges, err := prepareRanges(cfg, snapshot, source)
@@ -449,7 +457,7 @@ func DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Wri
 
 	resumeDigest := readResumeDigest(cfg)
 	resumeStart := findResumeIndex(cfg, srcFile, ranges, resumeDigest)
-	results := startParallelWorkers(cfg, srcFile, ranges, resumeStart)
+	results := t.startParallelWorkers(cfg, srcFile, ranges, resumeStart)
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
@@ -625,7 +633,7 @@ func applyBlocks(cfg *config.Config, reader *bufio.Reader, destFile *os.File, de
 	return totalBytes, nil
 }
 
-func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
+func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
 	bufReader := bufio.NewReader(in)
 	var hs common.Handshake
 	hs, err = readAndValidateHandshake(bufReader, dedup, verify)
@@ -684,13 +692,13 @@ func processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedu
 }
 
 // ProcessDumpDataWithDeduplication applies a dump stream to destPath using the given dedup strategy without checksum verification, updating the strategy's state.
-func ProcessDumpDataWithDeduplication(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy) error {
-	return processDumpDataCore(cfg, in, destPath, dedup, false)
+func (t *Transfer) ProcessDumpDataWithDeduplication(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy) error {
+	return t.processDumpDataCore(cfg, in, destPath, dedup, false)
 }
 
 // ProcessDumpData applies a dump stream to destPath with checksum verification for each block before writing.
-func ProcessDumpData(cfg *config.Config, in io.Reader, destPath string) error {
-	return processDumpDataCore(cfg, in, destPath, nil, true)
+func (t *Transfer) ProcessDumpData(cfg *config.Config, in io.Reader, destPath string) error {
+	return t.processDumpDataCore(cfg, in, destPath, nil, true)
 }
 
 func openApplyReader(applyFile string) (io.ReadCloser, error) {
@@ -704,7 +712,7 @@ func openApplyReader(applyFile string) (io.ReadCloser, error) {
 	return f, nil
 }
 
-func applyData(cfg *config.Config, in io.Reader, destDevice string) error {
+func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string) error {
 	dedup := NewDeduplicationStrategy(cfg)
 	if dedup != nil {
 		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
@@ -713,17 +721,17 @@ func applyData(cfg *config.Config, in io.Reader, destDevice string) error {
 				Logger.Error("Failed to save dedup state", zap.Error(err))
 			}
 		}()
-		return ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)
+		return t.ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)
 	}
-	return ProcessDumpData(cfg, in, destDevice)
+	return t.ProcessDumpData(cfg, in, destDevice)
 }
 
 // RunApply reads a dump file or stdin and writes the data to destDevice.
-func RunApply(cfg *config.Config, applyFile, destDevice string) (err error) {
+func (t *Transfer) RunApply(cfg *config.Config, applyFile, destDevice string) (err error) {
 	rc, err := openApplyReader(applyFile)
 	if err != nil {
 		return err
 	}
 	defer common.CloseWithErr(rc, &err, "close apply file")
-	return applyData(cfg, rc, destDevice)
+	return t.applyData(cfg, rc, destDevice)
 }


### PR DESCRIPTION
## Summary
- add `Transfer` struct to carry logger and worker waitgroup
- pass dependencies via methods, removing package-level worker state
- adjust dump client and tests for new Transfer API

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b8fe1e26483238bee683146eca78d