### PR TITLE
feat(compression): add NEON detection and zstd auto levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Parallel Execution**: Configurable concurrency for optimal performance.
 - **Adaptive Transport Concurrency**: Maintains ~1–2×BDP of in-flight data and can be overridden with `--concurrency`.
 - **Rate-Limiting**: Control bandwidth usage during transfers.
-- **Compression**: Samples 8 KiB per chunk, skipping compression when the ratio exceeds a threshold. Auto mode selects LZ4 for chunks <256 KiB and Zstd level 1 for larger chunks on AVX2-capable CPUs.
+- **Compression**: Samples 8 KiB per chunk, skipping compression when the ratio exceeds a threshold. Auto mode selects LZ4 for chunks <256 KiB and Zstd levels 1–3 for larger chunks on AVX2 or NEON hosts; otherwise LZ4.
 - **Checksum Verification**: Ensures data integrity using SHA-256 or BLAKE3.
 - **Native LVM2 Integration**: Uses Go bindings to `liblvm2cmd` instead of shelling out.
 - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or a Bloom filter with optional FastCDC content-defined chunking and mmap-backed index.
@@ -1013,8 +1013,9 @@ LVMSync automatically reloads this state file on startup. Delete it to reset ded
 
 LVMSync samples 8 KiB from each chunk to gauge compression efficiency. If the
 compressed sample ratio is greater than or equal to `--compress_threshold`, the
-chunk is sent uncompressed. In `auto` mode, chunks smaller than 256 KiB use LZ4
-and larger ones select Zstd level 1 when AVX2 is available.
+chunk is sent uncompressed. In `auto` mode, chunks smaller than 256 KiB use LZ4,
+and larger ones select Zstd (levels 1–3) when AVX2 or NEON is available;
+otherwise LZ4.
 Levels can be tuned with `--zstd_level` (1-5) or `--lz4_level` (`fast` or `hc`).
 
 CLI:

--- a/internal/compressiondetect/compressiondetect.go
+++ b/internal/compressiondetect/compressiondetect.go
@@ -39,7 +39,7 @@ func DetectOptimalCompression() string {
 			cacheSize += cpuid.CPU.Cache.L2
 		}
 
