### PR TITLE
fix(remote): respect SSH host key verification flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--ssh_timeout` | `LVMSYNC_SSH_TIMEOUT` | `ssh_timeout` | SSH connection timeout |
 | `--ssh_keepalive` | `LVMSYNC_SSH_KEEPALIVE` | `ssh_keepalive` | SSH keepalive interval |
 | `--known_hosts` | `LVMSYNC_KNOWN_HOSTS` | `known_hosts` | Path to known_hosts file |
-| `--strict_host_key_checking` | `LVMSYNC_STRICT_HOST_KEY_CHECKING` | `strict_host_key_checking` | Require host keys to be present in `known_hosts` |
+| `--strict_host_key_checking` | `LVMSYNC_STRICT_HOST_KEY_CHECKING` | `strict_host_key_checking` | Require host keys to be present in `known_hosts`; when `false`, host key verification is disabled |
 | `--lvmsync_path` | `LVMSYNC_LVMSYNC_PATH` | `lvmsync_path` | Remote command to run (basename sanitized; only `[a-zA-Z0-9._-]+` allowed) |
 | `--remote_pre_script` | `LVMSYNC_REMOTE_PRE_SCRIPT` | `remote_pre_script` | Remote script to run before transfer (times out after `ssh_timeout`) |
 | `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer (separate `ssh_timeout`) |
@@ -761,7 +761,7 @@ The tool supports both local and remote transfers, as well as an "apply mode" fo
 | `--ssh_key`               | Path to SSH private key or use the SSH agent                    | `""`                     |
 | `--ssh_port`              | SSH port number                                                 | `22`                     |
 | `--known_hosts`           | Path to known_hosts file (defaults to `$HOME/.ssh/known_hosts`) | `$HOME/.ssh/known_hosts` |
-| `--strict_host_key_checking` | Require host keys to be present in `known_hosts`            | `true`                   |
+| `--strict_host_key_checking` | Require host keys to be present in `known_hosts`; when `false`, host key verification is disabled | `true`                   |
 
 Programmatic use of the SSH transport requires a configuration populated with
 fields like `SSHUser`, `SSHKeyPath`, `SSHPort`, `KnownHosts`,

--- a/remote/hostkey_test.go
+++ b/remote/hostkey_test.go
@@ -1,0 +1,24 @@
+package remote
+
+import (
+	"testing"
+
+	remotetest "lvmsync_go/remote/testutil"
+)
+
+func TestSetupHostKeyCallbackInsecure(t *testing.T) {
+	cb, err := setupHostKeyCallback(false, "")
+	if err != nil {
+		t.Fatalf("setupHostKeyCallback returned error: %v", err)
+	}
+	if err := cb("example.com", nil, nil); err != nil {
+		t.Fatalf("insecure callback returned error: %v", err)
+	}
+}
+
+func TestSetupHostKeyCallbackVerify(t *testing.T) {
+	kh := remotetest.CreateEmptyKnownHosts(t)
+	if _, err := setupHostKeyCallback(true, kh); err != nil {
+		t.Fatalf("setupHostKeyCallback returned error: %v", err)
+	}
+}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -112,7 +112,10 @@ func selectAuthMethods(logger *zap.Logger, keyPath string) ([]ssh.AuthMethod, er
 	return authMethods, nil
 }
 
-func setupHostKeyCallback(_ bool, knownHostsPath string) (ssh.HostKeyCallback, error) {
+func setupHostKeyCallback(verify bool, knownHostsPath string) (ssh.HostKeyCallback, error) {
+	if !verify {
+		return ssh.InsecureIgnoreHostKey(), nil
+	}
 	hostKeyCallback, err := knownhosts.New(knownHostsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create knownhosts callback: %w", err)

--- a/reports/doc-updates.md
+++ b/reports/doc-updates.md
@@ -1,1 +1,2 @@
 - README.md: removed transport selection example and marked `--transport` flag as currently ignored in option list and configuration tables.
+- README.md: clarified `--strict_host_key_checking` flag; disabling it now skips SSH host key verification.

--- a/reports/flow.md
+++ b/reports/flow.md
@@ -3,11 +3,13 @@
 ## Before
 ```
 main -> Configure -> selectTransport -> SetupGRPC -> ExecuteClient -> SyncLogger
+NewSSHClient -> setupHostKeyCallback (verify ignored) -> knownhosts.New -> dialWithRetry
 ```
 
 ## After
 ```
 main -> Configure -> SetupGRPC -> ExecuteClient -> SyncLogger
+NewSSHClient -> setupHostKeyCallback (honors verify) -> [verify true: knownhosts.New, verify false: ssh.InsecureIgnoreHostKey] -> dialWithRetry
 ```
 
 `selectTransport` previously depended on an unused transport package. The new flow removes the unused dependency and warns when a transport is requested.

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -3,3 +3,4 @@
 | deprecated-api | grpc/client/client.go | used grpc.DialContext deprecated API | future gRPC releases could break dialing | replaced with grpc.NewClient | P1 |
 | unreachable | internal/transport | package unused and failing vet | dead code increased maintenance | removed package and callers | P1 |
 | doc-missing | README.md | `--transport` flag documented but not implemented | users misled about transport selection | docs note flag is ignored | P2 |
+| bug | remote/remote.go | `setupHostKeyCallback` ignored verify flag | users could not disable host key verification | respect flag and use `ssh.InsecureIgnoreHostKey` when false | P1 |

--- a/reports/machine/gaps.json
+++ b/reports/machine/gaps.json
@@ -22,5 +22,13 @@
     "impact": "users misled about transport selection",
     "fix": "docs note flag is ignored",
     "priority": "P2"
+  },
+  {
+    "type": "bug",
+    "component": "remote/remote.go",
+    "evidence": "setupHostKeyCallback ignored verify flag",
+    "impact": "users could not disable host key verification",
+    "fix": "respect flag and use ssh.InsecureIgnoreHostKey when false",
+    "priority": "P1"
   }
 ]

--- a/reports/summary.md
+++ b/reports/summary.md
@@ -2,6 +2,7 @@
 - Removed unused gRPC daemon and internal transport packages.
 - Fixed compression algorithm selection and deprecated gRPC dial API.
 - Updated documentation to reflect current transport support.
+- Fixed SSH host key verification flag handling.
 
 ## Risks
 - Transport selection remains unimplemented; future work needed for real transports.


### PR DESCRIPTION
## Summary
- use `ssh.InsecureIgnoreHostKey` when `--strict_host_key_checking` is disabled
- document SSH host key verification flag semantics
- add coverage for host key callback behavior

## Testing
- `go vet ./...`
- `go test ./...`
- `staticcheck ./...`
- `awk '/^```go/{p=1;next}/^```/{p=0}p' README.md > /tmp/readme_example.go`
- `test -s /tmp/readme_example.go && go build /tmp/readme_example.go`


------
https://chatgpt.com/codex/tasks/task_e_689bc9dc369c8323ac8ec9ff8a69d390