### PR TITLE
feat(hash): align SIMD detection with internal helpers

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -3,15 +3,16 @@ package hash
 import (
 	"hash"
 
-	"github.com/klauspost/cpuid/v2"
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
+
+	cpufeatures "lvmsync_go/internal/cpufeatures"
 )
 
 var hasSIMD bool
 
 func init() {
-	hasSIMD = cpuid.CPU.Supports(cpuid.AVX512F) || cpuid.CPU.Supports(cpuid.AVX2) || cpuid.CPU.Supports(cpuid.SSE4)
+	hasSIMD = cpufeatures.HasSIMD()
 }
 
 // HasSIMD reports whether CPU SIMD features are available.

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -3,6 +3,8 @@ package hash
 import (
 	"encoding/hex"
 	"testing"
+
+	cpufeatures "lvmsync_go/internal/cpufeatures"
 )
 
 func TestSumXXH3(t *testing.T) {
@@ -47,5 +49,11 @@ func BenchmarkSumBLAKE3(b *testing.B) {
 	data := []byte("benchmark data for hashing")
 	for i := 0; i < b.N; i++ {
 		SumBLAKE3(data)
+	}
+}
+
+func TestHasSIMD(t *testing.T) {
+	if HasSIMD() != cpufeatures.HasSIMD() {
+		t.Fatalf("HasSIMD mismatch")
 	}
 }


### PR DESCRIPTION
## Summary
- reuse internal cpufeatures helpers for SIMD detection in hash package
- validate hash HasSIMD output against cpufeatures in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689bbf2a99bc8323b27c306bbb979052