### PR TITLE
feat(ssh): add context-aware remote validation

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -169,8 +169,8 @@ func WaitForRemoteCompletion(session waitSession, stdoutErrCh, stderrErrCh <-cha
 }
 
 // ExecuteRemoteCommand runs the remote apply command over SSH.
-func ExecuteRemoteCommand(cfg *config.Config, client *remote.SSHClient, destDevice, snapshotDevice, originDevice string, logger *zap.Logger) (err error) {
-	if err = client.ValidateRemoteCommand(context.Background(), cfg.LVMSyncPath); err != nil {
+func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remote.SSHClient, destDevice, snapshotDevice, originDevice string, logger *zap.Logger) (err error) {
+	if err = client.ValidateRemoteCommand(ctx, cfg.LVMSyncPath); err != nil {
 		return fmt.Errorf("remote command validation failed: %w", err)
 	}
 
@@ -236,7 +236,9 @@ func RunRemoteDump(cfg *config.Config, snapshotDevice, originDevice, dest string
 		}()
 	}
 
-	return ExecuteRemoteCommand(cfg, client, destDevice, snapshotDevice, originDevice, logger)
+	validationCtx, cancel := context.WithTimeout(ctx, cfg.SSHTimeout)
+	defer cancel()
+	return ExecuteRemoteCommand(validationCtx, cfg, client, destDevice, snapshotDevice, originDevice, logger)
 }
 
 // SelectTransport chooses and logs the transport if configured.

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -1,11 +1,14 @@
 package dump
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -117,5 +120,66 @@ func TestRunRemoteDumpError(t *testing.T) {
 	err = RunRemoteDump(cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "remote command error") {
 		t.Fatalf("expected remote command error, got %v", err)
+	}
+}
+
+// TestRunRemoteDumpTimeout verifies that command validation respects SSHTimeout.
+func TestRunRemoteDumpTimeout(t *testing.T) {
+	var cmdCount int
+	server := remotetest.NewMockSSHServer(t, func(cmd string) int {
+		cmdCount++
+		switch {
+		case cmd == "lvmsync --version":
+			time.Sleep(100 * time.Millisecond)
+			return 0
+		case strings.HasPrefix(cmd, "lvmsync --apply - /dev/null"):
+			return 0
+		default:
+			t.Fatalf("unexpected command: %s", cmd)
+			return 1
+		}
+	})
+	defer server.Close()
+
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	cfg.SSHUser = "test"
+	cfg.SSHPort = port
+	cfg.SSHKeyPath = remotetest.CreateTempKey(t)
+	cfg.KnownHosts = remotetest.CreateKnownHostsFile(t, server)
+	cfg.StrictHostKeyCheck = true
+	cfg.LVMSyncPath = "lvmsync"
+	cfg.Parallel = 1
+	cfg.SSHTimeout = 20 * time.Millisecond
+
+	origDump := dumpChangesSequential
+	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+		return nil
+	}
+	defer func() { dumpChangesSequential = origDump }()
+
+	dest := host + ":/dev/null"
+	err = RunRemoteDump(cfg, "snap", "origin", dest, zap.NewNop())
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+
+	cmds := server.Commands()
+	if len(cmds) != 1 || cmds[0] != "lvmsync --version" {
+		t.Fatalf("unexpected commands: %v", cmds)
+	}
+	if cmdCount != 1 {
+		t.Fatalf("expected only validation command, got %d", cmdCount)
 	}
 }


### PR DESCRIPTION
## Summary
- allow ExecuteRemoteCommand to receive a context for validation
- enforce SSH timeout during RunRemoteDump validation
- add timeout test for remote dumps

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b98d128d483239af28444d1e9b4d1