### PR TITLE
feat: add manifest diff and checksum verification

### DIFF
--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"bufio"
-	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -31,7 +30,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 	skippedBlocks := 0
 	var header [12]byte
 	manifest := &Manifest{}
-	sha := sha256.New()
+	h := newDigestHasher(cfg.ChecksumAlgorithm)
 	for _, r := range ranges {
 		offset, blockSize, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
 		if err != nil {
@@ -72,7 +71,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 			return totalBytes, skippedBlocks, manifest, fmt.Errorf("failed to write block data: %w", err)
 		}
 
-		sha.Write(data)
+		h.Write(data)
 		sum := blake3.Sum256(data)
 		manifest.Append(sum, int64(r.Start), int(blockSize))
 		saveResumeState(cfg, sum, int64(blockSize), logger)
@@ -81,7 +80,8 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 
 		totalBytes += int64(blockSize)
 	}
-	copy(manifest.FinalSHA256[:], sha.Sum(nil))
+	manifest.DigestAlgo = cfg.ChecksumAlgorithm
+	manifest.FinalDigest = h.Sum(nil)
 	return totalBytes, skippedBlocks, manifest, nil
 }
 
@@ -122,7 +122,7 @@ func processParallelResults(
 	}
 	header := make([]byte, headerSize)
 	var totalBytesTransferred int64
-	sha := sha256.New()
+	h := newDigestHasher(cfg.ChecksumAlgorithm)
 	manifest := &Manifest{}
 	for res := range results {
 		if res.Err != nil {
@@ -137,7 +137,7 @@ func processParallelResults(
 			return totalBytesTransferred, manifest, err
 		}
 		if res.Data != nil {
-			sha.Write(res.Data)
+			h.Write(res.Data)
 			manifest.Append(res.ChunkID, int64(res.Offset), int(res.Size))
 			saveResumeState(cfg, res.ChunkID, int64(res.Size), logger)
 			putBlockBuffer(res.Data)
@@ -148,7 +148,8 @@ func processParallelResults(
 		totalBytesTransferred += int64(res.Size)
 		reportProgress(cfg, totalBytesTransferred, totalDataSize, res.Index, startTime, logger)
 	}
-	copy(manifest.FinalSHA256[:], sha.Sum(nil))
+	manifest.DigestAlgo = cfg.ChecksumAlgorithm
+	manifest.FinalDigest = h.Sum(nil)
 	return totalBytesTransferred, manifest, nil
 }
 

--- a/transfer/digest_verification_test.go
+++ b/transfer/digest_verification_test.go
@@ -41,10 +41,13 @@ func TestIterateBlocksFinalSHA(t *testing.T) {
 	w.Close()
 	raw := bytes.Repeat([]byte{1}, int(blockSize))
 	want := sha256.Sum256(raw)
-	if manifest.FinalSHA256 != want {
+	if !bytes.Equal(manifest.FinalDigest, want[:]) {
 		t.Fatalf("sha mismatch")
 	}
 	if !manifest.Verify([][]byte{raw}) {
 		t.Fatalf("verify failed")
+	}
+	if err := manifest.VerifyDevice(src); err != nil {
+		t.Fatalf("verify device: %v", err)
 	}
 }

--- a/transfer/manifest.go
+++ b/transfer/manifest.go
@@ -1,8 +1,16 @@
 package transfer
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/zeebo/blake3"
 )
 
 // Chunk describes a block in the transfer with its BLAKE3 hash.
@@ -12,10 +20,11 @@ type Chunk struct {
 	Length int      `json:"length"`
 }
 
-// Manifest records all transferred chunks and the final SHA-256 hash.
+// Manifest records all transferred chunks and the final device digest.
 type Manifest struct {
-	Chunks      []Chunk  `json:"chunks"`
-	FinalSHA256 [32]byte `json:"final_sha256"`
+	Chunks      []Chunk `json:"chunks"`
+	FinalDigest []byte  `json:"final_digest"`
+	DigestAlgo  string  `json:"digest_algo"`
 }
 
 // Append adds a chunk entry to the manifest.
@@ -35,14 +44,65 @@ func UnmarshalManifest(b []byte) (Manifest, error) {
 	return m, err
 }
 
-// Verify recomputes the SHA-256 over the provided raw chunk data and compares
+// MissingIndices returns indices from m that are absent in peer.
+func (m *Manifest) MissingIndices(peer Manifest) []int {
+	present := make(map[[32]byte]struct{}, len(peer.Chunks))
+	for _, c := range peer.Chunks {
+		present[c.Hash] = struct{}{}
+	}
+	var missing []int
+	for i, c := range m.Chunks {
+		if _, ok := present[c.Hash]; !ok {
+			missing = append(missing, i)
+		}
+	}
+	return missing
+}
+
+func newDigestHasher(algo string) hash.Hash {
+	switch strings.ToLower(algo) {
+	case "blake3", "blake3-256":
+		return blake3.New()
+	default:
+		return sha256.New()
+	}
+}
+
+// Verify recomputes the digest over the provided raw chunk data and compares
 // it to the manifest's final digest.
 func (m *Manifest) Verify(chunks [][]byte) bool {
-	sha := sha256.New()
+	h := newDigestHasher(m.DigestAlgo)
 	for _, c := range chunks {
-		sha.Write(c)
+		h.Write(c)
 	}
-	var sum [32]byte
-	copy(sum[:], sha.Sum(nil))
-	return sum == m.FinalSHA256
+	return bytes.Equal(h.Sum(nil), m.FinalDigest)
+}
+
+// VerifyDevice computes the digest of the given device or file and compares it
+// against the manifest's final digest.
+func (m *Manifest) VerifyDevice(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open device for digest: %w", err)
+	}
+	defer f.Close()
+
+	h := newDigestHasher(m.DigestAlgo)
+	buf := make([]byte, 1<<20)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			h.Write(buf[:n])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read device: %w", err)
+		}
+	}
+	if !bytes.Equal(h.Sum(nil), m.FinalDigest) {
+		return fmt.Errorf("final checksum mismatch")
+	}
+	return nil
 }

