### PR TITLE
feat(dump): add context cancellation to pipe copying

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -34,11 +34,32 @@ var (
 )
 
 // CopyPipeAsync copies data from src to dst in a new goroutine and returns a channel with the result.
-func CopyPipeAsync(dst io.Writer, src io.Reader) <-chan error {
+func CopyPipeAsync(ctx context.Context, dst io.Writer, src io.Reader) <-chan error {
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(dst, src)
-		errCh <- err
+		defer close(errCh)
+		const chunkSize = int64(32 * 1024)
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			default:
+				n, err := io.Copy(dst, io.LimitReader(src, chunkSize))
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						errCh <- nil
+					} else {
+						errCh <- err
+					}
+					return
+				}
+				if n < chunkSize {
+					errCh <- nil
+					return
+				}
+			}
+		}
 	}()
 	return errCh
 }
@@ -113,7 +134,7 @@ type pipeSession interface {
 }
 
 // SetupSessionStreams wires local stdio to the remote session.
-func SetupSessionStreams(session pipeSession) (io.WriteCloser, <-chan error, <-chan error, error) {
+func SetupSessionStreams(ctx context.Context, session pipeSession) (io.WriteCloser, <-chan error, <-chan error, error) {
 	stdoutPipe, err := session.StdoutPipe()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get stdout pipe: %w", err)
@@ -122,8 +143,8 @@ func SetupSessionStreams(session pipeSession) (io.WriteCloser, <-chan error, <-c
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get stderr pipe: %w", err)
 	}
-	stdoutErrCh := CopyPipeAsync(os.Stdout, stdoutPipe)
-	stderrErrCh := CopyPipeAsync(os.Stderr, stderrPipe)
+	stdoutErrCh := CopyPipeAsync(ctx, os.Stdout, stdoutPipe)
+	stderrErrCh := CopyPipeAsync(ctx, os.Stderr, stderrPipe)
 
 	remoteStdin, err := session.StdinPipe()
 	if err != nil {
@@ -169,8 +190,8 @@ func WaitForRemoteCompletion(session waitSession, stdoutErrCh, stderrErrCh <-cha
 }
 
 // ExecuteRemoteCommand runs the remote apply command over SSH.
-func ExecuteRemoteCommand(cfg *config.Config, client *remote.SSHClient, destDevice, snapshotDevice, originDevice string, logger *zap.Logger) (err error) {
-	if err = client.ValidateRemoteCommand(context.Background(), cfg.LVMSyncPath); err != nil {
+func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remote.SSHClient, destDevice, snapshotDevice, originDevice string, logger *zap.Logger) (err error) {
+	if err = client.ValidateRemoteCommand(ctx, cfg.LVMSyncPath); err != nil {
 		return fmt.Errorf("remote command validation failed: %w", err)
 	}
 
@@ -180,7 +201,7 @@ func ExecuteRemoteCommand(cfg *config.Config, client *remote.SSHClient, destDevi
 	}
 	defer closeSession(session, &err)
 
-	remoteStdin, stdoutErrCh, stderrErrCh, err := SetupSessionStreams(session)
+	remoteStdin, stdoutErrCh, stderrErrCh, err := SetupSessionStreams(ctx, session)
 	if err != nil {
 		return err
 	}
@@ -236,7 +257,7 @@ func RunRemoteDump(cfg *config.Config, snapshotDevice, originDevice, dest string
 		}()
 	}
 
-	return ExecuteRemoteCommand(cfg, client, destDevice, snapshotDevice, originDevice, logger)
+	return ExecuteRemoteCommand(ctx, cfg, client, destDevice, snapshotDevice, originDevice, logger)
 }
 
 // SelectTransport chooses and logs the transport if configured.

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -121,7 +121,7 @@ func TestSetupSessionStreamsPipeErrors(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, _, err := SetupSessionStreams(tc.sess)
+			_, _, _, err := SetupSessionStreams(context.Background(), tc.sess)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("expected %s error, got %v", tc.want, err)
 			}

--- a/error_handling_test.go
+++ b/error_handling_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"io"
 	"testing"
@@ -23,7 +24,7 @@ func (c *failingSyncCore) Sync() error {
 
 func TestCopyPipeAsyncError(t *testing.T) {
 	r, w := io.Pipe()
-	errCh := dumpcmd.CopyPipeAsync(io.Discard, r)
+	errCh := dumpcmd.CopyPipeAsync(context.Background(), io.Discard, r)
 	expected := errors.New("copy fail")
 	w.CloseWithError(expected)
 	if err := <-errCh; !errors.Is(err, expected) {


### PR DESCRIPTION
## Summary
- add context-aware CopyPipeAsync to allow early abort
- wire session stream setup through lifecycle context
- adjust tests for new context requirements

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b98c906ac83238b74f0d739169618