### PR TITLE
fix(cmd): error on unsupported transport flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,7 @@ golangci-lint run
 - [x] Implement full transport registry with working QUIC, HTTP/2, TCP+TLS, and SSH backends and accompanying tests.
 - [x] Finalize hybrid deduplication and document CDC tuning knobs.
 - [x] Integrate adaptive compression sampling with configurable thresholds and unit benchmarks.
+- [x] Fail fast when unsupported transports are requested and document `--transport` as reserved.
 ## Roadmap
 
 - [ ] Implement gRPC control plane with mTLS and port configurability.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The overall loading flow works in three stages:
 
 Recent refactors added several configuration options:
 
-- `--transport` selects the ordered list of transports to try (currently ignored).
+- `--transport` is reserved for future use; specifying it returns an error.
 - `--quic_listen` and `--quic_connect` configure QUIC addresses.
 - `--tcp_port`, `--h2_port`, and `--ssh_port` expose TCP+TLS, HTTP/2, and SSH endpoints.
 - `--tcp_parallel` controls the number of parallel TCP connections (2–4).
@@ -219,14 +219,15 @@ Recent refactors added several configuration options:
 - `--checkpoint_interval` sets how often resume state is persisted.
 - `--block_size` sets the transfer block size (use `auto` for detection).
 
-### QUIC transport
+### QUIC transport (planned)
 
-Include `quic` in the `--transport` list or configuration to enable the QUIC data plane.
-Use `--quic_listen` (`LVMSYNC_QUIC_LISTEN` / `quic_listen`) to bind a listener and `--quic_connect`
-(`LVMSYNC_QUIC_CONNECT` / `quic_connect`) to dial a peer. Select the congestion control algorithm with
-`--quic_cc` or `LVMSYNC_QUIC_CC` (defaults to `bbr`).
+Transport negotiation is not implemented. Future versions will allow enabling the QUIC data plane with
+`--transport quic`. Planned options include `--quic_listen` (`LVMSYNC_QUIC_LISTEN` / `quic_listen`) to bind a
+listener and `--quic_connect` (`LVMSYNC_QUIC_CONNECT` / `quic_connect`) to dial a peer. Congestion control will
+be selected using `--quic_cc` or `LVMSYNC_QUIC_CC` (default `bbr`).
 
 ```sh
+# planned example - currently returns "transport not implemented"
 lvmsync --transport quic --quic_listen :9000
 ```
 
@@ -336,7 +337,7 @@ If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
 | `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
 | `--target_vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
-| `--transport` | `LVMSYNC_TRANSPORT` | `transport` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) (currently ignored) |
+| `--transport` | `LVMSYNC_TRANSPORT` | `transport` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) (reserved; specifying returns an error) |
 | `--quic_listen` | `LVMSYNC_QUIC_LISTEN` | `quic_listen` | QUIC listen address |
 | `--quic_connect` | `LVMSYNC_QUIC_CONNECT` | `quic_connect` | QUIC connect address |
 | `--tcp_port` | `LVMSYNC_TCP_PORT` | `tcp_port` | TCP+TLS port |
@@ -508,13 +509,14 @@ lvmsync --config config.yaml /dev/vg0/snap0 /mnt/backup
 
 ## Transport Registry
 
-Transport selection is currently not implemented; the `--transport` flag is accepted but ignored.
+Transport selection is currently not implemented; specifying `--transport` results in an error. The flags below
+are reserved for future work and the examples will fail with "transport not implemented".
 
 ### Flags and environment variables
 
 | Flag | Environment variable | Description |
 |------|----------------------|-------------|
-| `--transport` | `LVMSYNC_TRANSPORT` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) (currently ignored) |
+| `--transport` | `LVMSYNC_TRANSPORT` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) (reserved; specifying returns an error) |
 | `--quic_listen` | `LVMSYNC_QUIC_LISTEN` | QUIC listen address |
 | `--quic_connect` | `LVMSYNC_QUIC_CONNECT` | QUIC connect address |
 | `--quic_cc` | `LVMSYNC_QUIC_CC` | QUIC congestion control algorithm |

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -281,10 +281,13 @@ func RunRemoteDump(ctx context.Context, cfg *config.Config, snapshotDevice, orig
 	return ExecuteRemoteCommand(validationCtx, cfg, client, destDevice, snapshotDevice, originDevice, logger)
 }
 
-// SelectTransport chooses and logs the transport if configured.
+// SelectTransport returns an error when a transport is requested because
+// transport negotiation is not yet implemented. The selected transport is
+// logged for visibility.
 func SelectTransport(cfg *config.Config, logger *zap.Logger) error {
 	if cfg.Transport != "" {
-		logger.Warn("transport selection not implemented", zap.String("transport", cfg.Transport))
+		logger.Error("transport selection not implemented", zap.String("transport", cfg.Transport))
+		return fmt.Errorf("transport %q not implemented", cfg.Transport)
 	}
 	return nil
 }