-		if cpu.X86.HasAVX512F || cpu.X86.HasAVX2 || cpu.X86.HasBMI2 || cpu.X86.HasSSE42 || (cores >= 4 && cacheSize >= 2<<20) {
+		if cpu.X86.HasAVX512F || cpu.X86.HasAVX2 || cpu.X86.HasBMI2 || cpu.X86.HasSSE42 || cpu.ARM64.HasASIMD || cpu.ARM.HasNEON || (cores >= 4 && cacheSize >= 2<<20) {
 			detected = "zstd"
 		} else {
 			detected = benchmarkCached(cores, cacheSize)
@@ -151,4 +151,9 @@ func ResetForTest() {
 // HasAVX2 reports whether the current CPU supports AVX2 instructions.
 func HasAVX2() bool {
 	return cpu.X86.HasAVX2
+}
+
+// HasNEON reports whether the current CPU supports ARM NEON instructions.
+func HasNEON() bool {
+	return cpu.ARM64.HasASIMD || cpu.ARM.HasNEON
 }

--- a/internal/compressiondetect/compressiondetect_test.go
+++ b/internal/compressiondetect/compressiondetect_test.go
@@ -33,3 +33,7 @@ func TestResetForTest(t *testing.T) {
 func TestHasAVX2(t *testing.T) {
 	_ = HasAVX2()
 }
+
+func TestHasNEON(t *testing.T) {
+	_ = HasNEON()
+}

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -21,6 +21,10 @@ const (
 // a variable to allow tests to override the detection behavior.
 var hasAVX2 = compressiondetect.HasAVX2
 
+// hasNEON reports whether the current CPU supports NEON instructions. It is
+// a variable to allow tests to override the detection behavior.
+var hasNEON = compressiondetect.HasNEON
+
 // No shared state is kept between decompression readers.
 
 // NewCompressionWriter creates a compression writer that wraps the destination
@@ -66,6 +70,7 @@ const (
 	sampleSize    = 8 * 1024
 	lz4MaxChunk   = 256 * 1024
 	defaultZstdLv = 1
+	maxAutoZstdLv = 3
 )
 
 // selectAlgorithm chooses a compression algorithm and level based on the
@@ -78,8 +83,13 @@ func selectAlgorithm(chunkLen int, compress string, level int) (string, int) {
 			}
 			return compressionLZ4, level
 		}
-		if hasAVX2() {
-			return compressionZSTD, defaultZstdLv
+		if hasAVX2() || hasNEON() {
+			if level <= 0 {
+				level = defaultZstdLv
+			} else if level > maxAutoZstdLv {
+				level = maxAutoZstdLv
+			}
+			return compressionZSTD, level
 		}
 		if level == 0 {
 			level = int(lz4.Level1)

--- a/transfer/compression_test.go
+++ b/transfer/compression_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"testing"
 
@@ -172,8 +173,12 @@ func TestCompressChunkThreshold(t *testing.T) {
 // TestCompressChunkAutoSelects verifies that automatic compression selects the
 // expected algorithm based on chunk size and CPU capabilities.
 func TestCompressChunkAutoSelects(t *testing.T) {
-	orig := hasAVX2
-	defer func() { hasAVX2 = orig }()
+	origAVX2 := hasAVX2
+	origNEON := hasNEON
+	defer func() {
+		hasAVX2 = origAVX2
+		hasNEON = origNEON
+	}()
 
 	small := bytes.Repeat([]byte("a"), 64*1024)
 	large := bytes.Repeat([]byte("a"), 300*1024)
@@ -182,16 +187,19 @@ func TestCompressChunkAutoSelects(t *testing.T) {
 		name   string
 		data   []byte
 		avx2   bool
+		neon   bool
 		expect string
 	}{
-		{"smallAvx2", small, true, compressionLZ4},
-		{"largeAvx2", large, true, compressionZSTD},
-		{"largeNoAvx2", large, false, compressionLZ4},
+		{"smallAvx2", small, true, false, compressionLZ4},
+		{"largeAvx2", large, true, false, compressionZSTD},
+		{"largeNeon", large, false, true, compressionZSTD},
+		{"largeNoAccel", large, false, false, compressionLZ4},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			hasAVX2 = func() bool { return tc.avx2 }
+			hasNEON = func() bool { return tc.neon }
 			_, algo, err := CompressChunk(tc.data, StrategyAuto, 0, 1, 1.0)
 			if err != nil {
 				t.Fatalf("compress chunk: %v", err)
@@ -200,6 +208,27 @@ func TestCompressChunkAutoSelects(t *testing.T) {
 				t.Fatalf("expected %s, got %s", tc.expect, algo)
 			}
 		})
+	}
+}
+
+func TestSelectAlgorithmZstdLevelClamp(t *testing.T) {
+	origAVX2 := hasAVX2
+	origNEON := hasNEON
+	defer func() {
+		hasAVX2 = origAVX2
+		hasNEON = origNEON
+	}()
+
+	hasAVX2 = func() bool { return true }
+	hasNEON = func() bool { return false }
+
+	_, lvl := selectAlgorithm(300*1024, StrategyAuto, 5)
+	if lvl != maxAutoZstdLv {
+		t.Fatalf("expected level %d, got %d", maxAutoZstdLv, lvl)
+	}
+	_, lvl = selectAlgorithm(300*1024, StrategyAuto, 0)
+	if lvl != defaultZstdLv {
+		t.Fatalf("expected default level %d, got %d", defaultZstdLv, lvl)
 	}
 }
 
@@ -335,6 +364,25 @@ func BenchmarkCompressChunk(b *testing.B) {
 				if _, _, err := CompressChunk(data, algo, 0, 1, 0.9); err != nil {
 					b.Fatalf("compress chunk: %v", err)
 				}
+			}
+		})
+	}
+}
+
+func BenchmarkSelectAlgorithm(b *testing.B) {
+	origAVX2 := hasAVX2
+	origNEON := hasNEON
+	defer func() {
+		hasAVX2 = origAVX2
+		hasNEON = origNEON
+	}()
+
+	for _, sz := range []int{64 * 1024, 300 * 1024} {
+		b.Run(fmt.Sprintf("size_%d", sz), func(b *testing.B) {
+			hasAVX2 = func() bool { return true }
+			hasNEON = func() bool { return false }
+			for i := 0; i < b.N; i++ {
+				selectAlgorithm(sz, StrategyAuto, 0)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- detect NEON support alongside AVX2 for compression decisions
- clamp auto zstd levels to 1-3 and favor zstd on accelerated CPUs
- document and test compression sampling and selection logic

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out $(go list ./... | grep -v cmd/grpcd)`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689bb22931fc8323819fc48633fabaf5