### PR TITLE
docs: add exit code references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,8 @@ LVMSync commands such as `lvmsync` and `lvmsync-grpcd` return conventional exit 
 | `0` | Success |
 | `1` | Configuration or runtime failure |
 
+Exit code handling lives in [main.go](main.go#L21-L37), with configuration errors bubbling up from [cmd/root/root.go](cmd/root/root.go#L42-L52) and runtime errors from [cmd/root/root.go](cmd/root/root.go#L121-L186).
+
 Example shell usage:
 
 ```sh


### PR DESCRIPTION
## Summary
- reference exit code handling and error paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689baab21ce4832396692da70b7bf9fc