--- a/cmd/dump/select_transport_test.go
+++ b/cmd/dump/select_transport_test.go
@@ -1,0 +1,26 @@
+package dump
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"lvmsync_go/config"
+)
+
+func TestSelectTransportNoConfig(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	if err := SelectTransport(cfg, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSelectTransportError(t *testing.T) {
+	cfg := &config.Config{Transport: "quic"}
+	logger := zap.NewNop()
+	err := SelectTransport(cfg, logger)
+	if err == nil || !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -136,7 +136,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	}
 
 	if err := selectTransport(cfg, logger); err != nil {
-		return err
+		return fmt.Errorf("select transport: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/reports/doc-updates.md
+++ b/reports/doc-updates.md
@@ -1,3 +1,4 @@
 - README.md: removed transport selection example and marked `--transport` flag as currently ignored in option list and configuration tables.
+- README.md: document `--transport` as reserved; examples note "transport not implemented" error.
 - README.md: clarified `--strict_host_key_checking` flag; disabling it now skips SSH host key verification.
 - README.md: documented SSH agent usage when `--ssh_key` is unset and that the connection respects `--ssh_timeout`.

--- a/reports/flow.md
+++ b/reports/flow.md
@@ -8,8 +8,8 @@ NewSSHClient -> setupHostKeyCallback (verify ignored) -> knownhosts.New -> dialW
 
 ## After
 ```
-main -> Configure -> SetupGRPC -> ExecuteClient -> SyncLogger
+main -> Configure -> selectTransport -> SetupGRPC -> ExecuteClient -> SyncLogger
 NewSSHClient -> [key provided: loadPrivateKey | none: sshAgentAuth (context timeout)] -> setupHostKeyCallback (honors verify) -> [verify true: knownhosts.New, verify false: ssh.InsecureIgnoreHostKey] -> dialWithRetry
 ```
 
-`selectTransport` previously depended on an unused transport package. The new flow removes the unused dependency and warns when a transport is requested.
+`selectTransport` now fails fast when a transport is specified, preventing silent misconfiguration.

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -5,3 +5,4 @@
 | doc-missing | README.md | `--transport` flag documented but not implemented | users misled about transport selection | docs note flag is ignored | P2 |
 | bug | remote/remote.go | `setupHostKeyCallback` ignored verify flag | users could not disable host key verification | respect flag and use `ssh.InsecureIgnoreHostKey` when false | P1 |
 | bug | remote/ssh_manager.go | `sshAgentAuth` used `net.Dial` without context or timeout | unresponsive SSH agent could hang start-up | added context-aware dial with timeout and tests | P1 |
+| bug | cmd/dump/client.go | `SelectTransport` ignored configured transport | misconfiguration silently ignored | return error and log unsupported transport | P1 |

--- a/reports/machine/gaps.json
+++ b/reports/machine/gaps.json
@@ -38,5 +38,13 @@
     "impact": "unresponsive SSH agent could hang start-up",
     "fix": "add context-aware dial with timeout and tests",
     "priority": "P1"
+  },
+  {
+    "type": "bug",
+    "component": "cmd/dump/client.go",
+    "evidence": "SelectTransport ignored configured transport",
+    "impact": "misconfiguration silently ignored",
+    "fix": "return error and log unsupported transport",
+    "priority": "P1"
   }
 ]

--- a/reports/summary.md
+++ b/reports/summary.md
@@ -4,9 +4,10 @@
 - Updated documentation to reflect current transport support.
 - Fixed SSH host key verification flag handling.
 - Added timeout-aware SSH agent authentication and tests verifying SSH client reuse.
+- SelectTransport now errors when unsupported transports are requested and documentation reflects reserved status.
 
 ## Risks
-- Transport selection remains unimplemented; future work needed for real transports.
+- Transport selection remains unimplemented; implement real transports to replace the current error.
 
 ## Next Steps
 - Implement transport backends and reintroduce comprehensive compression tests.


### PR DESCRIPTION
## Summary
- fail fast when unsupported transports are configured
- document `--transport` as reserved and update flow reports
- add tests for transport selection

## Testing
- `go vet ./...`
- `go test ./...`
- `staticcheck ./...`
- `awk '/^```go/{p=1;next}/^```/{p=0}p' README.md > /tmp/readme_example.go`
- `test -s /tmp/readme_example.go && go build /tmp/readme_example.go`


------
https://chatgpt.com/codex/tasks/task_e_689c19a4596c83239ece7ebad68780bc