### PR TITLE
feat(quic): add multi-stream control with BDP tuning

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -29,7 +29,7 @@ var acceptFunc = func(ctx context.Context, cfg *config.Config) (io.ReadWriteClos
 
 	listenCtx, listenCancel := context.WithTimeout(ctx, cfg.ServeAcceptTimeout)
 	defer listenCancel()
-	l, err := q.ListenAddr(cfg.ServeListen, tlsConf, qn.NewQUICConfig())
+	l, err := q.ListenAddr(cfg.ServeListen, tlsConf, qn.NewQUICConfig(0))
 	if err != nil {
 		return nil, err
 	}

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -4,7 +4,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math"
 	"os"
+
+	"golang.org/x/sys/cpu"
 
 	q "github.com/quic-go/quic-go"
 )
@@ -16,12 +19,30 @@ type Config struct {
 	AllowInsecure bool
 }
 
+// cipherSuites selects AES-GCM when hardware acceleration is available and
+// falls back to ChaCha20 otherwise.
+func cipherSuites() []uint16 {
+	aes := cpu.X86.HasAES || cpu.ARM64.HasAES
+	if aes {
+		return []uint16{
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+		}
+	}
+	return []uint16{
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+		tls.TLS_AES_128_GCM_SHA256,
+	}
+}
+
 func NewTLSConfig(conf Config, server bool) (*tls.Config, error) {
 	if conf.AllowInsecure {
 		return &tls.Config{
 			InsecureSkipVerify: true,
 			MinVersion:         tls.VersionTLS13,
 			MaxVersion:         tls.VersionTLS13,
+			NextProtos:         []string{"lvmsync"},
+			CipherSuites:       cipherSuites(),
 		}, nil
 	}
 	cert, err := tls.LoadX509KeyPair(conf.TLSCert, conf.TLSKey)
@@ -40,6 +61,8 @@ func NewTLSConfig(conf Config, server bool) (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS13,
 		MaxVersion:   tls.VersionTLS13,
+		NextProtos:   []string{"lvmsync"},
+		CipherSuites: cipherSuites(),
 	}
 	if server {
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
@@ -50,6 +73,19 @@ func NewTLSConfig(conf Config, server bool) (*tls.Config, error) {
 	return cfg, nil
 }
 
-func NewQUICConfig() *q.Config {
-	return &q.Config{Allow0RTT: false}
+// NewQUICConfig returns a quic-go configuration tuned for the provided BDP
+// (in bytes). It configures flow control windows and stream counts to keep
+// roughly one BDP of data in flight.
+func NewQUICConfig(bdpBytes int64) *q.Config {
+	cfg := &q.Config{Allow0RTT: false}
+	if bdpBytes <= 0 {
+		return cfg
+	}
+	streams := int64(math.Max(1, float64(bdpBytes)/(64*1024)))
+	window := uint64(bdpBytes * 2)
+	cfg.MaxIncomingStreams = streams
+	cfg.MaxIncomingUniStreams = 1
+	cfg.MaxStreamReceiveWindow = window
+	cfg.MaxConnectionReceiveWindow = window * uint64(streams)
+	return cfg
 }

--- a/quic/quic_test.go
+++ b/quic/quic_test.go
@@ -25,8 +25,12 @@ func TestNewTLSConfigMissingCert(t *testing.T) {
 }
 
 func TestNewQUICConfig(t *testing.T) {
-	qc := NewQUICConfig()
+	qc := NewQUICConfig(0)
 	if qc.Allow0RTT {
 		t.Fatalf("0-RTT should be disabled")
+	}
+	tuned := NewQUICConfig(128 * 1024)
+	if tuned.MaxIncomingStreams == 0 || tuned.MaxStreamReceiveWindow == 0 {
+		t.Fatalf("expected tuning to set windows and streams")
 	}
 }

--- a/quic/streams.go
+++ b/quic/streams.go
@@ -1,0 +1,35 @@
+package quic
+
+import (
+	"context"
+
+	q "github.com/quic-go/quic-go"
+)
+
+// StreamSet holds the control stream and a set of data streams.
+type StreamSet struct {
+	Control q.SendStream
+	Data    []q.Stream
+}
+
+// OpenStreams opens a control stream for manifest/bitmap/acks and n
+// bidirectional data streams for chunk transfer.
+func OpenStreams(ctx context.Context, conn q.Connection, n int) (*StreamSet, error) {
+	ctrl, err := conn.OpenUniStreamSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ss := &StreamSet{Control: ctrl}
+	for i := 0; i < n; i++ {
+		s, err := conn.OpenStreamSync(ctx)
+		if err != nil {
+			_ = ctrl.Close()
+			for _, ds := range ss.Data {
+				_ = ds.Close()
+			}
+			return nil, err
+		}
+		ss.Data = append(ss.Data, s)
+	}
+	return ss, nil
+}

--- a/quic/streams_test.go
+++ b/quic/streams_test.go
@@ -1,0 +1,224 @@
+package quic
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	q "github.com/quic-go/quic-go"
+)
+
+// generateCert creates a self-signed certificate for tests.
+func generateCert(t *testing.T) (certFile, keyFile, caFile string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	certFile = writeTemp(t, certPEM)
+	keyFile = writeTemp(t, keyPEM)
+	caFile = certFile
+	return
+}
+
+func writeTemp(t *testing.T, b []byte) string {
+	f, err := os.CreateTemp(t.TempDir(), "cert")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	if _, err := f.Write(b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return f.Name()
+}
+
+func TestQUICHandshake(t *testing.T) {
+	cert, key, ca := generateCert(t)
+	serverTLS, err := NewTLSConfig(Config{TLSCert: cert, TLSKey: key, CACert: ca}, true)
+	if err != nil {
+		t.Fatalf("server tls: %v", err)
+	}
+	clientTLS, err := NewTLSConfig(Config{TLSCert: cert, TLSKey: key, CACert: ca}, false)
+	if err != nil {
+		t.Fatalf("client tls: %v", err)
+	}
+	qc := NewQUICConfig(128 * 1024)
+	listener, err := q.ListenAddr("127.0.0.1:0", serverTLS, qc)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	expected := Negotiation{Protocol: "p", Algorithm: "a"}
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept(context.Background())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		stream, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- Negotiate(stream, expected)
+	}()
+
+	conn, err := q.DialAddr(context.Background(), listener.Addr().String(), clientTLS, qc)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	stream, err := conn.OpenStreamSync(context.Background())
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if err := WriteNegotiation(stream, expected); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	if _, err := ReadNegotiation(bufio.NewReader(stream)); err != nil {
+		t.Fatalf("read negotiation: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("negotiate: %v", err)
+	}
+}
+
+func TestQUICChunkTransfer(t *testing.T) {
+	cert, key, ca := generateCert(t)
+	serverTLS, err := NewTLSConfig(Config{TLSCert: cert, TLSKey: key, CACert: ca}, true)
+	if err != nil {
+		t.Fatalf("server tls: %v", err)
+	}
+	clientTLS, err := NewTLSConfig(Config{TLSCert: cert, TLSKey: key, CACert: ca}, false)
+	if err != nil {
+		t.Fatalf("client tls: %v", err)
+	}
+	qc := NewQUICConfig(256 * 1024)
+	listener, err := q.ListenAddr("127.0.0.1:0", serverTLS, qc)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	expected := Negotiation{Protocol: "p"}
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept(context.Background())
+		if err != nil {
+			done <- err
+			return
+		}
+		hs, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			done <- err
+			return
+		}
+		if err := Negotiate(hs, expected); err != nil {
+			done <- err
+			return
+		}
+		ctrl, err := conn.AcceptUniStream(context.Background())
+		if err != nil {
+			done <- err
+			return
+		}
+		manifest, err := io.ReadAll(ctrl)
+		if err != nil {
+			done <- err
+			return
+		}
+		if string(manifest) != "manifest" {
+			done <- fmt.Errorf("bad manifest: %s", manifest)
+			return
+		}
+		data1, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			done <- err
+			return
+		}
+		b1, err := io.ReadAll(data1)
+		if err != nil {
+			done <- err
+			return
+		}
+		data2, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			done <- err
+			return
+		}
+		b2, err := io.ReadAll(data2)
+		if err != nil {
+			done <- err
+			return
+		}
+		if string(b1) != "chunk1" || string(b2) != "chunk2" {
+			done <- fmt.Errorf("unexpected chunks")
+			return
+		}
+		done <- nil
+	}()
+
+	conn, err := q.DialAddr(context.Background(), listener.Addr().String(), clientTLS, qc)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	hs, err := conn.OpenStreamSync(context.Background())
+	if err != nil {
+		t.Fatalf("handshake stream: %v", err)
+	}
+	if err := WriteNegotiation(hs, expected); err != nil {
+		t.Fatalf("write negotiation: %v", err)
+	}
+	if _, err := ReadNegotiation(bufio.NewReader(hs)); err != nil {
+		t.Fatalf("read negotiation: %v", err)
+	}
+	ss, err := OpenStreams(context.Background(), conn, 2)
+	if err != nil {
+		t.Fatalf("open streams: %v", err)
+	}
+	if _, err := ss.Control.Write([]byte("manifest")); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	_ = ss.Control.Close()
+	if _, err := ss.Data[0].Write([]byte("chunk1")); err != nil {
+		t.Fatalf("write chunk1: %v", err)
+	}
+	_ = ss.Data[0].Close()
+	if _, err := ss.Data[1].Write([]byte("chunk2")); err != nil {
+		t.Fatalf("write chunk2: %v", err)
+	}
+	_ = ss.Data[1].Close()
+	if err := <-done; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- select AES-GCM vs ChaCha20 based on CPU features
- tune QUIC flow control and stream counts to bandwidth delay product
- open dedicated control and data streams with handshake and chunk transfer tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/grpcd/main_test.go syntax error)*
- `go list ./... | grep -v cmd/grpcd | grep -v cmd/dump | xargs go test -coverprofile=coverage.out`
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689bb205b6108323ba05e59df99f4d71