### PR TITLE
refactor: inject logger into transfer helpers

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -4,22 +4,24 @@ import (
 	"fmt"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/config"
 	"lvmsync_go/transfer"
 )
 
 // applyFunc allows tests to override the apply implementation.
-var applyFunc = func(cfg *config.Config, applyFile, destDevice string) error {
-	t := transfer.NewTransfer(transfer.Logger, &sync.WaitGroup{})
+var applyFunc = func(cfg *config.Config, applyFile, destDevice string, logger *zap.Logger) error {
+	t := transfer.NewTransfer(logger, &sync.WaitGroup{})
 	return t.RunApply(cfg, applyFile, destDevice)
 }
 
 // Run executes apply mode using the provided configuration and arguments.
 // args should contain the destination device as the first element.
-func Run(cfg *config.Config, applyFile string, args []string) error {
+func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error {
 	if len(args) < 1 {
 		return fmt.Errorf("no destination device specified for apply mode")
 	}
 	destDevice := args[0]
-	return applyFunc(cfg, applyFile, destDevice)
+	return applyFunc(cfg, applyFile, destDevice, logger)
 }

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -3,6 +3,8 @@ package apply
 import (
 	"testing"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/config"
 )
 
@@ -16,7 +18,7 @@ func TestRun(t *testing.T) {
 
 	called := false
 	original := applyFunc
-	applyFunc = func(c *config.Config, applyFileArg, destDevice string) error {
+	applyFunc = func(c *config.Config, applyFileArg, destDevice string, _ *zap.Logger) error {
 		called = true
 		if applyFileArg != applyFile {
 			t.Fatalf("expected applyFile %s, got %s", applyFile, applyFileArg)
@@ -28,7 +30,7 @@ func TestRun(t *testing.T) {
 	}
 	defer func() { applyFunc = original }()
 
-	if err := Run(cfg, applyFile, []string{dest}); err != nil {
+	if err := Run(cfg, applyFile, []string{dest}, zap.NewNop()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if !called {

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -46,7 +46,7 @@ func CopyPipeAsync(dst io.Writer, src io.Reader) <-chan error {
 // ExecuteDump selects the appropriate dump implementation based on configuration.
 func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io.Writer, logger *zap.Logger) error {
 	t := transfer.NewTransfer(logger, &sync.WaitGroup{})
-	dedup := transfer.NewDeduplicationStrategy(cfg)
+	dedup := transfer.NewDeduplicationStrategy(cfg, logger)
 	if dedup != nil {
 		defer func() {
 			if err := dedup.SaveState(); err != nil {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -129,7 +129,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	defer lvm.Cleanup()
 
 	if cfg.ApplyMode != "" {
-		if err := applycmd.Run(cfg, cfg.ApplyMode, pflag.Args()); err != nil {
+		if err := applycmd.Run(cfg, cfg.ApplyMode, pflag.Args(), logger); err != nil {
 			return fmt.Errorf("apply operation failed: %w", err)
 		}
 		return nil

--- a/transfer/block_benchmark_test.go
+++ b/transfer/block_benchmark_test.go
@@ -5,6 +5,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/config"
 	"syscall"
 )
@@ -44,7 +46,7 @@ func BenchmarkReadBlockWithRetriesEphemeral(b *testing.B) {
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
 	for i := 0; i < b.N; i++ {
-		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, [2]int{-1, -1}); err != nil {
+		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, [2]int{-1, -1}, zap.NewNop()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -81,7 +83,7 @@ func BenchmarkReadBlockWithRetriesPersistent(b *testing.B) {
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
 	for i := 0; i < b.N; i++ {
-		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, pipeFds); err != nil {
+		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, pipeFds, zap.NewNop()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/transfer/block_common.go
+++ b/transfer/block_common.go
@@ -30,15 +30,15 @@ func ReadBlock(src *os.File, offset int64, size int) ([]byte, error) {
 }
 
 //nolint:revive // high complexity is acceptable for this low-level function
-func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int) ([]byte, error) {
+func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
 	if useZeroCopy {
-		return readWithZeroCopy(cfg, src, offset, pipeFds)
+		return readWithZeroCopy(cfg, src, offset, pipeFds, logger)
 	}
-	return retryRead(cfg, src, offset)
+	return retryRead(cfg, src, offset, logger)
 }
 
 //revive:disable-next-line:cognitive-complexity
-func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2]int) ([]byte, error) {
+func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
 	blockSize := cfg.BlockSize
 	maxRetries := cfg.MaxRetries
 
@@ -49,12 +49,16 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 		atomic.AddInt64(&PipeCreationCount, 1)
 		defer func() {
 			if closeErr := syscall.Close(pipeFds[0]); closeErr != nil {
-				Logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
+				if logger != nil {
+					logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
+				}
 			}
 		}()
 		defer func() {
 			if closeErr := syscall.Close(pipeFds[1]); closeErr != nil {
-				Logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
+				if logger != nil {
+					logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
+				}
 			}
 		}()
 	}
@@ -65,7 +69,9 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 	}
 	defer func() {
 		if closeErr := r.Close(); closeErr != nil {
-			Logger.Warn("pipe read close", zap.Error(closeErr))
+			if logger != nil {
+				logger.Warn("pipe read close", zap.Error(closeErr))
+			}
 		}
 	}()
 
@@ -75,11 +81,13 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 			break
 		}
 
-		Logger.Warn("Zero-copy transfer failed",
-			zap.Int64("offset", offset),
-			zap.Int("size_bytes", blockSize),
-			zap.Int("attempt", attempt+1),
-			zap.Error(err))
+		if logger != nil {
+			logger.Warn("Zero-copy transfer failed",
+				zap.Int64("offset", offset),
+				zap.Int("size_bytes", blockSize),
+				zap.Int("attempt", attempt+1),
+				zap.Error(err))
+		}
 
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -108,7 +116,7 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 	return data, nil
 }
 
-func retryRead(cfg *config.Config, src *os.File, offset int64) ([]byte, error) {
+func retryRead(cfg *config.Config, src *os.File, offset int64, logger *zap.Logger) ([]byte, error) {
 	blockSize := cfg.BlockSize
 	maxRetries := cfg.MaxRetries
 
@@ -124,11 +132,13 @@ func retryRead(cfg *config.Config, src *os.File, offset int64) ([]byte, error) {
 			return buf, nil
 		}
 
-		Logger.Warn("Failed to read block",
-			zap.Int64("offset", offset),
-			zap.Int("size_bytes", blockSize),
-			zap.Int("attempt", attempt+1),
-			zap.Error(err))
+		if logger != nil {
+			logger.Warn("Failed to read block",
+				zap.Int64("offset", offset),
+				zap.Int("size_bytes", blockSize),
+				zap.Int("attempt", attempt+1),
+				zap.Error(err))
+		}
 
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/transfer/block_test.go
+++ b/transfer/block_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
-	Logger = zap.NewNop()
+	logger := zap.NewNop()
 
 	blockSize := 4
 	data := []byte{1, 2, 3, 4}
@@ -30,7 +30,7 @@ func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
 	}()
 
 	start := time.Now()
-	buf, err := ReadBlockWithRetries(cfg, tmp, 0, false, [2]int{-1, -1})
+	buf, err := ReadBlockWithRetries(cfg, tmp, 0, false, [2]int{-1, -1}, logger)
 	if err != nil {
 		t.Fatalf("ReadBlockWithRetries returned error: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
 }
 
 func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
-	Logger = zap.NewNop()
+	logger := zap.NewNop()
 
 	blockSize := 4
 	data := []byte{1, 2, 3, 4}
@@ -57,7 +57,7 @@ func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
 	}
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
-	buf, err := ReadBlockWithRetries(cfg, tmp, 0, true, [2]int{-1, -1})
+	buf, err := ReadBlockWithRetries(cfg, tmp, 0, true, [2]int{-1, -1}, logger)
 	if err != nil {
 		t.Fatalf("ReadBlockWithRetries error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
 	}()
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
-	buf, err = ReadBlockWithRetries(cfg, tmp, 0, true, fds)
+	buf, err = ReadBlockWithRetries(cfg, tmp, 0, true, fds, logger)
 	if err != nil {
 		t.Fatalf("ReadBlockWithRetries error: %v", err)
 	}

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
 
 	"lvmsync_go/config"
 )
@@ -25,7 +26,7 @@ func validateOffsetAndSize(offset uint64, size int) (int64, uint32, error) {
 	return int64(offset), uint32(size), nil
 }
 
-func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int) (int64, int, *Manifest, error) {
+func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int, logger *zap.Logger) (int64, int, *Manifest, error) {
 	var totalBytes int64
 	skippedBlocks := 0
 	var header [12]byte
@@ -36,7 +37,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		if err != nil {
 			return totalBytes, skippedBlocks, manifest, err
 		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, pipeFds)
+		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, pipeFds, logger)
 		if err != nil {
 			return totalBytes, skippedBlocks, manifest, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
 		}
@@ -56,7 +57,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 				putBlockBuffer(data)
 				return totalBytes, skippedBlocks, manifest, fmt.Errorf("failed to write header: %w", err)
 			}
-			saveResumeState(cfg, [32]byte{}, int64(blockSize))
+			saveResumeState(cfg, [32]byte{}, int64(blockSize), logger)
 			putBlockBuffer(data)
 			totalBytes += int64(blockSize)
 			continue
@@ -74,7 +75,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		sha.Write(data)
 		sum := blake3.Sum256(data)
 		manifest.Append(sum, int64(r.Start), int(blockSize))
-		saveResumeState(cfg, sum, int64(blockSize))
+		saveResumeState(cfg, sum, int64(blockSize), logger)
 
 		putBlockBuffer(data)
 
@@ -106,7 +107,15 @@ func writeResult(bufOut *bufio.Writer, header, data []byte) error {
 	return nil
 }
 
-func processParallelResults(cfg *config.Config, results <-chan *BlockResult, bufOut *bufio.Writer, checksum ChecksumStrategy, totalDataSize int64, startTime time.Time) (int64, *Manifest, error) {
+func processParallelResults(
+	cfg *config.Config,
+	results <-chan *BlockResult,
+	bufOut *bufio.Writer,
+	checksum ChecksumStrategy,
+	totalDataSize int64,
+	startTime time.Time,
+	logger *zap.Logger,
+) (int64, *Manifest, error) {
 	headerSize := 12
 	if cfg.VerifyChecksum {
 		headerSize += checksum.Size()
@@ -130,22 +139,22 @@ func processParallelResults(cfg *config.Config, results <-chan *BlockResult, buf
 		if res.Data != nil {
 			sha.Write(res.Data)
 			manifest.Append(res.ChunkID, int64(res.Offset), int(res.Size))
-			saveResumeState(cfg, res.ChunkID, int64(res.Size))
+			saveResumeState(cfg, res.ChunkID, int64(res.Size), logger)
 			putBlockBuffer(res.Data)
 		} else {
-			saveResumeState(cfg, res.ChunkID, 0)
+			saveResumeState(cfg, res.ChunkID, 0, logger)
 		}
 
 		totalBytesTransferred += int64(res.Size)
-		reportProgress(cfg, totalBytesTransferred, totalDataSize, res.Index, startTime)
+		reportProgress(cfg, totalBytesTransferred, totalDataSize, res.Index, startTime, logger)
 	}
 	copy(manifest.FinalSHA256[:], sha.Sum(nil))
 	return totalBytesTransferred, manifest, nil
 }
 
-func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult, wg *sync.WaitGroup) {
+func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult, wg *sync.WaitGroup, logger *zap.Logger) {
 	defer wg.Done()
-	unlock := pinWorkerToDevice(cfg, srcFile)
+	unlock := pinWorkerToDevice(cfg, srcFile, logger)
 	defer unlock()
 	for task := range tasks {
 		offset, blockSize, err := validateOffsetAndSize(task.R.Start, cfg.BlockSize)
@@ -153,7 +162,7 @@ func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, result
 			results <- &BlockResult{Index: task.Index, Err: err}
 			continue
 		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, false, [2]int{-1, -1})
+		data, err := ReadBlockWithRetries(cfg, srcFile, offset, false, [2]int{-1, -1}, logger)
 		zero := err == nil && isAllZero(data)
 		var resData []byte
 		size := blockSize

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -31,15 +31,15 @@ var createStateFile = func(name string) (io.WriteCloser, error) {
 	return f, nil
 }
 
-func saveStateFile(path string, write func(io.Writer) error) error {
+func saveStateFile(logger *zap.Logger, path string, write func(io.Writer) error) error {
 	file, err := createStateFile(path)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			if Logger != nil {
-				Logger.Warn("failed to close state file", zap.Error(closeErr))
+			if logger != nil {
+				logger.Warn("failed to close state file", zap.Error(closeErr))
 			}
 		}
 	}()
@@ -61,6 +61,7 @@ type ChecksumDedup struct {
 	hashes    map[int64][]byte
 	mu        sync.RWMutex
 	strategy  ChecksumStrategy
+	logger    *zap.Logger
 }
 
 // BloomFilterDedup uses a Bloom filter to track transferred blocks.
@@ -72,6 +73,7 @@ type BloomFilterDedup struct {
 	entries   uint
 	fpRate    float64
 	strategy  ChecksumStrategy
+	logger    *zap.Logger
 }
 
 // RollingHashDedup computes a rolling hash for block comparison.
@@ -81,6 +83,7 @@ type RollingHashDedup struct {
 	hashes    map[int64]uint64
 	mu        sync.RWMutex
 	seed      maphash.Seed
+	logger    *zap.Logger
 }
 
 var rollingHashPool = sync.Pool{
@@ -105,7 +108,7 @@ func supportsChecksumAcceleration() bool {
 // NewDeduplicationStrategy returns a deduplication strategy based on cfg.
 // When cfg.DedupStrategy is auto, it selects the best available algorithm
 // and updates cfg accordingly.
-func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
+func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) DeduplicationStrategy {
 	strategy := cfg.DedupStrategy
 	if strategy == StrategyAuto {
 		strategy = detectBestStrategy()
@@ -119,17 +122,18 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 			stateFile: cfg.DedupStateFile,
 			hashes:    make(map[int64]uint64),
 			seed:      maphash.MakeSeed(),
+			logger:    logger,
 		}
 		if err := d.loadState(); err != nil {
-			if Logger != nil {
-				Logger.Warn("failed to load dedup state", zap.Error(err))
+			if logger != nil {
+				logger.Warn("failed to load dedup state", zap.Error(err))
 			}
 		}
 		return d
 	case "bloom":
 		if cfg.BloomEntries < 0 || uint64(cfg.BloomEntries) > uint64(math.MaxUint) {
-			if Logger != nil {
-				Logger.Warn("invalid bloom entries", zap.Int("entries", cfg.BloomEntries))
+			if logger != nil {
+				logger.Warn("invalid bloom entries", zap.Int("entries", cfg.BloomEntries))
 			}
 			return nil
 		}
@@ -140,10 +144,11 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 			entries:   entries,
 			fpRate:    cfg.BloomFpRate,
 			strategy:  GetChecksumStrategy(cfg.ChecksumAlgorithm),
+			logger:    logger,
 		}
 		if err := d.loadState(); err != nil {
-			if Logger != nil {
-				Logger.Warn("failed to load dedup state", zap.Error(err))
+			if logger != nil {
+				logger.Warn("failed to load dedup state", zap.Error(err))
 			}
 		}
 		return d
@@ -152,10 +157,11 @@ func NewDeduplicationStrategy(cfg *config.Config) DeduplicationStrategy {
 			stateFile: cfg.DedupStateFile,
 			hashes:    make(map[int64][]byte),
 			strategy:  GetChecksumStrategy(cfg.ChecksumAlgorithm),
+			logger:    logger,
 		}
 		if err := d.loadState(); err != nil {
-			if Logger != nil {
-				Logger.Warn("failed to load dedup state", zap.Error(err))
+			if logger != nil {
+				logger.Warn("failed to load dedup state", zap.Error(err))
 			}
 		}
 		return d
@@ -182,7 +188,7 @@ func (c *ChecksumDedup) RecordTransfer(offset int64, data []byte) {
 func (c *ChecksumDedup) SaveState() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return saveStateFile(c.stateFile, func(file io.Writer) error {
+	return saveStateFile(c.logger, c.stateFile, func(file io.Writer) error {
 		size := c.strategy.Size()
 		for offset, hash := range c.hashes {
 			if err := binary.Write(file, binary.LittleEndian, offset); err != nil {
@@ -209,8 +215,8 @@ func (c *ChecksumDedup) loadState() error {
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			if Logger != nil {
-				Logger.Warn("failed to close state file", zap.Error(closeErr))
+			if c.logger != nil {
+				c.logger.Warn("failed to close state file", zap.Error(closeErr))
 			}
 		}
 	}()
@@ -251,8 +257,8 @@ func (r *RollingHashDedup) computeHash(data []byte) (uint64, error) {
 func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
 	h, err := r.computeHash(data)
 	if err != nil {
-		if Logger != nil {
-			Logger.Error("compute hash failed", zap.Error(err))
+		if r.logger != nil {
+			r.logger.Error("compute hash failed", zap.Error(err))
 		}
 		return true
 	}
@@ -267,8 +273,8 @@ func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
 func (r *RollingHashDedup) RecordTransfer(offset int64, data []byte) {
 	h, err := r.computeHash(data)
 	if err != nil {
-		if Logger != nil {
-			Logger.Error("compute hash failed", zap.Error(err))
+		if r.logger != nil {
+			r.logger.Error("compute hash failed", zap.Error(err))
 		}
 		return
 	}
@@ -281,7 +287,7 @@ func (r *RollingHashDedup) RecordTransfer(offset int64, data []byte) {
 func (r *RollingHashDedup) SaveState() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return saveStateFile(r.stateFile, func(file io.Writer) error {
+	return saveStateFile(r.logger, r.stateFile, func(file io.Writer) error {
 		seedArr := *(*[2]uint64)(unsafe.Pointer(&r.seed))
 		if err := binary.Write(file, binary.LittleEndian, seedArr); err != nil {
 			return err
@@ -309,8 +315,8 @@ func (r *RollingHashDedup) loadState() error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			if Logger != nil {
-				Logger.Warn("failed to close state file", zap.Error(err))
+			if r.logger != nil {
+				r.logger.Warn("failed to close state file", zap.Error(err))
 			}
 		}
 	}()
@@ -367,7 +373,7 @@ func (b *BloomFilterDedup) RecordTransfer(_ int64, data []byte) {
 func (b *BloomFilterDedup) SaveState() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return saveStateFile(b.stateFile, func(file io.Writer) error {
+	return saveStateFile(b.logger, b.stateFile, func(file io.Writer) error {
 		_, err := b.filter.WriteTo(file)
 		return err
 	})
@@ -383,8 +389,8 @@ func (b *BloomFilterDedup) loadState() error {
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			if Logger != nil {
-				Logger.Warn("failed to close state file", zap.Error(closeErr))
+			if b.logger != nil {
+				b.logger.Warn("failed to close state file", zap.Error(closeErr))
 			}
 		}
 	}()

--- a/transfer/dedup_cdc.go
+++ b/transfer/dedup_cdc.go
@@ -111,7 +111,7 @@ func (c *CDCDedup) ChunkAndHash(p []byte) ([]dedup.Chunk, [32]byte, error) {
 func (c *CDCDedup) SaveState() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if err := saveStateFile(c.stateFile, func(w io.Writer) error {
+	if err := saveStateFile(nil, c.stateFile, func(w io.Writer) error {
 		_, err := c.bloom.WriteTo(w)
 		return err
 	}); err != nil {

--- a/transfer/digest_verification_test.go
+++ b/transfer/digest_verification_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 func TestIterateBlocksFinalSHA(t *testing.T) {
-	Logger = zap.NewNop()
+	logger := zap.NewNop()
 	blockSize := int64(1024)
 	snapshot := "vg-lv"
 	_, src := createVolumeFiles(t, snapshot, blockSize, []int{0})
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "zstd", ZstdLevel: 1, CompressLevel: 1, MaxRetries: 1}
-	ranges, err := gatherChangedRanges(snapshot, blockSize)
+	ranges, err := gatherChangedRanges(snapshot, blockSize, logger)
 	if err != nil {
 		t.Fatalf("gather ranges: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestIterateBlocksFinalSHA(t *testing.T) {
 		t.Fatalf("compression writer: %v", err)
 	}
 	bufOut := bufio.NewWriter(w)
-	_, _, manifest, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1})
+	_, _, manifest, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, logger)
 	if err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}

--- a/transfer/handshake.go
+++ b/transfer/handshake.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/common"
 	"lvmsync_go/config"
 )
@@ -22,11 +24,11 @@ func composeHandshake(cfg *config.Config, mode string) common.Handshake {
 	return hs
 }
 
-func setupOutput(cfg *config.Config, out io.Writer, handshake string) (io.WriteCloser, *bufio.Writer, error) {
+func setupOutput(cfg *config.Config, out io.Writer, handshake string, logger *zap.Logger) (io.WriteCloser, *bufio.Writer, error) {
 	if err := common.WriteHandshake(out, composeHandshake(cfg, handshake)); err != nil {
 		return nil, nil, err
 	}
-	return prepareOutputWriter(out, cfg)
+	return prepareOutputWriter(out, cfg, logger)
 }
 
 func prepareParallelHandshake(cfg *config.Config) string {

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -48,7 +48,7 @@ func TestDumpChangesSequentialLogFields(t *testing.T) {
 
 func TestReadResumeDigestLogField(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	Logger = zap.New(core)
+	logger := zap.New(core)
 
 	tmp := t.TempDir()
 	stateFile := filepath.Join(tmp, "resume")
@@ -58,7 +58,7 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	}
 
 	cfg := &config.Config{ResumeState: stateFile}
-	val := readResumeDigest(cfg)
+	val := readResumeDigest(cfg, logger)
 	if val != digest {
 		t.Fatalf("expected digest match")
 	}

--- a/transfer/numa_linux.go
+++ b/transfer/numa_linux.go
@@ -86,14 +86,14 @@ func parseCPUList(list string) []int {
 // pinWorkerToDevice pins the current goroutine to the NUMA node associated
 // with the source device when cfg.NumaPin is true. The returned function must
 // be deferred to release the thread lock.
-func pinWorkerToDevice(cfg *config.Config, src *os.File) func() {
+func pinWorkerToDevice(cfg *config.Config, src *os.File, logger *zap.Logger) func() {
 	if cfg == nil || !cfg.NumaPin {
 		return func() {}
 	}
 	runtime.LockOSThread()
 	if err := pinCurrentThreadToDevice(src); err != nil {
-		if Logger != nil {
-			Logger.Warn("numa pin failed", zap.Error(err))
+		if logger != nil {
+			logger.Warn("numa pin failed", zap.Error(err))
 		}
 	}
 	return runtime.UnlockOSThread

--- a/transfer/numa_stub.go
+++ b/transfer/numa_stub.go
@@ -5,9 +5,11 @@ package transfer
 import (
 	"os"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/config"
 )
 
-func pinWorkerToDevice(cfg *config.Config, src *os.File) func() {
+func pinWorkerToDevice(cfg *config.Config, src *os.File, _ *zap.Logger) func() {
 	return func() {}
 }

--- a/transfer/pool_test.go
+++ b/transfer/pool_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/config"
 )
 
@@ -28,7 +30,7 @@ func BenchmarkReadBlockWithPool(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		buf, err := ReadBlockWithRetries(cfg, f, 0, false, [2]int{-1, -1})
+		buf, err := ReadBlockWithRetries(cfg, f, 0, false, [2]int{-1, -1}, zap.NewNop())
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -8,48 +8,48 @@ import (
 	"lvmsync_go/config"
 )
 
-func finalizeProgress(cfg *config.Config) {
-	if cfg.Progress && Logger != nil {
-		Logger.Info("progress complete")
+func finalizeProgress(cfg *config.Config, logger *zap.Logger) {
+	if cfg.Progress && logger != nil {
+		logger.Info("progress complete")
 	}
 }
 
-func reportProgress(cfg *config.Config, transferred, total int64, index int, start time.Time) {
-	if Logger == nil {
+func reportProgress(cfg *config.Config, transferred, total int64, index int, start time.Time, logger *zap.Logger) {
+	if logger == nil {
 		return
 	}
 	if cfg.Progress {
 		progressPercent := float64(transferred) / float64(total) * 100.0
 
-		Logger.Info("transfer progress", zap.Float64("progress_percent", progressPercent))
+		logger.Info("transfer progress", zap.Float64("progress_percent", progressPercent))
 	}
 	if cfg.Verbose > 0 && index > 0 && index%100 == 0 {
 		elapsed := time.Since(start).Seconds()
 		speed := float64(transferred) / elapsed / 1048576.0
-		Logger.Debug("parallel dump progress",
+		logger.Debug("parallel dump progress",
 			zap.Int("block_index", index+1),
 			zap.Float64("mb_per_sec", speed))
 	}
 }
 
-func logSequentialSummary(bytes int64, skipped int, start time.Time) {
-	if Logger == nil {
+func logSequentialSummary(logger *zap.Logger, bytes int64, skipped int, start time.Time) {
+	if logger == nil {
 		return
 	}
 	elapsed := time.Since(start).Seconds()
-	Logger.Info("Sequential transfer complete",
+	logger.Info("Sequential transfer complete",
 		zap.Int64("size_bytes", bytes),
 		zap.Int("skipped_blocks", skipped),
 		zap.Float64("duration_sec", elapsed),
 		zap.Float64("mb_per_sec", float64(bytes)/elapsed/1048576.0))
 }
 
-func logParallelSummary(bytes int64, start time.Time) {
-	if Logger == nil {
+func logParallelSummary(logger *zap.Logger, bytes int64, start time.Time) {
+	if logger == nil {
 		return
 	}
 	elapsed := time.Since(start).Seconds()
-	Logger.Info("Parallel transfer complete",
+	logger.Info("Parallel transfer complete",
 		zap.Int64("size_bytes", bytes),
 		zap.Float64("duration_sec", elapsed),
 		zap.Float64("mb_per_sec", float64(bytes)/elapsed/1048576.0))

--- a/transfer/progress_test.go
+++ b/transfer/progress_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestFinalizeProgress(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	Logger = zap.New(core)
+	logger := zap.New(core)
 	cfg := &config.Config{Progress: true}
-	finalizeProgress(cfg)
+	finalizeProgress(cfg, logger)
 	if logs.FilterMessage("progress complete").Len() != 1 {
 		t.Fatalf("expected progress completion log, got %d", logs.FilterMessage("progress complete").Len())
 	}
@@ -22,9 +22,9 @@ func TestFinalizeProgress(t *testing.T) {
 
 func TestReportProgress(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	Logger = zap.New(core)
+	logger := zap.New(core)
 	cfg := &config.Config{Progress: true}
-	reportProgress(cfg, 50, 100, 1, time.Now())
+	reportProgress(cfg, 50, 100, 1, time.Now(), logger)
 	if logs.FilterMessage("transfer progress").Len() == 0 {
 		t.Fatal("expected progress log")
 	}
@@ -32,10 +32,10 @@ func TestReportProgress(t *testing.T) {
 
 func TestLogSummaries(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	Logger = zap.New(core)
+	logger := zap.New(core)
 	start := time.Now().Add(-time.Second)
-	logSequentialSummary(1024, 1, start)
-	logParallelSummary(2048, start)
+	logSequentialSummary(logger, 1024, 1, start)
+	logParallelSummary(logger, 2048, start)
 	if logs.Len() != 2 {
 		t.Fatalf("expected 2 log entries, got %d", logs.Len())
 	}

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -79,7 +79,7 @@ func TestResumeSequential(t *testing.T) {
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
-	finalizeResumeState(cfg)
+	finalizeResumeState(cfg, zap.NewNop())
 
 	offsets := parseOffsets(t, buf.Bytes(), blockSize)
 	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
@@ -103,7 +103,7 @@ func TestResumeParallel(t *testing.T) {
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
-	finalizeResumeState(cfg)
+	finalizeResumeState(cfg, zap.NewNop())
 
 	offsets := parseOffsets(t, buf.Bytes(), blockSize)
 	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -24,9 +24,6 @@ import (
 	"lvmsync_go/internal/blocksize"
 )
 
-// Logger holds the package-wide zap.Logger used for progress and error reporting.
-var Logger *zap.Logger
-
 // Transfer encapsulates transfer state shared across operations.
 type Transfer struct {
 	Logger   *zap.Logger
@@ -34,13 +31,11 @@ type Transfer struct {
 }
 
 // NewTransfer creates a Transfer with the provided logger and wait group.
-// When wg is nil, a new instance is allocated. The package-wide Logger is
-// set to the provided logger for internal helpers that rely on it.
+// When wg is nil, a new instance is allocated.
 func NewTransfer(logger *zap.Logger, wg *sync.WaitGroup) *Transfer {
 	if wg == nil {
 		wg = &sync.WaitGroup{}
 	}
-	Logger = logger
 	return &Transfer{Logger: logger, workerWG: wg}
 }
 
@@ -77,7 +72,7 @@ func LoadChecksumState(filename string) (state *ChecksumState, err error) {
 }
 
 //revive:disable-next-line:cognitive-complexity
-func SaveChecksumState(filename string, state *ChecksumState) (err error) {
+func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger) (err error) {
 	var file *os.File
 	file, err = os.Create(filename)
 	if err != nil {
@@ -85,8 +80,8 @@ func SaveChecksumState(filename string, state *ChecksumState) (err error) {
 	}
 	if err = file.Chmod(0o600); err != nil {
 		if closeErr := file.Close(); closeErr != nil {
-			if Logger != nil {
-				Logger.Warn("Failed to close checksum state file", zap.Error(closeErr))
+			if logger != nil {
+				logger.Warn("Failed to close checksum state file", zap.Error(closeErr))
 			}
 			return fmt.Errorf("chmod checksum state: %v; close checksum state: %w", err, closeErr)
 		}
@@ -101,7 +96,8 @@ func SaveChecksumState(filename string, state *ChecksumState) (err error) {
 	return nil
 }
 
-func prepareOutputWriter(out io.Writer, cfg *config.Config) (io.WriteCloser, *bufio.Writer, error) {
+func prepareOutputWriter(out io.Writer, cfg *config.Config, logger *zap.Logger) (io.WriteCloser, *bufio.Writer, error) {
+	_ = logger
 	limitedOut := WrapRateLimitedWriter(out, cfg.SpeedLimit)
 	compWriter, err := NewCompressionWriter(limitedOut, cfg.Compress, cfg.CompressLevel, cfg.CompressConcurrency)
 	if err != nil {
@@ -111,20 +107,20 @@ func prepareOutputWriter(out io.Writer, cfg *config.Config) (io.WriteCloser, *bu
 	return compWriter, bufOut, nil
 }
 
-func cleanupOutput(buf *bufio.Writer, w io.WriteCloser) {
+func cleanupOutput(buf *bufio.Writer, w io.WriteCloser, logger *zap.Logger) {
 	if err := buf.Flush(); err != nil {
-		if Logger != nil {
-			Logger.Warn("Failed to flush output", zap.Error(err))
+		if logger != nil {
+			logger.Warn("Failed to flush output", zap.Error(err))
 		}
 	}
 	if err := w.Close(); err != nil {
-		if Logger != nil {
-			Logger.Warn("Failed to close writer", zap.Error(err))
+		if logger != nil {
+			logger.Warn("Failed to close writer", zap.Error(err))
 		}
 	}
 }
 
-func detectBlockSize(cfg *config.Config, source string) error {
+func detectBlockSize(cfg *config.Config, source string, logger *zap.Logger) error {
 	if cfg.BlockSize != 0 {
 		return nil
 	}
@@ -133,11 +129,13 @@ func detectBlockSize(cfg *config.Config, source string) error {
 		return fmt.Errorf("auto-detect block size: %w", err)
 	}
 	cfg.BlockSize = bs
-	Logger.Info("Auto-detected block size", zap.Int("block_size_bytes", cfg.BlockSize))
+	if logger != nil {
+		logger.Info("Auto-detected block size", zap.Int("block_size_bytes", cfg.BlockSize))
+	}
 	return nil
 }
 
-func gatherChangedRanges(snapshot string, blockSize int64) ([]Range, error) {
+func gatherChangedRanges(snapshot string, blockSize int64, logger *zap.Logger) ([]Range, error) {
 	metadataDevice := GetMetadataDevice(snapshot)
 	if metadataDevice == "" {
 		return nil, fmt.Errorf("failed to determine metadata device from snapshot %s", snapshot)
@@ -146,21 +144,25 @@ func gatherChangedRanges(snapshot string, blockSize int64) ([]Range, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting differences: %w", err)
 	}
-	Logger.Info("Changed blocks determined", zap.Int("block_count", len(ranges)))
+	if logger != nil {
+		logger.Info("Changed blocks determined", zap.Int("block_count", len(ranges)))
+	}
 	return ranges, nil
 }
 
-func prepareRanges(cfg *config.Config, snapshot, source string) ([]Range, error) {
-	if err := detectBlockSize(cfg, source); err != nil {
+func prepareRanges(cfg *config.Config, snapshot, source string, logger *zap.Logger) ([]Range, error) {
+	if err := detectBlockSize(cfg, source, logger); err != nil {
 		return nil, err
 	}
-	Logger.Info("Using block size", zap.Int("block_size_bytes", cfg.BlockSize))
+	if logger != nil {
+		logger.Info("Using block size", zap.Int("block_size_bytes", cfg.BlockSize))
+	}
 
 	_, blockSize, err := validateOffsetAndSize(0, cfg.BlockSize)
 	if err != nil {
 		return nil, err
 	}
-	ranges, err := gatherChangedRanges(snapshot, int64(blockSize))
+	ranges, err := gatherChangedRanges(snapshot, int64(blockSize), logger)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +190,7 @@ func setupSourceFile(cfg *config.Config, source string) (*os.File, error) {
 	return srcFile, nil
 }
 
-func setupPipe(cfg *config.Config) ([2]int, func(), error) {
+func setupPipe(cfg *config.Config, logger *zap.Logger) ([2]int, func(), error) {
 	var pipeFds [2]int
 	cleanup := func() {}
 	if cfg.ZeroCopy {
@@ -197,10 +199,14 @@ func setupPipe(cfg *config.Config) ([2]int, func(), error) {
 		}
 		cleanup = func() {
 			if closeErr := syscall.Close(pipeFds[0]); closeErr != nil {
-				Logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
+				if logger != nil {
+					logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
+				}
 			}
 			if closeErr := syscall.Close(pipeFds[1]); closeErr != nil {
-				Logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
+				if logger != nil {
+					logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
+				}
 			}
 		}
 	} else {
@@ -210,16 +216,16 @@ func setupPipe(cfg *config.Config) ([2]int, func(), error) {
 }
 
 func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
-	ranges, err := prepareRanges(cfg, snapshot, source)
+	ranges, err := prepareRanges(cfg, snapshot, source, t.Logger)
 	if err != nil {
 		return err
 	}
 
-	compWriter, bufOut, err := setupOutput(cfg, out, handshake)
+	compWriter, bufOut, err := setupOutput(cfg, out, handshake, t.Logger)
 	if err != nil {
 		return err
 	}
-	defer cleanupOutput(bufOut, compWriter)
+	defer cleanupOutput(bufOut, compWriter, t.Logger)
 
 	srcFile, err := setupSourceFile(cfg, source)
 	if err != nil {
@@ -227,14 +233,14 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	}
 	defer common.CloseWithErr(srcFile, &err, "close source file")
 
-	pipeFds, cleanupPipe, err := setupPipe(cfg)
+	pipeFds, cleanupPipe, err := setupPipe(cfg, t.Logger)
 	if err != nil {
 		return err
 	}
 	defer cleanupPipe()
 
-	resumeDigest := readResumeDigest(cfg)
-	startIdx := findResumeIndex(cfg, srcFile, ranges, resumeDigest)
+	resumeDigest := readResumeDigest(cfg, t.Logger)
+	startIdx := findResumeIndex(cfg, srcFile, ranges, resumeDigest, t.Logger)
 	if startIdx > 0 {
 		ranges = ranges[startIdx:]
 	}
@@ -243,32 +249,34 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	var totalBytesTransferred int64
 	var skippedBlocks int
 	var manifest *Manifest
-	totalBytesTransferred, skippedBlocks, manifest, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds)
+	totalBytesTransferred, skippedBlocks, manifest, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds, t.Logger)
 	if err != nil {
 		return err
 	}
-	finalizeProgress(cfg)
+	finalizeProgress(cfg, t.Logger)
 
-	logSequentialSummary(totalBytesTransferred, skippedBlocks, startTime)
-	finalizeResumeState(cfg)
+	logSequentialSummary(t.Logger, totalBytesTransferred, skippedBlocks, startTime)
+	finalizeResumeState(cfg, t.Logger)
 	if manifest != nil {
-		if Logger != nil {
-			Logger.Info("final checksum", zap.String("final_sha256", fmt.Sprintf("%x", manifest.FinalSHA256)))
+		if t.Logger != nil {
+			t.Logger.Info("final checksum", zap.String("final_sha256", fmt.Sprintf("%x", manifest.FinalSHA256)))
 		}
 	}
-	if Logger != nil {
-		_ = Logger.Sync()
+	if t.Logger != nil {
+		_ = t.Logger.Sync()
 	}
 	return nil
 }
 
 func (t *Transfer) setupDedup(cfg *config.Config) (DeduplicationStrategy, func()) {
-	dedup := NewDeduplicationStrategy(cfg)
+	dedup := NewDeduplicationStrategy(cfg, t.Logger)
 	cleanup := func() {}
 	if dedup != nil {
 		cleanup = func() {
 			if err := dedup.SaveState(); err != nil {
-				Logger.Error("Failed to save dedup state", zap.Error(err))
+				if t.Logger != nil {
+					t.Logger.Error("Failed to save dedup state", zap.Error(err))
+				}
 			}
 		}
 	}
@@ -294,10 +302,14 @@ func (t *Transfer) DumpChanges(cfg *config.Config, snapshot, source string, out 
 	dedup, cleanup := t.setupDedup(cfg)
 	if dedup != nil {
 		defer cleanup()
-		Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
+		if t.Logger != nil {
+			t.Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
+		}
 		return t.DumpChangesWithDeduplication(cfg, snapshot, source, out, dedup)
 	}
-	Logger.Info("Deduplication disabled, performing full block transfer")
+	if t.Logger != nil {
+		t.Logger.Info("Deduplication disabled, performing full block transfer")
+	}
 	return t.DumpChangesSequential(cfg, snapshot, source, out)
 }
 
@@ -308,14 +320,16 @@ var (
 	resumeChunk [32]byte
 )
 
-func writeResumeState(path string, chunk [32]byte) {
+func writeResumeState(logger *zap.Logger, path string, chunk [32]byte) {
 	err := os.WriteFile(path, []byte(hex.EncodeToString(chunk[:])), 0o600)
 	if err != nil {
-		Logger.Warn("Failed to update resume state", zap.Error(err))
+		if logger != nil {
+			logger.Warn("Failed to update resume state", zap.Error(err))
+		}
 	}
 }
 
-func saveResumeState(cfg *config.Config, chunk [32]byte, size int64) {
+func saveResumeState(cfg *config.Config, chunk [32]byte, size int64, logger *zap.Logger) {
 	if cfg.ResumeState == "" {
 		return
 	}
@@ -327,13 +341,13 @@ func saveResumeState(cfg *config.Config, chunk [32]byte, size int64) {
 	resumeBytes += size
 	resumeChunk = chunk
 	if resumeBytes >= 1<<30 || time.Since(resumeLast) >= 10*time.Second {
-		writeResumeState(cfg.ResumeState, resumeChunk)
+		writeResumeState(logger, cfg.ResumeState, resumeChunk)
 		resumeBytes = 0
 		resumeLast = time.Now()
 	}
 }
 
-func finalizeResumeState(cfg *config.Config) {
+func finalizeResumeState(cfg *config.Config, logger *zap.Logger) {
 	if cfg.ResumeState == "" {
 		return
 	}
@@ -342,11 +356,11 @@ func finalizeResumeState(cfg *config.Config) {
 	if resumeLast.IsZero() {
 		return
 	}
-	writeResumeState(cfg.ResumeState, resumeChunk)
+	writeResumeState(logger, cfg.ResumeState, resumeChunk)
 	resumeBytes = 0
 }
 
-func readResumeDigest(cfg *config.Config) [32]byte {
+func readResumeDigest(cfg *config.Config, logger *zap.Logger) [32]byte {
 	var out [32]byte
 	if cfg.ResumeState == "" {
 		return out
@@ -360,11 +374,13 @@ func readResumeDigest(cfg *config.Config) [32]byte {
 		return out
 	}
 	copy(out[:], b)
-	Logger.Info("Resuming from chunk", zap.String("resume_chunk", hex.EncodeToString(out[:])))
+	if logger != nil {
+		logger.Info("Resuming from chunk", zap.String("resume_chunk", hex.EncodeToString(out[:])))
+	}
 	return out
 }
 
-func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, digest [32]byte) int {
+func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, digest [32]byte, logger *zap.Logger) int {
 	if cfg.ResumeState == "" || digest == [32]byte{} {
 		return 0
 	}
@@ -373,14 +389,16 @@ func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, diges
 		if err != nil {
 			return 0
 		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, [2]int{-1, -1})
+		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, [2]int{-1, -1}, logger)
 		if err != nil {
 			continue
 		}
 		sum := blake3.Sum256(data)
 		putBlockBuffer(data)
 		if sum == digest {
-			Logger.Info("Resuming after index", zap.Int("resume_index", i+1))
+			if logger != nil {
+				logger.Info("Resuming after index", zap.Int("resume_index", i+1))
+			}
 			return i + 1
 		}
 	}
@@ -403,7 +421,7 @@ func calculateTotalDataSize(ranges []Range) int64 {
 	return int64(total)
 }
 
-func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, resumeStart int) <-chan *BlockResult {
+func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, resumeStart int, logger *zap.Logger) <-chan *BlockResult {
 	numBlocks := len(ranges)
 	taskBuf := cfg.Parallel
 	if taskBuf < 1 {
@@ -413,7 +431,7 @@ func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ra
 	results := make(chan *BlockResult, taskBuf)
 	for i := 0; i < cfg.Parallel; i++ {
 		t.workerWG.Add(1)
-		go worker(cfg, srcFile, tasks, results, t.workerWG)
+		go worker(cfg, srcFile, tasks, results, t.workerWG, logger)
 	}
 
 	go func() {
@@ -429,11 +447,13 @@ func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ra
 
 func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
 	if cfg.ZeroCopy {
-		Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
+		if t.Logger != nil {
+			t.Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
+		}
 		return t.DumpChangesSequential(cfg, snapshot, source, out)
 	}
 
-	ranges, err := prepareRanges(cfg, snapshot, source)
+	ranges, err := prepareRanges(cfg, snapshot, source, t.Logger)
 	if err != nil {
 		return err
 	}
@@ -443,11 +463,11 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 		return err
 	}
 
-	compWriter, bufOut, err := prepareOutputWriter(out, cfg)
+	compWriter, bufOut, err := prepareOutputWriter(out, cfg, t.Logger)
 	if err != nil {
 		return err
 	}
-	defer cleanupOutput(bufOut, compWriter)
+	defer cleanupOutput(bufOut, compWriter, t.Logger)
 
 	srcFile, err := setupSourceFile(cfg, source)
 	if err != nil {
@@ -455,26 +475,26 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 	}
 	defer common.CloseWithErr(srcFile, &err, "close source file")
 
-	resumeDigest := readResumeDigest(cfg)
-	resumeStart := findResumeIndex(cfg, srcFile, ranges, resumeDigest)
-	results := t.startParallelWorkers(cfg, srcFile, ranges, resumeStart)
+	resumeDigest := readResumeDigest(cfg, t.Logger)
+	resumeStart := findResumeIndex(cfg, srcFile, ranges, resumeDigest, t.Logger)
+	results := t.startParallelWorkers(cfg, srcFile, ranges, resumeStart, t.Logger)
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	var totalBytesTransferred int64
 	var manifest *Manifest
-	totalBytesTransferred, manifest, err = processParallelResults(cfg, results, bufOut, checksum, totalDataSize, startTime)
+	totalBytesTransferred, manifest, err = processParallelResults(cfg, results, bufOut, checksum, totalDataSize, startTime, t.Logger)
 	if err != nil {
 		return err
 	}
-	finalizeProgress(cfg)
-	logParallelSummary(totalBytesTransferred, startTime)
-	finalizeResumeState(cfg)
-	if manifest != nil && Logger != nil {
-		Logger.Info("final checksum", zap.String("final_sha256", fmt.Sprintf("%x", manifest.FinalSHA256)))
+	finalizeProgress(cfg, t.Logger)
+	logParallelSummary(t.Logger, totalBytesTransferred, startTime)
+	finalizeResumeState(cfg, t.Logger)
+	if manifest != nil && t.Logger != nil {
+		t.Logger.Info("final checksum", zap.String("final_sha256", fmt.Sprintf("%x", manifest.FinalSHA256)))
 	}
-	if Logger != nil {
-		_ = Logger.Sync()
+	if t.Logger != nil {
+		_ = t.Logger.Sync()
 	}
 	return nil
 }
@@ -539,12 +559,14 @@ func verifyChecksum(verify bool, checksum ChecksumStrategy, data, transmitted []
 	return nil
 }
 
-func writeData(destFile *os.File, offset uint64, data []byte) error {
+func writeData(destFile *os.File, offset uint64, data []byte, logger *zap.Logger) error {
 	if offset > math.MaxInt64 {
 		return fmt.Errorf("offset %d overflows int64", offset)
 	}
 	if _, err := destFile.Seek(int64(offset), io.SeekStart); err != nil {
-		Logger.Warn("Seek error", zap.Uint64("offset", offset), zap.Error(err))
+		if logger != nil {
+			logger.Warn("Seek error", zap.Uint64("offset", offset), zap.Error(err))
+		}
 		return nil
 	}
 	if _, err := destFile.Write(data); err != nil {
@@ -553,7 +575,17 @@ func writeData(destFile *os.File, offset uint64, data []byte) error {
 	return nil
 }
 
-func processBlock(cfg *config.Config, destFile *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, offset uint64, transmitted, data []byte, chunkSize uint32) (bool, error) {
+func processBlock(
+	cfg *config.Config,
+	destFile *os.File,
+	dedup DeduplicationStrategy,
+	verify bool,
+	checksum ChecksumStrategy,
+	offset uint64,
+	transmitted, data []byte,
+	chunkSize uint32,
+	logger *zap.Logger,
+) (bool, error) {
 	if offset > math.MaxInt64 {
 		return false, fmt.Errorf("offset %d overflows int64", offset)
 	}
@@ -563,7 +595,7 @@ func processBlock(cfg *config.Config, destFile *os.File, dedup DeduplicationStra
 	if chunkSize == 0 || isAllZero(data) {
 		if err := punchHole(destFile, offset, cfg.BlockSize); err != nil {
 			zero := getAlignedBlockBuffer(cfg.BlockSize)
-			if err := writeData(destFile, offset, zero); err != nil {
+			if err := writeData(destFile, offset, zero, logger); err != nil {
 				putAlignedBlockBuffer(zero)
 				return false, err
 			}
@@ -578,13 +610,13 @@ func processBlock(cfg *config.Config, destFile *os.File, dedup DeduplicationStra
 		}
 		dedup.RecordTransfer(intOffset, data)
 	}
-	if err := writeData(destFile, offset, data); err != nil {
+	if err := writeData(destFile, offset, data, logger); err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
-func applyBlocks(cfg *config.Config, reader *bufio.Reader, destFile *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy) (int64, error) {
+func applyBlocks(cfg *config.Config, reader *bufio.Reader, destFile *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger) (int64, error) {
 	var totalBytes int64
 	var sinceSync int64
 	headerLen := 12
@@ -608,7 +640,7 @@ func applyBlocks(cfg *config.Config, reader *bufio.Reader, destFile *os.File, de
 		if err != nil {
 			return totalBytes, err
 		}
-		written, err := processBlock(cfg, destFile, dedup, verify, checksum, offset, transmittedSum, data, chunkSize)
+		written, err := processBlock(cfg, destFile, dedup, verify, checksum, offset, transmittedSum, data, chunkSize, logger)
 		if cfg.ODirect {
 			if data != nil {
 				putAlignedBlockBuffer(data)
@@ -646,8 +678,8 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 		return fmt.Errorf("failed to create decompression reader: %w", err)
 	}
 	defer func() {
-		if closeErr := decReader.Close(); closeErr != nil && Logger != nil {
-			Logger.Warn("Failed to close decompression reader", zap.Error(closeErr))
+		if closeErr := decReader.Close(); closeErr != nil && t.Logger != nil {
+			t.Logger.Warn("Failed to close decompression reader", zap.Error(closeErr))
 		}
 	}()
 
@@ -678,16 +710,18 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	var totalBytes int64
-	totalBytes, err = applyBlocks(cfg, reader, destFile, dedup, verify, checksum)
+	totalBytes, err = applyBlocks(cfg, reader, destFile, dedup, verify, checksum, t.Logger)
 	if err != nil {
 		return err
 	}
 
 	elapsed := time.Since(startTime).Seconds()
-	Logger.Info("Applied changes",
-		zap.Int64("bytes", totalBytes),
-		zap.Float64("seconds", elapsed),
-		zap.Float64("MB/s", float64(totalBytes)/elapsed/1048576.0))
+	if t.Logger != nil {
+		t.Logger.Info("Applied changes",
+			zap.Int64("bytes", totalBytes),
+			zap.Float64("seconds", elapsed),
+			zap.Float64("MB/s", float64(totalBytes)/elapsed/1048576.0))
+	}
 	return nil
 }
 
@@ -713,12 +747,16 @@ func openApplyReader(applyFile string) (io.ReadCloser, error) {
 }
 
 func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string) error {
-	dedup := NewDeduplicationStrategy(cfg)
+	dedup := NewDeduplicationStrategy(cfg, t.Logger)
 	if dedup != nil {
-		Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
+		if t.Logger != nil {
+			t.Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
+		}
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
-				Logger.Error("Failed to save dedup state", zap.Error(err))
+				if t.Logger != nil {
+					t.Logger.Error("Failed to save dedup state", zap.Error(err))
+				}
 			}
 		}()
 		return t.ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bits-and-blooms/bloom/v3"
+	"go.uber.org/zap"
 
 	"lvmsync_go/config"
 )
@@ -33,7 +34,7 @@ func TestWrapRateLimitedWriterEnabled(t *testing.T) {
 
 func TestNewDeduplicationStrategy(t *testing.T) {
 	cfg := &config.Config{DedupStrategy: "bloom", DedupStateFile: "state", BloomEntries: 1000, BloomFpRate: 0.05}
-	d := NewDeduplicationStrategy(cfg)
+	d := NewDeduplicationStrategy(cfg, zap.NewNop())
 	bf, ok := d.(*BloomFilterDedup)
 	if !ok {
 		t.Fatal("expected bloom filter strategy")
@@ -44,7 +45,7 @@ func TestNewDeduplicationStrategy(t *testing.T) {
 	}
 
 	cfg.DedupStrategy = "checksum"
-	if _, ok := NewDeduplicationStrategy(cfg).(*ChecksumDedup); !ok {
+	if _, ok := NewDeduplicationStrategy(cfg, zap.NewNop()).(*ChecksumDedup); !ok {
 		t.Fatal("expected checksum strategy")
 	}
 
@@ -53,20 +54,20 @@ func TestNewDeduplicationStrategy(t *testing.T) {
 
 	cfg.DedupStrategy = "auto"
 	detectBestStrategy = func() string { return "rolling_hash" }
-	if _, ok := NewDeduplicationStrategy(cfg).(*RollingHashDedup); !ok {
+	if _, ok := NewDeduplicationStrategy(cfg, zap.NewNop()).(*RollingHashDedup); !ok {
 		t.Fatal("expected rolling hash strategy for auto")
 	}
 
 	cfg.DedupStrategy = "auto"
 	detectBestStrategy = func() string { return "checksum" }
-	if _, ok := NewDeduplicationStrategy(cfg).(*ChecksumDedup); !ok {
+	if _, ok := NewDeduplicationStrategy(cfg, zap.NewNop()).(*ChecksumDedup); !ok {
 		t.Fatal("expected checksum strategy for auto")
 	}
 }
 
 func TestNewDeduplicationStrategyInvalidBloomEntries(t *testing.T) {
 	cfg := &config.Config{DedupStrategy: "bloom", BloomEntries: -1, BloomFpRate: 0.05}
-	if NewDeduplicationStrategy(cfg) != nil {
+	if NewDeduplicationStrategy(cfg, zap.NewNop()) != nil {
 		t.Fatal("expected nil strategy for invalid bloom entries")
 	}
 }

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/config"
 )
 
@@ -20,7 +22,7 @@ func TestIterateBlocksOffsetOverflow(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: 4096}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1})
+	_, _, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "offset") {
 		t.Fatalf("expected offset error, got %v", err)
 	}
@@ -32,7 +34,7 @@ func TestIterateBlocksOversizedBlockSize(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(math.MaxUint32) + 1}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1})
+	_, _, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "block size") {
 		t.Fatalf("expected block size error, got %v", err)
 	}
@@ -41,7 +43,7 @@ func TestIterateBlocksOversizedBlockSize(t *testing.T) {
 func TestSaveResumeStatePermissions(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{ResumeState: filepath.Join(dir, "resume")}
-	saveResumeState(cfg, [32]byte{}, 1<<30)
+	saveResumeState(cfg, [32]byte{}, 1<<30, zap.NewNop())
 
 	info, err := os.Stat(cfg.ResumeState)
 	if err != nil {
@@ -81,7 +83,7 @@ func TestReadBlockHeaderOffsetOverflow(t *testing.T) {
 func TestWriteDataOffsetOverflow(t *testing.T) {
 	dest := newTempFile(t, "dest")
 	defer dest.Close()
-	err := writeData(dest, math.MaxUint64, []byte("data"))
+	err := writeData(dest, math.MaxUint64, []byte("data"), zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "overflows int64") {
 		t.Fatalf("expected overflow error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove package-level logger from transfer package
- pass *zap.Logger explicitly to transfer helpers and dedup strategies
- update apply command and tests to provide loggers

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689b98bfd8948323afc5f18cde7e5c1d