### PR TITLE
feat(remote): add pipelined privileged helper

### DIFF
--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -1,0 +1,137 @@
+package remote
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sys/unix"
+)
+
+// PrivHelperClient manages communication with the privileged helper over an exec channel.
+type PrivHelperClient struct {
+	stdin   io.WriteCloser
+	stdout  io.Reader
+	session *ssh.Session
+	logger  *zap.Logger
+}
+
+// StartPrivHelper starts the remote privileged helper using the provided SSH client.
+// The helper reads (index, payload, hash) messages and performs pwrite operations.
+func StartPrivHelper(client *ssh.Client, command string, logger *zap.Logger) (*PrivHelperClient, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		session.Close() //nolint:errcheck
+		return nil, err
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		stdin.Close()   //nolint:errcheck
+		session.Close() //nolint:errcheck
+		return nil, err
+	}
+	if err := session.Start(command); err != nil {
+		stdin.Close()   //nolint:errcheck
+		session.Close() //nolint:errcheck
+		return nil, err
+	}
+	return &PrivHelperClient{stdin: stdin, stdout: stdout, session: session, logger: logger}, nil
+}
+
+func (c *PrivHelperClient) send(offset uint64, payload []byte, hash [32]byte) error {
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, offset); err != nil {
+		return err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, uint32(len(payload))); err != nil {
+		return err
+	}
+	buf.Write(hash[:])
+	buf.Write(payload)
+	_, err := c.stdin.Write(buf.Bytes())
+	return err
+}
+
+// Send queues a write operation at the given offset with the provided payload.
+// The payload's SHA-256 hash is calculated and sent to the helper for verification.
+func (c *PrivHelperClient) Send(offset uint64, payload []byte) error {
+	hash := sha256.Sum256(payload)
+	return c.send(offset, payload, hash)
+}
+
+// RecvAck reads the next acknowledgment from the helper.
+// It returns true for ACK and false for NACK.
+func (c *PrivHelperClient) RecvAck() (bool, error) {
+	var b [1]byte
+	if _, err := io.ReadFull(c.stdout, b[:]); err != nil {
+		return false, err
+	}
+	switch b[0] {
+	case 'A':
+		return true, nil
+	case 'N':
+		return false, nil
+	default:
+		return false, errors.New("invalid ack byte")
+	}
+}
+
+// Close closes the helper session.
+func (c *PrivHelperClient) Close() error {
+	_ = c.stdin.Close()
+	if err := c.session.Wait(); err != nil && !errors.Is(err, io.EOF) {
+		_ = c.session.Close()
+		return err
+	}
+	return c.session.Close()
+}
+
+// PrivilegedPwriteServer processes (index, payload, hash) messages from r and writes
+// them to the file descriptor fd using pwrite. ACK ("A") is written to w on success
+// and NACK ("N") on failure.
+func PrivilegedPwriteServer(rw io.ReadWriter, fd int) error {
+	header := make([]byte, 8+4+32) // offset uint64, length uint32, hash [32]byte
+	for {
+		if _, err := io.ReadFull(rw, header); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		offset := binary.BigEndian.Uint64(header[0:8])
+		length := binary.BigEndian.Uint32(header[8:12])
+		var expHash [32]byte
+		copy(expHash[:], header[12:44])
+		payload := make([]byte, length)
+		if _, err := io.ReadFull(rw, payload); err != nil {
+			return err
+		}
+		calc := sha256.Sum256(payload)
+		if !bytes.Equal(expHash[:], calc[:]) {
+			if _, werr := rw.Write([]byte{'N'}); werr != nil {
+				return werr
+			}
+			continue
+		}
+		if _, err := unix.Pwrite(fd, payload, int64(offset)); err != nil {
+			if _, werr := rw.Write([]byte{'N'}); werr != nil {
+				return werr
+			}
+			continue
+		}
+		if _, err := rw.Write([]byte{'A'}); err != nil {
+			return err
+		}
+	}
+}

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -1,0 +1,56 @@
+package remote
+
+import (
+	"crypto/sha256"
+	"io"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestPrivilegedHelperACKNACK(t *testing.T) {
+	var tmpPath string
+	handler := func(cmd string, ch ssh.Channel) int {
+		f, err := os.CreateTemp(t.TempDir(), "priv")
+		if err != nil {
+			return 1
+		}
+		tmpPath = f.Name()
+		defer f.Close() //nolint:errcheck
+		if err := PrivilegedPwriteServer(ch, int(f.Fd())); err != nil && err != io.EOF {
+			return 1
+		}
+		return 0
+	}
+	_, client := newSSHServerClientWithChannel(t, handler)
+	privClient, err := StartPrivHelper(client, "privhelper", zap.NewNop())
+	if err != nil {
+		t.Fatalf("StartPrivHelper: %v", err)
+	}
+	defer privClient.Close() //nolint:errcheck
+
+	if err := privClient.Send(0, []byte("hello")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	badHash := sha256.Sum256([]byte("wrong"))
+	if err := privClient.send(5, []byte("world"), badHash); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	ack, err := privClient.RecvAck()
+	if err != nil || !ack {
+		t.Fatalf("expected ACK, got %v, err %v", ack, err)
+	}
+	ack, err = privClient.RecvAck()
+	if err != nil || ack {
+		t.Fatalf("expected NACK, got %v, err %v", ack, err)
+	}
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected file content %q", string(data))
+	}
+}

--- a/remote/test_helpers_test.go
+++ b/remote/test_helpers_test.go
@@ -47,3 +47,39 @@ func newSSHServerClient(t *testing.T, handler func(string) int) (*remotetest.Moc
 	})
 	return server, client
 }
