### PR TITLE
feat(signals): honor context deadlines on shutdown

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -176,11 +176,11 @@ func ClientHandshake(cfg *config.Config, logger *zap.Logger) (func(), chan error
 }
 
 // SetupSignalHandling configures signal handling and returns the signal and error channels.
-func SetupSignalHandling(cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
+func SetupSignalHandling(ctx context.Context, cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	sigErrCh := make(chan error, 1)
-	go handleSignals(cfg, logger, signals, snapshotPath, sigErrCh)
+	go handleSignals(ctx, cfg, logger, signals, snapshotPath, sigErrCh)
 	return signals, sigErrCh
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -282,13 +282,13 @@ func TestSetupSignalHandling(t *testing.T) {
 	called := make(chan struct{})
 	origHandle := handleSignals
 	defer func() { handleSignals = origHandle }()
-	handleSignals = func(cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	handleSignals = func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		<-sigs
 		*p = "set"
 		close(called)
 	}
 	logger := zap.NewNop()
-	signals, sigErrCh := SetupSignalHandling(cfg, &path, logger)
+	signals, sigErrCh := SetupSignalHandling(context.Background(), cfg, &path, logger)
 	signals <- os.Interrupt
 	select {
 	case <-called:
@@ -313,11 +313,11 @@ func TestSetupSignalHandlingError(t *testing.T) {
 	var path string
 	origHandle := handleSignals
 	defer func() { handleSignals = origHandle }()
-	handleSignals = func(cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	handleSignals = func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		errCh <- errors.New("boom")
 	}
 	logger := zap.NewNop()
-	_, sigErrCh := SetupSignalHandling(cfg, &path, logger)
+	_, sigErrCh := SetupSignalHandling(context.Background(), cfg, &path, logger)
 	if err := <-sigErrCh; err == nil {
 		t.Fatalf("expected error")
 	}

--- a/cmd/lvmsync/signals/signals.go
+++ b/cmd/lvmsync/signals/signals.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -16,11 +17,13 @@ var removeSnapshot = lvm.RemoveSnapshot
 
 // Handle waits for an OS signal, logs it, and removes the snapshot when
 // necessary.
-func Handle(cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error) {
+func Handle(ctx context.Context, cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error) {
 	sig := <-signals
 	logger.Info("received signal, aborting", zap.String("signal", sig.String()))
 	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
-		if err := removeSnapshot(context.Background(), *snapshotPath); err != nil {
+		rmCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		if err := removeSnapshot(rmCtx, *snapshotPath); err != nil {
 			logger.Warn("failed to remove snapshot on shutdown", zap.Error(err))
 		} else {
 			logger.Info("snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))

--- a/cmd/lvmsync/signals/signals_test.go
+++ b/cmd/lvmsync/signals/signals_test.go
@@ -1,6 +1,7 @@
 package signals
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -16,7 +17,7 @@ func TestHandle(t *testing.T) {
 	errCh := make(chan error, 1)
 	var snap string
 	logger := zap.NewNop()
-	go Handle(cfg, logger, sigCh, &snap, errCh)
+	go Handle(context.Background(), cfg, logger, sigCh, &snap, errCh)
 	sigCh <- os.Interrupt
 	err := <-errCh
 	if err == nil || !strings.Contains(err.Error(), "received signal") {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -152,7 +152,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	defer cleanupClient()
 
 	var snapshotPath string
-	signals, sigErrCh := setupSignalHandle(cfg, &snapshotPath, logger)
+	signals, sigErrCh := setupSignalHandle(ctx, cfg, &snapshotPath, logger)
 	defer signal.Stop(signals)
 
 	go func() {

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -215,7 +215,7 @@ func TestRunHeartbeatError(t *testing.T) {
 	selectTransport = func(*config.Config, *zap.Logger) error { return nil }
 
 	sigErrCh := make(chan error, 1)
-	setupSignalHandle = func(*config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+	setupSignalHandle = func(_ context.Context, _ *config.Config, _ *string, _ *zap.Logger) (chan os.Signal, chan error) {
 		return nil, sigErrCh
 	}
 	prepareSnapshotFn = func(*config.Config, string, *zap.Logger) (string, chan error, func(), error) {

--- a/cmd/serve/flag_test.go
+++ b/cmd/serve/flag_test.go
@@ -15,7 +15,12 @@ import (
 
 func TestServeFlagBindingSuccess(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
-	cfg, err := config.LoadConfig()
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	flagSets := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(flagSets, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -48,7 +53,12 @@ func TestServeFlagBindingSuccess(t *testing.T) {
 
 func TestServeFlagBindingInvalidPolicy(t *testing.T) {
 	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "deny"})
-	cfg, err := config.LoadConfig()
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	flagSets := config.NewFlagSets(defaults)
+	cfg, err := config.LoadConfig(flagSets, defaults)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}


### PR DESCRIPTION
## Summary
- accept a `context.Context` in signal handler and remove snapshots with a timeout
- propagate context through setup helpers and root command
- align serve flag tests with current configuration API

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b8f7c50ec8323bfe3208a9332b270