### PR TITLE
feat: introduce transport interface and frame codec

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -288,7 +288,7 @@ func SelectTransport(cfg *config.Config, logger *zap.Logger) error {
 		return nil
 	}
 	order := strings.Split(cfg.Transport, ",")
-	_, _, name, err := transport.Select(cfg, order, logger)
+	_, name, err := transport.Select(cfg, order, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/transport/fake.go
+++ b/internal/transport/fake.go
@@ -1,0 +1,49 @@
+package transport
+
+import "context"
+
+// Fake is a test transport that records sent chunks and optionally returns a bitmap.
+type Fake struct {
+	OpenErr  error
+	Chunks   []Frame
+	Bitmap   []byte
+	FlushErr error
+	CloseErr error
+}
+
+// Open implements Transport.
+func (f *Fake) Open(ctx context.Context) error {
+	if f.OpenErr != nil {
+		return f.OpenErr
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}
+
+// SendChunk implements Transport.
+func (f *Fake) SendChunk(index uint64, flags uint16, hash []byte, payload []byte) error {
+	f.Chunks = append(f.Chunks, Frame{Index: index, Flags: flags, Hash: append([]byte(nil), hash...), Payload: append([]byte(nil), payload...)})
+	return nil
+}
+
+// RecvBitmap implements Transport.
+func (f *Fake) RecvBitmap(ctx context.Context) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return f.Bitmap, nil
+	}
+}
+
+// Flush implements Transport.
+func (f *Fake) Flush() error { return f.FlushErr }
+
+// Close implements Transport.
+func (f *Fake) Close() error { return f.CloseErr }
+
+var _ Transport = (*Fake)(nil)

--- a/internal/transport/frame.go
+++ b/internal/transport/frame.go
@@ -1,0 +1,102 @@
+package transport
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// Frame flags.
+const (
+	// FlagHasHash indicates the frame includes a valid hash field.
+	FlagHasHash uint16 = 1 << iota
+	// FlagZero denotes a chunk of zero bytes with no payload.
+	FlagZero
+)
+
+const (
+	indexSize  = 8
+	flagSize   = 2
+	hashSize   = 32
+	lengthSize = 4
+	headerSize = indexSize + flagSize + hashSize + lengthSize
+)
+
+// EncodeFrame writes a frame to w using the generic layout
+// index|flags|hash|length|payload.
+func EncodeFrame(w io.Writer, index uint64, flags uint16, hash []byte, payload []byte) error {
+	var header [headerSize]byte
+	binary.BigEndian.PutUint64(header[0:8], index)
+	binary.BigEndian.PutUint16(header[8:10], flags)
+	if len(hash) > hashSize {
+		return fmt.Errorf("hash too large: %d", len(hash))
+	}
+	copy(header[10:42], hash)
+	binary.BigEndian.PutUint32(header[42:46], uint32(len(payload)))
+	if _, err := w.Write(header[:]); err != nil {
+		return fmt.Errorf("write frame header: %w", err)
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("write frame payload: %w", err)
+	}
+	return nil
+}
+
+// DecodeFrame reads a frame from r using the generic layout
+// index|flags|hash|length|payload.
+func DecodeFrame(r io.Reader) (index uint64, flags uint16, hash []byte, payload []byte, err error) {
+	var header [headerSize]byte
+	if _, err = io.ReadFull(r, header[:]); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			err = io.EOF
+		} else {
+			err = fmt.Errorf("read frame header: %w", err)
+		}
+		return
+	}
+	index = binary.BigEndian.Uint64(header[0:8])
+	flags = binary.BigEndian.Uint16(header[8:10])
+	if flags&FlagHasHash != 0 {
+		hash = make([]byte, hashSize)
+		copy(hash, header[10:42])
+	}
+	size := binary.BigEndian.Uint32(header[42:46])
+	if size > 0 {
+		payload = make([]byte, size)
+		if _, err = io.ReadFull(r, payload); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				err = io.EOF
+			} else {
+				err = fmt.Errorf("read frame payload: %w", err)
+			}
+			return
+		}
+	}
+	return
+}
+
+// Frame represents a decoded frame for convenience in tests.
+type Frame struct {
+	Index   uint64
+	Flags   uint16
+	Hash    []byte
+	Payload []byte
+}
+
+// WriteTo encodes the frame to w.
+func (f *Frame) WriteTo(w io.Writer) error {
+	return EncodeFrame(w, f.Index, f.Flags, f.Hash, f.Payload)
+}
+
+// ReadFrame reads a frame from r into f.
+func (f *Frame) ReadFrame(r io.Reader) error {
+	idx, fl, h, p, err := DecodeFrame(r)
+	if err != nil {
+		return err
+	}
+	f.Index, f.Flags, f.Hash, f.Payload = idx, fl, h, p
+	return nil
+}

--- a/internal/transport/frame_test.go
+++ b/internal/transport/frame_test.go
@@ -1,0 +1,29 @@
+package transport
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFrameEncodeDecode(t *testing.T) {
+	f := Frame{Index: 1, Flags: FlagHasHash, Hash: bytes.Repeat([]byte{0xab}, 32), Payload: []byte("data")}
+	var buf bytes.Buffer
+	if err := f.WriteTo(&buf); err != nil {
+		t.Fatalf("encode frame: %v", err)
+	}
+	var out Frame
+	if err := out.ReadFrame(&buf); err != nil {
+		t.Fatalf("decode frame: %v", err)
+	}
+	if out.Index != f.Index || out.Flags != f.Flags || !bytes.Equal(out.Hash, f.Hash) || !bytes.Equal(out.Payload, f.Payload) {
+		t.Fatalf("roundtrip mismatch")
+	}
+}
+
+func TestEncodeFrameHashTooLarge(t *testing.T) {
+	var buf bytes.Buffer
+	hash := bytes.Repeat([]byte{1}, 33)
+	if err := EncodeFrame(&buf, 0, 0, hash, nil); err == nil {
+		t.Fatalf("expected error for large hash")
+	}
+}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"sync"
 
