### PR TITLE
feat(serve): add accept timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ incoming client. The server listens on `--serve_listen` (default `:9000`) and
 expects the client to present matching `--serve_protocol`, `--serve_algorithm`,
 and optional `--serve_test_space` values. A mismatched value aborts the
 connection. Transfers proceed only when `--serve_policy` is `accept` (the
-default). The server closes the stream, QUIC connection, and listener when the transfer completes, logging any shutdown errors at `warn` level, and exits gracefully when it receives `SIGINT` or `SIGTERM`.
+default). Listener and stream acceptance are bounded by `--serve_accept_timeout` (default `30s`). The server closes the stream, QUIC connection, and listener when the transfer completes, logging any shutdown errors at `warn` level, and exits gracefully when it receives `SIGINT` or `SIGTERM`.
 
 ```sh
 lvmsync --serve --serve_listen :9000
@@ -356,6 +356,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--serve_algorithm` | `LVMSYNC_SERVE_ALGORITHM` | `serve_algorithm` | `sha256` | Algorithm identifier to negotiate |
 | `--serve_test_space` | `LVMSYNC_SERVE_TEST_SPACE` | `serve_test_space` | `""` | Optional test-space string |
 | `--serve_policy` | `LVMSYNC_SERVE_POLICY` | `serve_policy` | `accept` | Transfer policy (non-`accept` rejects) |
+| `--serve_accept_timeout` | `LVMSYNC_SERVE_ACCEPT_TIMEOUT` | `serve_accept_timeout` | `30s` | Timeout for listener and stream acceptance |
 
 CLI:
 
@@ -817,6 +818,18 @@ timeouts or cancellations are reported separately.
 | `--tls_key`        | TLS key file                 | `""`            |
 | `--ca_cert`        | CA certificate file          | `""`            |
 | `--allow_insecure` | Allow insecure (disable TLS) | `false`         |
+
+#### Serve Options
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| `--serve` | Run QUIC server instead of client | `false` |
+| `--serve_listen` | QUIC listen address | `:9000` |
+| `--serve_protocol` | Protocol name to negotiate | `lvmsync` |
+| `--serve_algorithm` | Algorithm identifier to negotiate | `sha256` |
+| `--serve_test_space` | Optional test-space string | `""` |
+| `--serve_policy` | Transfer policy (non-`accept` rejects) | `accept` |
+| `--serve_accept_timeout` | Timeout for listener and stream acceptance | `30s` |
 
 ### Examples
 

