### PR TITLE
refactor(grpcd): log server errors and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ Run the daemon with TLS:
 lvmsync-grpcd --grpc-port 9443 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
 
+On failure, `lvmsync-grpcd` logs the error and exits with status `1` so calling scripts can inspect `$?`.
+
 Environment variables provide the same settings:
 
 ```sh
@@ -1089,7 +1091,7 @@ Invalid configurations will cause the tool to abort with a clear error message.
 
 ## Exit Codes
 
-LVMSync returns conventional exit codes to indicate overall status:
+LVMSync commands such as `lvmsync` and `lvmsync-grpcd` return conventional exit codes to indicate overall status:
 
 | Code | Meaning |
 |------|---------|

--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 
 	grpcserver "lvmsync_go/grpc/server"
 	lvmagent "lvmsync_go/internal/lvm"
@@ -19,6 +20,9 @@ import (
 var (
 	newZapProduction = zap.NewProduction
 	exitFunc         = os.Exit
+	newServer        = grpcserver.New
+	listen           = net.Listen
+	serve            = func(s *grpc.Server, lis net.Listener) error { return s.Serve(lis) }
 )
 
 func main() {
@@ -26,14 +30,16 @@ func main() {
 	if err != nil {
 		zap.NewNop().Error("init logger", zap.Error(err))
 		exitFunc(1)
+		return
 	}
-	zap.ReplaceGlobals(logger)
 	defer syncLogger(logger)
 
 	v, err := initConfig(os.Args[1:])
 	if err != nil {
-		zap.L().Error("init config", zap.Error(err))
+		logger.Error("init config", zap.Error(err))
+		syncLogger(logger)
 		exitFunc(1)
+		return
 	}
 
 	cfg := grpcserver.Config{
@@ -44,20 +50,29 @@ func main() {
 	}
 
 	agent := lvmagent.NewAgent(nil, nil)
-	srv, srvErr := grpcserver.New(cfg, agent)
+	srv, srvErr := newServer(cfg, agent)
 	if srvErr != nil {
-		zap.L().Fatal("init gRPC server", zap.Error(srvErr))
+		logger.Error("init gRPC server", zap.Error(srvErr))
+		syncLogger(logger)
+		exitFunc(1)
+		return
 	}
 
 	port := v.GetInt("grpc-port")
-	lis, listenErr := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	lis, listenErr := listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if listenErr != nil {
-		zap.L().Fatal("listen", zap.Error(listenErr))
+		logger.Error("listen", zap.Error(listenErr))
+		syncLogger(logger)
+		exitFunc(1)
+		return
 	}
 
-	zap.L().Info("gRPC server listening", zap.Int("port", port))
-	if serveErr := srv.Serve(lis); serveErr != nil {
-		zap.L().Fatal("serve", zap.Error(serveErr))
+	logger.Info("gRPC server listening", zap.Int("port", port))
+	if serveErr := serve(srv, lis); serveErr != nil {
+		logger.Error("serve", zap.Error(serveErr))
+		syncLogger(logger)
+		exitFunc(1)
+		return
 	}
 }
 

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,10 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/grpc"
+
+	grpcserver "lvmsync_go/grpc/server"
+	lvmagent "lvmsync_go/internal/lvm"
 )
 
 type failingSyncCore struct {
@@ -130,5 +135,90 @@ func TestInitConfigInvalidConfigFile(t *testing.T) {
 	}
 	if _, err := initConfig([]string{"--config", cfgFile}); err == nil {
 		t.Fatalf("expected error for malformed config")
+	}
+}
+
+type fakeListener struct{}
+
+func (fakeListener) Accept() (net.Conn, error) { return nil, errors.New("not implemented") }
+func (fakeListener) Close() error              { return nil }
+func (fakeListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
+func TestMainErrorPropagation(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func()
+		wantMsg string
+	}{
+		{
+			name: "server error",
+			setup: func() {
+				newServer = func(cfg grpcserver.Config, a lvmagent.Agent) (*grpc.Server, error) {
+					return nil, errors.New("srv err")
+				}
+			},
+			wantMsg: "init gRPC server",
+		},
+		{
+			name: "listen error",
+			setup: func() {
+				newServer = func(cfg grpcserver.Config, a lvmagent.Agent) (*grpc.Server, error) {
+					return grpc.NewServer(), nil
+				}
+				listen = func(network, addr string) (net.Listener, error) {
+					return nil, errors.New("listen err")
+				}
+			},
+			wantMsg: "listen",
+		},
+		{
+			name: "serve error",
+			setup: func() {
+				newServer = func(cfg grpcserver.Config, a lvmagent.Agent) (*grpc.Server, error) {
+					return grpc.NewServer(), nil
+				}
+				listen = func(network, addr string) (net.Listener, error) {
+					return fakeListener{}, nil
+				}
+				serve = func(s *grpc.Server, lis net.Listener) error {
+					return errors.New("serve err")
+				}
+			},
+			wantMsg: "serve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				newZapProduction = zap.NewProduction
+				newServer = grpcserver.New
+				listen = net.Listen
+				serve = func(s *grpc.Server, lis net.Listener) error { return s.Serve(lis) }
+				exitFunc = os.Exit
+				os.Args = []string{"grpcd"}
+			}()
+
+			core, logs := observer.New(zap.ErrorLevel)
+			newZapProduction = func(...zap.Option) (*zap.Logger, error) { return zap.New(core), nil }
+
+			var code int
+			exitFunc = func(c int) { code = c }
+
+			os.Args = []string{"grpcd"}
+			tt.setup()
+			main()
+
+			if code != 1 {
+				t.Fatalf("expected exit code 1, got %d", code)
+			}
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("expected one log entry, got %d", len(entries))
+			}
+			if entries[0].Message != tt.wantMsg {
+				t.Fatalf("expected log message %q, got %q", tt.wantMsg, entries[0].Message)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- handle grpc server, listener, and serve errors via logger.Error and os.Exit
- remove zap.ReplaceGlobals and pass logger explicitly
- document gRPC daemon exit codes and add tests for error propagation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689ba7415f24832395f47fd48b5d3c48