### PR TITLE
feat(transport): log lifecycle and add env precedence tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Transports are pluggable and selected in order using the `--transport` flag. LVM
 | `--quic_listen` | `LVMSYNC_QUIC_LISTEN` | QUIC listen address |
 | `--quic_connect` | `LVMSYNC_QUIC_CONNECT` | QUIC connect address |
 | `--quic_cc` | `LVMSYNC_QUIC_CC` | QUIC congestion control algorithm |
+| `--concurrency` | `LVMSYNC_CONCURRENCY` | Stream concurrency (0 to autotune based on BDP) |
 | `--h2_port` | `LVMSYNC_H2_PORT` | HTTP/2 TLS port |
 | `--tcp_port` | `LVMSYNC_TCP_PORT` | TCP+TLS port |
 | `--ssh_port` | `LVMSYNC_SSH_PORT` | SSH port |

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -170,6 +170,9 @@ func TestMainLogsErrorAndExits(t *testing.T) {
 		}
 	}()
 
+	main()
+}
+
 type fakeListener struct{}
 
 func (fakeListener) Accept() (net.Conn, error) { return nil, errors.New("not implemented") }

--- a/config/config.go
+++ b/config/config.go
@@ -644,7 +644,20 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.SetEnvPrefix("LVMSYNC")
 	v.AutomaticEnv()
-
+	keys := []string{
+		"transport",
+		"quic_listen",
+		"quic_connect",
+		"quic_cc",
+		"concurrency",
+		"tcp_port",
+		"h2_port",
+	}
+	for _, k := range keys {
+		if err := v.BindEnv(k); err != nil {
+			return nil, err
+		}
+	}
 	for _, fs := range flagSets.All() {
 		if err := v.BindPFlags(fs); err != nil {
 			return nil, err

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -224,3 +224,111 @@ func TestSSHHostEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("expected ssh_host env, got %s", conf.SSHHost)
 	}
 }
+
+func TestTransportCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "transport: quic\n")
+	resetFlags([]string{"--config", cfgPath, "--transport", "h2"})
+	t.Setenv("LVMSYNC_TRANSPORT", "tcp+tls")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
+	pflag.Parse()
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.Transport != "h2" {
+		t.Fatalf("expected transport h2, got %s", conf.Transport)
+	}
+}
+
+func TestTransportEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "transport: quic\n")
+	resetFlags([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_TRANSPORT", "tcp+tls")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
+	pflag.Parse()
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.Transport != "tcp+tls" {
+		t.Fatalf("expected transport tcp+tls, got %s", conf.Transport)
+	}
+}
+
+func TestConcurrencyCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "concurrency: 1\n")
+	resetFlags([]string{"--config", cfgPath, "--concurrency", "3"})
+	t.Setenv("LVMSYNC_CONCURRENCY", "2")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
+	pflag.Parse()
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.Concurrency != 3 {
+		t.Fatalf("expected concurrency 3, got %d", conf.Concurrency)
+	}
+}
+
+func TestConcurrencyEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "concurrency: 1\n")
+	resetFlags([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_CONCURRENCY", "2")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs)
+	pflag.Parse()
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.Concurrency != 2 {
+		t.Fatalf("expected concurrency 2, got %d", conf.Concurrency)
+	}
+}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -46,17 +46,26 @@ func Get(name string) (Factory, bool) {
 }
 
 // Select returns the first transport in order that initializes successfully.
+// It logs lifecycle events for each attempt.
 func Select(cfg *config.Config, order []string, logger *zap.Logger) (Sender, Receiver, string, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	for _, name := range order {
+		logger.Info("initializing transport", zap.String("transport", name))
 		f, ok := Get(name)
 		if !ok {
+			logger.Warn("transport not registered", zap.String("transport", name))
 			continue
 		}
 		s, r, err := f(cfg, logger)
 		if err == nil {
+			logger.Info("transport initialized", zap.String("transport", name))
 			return s, r, name, nil
 		}
+		logger.Warn("transport init failed", zap.String("transport", name), zap.Error(err))
 	}
+	logger.Error("no working transport", zap.Strings("transports", order))
 	return nil, nil, "", fmt.Errorf("no working transport")
 }
 


### PR DESCRIPTION
## Summary
- log transport initialization and failure using zap
- bind transport flags to viper env vars
- cover transport flag precedence

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689bb23fd0f08323a21f36da0ebd4394