### PR TITLE
refactor(remote): make SSH dialing context-aware

### DIFF
--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -80,12 +80,12 @@ func TestSSHManager(t *testing.T) {
 		t.Fatalf("NewSSHManager error: %v", err)
 	}
 
-	client1, err := mgr.GetClient(host, port)
+	client1, err := mgr.GetClient(context.Background(), host, port)
 	if err != nil {
 		t.Fatalf("GetClient error: %v", err)
 	}
 
-	client2, err := mgr.GetClient(host, port)
+	client2, err := mgr.GetClient(context.Background(), host, port)
 	if err != nil {
 		t.Fatalf("GetClient second error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestSSHManager(t *testing.T) {
 		t.Fatalf("CloseAll error: %v", err)
 	}
 
-	client3, err := mgr.GetClient(host, port)
+	client3, err := mgr.GetClient(context.Background(), host, port)
 	if err != nil {
 		t.Fatalf("GetClient after CloseAll error: %v", err)
 	}

--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -2,6 +2,7 @@
 package remote
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -66,7 +67,7 @@ func NewSSHManager(user, keyPath string, timeout time.Duration, knownHostsPath s
 // GetClient returns an SSH client connected to the specified host and port.
 // If a connection already exists it is reused; otherwise a new connection is
 // established.
-func (s *SSHManager) GetClient(host string, port int) (*ssh.Client, error) {
+func (s *SSHManager) GetClient(ctx context.Context, host string, port int) (*ssh.Client, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -75,7 +76,7 @@ func (s *SSHManager) GetClient(host string, port int) (*ssh.Client, error) {
 		return client, nil
 	}
 
-	client, err := dialSSH(addr, s.sshConfig, s.timeout)
+	client, err := dialSSH(ctx, addr, s.sshConfig, s.timeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish SSH connection: %w", err)
 	}
@@ -128,8 +129,12 @@ func getHostKeyCallback(knownHostsPath string) (ssh.HostKeyCallback, error) {
 	return knownhosts.New(knownHostsPath)
 }
 
-func dialSSH(addr string, sshConfig *ssh.ClientConfig, timeout time.Duration) (*ssh.Client, error) {
-	conn, err := net.DialTimeout("tcp", addr, timeout)
+func dialSSH(ctx context.Context, addr string, sshConfig *ssh.ClientConfig, timeout time.Duration) (*ssh.Client, error) {
+	dialer := net.Dialer{Timeout: timeout}
+	if deadline, ok := ctx.Deadline(); ok {
+		dialer.Deadline = deadline
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to %s: %w", addr, err)
 	}

--- a/remote/ssh_manager_context_test.go
+++ b/remote/ssh_manager_context_test.go
@@ -1,0 +1,44 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// TestDialSSHContextCancel ensures dialSSH respects context cancellation.
+func TestDialSSHContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	_, err := dialSSH(ctx, "192.0.2.1:22", cfg, time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+// TestDialSSHTimeout ensures dialSSH respects dial timeouts.
+func TestDialSSHTimeout(t *testing.T) {
+	ctx := context.Background()
+	cfg := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	_, err := dialSSH(ctx, "198.51.100.1:22", cfg, time.Nanosecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	var netErr net.Error
+	if !(errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout())) {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}

--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -2,6 +2,7 @@
 package remote
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -69,7 +70,7 @@ func (s *SSHSession) Close() {
 	}
 }
 
-func RunSSHCommand(logger *zap.Logger, host, user, keyPath, hostKeyPath string, port int, command string, timeout time.Duration) error {
+func RunSSHCommand(ctx context.Context, logger *zap.Logger, host, user, keyPath, hostKeyPath string, port int, command string, timeout time.Duration) error {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -81,7 +82,7 @@ func RunSSHCommand(logger *zap.Logger, host, user, keyPath, hostKeyPath string, 
 	if err != nil {
 		return fmt.Errorf("failed to load private key: %w", err)
 	}
-	client, err := dialSSH(fmt.Sprintf("%s:%d", host, port), &ssh.ClientConfig{
+	client, err := dialSSH(ctx, fmt.Sprintf("%s:%d", host, port), &ssh.ClientConfig{
 		User:            user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		HostKeyCallback: ssh.FixedHostKey(publicKey),


### PR DESCRIPTION
## Summary
- accept context in SSHManager.GetClient and internal dialer
- add context support to RunSSHCommand
- cover dial cancellation and timeout

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689baaafe45c8323bb8a54021ccfecb2