### PR TITLE
feat: add HTTP/2 resumable transfers

### DIFF
--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -170,6 +170,9 @@ func TestMainLogsErrorAndExits(t *testing.T) {
 		}
 	}()
 
+	main()
+}
+
 type fakeListener struct{}
 
 func (fakeListener) Accept() (net.Conn, error) { return nil, errors.New("not implemented") }

--- a/h2/server.go
+++ b/h2/server.go
@@ -1,0 +1,162 @@
+package h2
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// Server handles HTTP/2 transfers with resumable session state.
+type Server struct {
+	mu       sync.Mutex
+	sessions map[string]*Session
+	logger   *zap.Logger
+}
+
+// NewServer creates an in-memory HTTP/2 server.
+func NewServer(logger *zap.Logger) *Server {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Server{sessions: make(map[string]*Session), logger: logger}
+}
+
+// Handler returns an http.Handler implementing upload, download and bitmap endpoints.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/upload/", s.handleUpload)
+	mux.HandleFunc("/download/", s.handleDownload)
+	mux.HandleFunc("/bitmap/", s.handleBitmap)
+	return mux
+}
+
+func (s *Server) getSession(id string, total, chunkSize int) *Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		sess = newSession(id, total, chunkSize)
+		s.sessions[id] = sess
+	}
+	return sess
+}
+
+func parseContentRange(h string) (start, end, total int, err error) {
+	// format: bytes start-end/total
+	if !strings.HasPrefix(h, "bytes ") {
+		return 0, 0, 0, fmt.Errorf("invalid content-range")
+	}
+	parts := strings.Split(strings.TrimPrefix(h, "bytes "), "/")
+	if len(parts) != 2 {
+		return 0, 0, 0, fmt.Errorf("invalid content-range")
+	}
+	rng := strings.Split(parts[0], "-")
+	if len(rng) != 2 {
+		return 0, 0, 0, fmt.Errorf("invalid content-range")
+	}
+	start, err = strconv.Atoi(rng[0])
+	if err != nil {
+		return
+	}
+	end, err = strconv.Atoi(rng[1])
+	if err != nil {
+		return
+	}
+	total, err = strconv.Atoi(parts[1])
+	return
+}
+
+func parseRange(h string) (start, end int, err error) {
+	// format: bytes=start-end
+	if !strings.HasPrefix(h, "bytes=") {
+		return 0, 0, fmt.Errorf("invalid range")
+	}
+	parts := strings.Split(strings.TrimPrefix(h, "bytes="), "-")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid range")
+	}
+	start, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return
+	}
+	end, err = strconv.Atoi(parts[1])
+	return
+}
+
+func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/upload/")
+	cr := r.Header.Get("Content-Range")
+	start, end, total, err := parseContentRange(cr)
+	if err != nil {
+		s.logger.Warn("invalid_content_range", zap.String("session_id", id), zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.logger.Error("read_body", zap.String("session_id", id), zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	sess := s.getSession(id, total, end-start+1)
+	if err := sess.Upload(start, end, b); err != nil {
+		s.logger.Warn("upload_failed", zap.String("session_id", id), zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.logger.Info("chunk_uploaded", zap.String("session_id", id), zap.Int("start", start), zap.Int("end", end))
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/download/")
+	ra := r.Header.Get("Range")
+	start, end, err := parseRange(ra)
+	if err != nil {
+		s.logger.Warn("invalid_range", zap.String("session_id", id), zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	sess := s.sessions[id]
+	s.mu.Unlock()
+	if sess == nil {
+		s.logger.Warn("session_not_found", zap.String("session_id", id))
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	data, err := sess.Download(start, end)
+	if err != nil {
+		s.logger.Warn("download_failed", zap.String("session_id", id), zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, sess.size))
+	w.WriteHeader(http.StatusPartialContent)
+	if _, err := w.Write(data); err != nil {
+		s.logger.Error("write_body", zap.String("session_id", id), zap.Error(err))
+	}
+}
+
+func (s *Server) handleBitmap(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/bitmap/")
+	s.mu.Lock()
+	sess := s.sessions[id]
+	s.mu.Unlock()
+	if sess == nil {
+		s.logger.Warn("session_not_found", zap.String("session_id", id))
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	bm := sess.Bitmap()
+	w.Header().Set("Content-Length", strconv.Itoa(len(bm)))
+	if _, err := w.Write(bm); err != nil {
+		s.logger.Error("write_bitmap", zap.String("session_id", id), zap.Error(err))
+	}
+}

--- a/h2/server_test.go
+++ b/h2/server_test.go
@@ -1,0 +1,112 @@
+package h2
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+)
+
+func TestUploadDownload(t *testing.T) {
+	logger := zap.NewNop()
+	defer logger.Sync()
+	srv := NewServer(logger)
+	ts := httptest.NewUnstartedServer(srv.Handler())
+	http2.ConfigureServer(ts.Config, &http2.Server{})
+	ts.TLS = ts.Config.TLSConfig
+	ts.StartTLS()
+	defer ts.Close()
+
+	client := &http.Client{Transport: &http2.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+
+	data := []byte("HelloWorld")
+
+	// upload first chunk
+	req1, err := http.NewRequest("PUT", ts.URL+"/upload/s1", bytes.NewReader(data[:5]))
+	if err != nil {
+		t.Fatalf("req1: %v", err)
+	}
+	req1.Header.Set("Content-Range", "bytes 0-4/10")
+	resp, err := client.Do(req1)
+	if err != nil {
+		t.Fatalf("upload1: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("upload1 status: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// check bitmap after first chunk
+	respBM, err := client.Get(ts.URL + "/bitmap/s1")
+	if err != nil {
+		t.Fatalf("bitmap: %v", err)
+	}
+	bm, err := io.ReadAll(respBM.Body)
+	respBM.Body.Close()
+	if err != nil {
+		t.Fatalf("read bitmap: %v", err)
+	}
+	if len(bm) != 1 || bm[0]&0x1 == 0 {
+		t.Fatalf("unexpected bitmap: %v", bm)
+	}
+
+	// upload second chunk
+	req2, err := http.NewRequest("PUT", ts.URL+"/upload/s1", bytes.NewReader(data[5:]))
+	if err != nil {
+		t.Fatalf("req2: %v", err)
+	}
+	req2.Header.Set("Content-Range", "bytes 5-9/10")
+	resp, err = client.Do(req2)
+	if err != nil {
+		t.Fatalf("upload2: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("upload2 status: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// parallel range downloads
+	var wg sync.WaitGroup
+	parts := make([][]byte, 2)
+	ranges := [][2]int{{0, 4}, {5, 9}}
+	for i, r := range ranges {
+		wg.Add(1)
+		go func(i int, r [2]int) {
+			defer wg.Done()
+			req, err := http.NewRequest("GET", ts.URL+"/download/s1", nil)
+			if err != nil {
+				t.Errorf("req%d: %v", i, err)
+				return
+			}
+			req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", r[0], r[1]))
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Errorf("get%d: %v", i, err)
+				return
+			}
+			if resp.StatusCode != http.StatusPartialContent {
+				t.Errorf("status%d: %d", i, resp.StatusCode)
+			}
+			b, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				t.Errorf("read%d: %v", i, err)
+				return
+			}
+			parts[i] = b
+		}(i, r)
+	}
+	wg.Wait()
+
+	got := append(parts[0], parts[1]...)
+	if string(got) != string(data) {
+		t.Fatalf("download mismatch: got %q want %q", got, data)
+	}
+}

--- a/h2/session.go
+++ b/h2/session.go
@@ -1,0 +1,72 @@
+package h2
+
+import (
+	"errors"
+	"sync"
+)
+
+// Session holds state for a resumable transfer. Each bit in Bitmap tracks
+// whether the corresponding chunk has been uploaded.
+type Session struct {
+	id        string
+	size      int
+	chunkSize int
+	data      []byte
+	bitmap    []byte
+	mu        sync.Mutex
+}
+
+// newSession initializes a Session for the given id, total size and chunk size.
+func newSession(id string, size, chunkSize int) *Session {
+	chunkCount := (size + chunkSize - 1) / chunkSize
+	return &Session{
+		id:        id,
+		size:      size,
+		chunkSize: chunkSize,
+		data:      make([]byte, size),
+		bitmap:    make([]byte, (chunkCount+7)/8),
+	}
+}
+
+// Upload writes b into the session at the provided range.
+func (s *Session) Upload(start, end int, b []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if start < 0 || end >= s.size || end < start {
+		return errors.New("invalid range")
+	}
+	if len(b) != end-start+1 {
+		return errors.New("length mismatch")
+	}
+	copy(s.data[start:end+1], b)
+	// mark bits
+	first := start / s.chunkSize
+	last := end / s.chunkSize
+	for i := first; i <= last; i++ {
+		byteIdx := i / 8
+		bit := uint(i % 8)
+		s.bitmap[byteIdx] |= 1 << bit
+	}
+	return nil
+}
+
+// Download returns the data for the requested range.
+func (s *Session) Download(start, end int) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if start < 0 || end >= s.size || end < start {
+		return nil, errors.New("invalid range")
+	}
+	out := make([]byte, end-start+1)
+	copy(out, s.data[start:end+1])
+	return out, nil
+}
+
+// Bitmap returns a copy of the current bitmap.
+func (s *Session) Bitmap() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]byte, len(s.bitmap))
+	copy(cp, s.bitmap)
+	return cp
+}


### PR DESCRIPTION
## Summary
- add in-memory HTTP/2 server supporting chunked uploads and range downloads
- maintain bitmap session state for resumable transfers
- cover HTTP/2 transfer flow with integration test

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689bb20d4420832391fbd43b927e8019