### PR TITLE
Validate remote destination format

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,7 +830,7 @@ lvmsync /dev/vg0/snap0 /dev/vg0/data
 
 #### Remote Transfer
 
-Replicate data to a remote host (the destination is specified as `<user@host>:<device>`):
+Replicate data to a remote host. The destination must be specified in `host:device` format (optionally including a username, e.g., `user@host:/dev/vg0/data`):
 
 ```sh
 lvmsync /dev/vg0/snap0 user@remote:/dev/vg0/data

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -223,6 +223,9 @@ func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remot
 // RunRemoteDump streams snapshot data to a remote host over SSH.
 func RunRemoteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	parts := strings.SplitN(dest, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid destination %q: expected host:device", dest)
+	}
 	destHost, destDevice := parts[0], parts[1]
 	client, cancel, err := SetupSSHClient(cfg, destHost, logger)
 	if err != nil {

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -170,7 +170,7 @@ func TestRunRemoteDumpTimeout(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	err = RunRemoteDump(cfg, "snap", "origin", dest, zap.NewNop())
+	err = RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
@@ -181,5 +181,18 @@ func TestRunRemoteDumpTimeout(t *testing.T) {
 	}
 	if cmdCount != 1 {
 		t.Fatalf("expected only validation command, got %d", cmdCount)
+	}
+}
+
+// TestRunRemoteDumpInvalidDest verifies that an invalid destination format returns an error.
+func TestRunRemoteDumpInvalidDest(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	dest := "invalid"
+	err = RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop())
+	if err == nil || !strings.Contains(err.Error(), "host:device") {
+		t.Fatalf("expected host:device format error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure remote destination is parsed as `host:device`
- document remote `host:device` format in README examples
- test invalid destination formats

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689ba0fde24c8323998da2c054e81ce8