### PR TITLE
Add context to dump Run and propagate deadlines

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -83,14 +83,14 @@ func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io
 }
 
 // Run executes client mode transferring data to dest.
-func Run(cfg *config.Config, snapshotDevice, dest string, logger *zap.Logger) error {
+func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, logger *zap.Logger) error {
 	originDevice := snapshotDevice
 	if cfg.StdoutMode {
 		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)
 		return ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
 	}
 	if strings.Contains(dest, ":") {
-		return RunRemoteDump(context.Background(), cfg, snapshotDevice, originDevice, dest, logger)
+		return RunRemoteDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
 	}
 	return RunLocalDump(cfg, snapshotDevice, originDevice, dest, logger)
 }

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -63,7 +63,9 @@ func TestRunRemoteDump(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	if err := RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop()); err != nil {
 		t.Fatalf("runRemoteDump returned error: %v", err)
 	}
 
@@ -117,7 +119,9 @@ func TestRunRemoteDumpError(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	err = RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "remote command error") {
 		t.Fatalf("expected remote command error, got %v", err)
 	}
@@ -170,7 +174,9 @@ func TestRunRemoteDumpTimeout(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	err = RunRemoteDump(cfg, "snap", "origin", dest, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -1,6 +1,7 @@
 package dump
 
 import (
+	"context"
 	"io"
 	"net"
 	"strconv"
@@ -49,7 +50,9 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	defer func() { dumpChangesSequential = original }()
 
 	dest := host + ":/dev/null"
-	err = Run(cfg, "/dev/snap", dest, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "dumpChanges") {
 		t.Fatalf("expected dumpChanges error, got %v", err)
 	}
@@ -96,7 +99,9 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 
 	dest := host + ":/dev/null"
-	err = Run(cfg, "/dev/snap", dest, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil {
 		t.Fatalf("expected error from pre-script")
 	}
@@ -148,7 +153,9 @@ func TestRemotePostScriptContextError(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 
 	dest := host + ":/dev/null"
-	err = Run(cfg, "/dev/snap", dest, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "remote post-script context error") {
 		t.Fatalf("expected remote post-script context error, got %v", err)
 	}

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -1,9 +1,11 @@
 package dump
 
 import (
+	"context"
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -32,7 +34,9 @@ func TestRunLogsSaveStateError(t *testing.T) {
 	core, observed := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
 
-	if err := Run(cfg, "/dev/snap", "", logger); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Run(ctx, cfg, "/dev/snap", "", logger); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -1,9 +1,11 @@
 package dump
 
 import (
+	"context"
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -37,7 +39,9 @@ func TestRunStdout(t *testing.T) {
 	oldStdout := os.Stdout
 	os.Stdout = w
 
-	if err = Run(cfg, "/dev/snap", "", zap.NewNop()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err = Run(ctx, cfg, "/dev/snap", "", zap.NewNop()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -114,7 +114,7 @@ func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume str
 // ExecuteClient runs the client transfer logic.
 func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
 	return executeClientFn(ctx, func(ctx context.Context, snapshot, dest string) error {
-		return runDump(cfg, snapshot, dest, logger)
+		return runDump(ctx, cfg, snapshot, dest, logger)
 	}, snapshotPath, destPath, sigErrCh, monitorErrCh)
 }
 

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -169,7 +169,7 @@ func TestExecuteClient(t *testing.T) {
 		}
 		return f(ctx, snap, dest)
 	}
-	runDump = func(_ *config.Config, snap, dest string, _ *zap.Logger) error {
+	runDump = func(_ context.Context, _ *config.Config, snap, dest string, _ *zap.Logger) error {
 		if snap != "s" || dest != "d" {
 			t.Fatalf("unexpected dump args")
 		}


### PR DESCRIPTION
## Summary
- accept a context in `dump.Run` and forward it to `RunRemoteDump`
- propagate context through root command
- update dump tests to pass contexts with timeouts

## Testing
- `go test ./cmd/dump -run TestRunRemoteDump -v`
- `go test ./cmd/root -run TestExecuteClient -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ba0f382d083239d95dc665228c714