### PR TITLE
feat(serve): add accept timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ expects the client to present matching `--serve_protocol`, `--serve_algorithm`,
 and optional `--serve_test_space` values. A mismatched value aborts the
 connection. Transfers proceed only when `--serve_policy` is `accept` (the
 default). The server closes the stream, QUIC connection, and listener when the transfer completes, logging any shutdown errors at `warn` level, and exits gracefully when it receives `SIGINT` or `SIGTERM`.
+Pending accept operations time out after `--serve_accept_timeout` (default `30s`).
 
 ```sh
 lvmsync --serve --serve_listen :9000
@@ -356,6 +357,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--serve_algorithm` | `LVMSYNC_SERVE_ALGORITHM` | `serve_algorithm` | `sha256` | Algorithm identifier to negotiate |
 | `--serve_test_space` | `LVMSYNC_SERVE_TEST_SPACE` | `serve_test_space` | `""` | Optional test-space string |
 | `--serve_policy` | `LVMSYNC_SERVE_POLICY` | `serve_policy` | `accept` | Transfer policy (non-`accept` rejects) |
+| `--serve_accept_timeout` | `LVMSYNC_SERVE_ACCEPT_TIMEOUT` | `serve_accept_timeout` | `30s` | Timeout for accept operations |
 
 CLI:
 

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -26,16 +26,29 @@ var acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteClos
 	if err != nil {
 		return nil, err
 	}
+
+	listenCtx, listenCancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
+	defer listenCancel()
 	l, err := q.ListenAddr(cfg.ServeListen, tlsConf, qn.NewQUICConfig())
 	if err != nil {
 		return nil, err
 	}
-	conn, err := l.Accept(ctx)
+	if err := listenCtx.Err(); err != nil {
+		_ = l.Close()
+		return nil, err
+	}
+
+	connCtx, connCancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
+	conn, err := l.Accept(connCtx)
+	connCancel()
 	if err != nil {
 		_ = l.Close()
 		return nil, err
 	}
-	stream, err := conn.AcceptStream(ctx)
+
+	streamCtx, streamCancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
+	stream, err := conn.AcceptStream(streamCtx)
+	streamCancel()
 	if err != nil {
 		_ = conn.CloseWithError(0, "")
 		_ = l.Close()

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -3,12 +3,14 @@ package serve
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	q "github.com/quic-go/quic-go"
 	"github.com/spf13/pflag"
@@ -54,7 +56,7 @@ func resetFlags(args []string) {
 }
 
 func TestServeFlagParsing(t *testing.T) {
-	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--allow_insecure"})
+	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--serve_accept_timeout", "5s", "--allow_insecure"})
 	defaults, err := config.DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
@@ -67,7 +69,7 @@ func TestServeFlagParsing(t *testing.T) {
 	if !cfg.Serve {
 		t.Fatalf("expected Serve true")
 	}
-	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" {
+	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" || cfg.ServeAcceptTimeout != 5*time.Second {
 		t.Fatalf("unexpected serve config: %+v", cfg)
 	}
 }
@@ -111,6 +113,14 @@ func TestRunRejectsPolicy(t *testing.T) {
 	client.Close()
 	if err := <-errCh; err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestAcceptFuncTimeout(t *testing.T) {
+	cfg := &config.Config{ServeListen: "localhost:0", AllowInsecure: true, ServeAcceptTimeout: 10 * time.Millisecond}
+	_, err := acceptFunc(context.Background(), cfg)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,7 @@ serve_listen: ":9000"  # Server listen address
 serve_protocol: lvmsync  # Server protocol
 serve_algorithm: sha256  # Hash algorithm for served data
 serve_policy: accept  # Client acceptance policy
+serve_accept_timeout: 30s  # Timeout for accepting connection and stream
 
 # Deduplication Options
 # Strategy: "none", "auto", "checksum", "rolling_hash", or "bloom"

--- a/config/config.go
+++ b/config/config.go
@@ -152,12 +152,13 @@ type Config struct {
 	QUICCongestionControl string        `mapstructure:"quic_cc"`
 	SyncIntervalBytes     int           `mapstructure:"-"`
 
-	Serve          bool   `mapstructure:"serve"`
-	ServeListen    string `mapstructure:"serve_listen"`
-	ServeProtocol  string `mapstructure:"serve_protocol"`
-	ServeAlgorithm string `mapstructure:"serve_algorithm"`
-	ServeTestSpace string `mapstructure:"serve_test_space"`
-	ServePolicy    string `mapstructure:"serve_policy"`
+	Serve              bool          `mapstructure:"serve"`
+	ServeListen        string        `mapstructure:"serve_listen"`
+	ServeProtocol      string        `mapstructure:"serve_protocol"`
+	ServeAlgorithm     string        `mapstructure:"serve_algorithm"`
+	ServeTestSpace     string        `mapstructure:"serve_test_space"`
+	ServePolicy        string        `mapstructure:"serve_policy"`
+	ServeAcceptTimeout time.Duration `mapstructure:"serve_accept_timeout"`
 }
 
 func FormatBlockSize(blockSize int) (string, error) {
@@ -486,6 +487,7 @@ func DefaultConfig() (*Config, error) {
 		ServeAlgorithm:        "sha256",
 		ServeTestSpace:        "",
 		ServePolicy:           "accept",
+		ServeAcceptTimeout:    30 * time.Second,
 	}, nil
 }
 
@@ -605,6 +607,7 @@ func initServeFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("serve_algorithm", cfg.ServeAlgorithm, "Algorithm to negotiate")
 	fs.String("serve_test_space", cfg.ServeTestSpace, "Test-space option")
 	fs.String("serve_policy", cfg.ServePolicy, "Transfer policy")
+	fs.Duration("serve_accept_timeout", cfg.ServeAcceptTimeout, "Timeout for accepting connection and stream")
 	return fs
 }
 

--- a/config/serve_flags_test.go
+++ b/config/serve_flags_test.go
@@ -1,9 +1,12 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestServeFlagParsing(t *testing.T) {
-	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept"})
+	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--serve_accept_timeout", "5s"})
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
@@ -16,7 +19,7 @@ func TestServeFlagParsing(t *testing.T) {
 	if !cfg.Serve {
 		t.Fatalf("expected Serve true")
 	}
-	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" {
+	if cfg.ServeListen != "localhost:9900" || cfg.ServeProtocol != "p" || cfg.ServeAlgorithm != "a" || cfg.ServeTestSpace != "t" || cfg.ServePolicy != "accept" || cfg.ServeAcceptTimeout != 5*time.Second {
 		t.Fatalf("unexpected serve config: %+v", cfg)
 	}
 }


### PR DESCRIPTION
## Summary
- add ServeAcceptTimeout configuration and CLI flag
- wrap server listener and stream acceptance with configurable timeout
- document serve_accept_timeout in README and sample config

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689ba857e7f08323a08efbcdda2a2fee