--- a/cmd/serve/flag_test.go
+++ b/cmd/serve/flag_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func TestServeFlagBindingSuccess(t *testing.T) {
-	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
+	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--serve_accept_timeout", "1s"})
 	defaults, err := config.DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
@@ -27,7 +28,7 @@ func TestServeFlagBindingSuccess(t *testing.T) {
 	if !cfg.Serve {
 		t.Fatalf("expected Serve true")
 	}
-	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" {
+	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" || cfg.ServeAcceptTimeout != time.Second {
 		t.Fatalf("unexpected serve config: %+v", cfg)
 	}
 

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -26,16 +26,37 @@ var acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteClos
 	if err != nil {
 		return nil, err
 	}
-	l, err := q.ListenAddr(cfg.ServeListen, tlsConf, qn.NewQUICConfig())
-	if err != nil {
-		return nil, err
+	listenCtx, cancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
+	defer cancel()
+	type listenRes struct {
+		l   *q.Listener
+		err error
 	}
-	conn, err := l.Accept(ctx)
+	lch := make(chan listenRes, 1)
+	go func() {
+		l, err := q.ListenAddr(cfg.ServeListen, tlsConf, qn.NewQUICConfig())
+		lch <- listenRes{l: l, err: err}
+	}()
+	var l *q.Listener
+	select {
+	case <-listenCtx.Done():
+		return nil, listenCtx.Err()
+	case res := <-lch:
+		if res.err != nil {
+			return nil, res.err
+		}
+		l = res.l
+	}
+	connCtx, cancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
+	defer cancel()
+	conn, err := l.Accept(connCtx)
 	if err != nil {
 		_ = l.Close()
 		return nil, err
 	}
-	stream, err := conn.AcceptStream(ctx)
+	streamCtx, cancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
+	defer cancel()
+	stream, err := conn.AcceptStream(streamCtx)
 	if err != nil {
 		_ = conn.CloseWithError(0, "")
 		_ = l.Close()

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -3,12 +3,14 @@ package serve
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	q "github.com/quic-go/quic-go"
 	"github.com/spf13/pflag"
@@ -111,6 +113,23 @@ func TestRunRejectsPolicy(t *testing.T) {
 	client.Close()
 	if err := <-errCh; err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestRunAcceptTimeout(t *testing.T) {
+	orig := acceptFunc
+	acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteCloser, error) {
+		ctx, cancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
+		defer cancel()
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	defer func() { acceptFunc = orig }()
+
+	cfg := &config.Config{ServeProtocol: "proto", ServeAlgorithm: "alg", ServeTestSpace: "ts", ServePolicy: "accept", ServeAcceptTimeout: 10 * time.Millisecond}
+	err := Run(context.Background(), cfg, zap.NewNop())
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -152,12 +152,13 @@ type Config struct {
 	QUICCongestionControl string        `mapstructure:"quic_cc"`
 	SyncIntervalBytes     int           `mapstructure:"-"`
 
-	Serve          bool   `mapstructure:"serve"`
-	ServeListen    string `mapstructure:"serve_listen"`
-	ServeProtocol  string `mapstructure:"serve_protocol"`
-	ServeAlgorithm string `mapstructure:"serve_algorithm"`
-	ServeTestSpace string `mapstructure:"serve_test_space"`
-	ServePolicy    string `mapstructure:"serve_policy"`
+	Serve              bool          `mapstructure:"serve"`
+	ServeListen        string        `mapstructure:"serve_listen"`
+	ServeProtocol      string        `mapstructure:"serve_protocol"`
+	ServeAlgorithm     string        `mapstructure:"serve_algorithm"`
+	ServeTestSpace     string        `mapstructure:"serve_test_space"`
+	ServePolicy        string        `mapstructure:"serve_policy"`
+	ServeAcceptTimeout time.Duration `mapstructure:"serve_accept_timeout"`
 }
 
 func FormatBlockSize(blockSize int) (string, error) {
@@ -486,6 +487,7 @@ func DefaultConfig() (*Config, error) {
 		ServeAlgorithm:        "sha256",
 		ServeTestSpace:        "",
 		ServePolicy:           "accept",
+		ServeAcceptTimeout:    30 * time.Second,
 	}, nil
 }
 
@@ -605,6 +607,7 @@ func initServeFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("serve_algorithm", cfg.ServeAlgorithm, "Algorithm to negotiate")
 	fs.String("serve_test_space", cfg.ServeTestSpace, "Test-space option")
 	fs.String("serve_policy", cfg.ServePolicy, "Transfer policy")
+	fs.Duration("serve_accept_timeout", cfg.ServeAcceptTimeout, "Timeout for accept operations")
 	return fs
 }
 

--- a/config/serve_flags_test.go
+++ b/config/serve_flags_test.go
@@ -1,9 +1,12 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestServeFlagParsing(t *testing.T) {
-	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
+	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--serve_accept_timeout", "2s"})
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
@@ -16,7 +19,7 @@ func TestServeFlagParsing(t *testing.T) {
 	if !cfg.Serve {
 		t.Fatalf("expected Serve true")
 	}
-	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" {
+	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" || cfg.ServeAcceptTimeout != 2*time.Second {
 		t.Fatalf("unexpected serve config: %+v", cfg)
 	}
 }


### PR DESCRIPTION
## Summary
- add `serve_accept_timeout` configuration with flag and env support
- bound QUIC listener and stream acceptance with configurable timeout
- document new serve acceptance timeout flag and cover timeout path in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689ba73e7da483239cfe45d9cfb63fa1