### PR TITLE
feat(config): validate mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--config` | `LVMSYNC_CONFIG` | `config` | Path to config YAML file |
 | `--apply` | `LVMSYNC_APPLY` | `apply` | Apply mode: read change dump from file ('-' for STDIN) and apply to destination device |
 | `--stdout` | `LVMSYNC_STDOUT` | `stdout` | Write change dump to STDOUT |
+| `--mode` | `LVMSYNC_MODE` | `mode` | Configuration preset: `default` or `throughput`; unknown modes fail validation |
 | `--parallel` | `LVMSYNC_PARALLEL` | `parallel` | Number of concurrent workers |
 | `--concurrency` | `LVMSYNC_CONCURRENCY` | `concurrency` | Stream concurrency (0 to autotune based on BDP) |
 | `--zerocopy` | `LVMSYNC_ZEROCOPY` | `zerocopy` | Enable zero-copy transfers |
@@ -625,6 +626,8 @@ are resolved with the following precedence (highest first):
 | `--ram_bytes` | `LVMSYNC_RAM_BYTES` | `ram_bytes` | RAM budget for the Bloom filter | `1073741824` |
 | `--volume_size` | `LVMSYNC_VOLUME_SIZE` | `volume_size` | Size of the volume being processed | `0` |
 | `--hash_key` | `LVMSYNC_HASH_KEY` | `hash_key` | Optional hex-encoded key for BLAKE3 hashing | `""` |
+
+Two presets are available via `--mode`: `default` and `throughput`. Any other value causes configuration validation to fail.
 
 ## Throughput Mode Presets
 

--- a/config/config.go
+++ b/config/config.go
@@ -704,6 +704,9 @@ func (c *Config) Validate() error { return c.ValidateWith(os.Geteuid) }
 
 // ValidateWith verifies configuration values using the provided geteuid function.
 func (c *Config) ValidateWith(geteuid func() int) error {
+	if c.Mode != "default" && c.Mode != "throughput" {
+		return fmt.Errorf("invalid mode %q: must be \"default\" or \"throughput\"", c.Mode)
+	}
 	if c.SSHKeepAliveInterval <= 0 {
 		return fmt.Errorf("ssh keepalive interval must be > 0")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -322,6 +322,7 @@ func TestConfigValidate(t *testing.T) {
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
 		cfg := &Config{
+			Mode:                 "default",
 			VolumeGroup:          "vg0",
 			LVMEscalation:        "sudo",
 			SSHKeepAliveInterval: time.Second,
@@ -342,7 +343,7 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second, TCPParallel: 1}
+		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second, TCPParallel: 1}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -454,7 +455,7 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+	cfg := &Config{Mode: "default", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
 	if err := cfg.ValidateWith(geteuid); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -462,6 +463,38 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	os.Setenv("PATH", "")
 	if err := cfg.ValidateWith(geteuid); err == nil {
 		t.Fatalf("expected error when command missing")
+	}
+}
+
+func TestValidateMode(t *testing.T) {
+	geteuid := func() int { return 0 }
+	base := Config{
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+	}
+
+	cases := []struct {
+		name    string
+		mode    string
+		wantErr bool
+	}{
+		{name: "default", mode: "default", wantErr: false},
+		{name: "throughput", mode: "throughput", wantErr: false},
+		{name: "invalid", mode: "fast", wantErr: true},
+		{name: "empty", mode: "", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			cfg.Mode = tc.mode
+			if err := cfg.ValidateWith(geteuid); (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateWith(%q) error = %v, wantErr %v", tc.mode, err, tc.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate configuration `Mode` only allows `default` or `throughput`
- add tests for allowed and disallowed modes
- document supported modes and validation error in README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c3edbf7708323a0d67cf8ed424a23