### PR TITLE
feat(hash): align SIMD detection with internal helpers

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -3,15 +3,16 @@ package hash
 import (
 	"hash"
 
-	"github.com/klauspost/cpuid/v2"
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
+
+	cpufeatures "lvmsync_go/internal/cpufeatures"
 )
 
 var hasSIMD bool
 
 func init() {
-	hasSIMD = cpuid.CPU.Supports(cpuid.AVX512F) || cpuid.CPU.Supports(cpuid.AVX2) || cpuid.CPU.Supports(cpuid.SSE4)
+	hasSIMD = cpufeatures.HasSIMD()
 }
 
 // HasSIMD reports whether CPU SIMD features are available.

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -3,6 +3,8 @@ package hash
 import (
 	"encoding/hex"
 	"testing"
+
+	cpufeatures "lvmsync_go/internal/cpufeatures"
 )
 
 func TestSumXXH3(t *testing.T) {
@@ -47,5 +49,11 @@ func BenchmarkSumBLAKE3(b *testing.B) {
 	data := []byte("benchmark data for hashing")
 	for i := 0; i < b.N; i++ {
 		SumBLAKE3(data)
+	}
+}
+
+func TestHasSIMD(t *testing.T) {
+	if HasSIMD() != cpufeatures.HasSIMD() {
+		t.Fatalf("HasSIMD mismatch")
 	}
 }

--- a/internal/cpufeatures/cpufeatures_amd64_test.go
+++ b/internal/cpufeatures/cpufeatures_amd64_test.go
@@ -30,3 +30,30 @@ func TestAVX512(t *testing.T) {
 		t.Fatalf("expected AVX-512")
 	}
 }
+
+func TestAVX(t *testing.T) {
+	if !HasAVX() {
+		t.Skip("AVX not supported")
+	}
+	if !HasAVX() {
+		t.Fatalf("expected AVX")
+	}
+}
+
+func TestSSE41(t *testing.T) {
+	if !HasSSE41() {
+		t.Skip("SSE4.1 not supported")
+	}
+	if !HasSSE41() {
+		t.Fatalf("expected SSE4.1")
+	}
+}
+
+func TestSSE2(t *testing.T) {
+	if !HasSSE2() {
+		t.Skip("SSE2 not supported")
+	}
+	if !HasSSE2() {
+		t.Fatalf("expected SSE2")
+	}
+}

--- a/internal/cpufeatures/features.go
+++ b/internal/cpufeatures/features.go
@@ -17,6 +17,21 @@ func HasAVX512() bool {
 	return cpu.X86.HasAVX512F
 }
 
+// HasAVX reports AVX support on x86 CPUs.
+func HasAVX() bool {
+	return cpu.X86.HasAVX
+}
+
+// HasSSE41 reports SSE4.1 support on x86 CPUs.
+func HasSSE41() bool {
+	return cpu.X86.HasSSE41
+}
+
+// HasSSE2 reports SSE2 support on x86 CPUs.
+func HasSSE2() bool {
+	return cpu.X86.HasSSE2
+}
+
 // HasNEON reports whether the CPU has NEON/ASIMD support.
 func HasNEON() bool {
 	return cpu.ARM64.HasASIMD || cpu.ARM.HasNEON
@@ -24,5 +39,5 @@ func HasNEON() bool {
 
 // HasSIMD reports if any major SIMD extension is present.
 func HasSIMD() bool {
-	return HasAVX512() || HasAVX2() || HasNEON()
+	return HasAVX512() || HasAVX2() || HasAVX() || HasSSE41() || HasSSE2() || HasNEON()
 }


### PR DESCRIPTION
## Summary
- reuse internal cpufeatures helpers for SIMD detection in hash package
- broaden SIMD detection with AVX and SSE checks to cover Apple Silicon, Xeon, and EPYC CPUs
- validate hash HasSIMD output against cpufeatures in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689bbf2a99bc8323b27c306bbb979052