### PR TITLE
feat(manifest): persist chunk progress and hashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module lvmsync_go
 go 1.23.0
 
 require (
+	github.com/bits-and-blooms/bitset v1.10.0
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/cpuid/v2 v2.2.7
@@ -21,7 +22,6 @@ require (
 )
 
 require (
-	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,0 +1,51 @@
+package manifest
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/bits-and-blooms/bitset"
+)
+
+// Version is the manifest format version.
+const Version uint32 = 1
+
+// Manifest tracks chunk completion and hashes for a logical volume.
+type Manifest struct {
+	LVUUID       string         `json:"lv_uuid"`
+	SizeBytes    uint64         `json:"size_bytes"`
+	ChunkSize    uint64         `json:"chunk_size"`
+	TotalChunks  uint64         `json:"total_chunks"`
+	Bitmap       *bitset.BitSet `json:"bitmap"`
+	PerChunkHash [][]byte       `json:"per_chunk_hash"`
+	Version      uint32         `json:"version"`
+}
+
+// Save writes the manifest to the given path in JSON format.
+func (m *Manifest) Save(path string) error {
+	if m == nil {
+		return errors.New("nil manifest")
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// Load reads a manifest from the given path.
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	if m.Bitmap == nil {
+		m.Bitmap = bitset.New(0)
+	}
+	return &m, nil
+}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,0 +1,101 @@
+package manifest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bits-and-blooms/bitset"
+	"github.com/zeebo/blake3"
+)
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	m := &Manifest{
+		LVUUID:      "1234-5678",
+		SizeBytes:   1024,
+		ChunkSize:   256,
+		TotalChunks: 4,
+		Bitmap:      bitset.New(4),
+		Version:     Version,
+	}
+	h0 := blake3.Sum256([]byte("chunk0"))
+	h2 := blake3.Sum256([]byte("chunk2"))
+	m.Bitmap.Set(0)
+	m.Bitmap.Set(2)
+	m.PerChunkHash = [][]byte{h0[:], nil, h2[:]}
+
+	f, err := os.CreateTemp(t.TempDir(), "manifest-*.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	if err := m.Save(f.Name()); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := Load(f.Name())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !loaded.Bitmap.Equal(m.Bitmap) {
+		t.Fatalf("bitmap mismatch")
+	}
+	if len(loaded.PerChunkHash) != len(m.PerChunkHash) {
+		t.Fatalf("per chunk hash length mismatch")
+	}
+	if string(loaded.PerChunkHash[0]) != string(h0[:]) || string(loaded.PerChunkHash[2]) != string(h2[:]) {
+		t.Fatalf("hashes mismatch")
+	}
+	if loaded.LVUUID != m.LVUUID || loaded.SizeBytes != m.SizeBytes || loaded.ChunkSize != m.ChunkSize || loaded.TotalChunks != m.TotalChunks || loaded.Version != m.Version {
+		t.Fatalf("fields mismatch")
+	}
+}
+
+func TestLoadPartialManifest(t *testing.T) {
+	m := &Manifest{
+		LVUUID:      "partial",
+		SizeBytes:   2048,
+		ChunkSize:   512,
+		TotalChunks: 4,
+		Bitmap:      bitset.New(4),
+		Version:     Version,
+	}
+	h0 := blake3.Sum256([]byte("chunk0"))
+	m.Bitmap.Set(0)
+	m.PerChunkHash = [][]byte{h0[:]}
+
+	f, err := os.CreateTemp(t.TempDir(), "manifest-partial-*.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	if err := m.Save(f.Name()); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := Load(f.Name())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded.PerChunkHash) != 1 {
+		t.Fatalf("expected 1 hash, got %d", len(loaded.PerChunkHash))
+	}
+	if !loaded.Bitmap.Test(0) {
+		t.Fatalf("expected bit 0 set")
+	}
+}
+
+func TestLoadCorruptManifest(t *testing.T) {
+	m := &Manifest{LVUUID: "bad", Bitmap: bitset.New(1), Version: Version}
+	f, err := os.CreateTemp(t.TempDir(), "manifest-corrupt-*.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	if err := m.Save(f.Name()); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := os.WriteFile(f.Name(), []byte("not json"), 0o600); err != nil {
+		t.Fatalf("corrupt: %v", err)
+	}
+	if _, err := Load(f.Name()); err == nil {
+		t.Fatalf("expected error on corrupt manifest")
+	}
+}


### PR DESCRIPTION
## Summary
- add manifest package tracking chunk hashes and completion
- support saving/loading manifest JSON with bitset bitmap
- cover partial and corrupt manifests in unit tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/grpcd/main_test.go:175:48: expected ';', found '{')*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689bb1caa60083239be0422129811351