--- a/transfer/manifest_test.go
+++ b/transfer/manifest_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/json"
 	"testing"
@@ -14,7 +15,8 @@ func TestManifestRoundTrip(t *testing.T) {
 	sum := blake3.Sum256(data)
 	m.Append(sum, 0, len(data))
 	sha := sha256.Sum256(data)
-	m.FinalSHA256 = sha
+	m.FinalDigest = sha[:]
+	m.DigestAlgo = "sha256"
 
 	b, err := m.Marshal()
 	if err != nil {
@@ -30,7 +32,7 @@ func TestManifestRoundTrip(t *testing.T) {
 	if m2.Chunks[0].Offset != 0 || m2.Chunks[0].Length != len(data) {
 		t.Fatalf("unexpected chunk values: %#v", m2.Chunks[0])
 	}
-	if m2.FinalSHA256 != sha {
+	if !bytes.Equal(m2.FinalDigest, sha[:]) {
 		t.Fatalf("final SHA mismatch")
 	}
 }
@@ -46,12 +48,35 @@ func TestManifestVerify(t *testing.T) {
 	sha := sha256.New()
 	sha.Write(data1)
 	sha.Write(data2)
-	copy(m.FinalSHA256[:], sha.Sum(nil))
+	m.FinalDigest = sha.Sum(nil)
+	m.DigestAlgo = "sha256"
 	if !m.Verify([][]byte{data1, data2}) {
 		t.Fatalf("verify failed")
 	}
 	data1[0]++
 	if m.Verify([][]byte{data1, data2}) {
 		t.Fatalf("verify should fail")
+	}
+}
+
+func TestMissingIndices(t *testing.T) {
+	var a, b Manifest
+	d1 := []byte("foo")
+	h1 := blake3.Sum256(d1)
+	a.Append(h1, 0, len(d1))
+	a.FinalDigest = []byte{1}
+	a.DigestAlgo = "sha256"
+
+	d2 := []byte("bar")
+	h2 := blake3.Sum256(d2)
+	a.Append(h2, int64(len(d1)), len(d2))
+
+	b.Append(h1, 0, len(d1))
+	b.FinalDigest = []byte{1}
+	b.DigestAlgo = "sha256"
+
+	missing := a.MissingIndices(b)
+	if len(missing) != 1 || missing[0] != 1 {
+		t.Fatalf("unexpected missing indices %v", missing)
 	}
 }

--- a/transfer/resume_checksum_test.go
+++ b/transfer/resume_checksum_test.go
@@ -1,0 +1,42 @@
+package transfer
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+)
+
+func TestResumeFinalChecksum(t *testing.T) {
+	logger := zap.NewNop()
+	blockSize := int64(1024)
+	src, snapshot, resume := createTestFiles(t, blockSize, 4)
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "sha256"}
+	ranges, err := gatherChangedRanges(snapshot, blockSize, logger)
+	if err != nil {
+		t.Fatalf("gather ranges: %v", err)
+	}
+	srcFile, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open src: %v", err)
+	}
+	defer srcFile.Close()
+	resumeDigest := readResumeDigest(cfg, logger)
+	start := findResumeIndex(cfg, srcFile, ranges, resumeDigest, logger)
+	w := bufio.NewWriter(io.Discard)
+	_, _, manifest, err := iterateBlocks(cfg, ranges[start:], srcFile, w, nil, [2]int{-1, -1}, logger)
+	if err != nil {
+		t.Fatalf("iterateBlocks: %v", err)
+	}
+	w.Flush()
+	raw1 := bytes.Repeat([]byte{3}, int(blockSize))
+	raw2 := bytes.Repeat([]byte{4}, int(blockSize))
+	if !manifest.Verify([][]byte{raw1, raw2}) {
+		t.Fatalf("verify after resume failed")
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -259,7 +259,7 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	finalizeResumeState(cfg, t.Logger)
 	if manifest != nil {
 		if t.Logger != nil {
-			t.Logger.Info("final checksum", zap.String("final_sha256", fmt.Sprintf("%x", manifest.FinalSHA256)))
+			t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", manifest.FinalDigest)))
 		}
 	}
 	if t.Logger != nil {
@@ -491,7 +491,7 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 	logParallelSummary(t.Logger, totalBytesTransferred, startTime)
 	finalizeResumeState(cfg, t.Logger)
 	if manifest != nil && t.Logger != nil {
-		t.Logger.Info("final checksum", zap.String("final_sha256", fmt.Sprintf("%x", manifest.FinalSHA256)))
+		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", manifest.FinalDigest)))
 	}
 	if t.Logger != nil {
 		_ = t.Logger.Sync()


### PR DESCRIPTION
## Summary
- add manifest helpers to compute missing indices and verify device digests
- compute final digests using configurable algorithms
- cover resume scenarios with checksum verification tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/grpcd/main_test.go:175: expected ';', found '{')*
- `go test -coverprofile=coverage.out ./transfer/...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689bb2392d148323bd36663ceeafaa98