### PR TITLE
feat(dump): add script timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--known_hosts` | `LVMSYNC_KNOWN_HOSTS` | `known_hosts` | Path to known_hosts file |
 | `--strict_host_key_checking` | `LVMSYNC_STRICT_HOST_KEY_CHECKING` | `strict_host_key_checking` | Require host keys to be present in `known_hosts` |
 | `--lvmsync_path` | `LVMSYNC_LVMSYNC_PATH` | `lvmsync_path` | Remote command to run (basename sanitized; only `[a-zA-Z0-9._-]+` allowed) |
-| `--remote_pre_script` | `LVMSYNC_REMOTE_PRE_SCRIPT` | `remote_pre_script` | Remote script to run before transfer |
-| `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer |
+| `--remote_pre_script` | `LVMSYNC_REMOTE_PRE_SCRIPT` | `remote_pre_script` | Remote script to run before transfer (times out after `ssh_timeout`) |
+| `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer (separate `ssh_timeout`) |
 | `--dedup_strategy` | `LVMSYNC_DEDUP_STRATEGY` | `dedup_strategy` | Deduplication strategy: `none`, `auto`, `checksum`, `rolling_hash`, or `bloom` |
 | `--dedup_state_file` | `LVMSYNC_DEDUP_STATE_FILE` | `dedup_state_file` | Path to deduplication state file |
 | `--bloom_entries` | `LVMSYNC_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
@@ -761,8 +761,12 @@ The `--lvmsync_path` value is sanitized to its basename and must match
 | Option                 | Description                                       | Default     |
 | ---------------------- | ------------------------------------------------- | ----------- |
 | `--lvmsync_path`       | Remote command to run (sanitized basename)         | `"lvmsync"` |
-| `--remote_pre_script`  | Remote script to run before starting the transfer | `""`        |
-| `--remote_post_script` | Remote script to run after finishing the transfer | `""`        |
+| `--remote_pre_script`  | Remote script to run before starting the transfer (`ssh_timeout` applies) | `""`        |
+| `--remote_post_script` | Remote script to run after finishing the transfer (uses a fresh `ssh_timeout`) | `""`        |
+
+Both scripts are run with the configured `ssh_timeout`. The post script uses its
+own timeout and still attempts to execute even when the main transfer fails;
+timeouts or cancellations are reported separately.
 
 #### Deduplication Options
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -69,7 +69,7 @@ func Run(cfg *config.Config, snapshotDevice, dest string, logger *zap.Logger) er
 		return ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
 	}
 	if strings.Contains(dest, ":") {
-		return RunRemoteDump(cfg, snapshotDevice, originDevice, dest, logger)
+		return RunRemoteDump(context.Background(), cfg, snapshotDevice, originDevice, dest, logger)
 	}
 	return RunLocalDump(cfg, snapshotDevice, originDevice, dest, logger)
 }
@@ -200,7 +200,7 @@ func ExecuteRemoteCommand(cfg *config.Config, client *remote.SSHClient, destDevi
 }
 
 // RunRemoteDump streams snapshot data to a remote host over SSH.
-func RunRemoteDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
+func RunRemoteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	parts := strings.SplitN(dest, ":", 2)
 	destHost, destDevice := parts[0], parts[1]
 	client, cancel, err := SetupSSHClient(cfg, destHost, logger)
@@ -218,19 +218,30 @@ func RunRemoteDump(cfg *config.Config, snapshotDevice, originDevice, dest string
 		}
 	}()
 
-	ctx := context.Background()
 	if cfg.RemotePreScript != "" {
-		if err = client.RunRemoteScript(ctx, cfg.RemotePreScript); err != nil {
+		scriptCtx, cancel := context.WithTimeout(ctx, cfg.SSHTimeout)
+		if err = client.RunRemoteScript(scriptCtx, cfg.RemotePreScript); err != nil {
+			cancel()
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("remote pre-script context error: %w", err)
+			}
 			return fmt.Errorf("remote pre-script failed: %w", err)
 		}
+		cancel()
 	}
 	if cfg.RemotePostScript != "" {
 		defer func() {
-			if err2 := client.RunRemoteScript(ctx, cfg.RemotePostScript); err2 != nil {
+			scriptCtx, cancel := context.WithTimeout(ctx, cfg.SSHTimeout)
+			defer cancel()
+			if err2 := client.RunRemoteScript(scriptCtx, cfg.RemotePostScript); err2 != nil {
+				msg := "remote post-script failed"
+				if errors.Is(err2, context.Canceled) || errors.Is(err2, context.DeadlineExceeded) {
+					msg = "remote post-script context error"
+				}
 				if err == nil {
-					err = fmt.Errorf("remote post-script failed: %w", err2)
+					err = fmt.Errorf("%s: %w", msg, err2)
 				} else {
-					err = fmt.Errorf("%v; remote post-script failed: %w", err, err2)
+					err = fmt.Errorf("%v; %s: %w", err, msg, err2)
 				}
 			}
 		}()

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -1,6 +1,7 @@
 package dump
 
 import (
+	"context"
 	"io"
 	"net"
 	"strconv"
@@ -60,7 +61,7 @@ func TestRunRemoteDump(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	if err := RunRemoteDump(cfg, "snap", "origin", dest, zap.NewNop()); err != nil {
+	if err := RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop()); err != nil {
 		t.Fatalf("runRemoteDump returned error: %v", err)
 	}
 
@@ -114,7 +115,7 @@ func TestRunRemoteDumpError(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	err = RunRemoteDump(cfg, "snap", "origin", dest, zap.NewNop())
+	err = RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "remote command error") {
 		t.Fatalf("expected remote command error, got %v", err)
 	}

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -103,5 +104,52 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	cmds := server.Commands()
 	if len(cmds) != 1 || cmds[0] != cfg.RemotePreScript {
 		t.Fatalf("post script should not run, commands: %v", cmds)
+	}
+}
+
+// Test that post script context errors are reported distinctly
+func TestRemotePostScriptContextError(t *testing.T) {
+	server := remotetest.NewMockSSHServer(t, func(cmd string) int {
+		switch {
+		case cmd == "lvmsync --version":
+			return 0
+		case strings.HasPrefix(cmd, "lvmsync --apply - /dev/null"):
+			return 0
+		case cmd == "slow-post":
+			time.Sleep(100 * time.Millisecond)
+			return 0
+		default:
+			t.Fatalf("unexpected command: %s", cmd)
+			return 1
+		}
+	})
+	defer server.Close()
+
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+
+	cfg, cfgErr := config.DefaultConfig()
+	if cfgErr != nil {
+		t.Fatalf("DefaultConfig returned error: %v", cfgErr)
+	}
+	cfg.RemotePostScript = "slow-post"
+	cfg.SSHUser = "test"
+	cfg.SSHPort = port
+	cfg.SSHTimeout = time.Millisecond
+	cfg.SSHKeyPath = remotetest.CreateTempKey(t)
+	cfg.KnownHosts = remotetest.CreateKnownHostsFile(t, server)
+	cfg.StrictHostKeyCheck = true
+	cfg.LVMSyncPath = "lvmsync"
+
+	dest := host + ":/dev/null"
+	err = Run(cfg, "/dev/snap", dest, zap.NewNop())
+	if err == nil || !strings.Contains(err.Error(), "remote post-script context error") {
+		t.Fatalf("expected remote post-script context error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- propagate context into `RunRemoteDump`
- run remote pre/post scripts with `ssh_timeout`
- note script timeout behavior in docs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689b98d98ff48323b1619cdd76d23d6d