### PR TITLE
feat(dump): add sentinel error for remote command

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -19,6 +19,9 @@ import (
 	"lvmsync_go/transfer"
 )
 
+// ErrRemoteCommand indicates that execution of the remote command failed.
+var ErrRemoteCommand = errors.New("remote command error")
+
 var (
 	dumpChangesSequential = func(t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
 		return t.DumpChangesSequential(cfg, snap, origin, out)
@@ -178,7 +181,7 @@ type waitSession interface {
 // WaitForRemoteCompletion waits for the remote command and I/O copies to finish.
 func WaitForRemoteCompletion(session waitSession, stdoutErrCh, stderrErrCh <-chan error) error {
 	if err := session.Wait(); err != nil {
-		return fmt.Errorf("remote command error: %w", err)
+		return fmt.Errorf("%w: %v", ErrRemoteCommand, err)
 	}
 	if err := <-stdoutErrCh; err != nil {
 		return fmt.Errorf("stdout copy error: %w", err)

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -122,7 +122,7 @@ func TestRunRemoteDumpError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	err = RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
-	if err == nil || !strings.Contains(err.Error(), "remote command error") {
+	if err == nil || !errors.Is(err, ErrRemoteCommand) {
 		t.Fatalf("expected remote command error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add ErrRemoteCommand sentinel
- wrap remote command failures with ErrRemoteCommand
- verify remote errors with errors.Is in tests

## Testing
- `go test ./cmd/dump`


------
https://chatgpt.com/codex/tasks/task_e_689ba39dffb08323897f3a968c418c53