### PR TITLE
remote: make StartPrivHelper context-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ LVMSync is organized into modular packages to keep concerns separated:
 - `lvm` – manages snapshot creation, monitoring, and cleanup.
 - `transfer` – performs block-level synchronization, compression, deduplication, and resume logic.
   - Internally split into focused modules: `progress.go`, `handshake.go`, and `block_writer.go` for clearer responsibilities.
-- `remote` – wraps SSH functionality for running commands on remote hosts and coordinating transfers.
+- `remote` – wraps SSH functionality for running commands on remote hosts and coordinating transfers. Callers must provide a `context.Context` with a timeout when starting the privileged helper to allow cancellation if the remote command fails to launch.
 - `config` – parses and validates configuration files and CLI options.
 - `dedup` – houses Bloom filter helpers, chunking logic, and other deduplication utilities.
 - `grpc` – provides the gRPC server and authentication helpers used by the remote daemon.

--- a/cmd/dump/client_benchmark_test.go
+++ b/cmd/dump/client_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 )
 
 func BenchmarkCopyPipeAsync(b *testing.B) {
@@ -12,7 +13,9 @@ func BenchmarkCopyPipeAsync(b *testing.B) {
 	b.SetBytes(int64(len(data)))
 	for i := 0; i < b.N; i++ {
 		src := bytes.NewReader(data)
-		errCh := CopyPipeAsync(context.Background(), io.Discard, src)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		errCh := CopyPipeAsync(ctx, io.Discard, src)
+		cancel()
 		if err := <-errCh; err != nil {
 			b.Fatal(err)
 		}

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -174,7 +174,9 @@ func TestRunRemoteDumpTimeout(t *testing.T) {
 	defer func() { dumpChangesSequential = origDump }()
 
 	dest := host + ":/dev/null"
-	err = RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
@@ -195,7 +197,9 @@ func TestRunRemoteDumpInvalidDest(t *testing.T) {
 		t.Fatalf("DefaultConfig returned error: %v", err)
 	}
 	dest := "invalid"
-	err = RunRemoteDump(context.Background(), cfg, "snap", "origin", dest, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "host:device") {
 		t.Fatalf("expected host:device format error, got %v", err)
 	}

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -33,7 +33,8 @@ func TestSetupSSHClient(t *testing.T) {
 		}
 		defer func() { newSSHClient = remote.NewSSHClient }()
 
-		client, cancel, err := SetupSSHClient(context.Background(), cfg, "dest", zap.NewNop())
+		ctx, outerCancel := context.WithTimeout(context.Background(), time.Second)
+		client, cancel, err := SetupSSHClient(ctx, cfg, "dest", zap.NewNop())
 		if err != nil {
 			t.Fatalf("SetupSSHClient returned error: %v", err)
 		}
@@ -44,6 +45,7 @@ func TestSetupSSHClient(t *testing.T) {
 			t.Fatalf("newSSHClient was not called")
 		}
 		cancel()
+		outerCancel()
 	})
 
 	t.Run("failure", func(t *testing.T) {
@@ -52,7 +54,9 @@ func TestSetupSSHClient(t *testing.T) {
 		}
 		defer func() { newSSHClient = remote.NewSSHClient }()
 
-		_, _, err := SetupSSHClient(context.Background(), cfg, "dest", zap.NewNop())
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, _, err := SetupSSHClient(ctx, cfg, "dest", zap.NewNop())
 		if err == nil || !strings.Contains(err.Error(), "failed to create SSH client") {
 			t.Fatalf("expected wrapped error, got %v", err)
 		}
@@ -121,7 +125,9 @@ func TestSetupSessionStreamsPipeErrors(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, _, err := SetupSessionStreams(context.Background(), tc.sess)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_, _, _, err := SetupSessionStreams(ctx, tc.sess)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("expected %s error, got %v", tc.want, err)
 			}

--- a/remote/logger_test.go
+++ b/remote/logger_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
@@ -28,7 +29,9 @@ func TestRunRemoteScriptNoLogger(t *testing.T) {
 	sshClient := &SSHClient{Client: client, Logger: zap.NewNop()}
 
 	script := "echo hi"
-	if scriptErr := sshClient.RunRemoteScript(context.Background(), script); scriptErr != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if scriptErr := sshClient.RunRemoteScript(ctx, script); scriptErr != nil {
 		t.Fatalf("RunRemoteScript error: %v", scriptErr)
 	}
 }

--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -22,7 +23,9 @@ type PrivHelperClient struct {
 
 // StartPrivHelper starts the remote privileged helper using the provided SSH client.
 // The helper reads (index, payload, hash) messages and performs pwrite operations.
-func StartPrivHelper(client *ssh.Client, command string, logger *zap.Logger) (*PrivHelperClient, error) {
+// The provided context controls the lifetime of the startup; if it is canceled
+// before the remote command begins executing, an error is returned.
+func StartPrivHelper(ctx context.Context, client *ssh.Client, command string, logger *zap.Logger) (*PrivHelperClient, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -41,10 +44,19 @@ func StartPrivHelper(client *ssh.Client, command string, logger *zap.Logger) (*P
 		session.Close() //nolint:errcheck
 		return nil, err
 	}
-	if err := session.Start(command); err != nil {
+	errCh := make(chan error, 1)
+	go func() { errCh <- session.Start(command) }()
+	select {
+	case <-ctx.Done():
 		stdin.Close()   //nolint:errcheck
 		session.Close() //nolint:errcheck
-		return nil, err
+		return nil, ctx.Err()
+	case err := <-errCh:
+		if err != nil {
+			stdin.Close()   //nolint:errcheck
+			session.Close() //nolint:errcheck
+			return nil, err
+		}
 	}
 	return &PrivHelperClient{stdin: stdin, stdout: stdout, session: session, logger: logger}, nil
 }

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -1,10 +1,12 @@
 package remote
 
 import (
+	"context"
 	"crypto/sha256"
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
@@ -25,7 +27,9 @@ func TestPrivilegedHelperACKNACK(t *testing.T) {
 		return 0
 	}
 	_, client := newSSHServerClientWithChannel(t, handler)
-	privClient, err := StartPrivHelper(client, "privhelper", zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	privClient, err := StartPrivHelper(ctx, client, "privhelper", zap.NewNop())
 	if err != nil {
 		t.Fatalf("StartPrivHelper: %v", err)
 	}

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -23,10 +23,14 @@ func TestValidateRemoteCommand(t *testing.T) {
 	})
 
 	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
-	if err := client.ValidateRemoteCommand(context.Background(), "echo"); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := client.ValidateRemoteCommand(ctx, "echo"); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
-	if err := client.ValidateRemoteCommand(context.Background(), "nonexistent"); err == nil {
+	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel2()
+	if err := client.ValidateRemoteCommand(ctx2, "nonexistent"); err == nil {
 		t.Fatalf("expected error for nonexistent command")
 	}
 }
@@ -41,7 +45,9 @@ func TestRunRemoteScript(t *testing.T) {
 	client := &SSHClient{Client: rawClient, Logger: logger}
 
 	script := "echo hi"
-	if err := client.RunRemoteScript(context.Background(), script); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := client.RunRemoteScript(ctx, script); err != nil {
 		t.Fatalf("RunRemoteScript error: %v", err)
 	}
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -47,14 +47,16 @@ func TestNewSSHClientNoAuth(t *testing.T) {
 	}()
 
 	knownHosts := remotetest.CreateEmptyKnownHosts(t)
-	_, err := NewSSHClient(context.Background(), "localhost", "root", "", 22, knownHosts, true, time.Second, time.Second, 0, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := NewSSHClient(ctx, "localhost", "root", "", 22, knownHosts, true, time.Second, time.Second, 0, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "no SSH authentication methods configured") {
 		t.Fatalf("expected error for missing auth methods, got %v", err)
 	}
 }
 
 func TestDialWithRetryContextCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	config := &ssh.ClientConfig{
 		User:            "test",
 		Auth:            []ssh.AuthMethod{ssh.Password("")},

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -30,7 +30,7 @@ func TestStartKeepAlive(t *testing.T) {
 
 	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	done := make(chan struct{})
 	go func() {
 		client.startKeepAlive(ctx, "host", 10*time.Millisecond)
@@ -56,7 +56,7 @@ func TestStartKeepAlive(t *testing.T) {
 func TestNewSSHClient(t *testing.T) {
 	server, host, port, knownHosts := newSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	keyPath := remotetest.CreateTempKey(t)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	client, err := NewSSHClient(ctx, host, "test", keyPath, port, knownHosts, true, time.Second, 10*time.Millisecond, 0, zap.NewNop())
 	if err != nil {
 		t.Fatalf("NewSSHClient error: %v", err)
@@ -80,12 +80,14 @@ func TestSSHManager(t *testing.T) {
 		t.Fatalf("NewSSHManager error: %v", err)
 	}
 
-	client1, err := mgr.GetClient(context.Background(), host, port)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	client1, err := mgr.GetClient(ctx, host, port)
 	if err != nil {
 		t.Fatalf("GetClient error: %v", err)
 	}
 
-	client2, err := mgr.GetClient(context.Background(), host, port)
+	client2, err := mgr.GetClient(ctx, host, port)
 	if err != nil {
 		t.Fatalf("GetClient second error: %v", err)
 	}
@@ -98,7 +100,9 @@ func TestSSHManager(t *testing.T) {
 		t.Fatalf("CloseAll error: %v", err)
 	}
 
-	client3, err := mgr.GetClient(context.Background(), host, port)
+	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel2()
+	client3, err := mgr.GetClient(ctx2, host, port)
 	if err != nil {
 		t.Fatalf("GetClient after CloseAll error: %v", err)
 	}

--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -39,7 +39,9 @@ func NewSSHManager(user, keyPath string, timeout time.Duration, knownHostsPath s
 		logger = zap.NewNop()
 	}
 
-	authMethods, err := getSSHAuthMethods(context.Background(), keyPath, timeout, logger)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	authMethods, err := getSSHAuthMethods(ctx, keyPath, timeout, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize authentication: %w", err)
 	}

--- a/remote/ssh_manager_context_test.go
+++ b/remote/ssh_manager_context_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestDialSSHContextCancel ensures dialSSH respects context cancellation.
 func TestDialSSHContextCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	cancel()
 	cfg := &ssh.ClientConfig{
 		User:            "test",
@@ -27,7 +27,8 @@ func TestDialSSHContextCancel(t *testing.T) {
 
 // TestDialSSHTimeout ensures dialSSH respects dial timeouts.
 func TestDialSSHTimeout(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	cfg := &ssh.ClientConfig{
 		User:            "test",
 		Auth:            []ssh.AuthMethod{ssh.Password("")},

--- a/remote/ssh_manager_test.go
+++ b/remote/ssh_manager_test.go
@@ -32,7 +32,8 @@ func TestSSHManagerGetClientReuse(t *testing.T) {
 	}
 	port, _ := strconv.Atoi(portStr)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	c1, err := mgr.GetClient(ctx, host, port)
 	if err != nil {
 		t.Fatalf("GetClient first: %v", err)
@@ -57,7 +58,8 @@ func TestSSHAgentAuthTimeout(t *testing.T) {
 	os.Setenv("SSH_AUTH_SOCK", tmpSock)
 	defer os.Unsetenv("SSH_AUTH_SOCK")
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	_, err := sshAgentAuth(ctx, 50*time.Millisecond, zaptest.NewLogger(t))
 	if err == nil {
 		t.Fatal("expected timeout error")
@@ -83,7 +85,8 @@ func TestSSHAgentAuthSuccess(t *testing.T) {
 	os.Setenv("SSH_AUTH_SOCK", sock)
 	defer os.Unsetenv("SSH_AUTH_SOCK")
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	auth, err := sshAgentAuth(ctx, time.Second, zaptest.NewLogger(t))
 	if err != nil {
 		t.Fatalf("sshAgentAuth: %v", err)


### PR DESCRIPTION
## Summary
- add context parameter to StartPrivHelper and abort session start on cancellation
- use context deadlines in remote and dump tests
- document context requirement for starting remote privileged helper

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c3ee3cb0483239cf935e965adba1d