### PR TITLE
fix(remote): add SSH agent timeout and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,9 +247,11 @@ Run these commands locally before opening a pull request:
 
 - [x] Run lint checks to keep style and correctness issues from creeping in for transports.
 
-  ```sh
-  golangci-lint run
-  ```
+```sh
+golangci-lint run
+```
+
+- [x] Ensure SSH agent connections use context timeouts and cover SSHManager reuse in tests.
 
 - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.
 - [ ] Implement QUIC `serve` command with minimal flags and `zap`-only logging.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer (separate `ssh_timeout`) |
 | `--dedup_strategy` | `LVMSYNC_DEDUP_STRATEGY` | `dedup_strategy` | Deduplication strategy: `none`, `auto`, `checksum`, `rolling_hash`, or `bloom` |
 | `--dedup_state_file` | `LVMSYNC_DEDUP_STATE_FILE` | `dedup_state_file` | Path to deduplication state file |
+
+If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh_timeout` as its deadline.
 | `--bloom_entries` | `LVMSYNC_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
 | `--bloom_fp_rate` | `LVMSYNC_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
 | `--bloom_mbits` | `LVMSYNC_BLOOM_MBITS` | `bloom_mbits` | Bloom filter m bits power |

--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -39,7 +39,7 @@ func NewSSHManager(user, keyPath string, timeout time.Duration, knownHostsPath s
 		logger = zap.NewNop()
 	}
 
-	authMethods, err := getSSHAuthMethods(keyPath, logger)
+	authMethods, err := getSSHAuthMethods(context.Background(), keyPath, timeout, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize authentication: %w", err)
 	}
@@ -103,7 +103,7 @@ func (s *SSHManager) CloseAll() error {
 	return errs
 }
 
-func getSSHAuthMethods(keyPath string, logger *zap.Logger) ([]ssh.AuthMethod, error) {
+func getSSHAuthMethods(ctx context.Context, keyPath string, timeout time.Duration, logger *zap.Logger) ([]ssh.AuthMethod, error) {
 	authMethods := []ssh.AuthMethod{}
 
 	if keyPath != "" {
@@ -113,7 +113,7 @@ func getSSHAuthMethods(keyPath string, logger *zap.Logger) ([]ssh.AuthMethod, er
 		}
 		authMethods = append(authMethods, ssh.PublicKeys(signer))
 	} else {
-		agentAuth, err := sshAgentAuth(logger)
+		agentAuth, err := sshAgentAuth(ctx, timeout, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -155,13 +155,14 @@ func loadPrivateKey(keyPath string) (ssh.Signer, error) {
 	return ssh.ParsePrivateKey(keyData)
 }
 
-func sshAgentAuth(logger *zap.Logger) (ssh.AuthMethod, error) {
+func sshAgentAuth(ctx context.Context, timeout time.Duration, logger *zap.Logger) (ssh.AuthMethod, error) {
 	agentSock := os.Getenv("SSH_AUTH_SOCK")
 	if agentSock == "" {
 		return nil, fmt.Errorf("SSH_AUTH_SOCK is not set")
 	}
 
-	conn, err := net.Dial("unix", agentSock)
+	d := net.Dialer{Timeout: timeout}
+	conn, err := d.DialContext(ctx, "unix", agentSock)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to SSH agent: %w", err)
 	}

--- a/remote/ssh_manager_test.go
+++ b/remote/ssh_manager_test.go
@@ -1,0 +1,94 @@
+package remote
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/crypto/ssh/agent"
+
+	"lvmsync_go/remote/testutil"
+)
+
+func TestSSHManagerGetClientReuse(t *testing.T) {
+	server := testutil.NewMockSSHServer(t, func(string) int { return 0 })
+	defer server.Close()
+	knownHosts := testutil.CreateKnownHostsFile(t, server)
+	keyPath := testutil.CreateTempKey(t)
+
+	mgr, err := NewSSHManager("user", keyPath, time.Second, knownHosts, zaptest.NewLogger(t))
+	if err != nil {
+		t.Fatalf("NewSSHManager: %v", err)
+	}
+
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, _ := strconv.Atoi(portStr)
+
+	ctx := context.Background()
+	c1, err := mgr.GetClient(ctx, host, port)
+	if err != nil {
+		t.Fatalf("GetClient first: %v", err)
+	}
+	c2, err := mgr.GetClient(ctx, host, port)
+	if err != nil {
+		t.Fatalf("GetClient second: %v", err)
+	}
+	if c1 != c2 {
+		t.Fatal("expected connection reuse")
+	}
+	if server.ConnectionCount() != 1 {
+		t.Fatalf("expected 1 connection, got %d", server.ConnectionCount())
+	}
+	if err := mgr.CloseAll(); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+}
+
+func TestSSHAgentAuthTimeout(t *testing.T) {
+	tmpSock := filepath.Join(t.TempDir(), "agent.sock")
+	os.Setenv("SSH_AUTH_SOCK", tmpSock)
+	defer os.Unsetenv("SSH_AUTH_SOCK")
+
+	ctx := context.Background()
+	_, err := sshAgentAuth(ctx, 50*time.Millisecond, zaptest.NewLogger(t))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestSSHAgentAuthSuccess(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "agent.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		agent.ServeAgent(agent.NewKeyring(), conn)
+	}()
+
+	os.Setenv("SSH_AUTH_SOCK", sock)
+	defer os.Unsetenv("SSH_AUTH_SOCK")
+
+	ctx := context.Background()
+	auth, err := sshAgentAuth(ctx, time.Second, zaptest.NewLogger(t))
+	if err != nil {
+		t.Fatalf("sshAgentAuth: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("expected auth method")
+	}
+}

--- a/reports/doc-updates.md
+++ b/reports/doc-updates.md
@@ -1,2 +1,3 @@
 - README.md: removed transport selection example and marked `--transport` flag as currently ignored in option list and configuration tables.
 - README.md: clarified `--strict_host_key_checking` flag; disabling it now skips SSH host key verification.
+- README.md: documented SSH agent usage when `--ssh_key` is unset and that the connection respects `--ssh_timeout`.

--- a/reports/flow.md
+++ b/reports/flow.md
@@ -9,7 +9,7 @@ NewSSHClient -> setupHostKeyCallback (verify ignored) -> knownhosts.New -> dialW
 ## After
 ```
 main -> Configure -> SetupGRPC -> ExecuteClient -> SyncLogger
