### PR TITLE
feat(dump): add context timeout to SSH setup

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -107,8 +107,8 @@ func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string,
 }
 
 // SetupSSHClient creates an SSH client for remote operations.
-func SetupSSHClient(cfg *config.Config, destHost string, logger *zap.Logger) (*remote.SSHClient, context.CancelFunc, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+func SetupSSHClient(ctx context.Context, cfg *config.Config, destHost string, logger *zap.Logger) (*remote.SSHClient, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(ctx, cfg.SSHTimeout)
 	client, err := newSSHClient(ctx, destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)
 	if err != nil {
 		cancel()
@@ -224,7 +224,7 @@ func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remot
 func RunRemoteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	parts := strings.SplitN(dest, ":", 2)
 	destHost, destDevice := parts[0], parts[1]
-	client, cancel, err := SetupSSHClient(cfg, destHost, logger)
+	client, cancel, err := SetupSSHClient(ctx, cfg, destHost, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -170,7 +170,7 @@ func TestRunRemoteDumpTimeout(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	err = RunRemoteDump(cfg, "snap", "origin", dest, zap.NewNop())
+	err = RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -33,7 +33,7 @@ func TestSetupSSHClient(t *testing.T) {
 		}
 		defer func() { newSSHClient = remote.NewSSHClient }()
 
-		client, cancel, err := SetupSSHClient(cfg, "dest", zap.NewNop())
+		client, cancel, err := SetupSSHClient(context.Background(), cfg, "dest", zap.NewNop())
 		if err != nil {
 			t.Fatalf("SetupSSHClient returned error: %v", err)
 		}
@@ -52,7 +52,7 @@ func TestSetupSSHClient(t *testing.T) {
 		}
 		defer func() { newSSHClient = remote.NewSSHClient }()
 
-		_, _, err := SetupSSHClient(cfg, "dest", zap.NewNop())
+		_, _, err := SetupSSHClient(context.Background(), cfg, "dest", zap.NewNop())
 		if err == nil || !strings.Contains(err.Error(), "failed to create SSH client") {
 			t.Fatalf("expected wrapped error, got %v", err)
 		}


### PR DESCRIPTION
## Summary
- pass context into SetupSSHClient and bound connection setup via timeout
- propagate context through RunRemoteDump and tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689ba0f8a9248323916c08b3e8c75ff9