+
+// newSSHServerWithChannel sets up a mock SSH server with a channel-aware handler.
+func newSSHServerWithChannel(t *testing.T, handler remotetest.ExecHandler) (*remotetest.MockSSHServer, string, int, string) {
+	t.Helper()
+	server := remotetest.NewMockSSHServerWithChannel(t, handler)
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+	knownHosts := remotetest.CreateKnownHostsFile(t, server)
+	t.Cleanup(func() { server.Close() })
+	return server, host, port, knownHosts
+}
+
+// newSSHServerClientWithChannel returns a mock SSH server and connected client using a channel-aware handler.
+func newSSHServerClientWithChannel(t *testing.T, handler remotetest.ExecHandler) (*remotetest.MockSSHServer, *ssh.Client) {
+	t.Helper()
+	server, _, _, knownHosts := newSSHServerWithChannel(t, handler)
+	hostKeyCallback, err := knownhosts.New(knownHosts)
+	if err != nil {
+		t.Fatalf("knownhosts.New: %v", err)
+	}
+	client, err := ssh.Dial("tcp", server.Addr, &ssh.ClientConfig{User: "test", HostKeyCallback: hostKeyCallback})
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close() //nolint:errcheck
+		server.Close()
+	})
+	return server, client
+}

--- a/remote/testutil/ssh_mock.go
+++ b/remote/testutil/ssh_mock.go
@@ -15,10 +15,12 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
+type ExecHandler func(string, ssh.Channel) int
+
 type MockSSHServer struct {
 	Addr       string
 	listener   net.Listener
-	handler    func(string) int
+	handler    ExecHandler
 	mu         sync.Mutex
 	commands   []string
 	globalReqs []string
@@ -27,6 +29,12 @@ type MockSSHServer struct {
 }
 
 func NewMockSSHServer(t *testing.T, handler func(string) int) *MockSSHServer {
+	return NewMockSSHServerWithChannel(t, func(cmd string, ch ssh.Channel) int {
+		return handler(cmd)
+	})
+}
+
+func NewMockSSHServerWithChannel(t *testing.T, handler ExecHandler) *MockSSHServer {
 	t.Helper()
 	private, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -92,14 +100,14 @@ func (s *MockSSHServer) handleChannel(ch ssh.Channel, in <-chan *ssh.Request) {
 			s.mu.Lock()
 			s.commands = append(s.commands, payload.Command)
 			s.mu.Unlock()
-			status := s.handler(payload.Command)
+			req.Reply(true, nil) //nolint:errcheck
+			status := s.handler(payload.Command, ch)
 			var exitStatus uint32
 			if status >= 0 && status <= 255 {
 				exitStatus = uint32(status)
 			} else {
 				exitStatus = 255
 			}
-			req.Reply(true, nil) //nolint:errcheck
 			exitPayload := struct{ Status uint32 }{Status: exitStatus}
 			ch.SendRequest("exit-status", false, ssh.Marshal(exitPayload)) //nolint:errcheck
 			return


### PR DESCRIPTION
## Summary
- add exec-based privileged helper capable of pipelined pwrites
- extend SSH test server with channel-aware handlers
- verify helper ACK/NACK responses over mocked SSH sessions

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/grpcd/main_test.go:175:48: expected ';', found '{')*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689bb215dbd083239d6cb4aca60c7f83