-NewSSHClient -> setupHostKeyCallback (honors verify) -> [verify true: knownhosts.New, verify false: ssh.InsecureIgnoreHostKey] -> dialWithRetry
+NewSSHClient -> [key provided: loadPrivateKey | none: sshAgentAuth (context timeout)] -> setupHostKeyCallback (honors verify) -> [verify true: knownhosts.New, verify false: ssh.InsecureIgnoreHostKey] -> dialWithRetry
 ```
 
 `selectTransport` previously depended on an unused transport package. The new flow removes the unused dependency and warns when a transport is requested.

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -4,3 +4,4 @@
 | unreachable | internal/transport | package unused and failing vet | dead code increased maintenance | removed package and callers | P1 |
 | doc-missing | README.md | `--transport` flag documented but not implemented | users misled about transport selection | docs note flag is ignored | P2 |
 | bug | remote/remote.go | `setupHostKeyCallback` ignored verify flag | users could not disable host key verification | respect flag and use `ssh.InsecureIgnoreHostKey` when false | P1 |
+| bug | remote/ssh_manager.go | `sshAgentAuth` used `net.Dial` without context or timeout | unresponsive SSH agent could hang start-up | added context-aware dial with timeout and tests | P1 |

--- a/reports/machine/gaps.json
+++ b/reports/machine/gaps.json
@@ -30,5 +30,13 @@
     "impact": "users could not disable host key verification",
     "fix": "respect flag and use ssh.InsecureIgnoreHostKey when false",
     "priority": "P1"
+  },
+  {
+    "type": "bug",
+    "component": "remote/ssh_manager.go",
+    "evidence": "sshAgentAuth used net.Dial without context or timeout",
+    "impact": "unresponsive SSH agent could hang start-up",
+    "fix": "add context-aware dial with timeout and tests",
+    "priority": "P1"
   }
 ]

--- a/reports/summary.md
+++ b/reports/summary.md
@@ -3,6 +3,7 @@
 - Fixed compression algorithm selection and deprecated gRPC dial API.
 - Updated documentation to reflect current transport support.
 - Fixed SSH host key verification flag handling.
+- Added timeout-aware SSH agent authentication and tests verifying SSH client reuse.
 
 ## Risks
 - Transport selection remains unimplemented; future work needed for real transports.


### PR DESCRIPTION
## Summary
- add context-aware SSH agent auth with timeout
- document SSH agent usage and update AGENTS TODO
- cover SSHManager connection reuse and agent dialing in tests

## Testing
- `go vet ./...`
- `go test ./...`
- `staticcheck ./...`
- `awk '/^```go/{p=1;next}/^```/{p=0}p' README.md > /tmp/readme_example.go`
- `test -s /tmp/readme_example.go && go build /tmp/readme_example.go`


------
https://chatgpt.com/codex/tasks/task_e_689c157d50ec8323a62122ae15f36993