@@ -12,18 +11,19 @@ import (
 	"lvmsync_go/config"
 )
 
-// Sender pushes data to a remote peer.
-type Sender interface {
-	Send(ctx context.Context, r io.Reader) error
+// Transport defines the common data-plane operations used by LVMSync
+// transports. Implementations may stream chunks to a remote peer and
+// receive bitmap responses.
+type Transport interface {
+	Open(ctx context.Context) error
+	SendChunk(index uint64, flags uint16, hash []byte, payload []byte) error
+	RecvBitmap(ctx context.Context) ([]byte, error)
+	Flush() error
+	Close() error
 }
 
-// Receiver accepts data from a remote peer.
-type Receiver interface {
-	Receive(ctx context.Context, w io.Writer) error
-}
-
-// Factory constructs a sender/receiver pair using the provided configuration and logger.
-type Factory func(cfg *config.Config, logger *zap.Logger) (Sender, Receiver, error)
+// Factory constructs a transport using the provided configuration and logger.
+type Factory func(cfg *config.Config, logger *zap.Logger) (Transport, error)
 
 var (
 	mu       sync.RWMutex
@@ -46,50 +46,54 @@ func Get(name string) (Factory, bool) {
 }
 
 // Select returns the first transport in order that initializes successfully.
-func Select(cfg *config.Config, order []string, logger *zap.Logger) (Sender, Receiver, string, error) {
+func Select(cfg *config.Config, order []string, logger *zap.Logger) (Transport, string, error) {
 	for _, name := range order {
 		f, ok := Get(name)
 		if !ok {
 			continue
 		}
-		s, r, err := f(cfg, logger)
+		t, err := f(cfg, logger)
 		if err == nil {
-			return s, r, name, nil
+			return t, name, nil
 		}
 	}
-	return nil, nil, "", fmt.Errorf("no working transport")
+	return nil, "", fmt.Errorf("no working transport")
 }
 
-// NopSender is a no-op sender implementation used by placeholder transports.
-type NopSender struct{}
+// NopTransport is a no-op implementation used by placeholder transports and tests.
+type NopTransport struct{}
 
-// Send implements the Sender interface.
-func (NopSender) Send(ctx context.Context, r io.Reader) error {
+// Open implements Transport.
+func (NopTransport) Open(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
-	}
-	if r == nil {
 		return nil
 	}
-	_, err := io.Copy(io.Discard, r)
-	return err
 }
 
-// NopReceiver is a no-op receiver implementation used by placeholder transports.
-type NopReceiver struct{}
+// SendChunk implements Transport.
+func (NopTransport) SendChunk(index uint64, flags uint16, hash []byte, payload []byte) error {
+	_ = index
+	_ = flags
+	_ = hash
+	_ = payload
+	return nil
+}
 
-// Receive implements the Receiver interface.
-func (NopReceiver) Receive(ctx context.Context, w io.Writer) error {
+// RecvBitmap implements Transport.
+func (NopTransport) RecvBitmap(ctx context.Context) ([]byte, error) {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	default:
+		return nil, nil
 	}
-	if w == nil {
-		return nil
-	}
-	_, err := w.Write(nil)
-	return err
 }
+
+// Flush implements Transport.
+func (NopTransport) Flush() error { return nil }
+
+// Close implements Transport.
+func (NopTransport) Close() error { return nil }

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRegistryLookup(t *testing.T) {
-	factory := func(*config.Config, *zap.Logger) (Sender, Receiver, error) { return NopSender{}, NopReceiver{}, nil }
+	factory := func(*config.Config, *zap.Logger) (Transport, error) { return NopTransport{}, nil }
 	Register("test", factory)
 	got, ok := Get("test")
 	if !ok {
@@ -22,8 +22,8 @@ func TestRegistryLookup(t *testing.T) {
 }
 
 func TestSelectOrder(t *testing.T) {
-	fail := func(*config.Config, *zap.Logger) (Sender, Receiver, error) { return nil, nil, errors.New("fail") }
-	ok := func(*config.Config, *zap.Logger) (Sender, Receiver, error) { return NopSender{}, NopReceiver{}, nil }
+	fail := func(*config.Config, *zap.Logger) (Transport, error) { return nil, errors.New("fail") }
+	ok := func(*config.Config, *zap.Logger) (Transport, error) { return NopTransport{}, nil }
 
 	tests := []struct {
 		name    string
@@ -47,7 +47,7 @@ func TestSelectOrder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			Register("fail", fail)
 			Register("ok", ok)
-			_, _, name, err := Select(&config.Config{}, tt.order, zap.NewNop())
+			_, name, err := Select(&config.Config{}, tt.order, zap.NewNop())
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")


### PR DESCRIPTION
## Summary
- add transport.Transport interface with chunk APIs
- factor out reusable frame encoding helpers
- provide fake transport for tests and update selection logic

## Testing
- `go test ./internal/transport -run TestFrameEncodeDecode -count=1`
- `go test ./...` *(fails: cmd/grpcd/main_test.go:175:48: expected ';', found '{')*


------
https://chatgpt.com/codex/tasks/task_e_689bb1fa4be08323b960f96843f74322