### PR TITLE
feat(transfer): add chunk reader and bitmap support

### DIFF
--- a/transfer/chunk_reader.go
+++ b/transfer/chunk_reader.go
@@ -1,0 +1,88 @@
+package transfer
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const defaultChunkSize = 8 * 1024 * 1024
+
+// ChunkReader streams fixed-size chunks from a device, skipping
+// indices already confirmed in the provided bitmap.
+// Each bit in the bitmap corresponds to a chunk index. If the bit is 1,
+// the chunk is considered confirmed and skipped.
+type ChunkReader struct {
+	f         *os.File
+	blockSize int
+	bitmap    []byte
+	index     int64
+}
+
+// NewChunkReader opens path using O_DIRECT when available and returns a ChunkReader.
+// blockSize defaults to 8MiB when set to 0. The caller must Close the reader.
+func NewChunkReader(path string, blockSize int, bitmap []byte) (*ChunkReader, error) {
+	if blockSize == 0 {
+		blockSize = defaultChunkSize
+	}
+	f, _, err := openFileODirect(path, os.O_RDONLY)
+	if err != nil {
+		return nil, fmt.Errorf("open source: %w", err)
+	}
+	return &ChunkReader{f: f, blockSize: blockSize, bitmap: bitmap}, nil
+}
+
+// Next reads the next unconfirmed chunk. It returns io.EOF when no data remains.
+// Returned buffers are page-aligned when O_DIRECT is in effect. Callers should
+// return the buffer via putAlignedBlockBuffer.
+func (cr *ChunkReader) Next() (int64, []byte, error) {
+	for {
+		if cr.bitmap != nil {
+			byteIdx := cr.index / 8
+			bit := cr.index % 8
+			if int(byteIdx) < len(cr.bitmap) && cr.bitmap[byteIdx]&(1<<uint(bit)) != 0 {
+				cr.index++
+				continue
+			}
+		}
+		offset := cr.index * int64(cr.blockSize)
+		buf := getAlignedBlockBuffer(cr.blockSize)
+		n, err := cr.f.ReadAt(buf, offset)
+		if err == io.EOF && n == 0 {
+			putAlignedBlockBuffer(buf)
+			return 0, nil, io.EOF
+		}
+		if err != nil && err != io.EOF {
+			putAlignedBlockBuffer(buf)
+			return 0, nil, err
+		}
+		if n != cr.blockSize {
+			putAlignedBlockBuffer(buf)
+			return 0, nil, fmt.Errorf("short read: expected %d, got %d", cr.blockSize, n)
+		}
+		cr.index++
+		return offset, buf, nil
+	}
+}
+
+// Close releases underlying resources.
+func (cr *ChunkReader) Close() error {
+	if cr.f != nil {
+		return cr.f.Close()
+	}
+	return nil
+}
+
+// Confirm marks the given chunk index as confirmed in the bitmap.
+// If the bitmap is nil or too small, it is resized.
+func (cr *ChunkReader) Confirm(index int64) {
+	byteIdx := index / 8
+	bit := index % 8
+	if int(byteIdx) >= len(cr.bitmap) {
+		newSize := byteIdx + 1
+		nb := make([]byte, newSize)
+		copy(nb, cr.bitmap)
+		cr.bitmap = nb
+	}
+	cr.bitmap[byteIdx] |= 1 << uint(bit)
+}

--- a/transfer/chunk_reader_test.go
+++ b/transfer/chunk_reader_test.go
@@ -1,0 +1,76 @@
+package transfer
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestChunkReaderSkipsConfirmed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "dev")
+	data := make([]byte, defaultChunkSize*2)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	// bitmap marks first chunk as confirmed
+	cr, err := NewChunkReader(path, defaultChunkSize, []byte{0x1})
+	if err != nil {
+		t.Fatalf("NewChunkReader: %v", err)
+	}
+	defer cr.Close()
+	off, buf, err := cr.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if off != int64(defaultChunkSize) {
+		t.Fatalf("expected offset %d, got %d", defaultChunkSize, off)
+	}
+	if len(buf) != defaultChunkSize {
+		t.Fatalf("expected chunk size %d, got %d", defaultChunkSize, len(buf))
+	}
+	putAlignedBlockBuffer(buf)
+	if _, _, err := cr.Next(); err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestChunkReaderShortRead(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "dev")
+	// create file smaller than block size
+	if err := os.WriteFile(path, []byte("abcd"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	cr, err := NewChunkReader(path, defaultChunkSize, nil)
+	if err != nil {
+		t.Fatalf("NewChunkReader: %v", err)
+	}
+	defer cr.Close()
+	if _, _, err := cr.Next(); err == nil {
+		t.Fatalf("expected error on short read")
+	}
+}
+
+func TestPunchHoleError(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "file")
+	if err := os.WriteFile(path, make([]byte, 4096), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	f, err := os.Open(path) // read-only
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if err := punchHole(f, 0, 4096); err == nil {
+		t.Fatalf("expected error punching hole on read-only file")
+	}
+}

--- a/transfer/manifest.go
+++ b/transfer/manifest.go
@@ -13,9 +13,12 @@ type Chunk struct {
 }
 
 // Manifest records all transferred chunks and the final SHA-256 hash.
+// When resuming transfers, Bitmap carries a bitset of confirmed chunk indices
+// to allow skipping already replicated data.
 type Manifest struct {
 	Chunks      []Chunk  `json:"chunks"`
 	FinalSHA256 [32]byte `json:"final_sha256"`
+	Bitmap      []byte   `json:"bitmap,omitempty"`
 }
 
 // Append adds a chunk entry to the manifest.


### PR DESCRIPTION
## Summary
- add page-aligned ChunkReader with optional O_DIRECT and manifest bitmap skipping
- track confirmed indices via new Manifest bitmap field
- test hole punching and short read paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/grpcd/main_test.go:175:48: expected ';', found '{')*
- `go test -coverprofile=coverage.out ./transfer`
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689bb1d63f0c8323bf3402950c18929b