### PR TITLE
refactor(lvm): inject logger dependencies

### DIFF
--- a/cmd/lvmsync/signals/signals.go
+++ b/cmd/lvmsync/signals/signals.go
@@ -23,7 +23,7 @@ func Handle(ctx context.Context, cfg *config.Config, logger *zap.Logger, signals
 	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
 		rmCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		if err := removeSnapshot(rmCtx, *snapshotPath); err != nil {
+		if err := removeSnapshot(rmCtx, *snapshotPath, logger); err != nil {
 			logger.Warn("failed to remove snapshot on shutdown", zap.Error(err))
 		} else {
 			logger.Info("snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -26,7 +26,7 @@ var (
 
 // SetParseSnapshotSizeForTest overrides the parseSnapshotSize helper for tests
 // and returns a function to restore the original behavior.
-func SetParseSnapshotSizeForTest(f func(string, string) (uint64, error)) func() {
+func SetParseSnapshotSizeForTest(f func(string, string, *zap.Logger) (uint64, error)) func() {
 	orig := parseSnapshotSize
 	parseSnapshotSize = f
 	return func() { parseSnapshotSize = orig }
@@ -34,7 +34,7 @@ func SetParseSnapshotSizeForTest(f func(string, string) (uint64, error)) func() 
 
 // SetCreateSnapshotForTest overrides the createSnapshot helper for tests and
 // returns a function to restore the original behavior.
-func SetCreateSnapshotForTest(f func(context.Context, string, string, string) error) func() {
+func SetCreateSnapshotForTest(f func(context.Context, string, string, string, *zap.Logger) error) func() {
 	orig := createSnapshot
 	createSnapshot = f
 	return func() { createSnapshot = orig }
@@ -42,7 +42,7 @@ func SetCreateSnapshotForTest(f func(context.Context, string, string, string) er
 
 // SetGetSnapshotDevicePathForTest overrides the getSnapshotDevicePath helper
 // for tests and returns a function to restore the original behavior.
-func SetGetSnapshotDevicePathForTest(f func(string, string) string) func() {
+func SetGetSnapshotDevicePathForTest(f func(string, string, *zap.Logger) string) func() {
 	orig := getSnapshotDevicePath
 	getSnapshotDevicePath = f
 	return func() { getSnapshotDevicePath = orig }
@@ -50,7 +50,7 @@ func SetGetSnapshotDevicePathForTest(f func(string, string) string) func() {
 
 // SetMonitorSnapshotForTest overrides the monitorSnapshot helper for tests and
 // returns a function to restore the original behavior.
-func SetMonitorSnapshotForTest(f func(context.Context, string, float64, time.Duration) error) func() {
+func SetMonitorSnapshotForTest(f func(context.Context, string, float64, time.Duration, *zap.Logger) error) func() {
 	orig := monitorSnapshot
 	monitorSnapshot = f
 	return func() { monitorSnapshot = orig }
@@ -58,7 +58,7 @@ func SetMonitorSnapshotForTest(f func(context.Context, string, float64, time.Dur
 
 // SetRemoveSnapshotForTest overrides the removeSnapshot helper for tests and
 // returns a function to restore the original behavior.
-func SetRemoveSnapshotForTest(f func(context.Context, string) error) func() {
+func SetRemoveSnapshotForTest(f func(context.Context, string, *zap.Logger) error) func() {
 	orig := removeSnapshot
 	removeSnapshot = f
 	return func() { removeSnapshot = orig }
@@ -67,7 +67,7 @@ func SetRemoveSnapshotForTest(f func(context.Context, string) error) func() {
 // PrepareSnapshot sets up a snapshot for the given original volume. It returns the snapshot path,
 // an optional monitor error channel, a cleanup function, and any error encountered.
 func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
-	snapshotBytes, err := calculateSnapshotSize(cfg, originalVolume)
+	snapshotBytes, err := calculateSnapshotSize(cfg, originalVolume, logger)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -83,8 +83,8 @@ func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume str
 	return createSnapshotIfNeeded(ctx, cfg, originalVolume, snapshotBytes, logger)
 }
 
-func calculateSnapshotSize(cfg *config.Config, originalVolume string) (uint64, error) {
-	snapshotBytes, err := parseSnapshotSize(cfg.SnapshotSize, originalVolume)
+func calculateSnapshotSize(cfg *config.Config, originalVolume string, logger *zap.Logger) (uint64, error) {
+	snapshotBytes, err := parseSnapshotSize(cfg.SnapshotSize, originalVolume, logger)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse snapshot size: %w", err)
 	}
@@ -102,7 +102,7 @@ func ensureVolumeGroups(ctx context.Context, cfg *config.Config, originalVolume 
 	}
 
 	if cfg.TargetVolumeGroup == "" && len(cfg.TargetVGCandidates) > 0 {
-		lvSize, err := getVolumeSize(originalVolume)
+		lvSize, err := getVolumeSize(originalVolume, logger)
 		if err != nil {
 			return fmt.Errorf("failed to determine volume size: %w", err)
 		}
@@ -120,14 +120,14 @@ func checkDiskSpaceForSnapshot(cfg *config.Config, snapshotBytes uint64, logger 
 	if cfg.SkipDiskCheck {
 		return nil
 	}
-	freeSpace, err := checkDiskSpace("/")
+	freeSpace, err := checkDiskSpace("/", logger)
 	if err != nil {
 		return fmt.Errorf("disk space check failed: %w", err)
 	}
 	if freeSpace < snapshotBytes {
 		return fmt.Errorf("insufficient disk space for snapshot: free %d required %d", freeSpace, snapshotBytes)
 	}
-	logger.Info("Disk space check passed", zap.Uint64("free", freeSpace))
+	logger.Info("Disk space check passed", zap.Uint64("free_bytes", freeSpace))
 	return nil
 }
 
@@ -142,17 +142,17 @@ func createSnapshotIfNeeded(ctx context.Context, cfg *config.Config, originalVol
 
 	monitorErrCh = make(chan error, 1)
 	snapshotName := fmt.Sprintf("snap-%d", time.Now().Unix())
-	if err := createSnapshot(ctx, originalVolume, snapshotName, strconv.FormatUint(snapshotBytes, 10)); err != nil {
+	if err := createSnapshot(ctx, originalVolume, snapshotName, strconv.FormatUint(snapshotBytes, 10), logger); err != nil {
 		return "", nil, nil, fmt.Errorf("snapshot creation failed: %w", err)
 	}
-	snapshotPath = getSnapshotDevicePath(snapshotName, cfg.VolumeGroup)
+	snapshotPath = getSnapshotDevicePath(snapshotName, cfg.VolumeGroup, logger)
 	logger.Info("Snapshot created", zap.String("snapshot", snapshotPath))
 
 	monitorCtx, cancel := context.WithCancel(ctx)
 	mon := monitorSnapshot
 	go func() {
 		defer close(monitorErrCh)
-		if err := mon(monitorCtx, snapshotPath, 80.0, 10*time.Second); err != nil && err != context.Canceled {
+		if err := mon(monitorCtx, snapshotPath, 80.0, 10*time.Second, logger); err != nil && err != context.Canceled {
 			logger.Error("Snapshot monitor error", zap.Error(err))
 			select {
 			case monitorErrCh <- err:
@@ -165,7 +165,7 @@ func createSnapshotIfNeeded(ctx context.Context, cfg *config.Config, originalVol
 		cancel()
 		removeCtx, removeCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer removeCancel()
-		if err := removeSnapshot(removeCtx, snapshotPath); err != nil {
+		if err := removeSnapshot(removeCtx, snapshotPath, logger); err != nil {
 			logger.Warn("Failed to remove snapshot", zap.Error(err))
 		} else {
 			logger.Info("Snapshot removed", zap.String("snapshot", snapshotPath))

--- a/internal/client/snapshot_helpers_test.go
+++ b/internal/client/snapshot_helpers_test.go
@@ -15,10 +15,10 @@ func TestCalculateSnapshotSize(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		cfg := &config.Config{SnapshotSize: "1024"}
 		origParse := parseSnapshotSize
-		parseSnapshotSize = func(string, string) (uint64, error) { return 1024, nil }
+		parseSnapshotSize = func(string, string, *zap.Logger) (uint64, error) { return 1024, nil }
 		defer func() { parseSnapshotSize = origParse }()
 
-		size, err := calculateSnapshotSize(cfg, "/dev/vg/lv")
+		size, err := calculateSnapshotSize(cfg, "/dev/vg/lv", zap.NewNop())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -30,10 +30,10 @@ func TestCalculateSnapshotSize(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		cfg := &config.Config{SnapshotSize: "bad"}
 		origParse := parseSnapshotSize
-		parseSnapshotSize = func(string, string) (uint64, error) { return 0, errors.New("bad") }
+		parseSnapshotSize = func(string, string, *zap.Logger) (uint64, error) { return 0, errors.New("bad") }
 		defer func() { parseSnapshotSize = origParse }()
 
-		if _, err := calculateSnapshotSize(cfg, "/dev/vg/lv"); err == nil {
+		if _, err := calculateSnapshotSize(cfg, "/dev/vg/lv", zap.NewNop()); err == nil {
 			t.Fatalf("expected error for invalid size")
 		}
 	})

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -23,7 +23,7 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
 
-	restore := client.SetParseSnapshotSizeForTest(func(string, string) (uint64, error) { return 1, nil })
+	restore := client.SetParseSnapshotSizeForTest(func(string, string, *zap.Logger) (uint64, error) { return 1, nil })
 	defer restore()
 
 	logger := zap.NewNop()
@@ -49,11 +49,11 @@ func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
 
-	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string) (uint64, error) { return 1024, nil })
+	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string, *zap.Logger) (uint64, error) { return 1024, nil })
 	defer restoreParse()
 
 	var created bool
-	restoreCreate := client.SetCreateSnapshotForTest(func(ctx context.Context, orig, name, size string) error {
+	restoreCreate := client.SetCreateSnapshotForTest(func(ctx context.Context, orig, name, size string, _ *zap.Logger) error {
 		created = true
 		if size != "1024" {
 			t.Fatalf("unexpected size: %s", size)
@@ -62,18 +62,18 @@ func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
 	})
 	defer restoreCreate()
 
-	restorePath := client.SetGetSnapshotDevicePathForTest(func(name, vg string) string {
+	restorePath := client.SetGetSnapshotDevicePathForTest(func(name, vg string, _ *zap.Logger) string {
 		return "/dev/" + vg + "/" + name
 	})
 	defer restorePath()
 
-	restoreMonitor := client.SetMonitorSnapshotForTest(func(ctx context.Context, path string, threshold float64, interval time.Duration) error {
+	restoreMonitor := client.SetMonitorSnapshotForTest(func(ctx context.Context, path string, threshold float64, interval time.Duration, _ *zap.Logger) error {
 		return nil
 	})
 	defer restoreMonitor()
 
 	var removedPath string
-	restoreRemove := client.SetRemoveSnapshotForTest(func(ctx context.Context, path string) error {
+	restoreRemove := client.SetRemoveSnapshotForTest(func(ctx context.Context, path string, _ *zap.Logger) error {
 		removedPath = path
 		return nil
 	})
@@ -109,24 +109,24 @@ func TestCreateSnapshotCleanupNoPanic(t *testing.T) {
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
 
-	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string) (uint64, error) { return 1024, nil })
+	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string, *zap.Logger) (uint64, error) { return 1024, nil })
 	defer restoreParse()
 
-	restoreCreate := client.SetCreateSnapshotForTest(func(context.Context, string, string, string) error { return nil })
+	restoreCreate := client.SetCreateSnapshotForTest(func(context.Context, string, string, string, *zap.Logger) error { return nil })
 	defer restoreCreate()
 
-	restorePath := client.SetGetSnapshotDevicePathForTest(func(name, vg string) string { return "/dev/" + vg + "/" + name })
+	restorePath := client.SetGetSnapshotDevicePathForTest(func(name, vg string, _ *zap.Logger) string { return "/dev/" + vg + "/" + name })
 	defer restorePath()
 
 	ready := make(chan struct{}, 1)
-	restoreMonitor := client.SetMonitorSnapshotForTest(func(ctx context.Context, path string, threshold float64, interval time.Duration) error {
+	restoreMonitor := client.SetMonitorSnapshotForTest(func(ctx context.Context, path string, threshold float64, interval time.Duration, _ *zap.Logger) error {
 		ready <- struct{}{}
 		<-ctx.Done()
 		return errors.New("monitor error")
 	})
 	defer restoreMonitor()
 
-	restoreRemove := client.SetRemoveSnapshotForTest(func(context.Context, string) error { return nil })
+	restoreRemove := client.SetRemoveSnapshotForTest(func(context.Context, string, *zap.Logger) error { return nil })
 	defer restoreRemove()
 
 	logger := zap.NewNop()

--- a/lvm/attr_read_test.go
+++ b/lvm/attr_read_test.go
@@ -4,19 +4,21 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestReadUintAttrMissingAndMalformed(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	if _, err := readUintAttr(tmpDir, "missing"); err == nil {
+	if _, err := readUintAttr(tmpDir, "missing", zap.NewNop()); err == nil {
 		t.Errorf("expected error for missing file")
 	}
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "bad"), []byte("abc"), 0644); err != nil {
 		t.Fatalf("failed to write bad file: %v", err)
 	}
-	if _, err := readUintAttr(tmpDir, "bad"); err == nil {
+	if _, err := readUintAttr(tmpDir, "bad", zap.NewNop()); err == nil {
 		t.Errorf("expected error for malformed content")
 	}
 }
@@ -24,21 +26,21 @@ func TestReadUintAttrMissingAndMalformed(t *testing.T) {
 func TestReadBoolAttrMissingAndMalformed(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	if _, err := readBoolAttr(tmpDir, "missing"); err == nil {
+	if _, err := readBoolAttr(tmpDir, "missing", zap.NewNop()); err == nil {
 		t.Errorf("expected error for missing file")
 	}
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "bad"), []byte("2"), 0644); err != nil {
 		t.Fatalf("failed to write bad file: %v", err)
 	}
-	if _, err := readBoolAttr(tmpDir, "bad"); err == nil {
+	if _, err := readBoolAttr(tmpDir, "bad", zap.NewNop()); err == nil {
 		t.Errorf("expected error for malformed content")
 	}
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "badstr"), []byte("abc"), 0644); err != nil {
 		t.Fatalf("failed to write bad string file: %v", err)
 	}
-	if _, err := readBoolAttr(tmpDir, "badstr"); err == nil {
+	if _, err := readBoolAttr(tmpDir, "badstr", zap.NewNop()); err == nil {
 		t.Errorf("expected error for non-numeric content")
 	}
 }

--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
 
@@ -86,7 +87,7 @@ func TestGetVolumeSizeCachesFD(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	size, err := GetVolumeSize(tmpFile)
+	size, err := GetVolumeSize(tmpFile, zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetVolumeSize failed: %v", err)
 	}
@@ -104,7 +105,7 @@ func TestGetVolumeSizeCachesFD(t *testing.T) {
 	}
 	fd := entry.fd
 
-	size, err = GetVolumeSize(tmpFile)
+	size, err = GetVolumeSize(tmpFile, zap.NewNop())
 	if err != nil {
 		t.Fatalf("second GetVolumeSize failed: %v", err)
 	}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -60,7 +60,7 @@ func SetBackend(b lvmBackend) func() {
 	return func() { backend = orig }
 }
 
-func CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) error {
+func CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string, logger *zap.Logger) error {
 	if err := checkPrivs(); err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) erro
 			snapshotName, lvPath, size, err)
 	}
 
-	zap.L().Info("Snapshot created successfully",
+	logger.Info("snapshot created successfully",
 		zap.String("lv_path", lvPath),
 		zap.String("snapshot_name", snapshotName),
 		zap.String("size", size))
@@ -82,7 +82,7 @@ func CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string) erro
 	return nil
 }
 
-func RemoveSnapshot(ctx context.Context, snapshotPath string) error {
+func RemoveSnapshot(ctx context.Context, snapshotPath string, logger *zap.Logger) error {
 	if err := checkPrivs(); err != nil {
 		return err
 	}
@@ -95,13 +95,13 @@ func RemoveSnapshot(ctx context.Context, snapshotPath string) error {
 		return fmt.Errorf("failed to remove snapshot [%s]: %w", snapshotPath, err)
 	}
 
-	zap.L().Info("Snapshot removed successfully",
+	logger.Info("snapshot removed successfully",
 		zap.String("snapshot_path", snapshotPath))
 
 	return nil
 }
 
-func GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error) {
+func GetSnapshotUsage(ctx context.Context, snapshotPath string, logger *zap.Logger) (float64, error) {
 	if err := checkPrivs(); err != nil {
 		return 0, err
 	}
@@ -115,14 +115,14 @@ func GetSnapshotUsage(ctx context.Context, snapshotPath string) (float64, error)
 		return 0, fmt.Errorf("failed to get snapshot usage for %s: %w", snapshotPath, err)
 	}
 
-	zap.L().Info("Snapshot usage retrieved",
+	logger.Info("snapshot usage retrieved",
 		zap.String("snapshot", snapshotPath),
 		zap.Float64("usage_percent", usage))
 
 	return usage, nil
 }
 
-func MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64, interval time.Duration) error {
+func MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64, interval time.Duration, logger *zap.Logger) error {
 	if err := checkPrivs(); err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64
 	for {
 		select {
 		case <-ticker.C:
-			usage, err := GetSnapshotUsage(ctx, snapshotPath)
+			usage, err := GetSnapshotUsage(ctx, snapshotPath, logger)
 			if err != nil {
 				return err
 			}
@@ -146,13 +146,13 @@ func MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64
 				return fmt.Errorf("snapshot usage (%.2f%%) exceeds threshold (%.2f%%)", usage, threshold)
 			}
 		case <-ctx.Done():
-			zap.L().Info("Snapshot monitoring stopped", zap.String("snapshot", snapshotPath))
+			logger.Info("snapshot monitoring stopped", zap.String("snapshot", snapshotPath))
 			return ctx.Err()
 		}
 	}
 }
 
-func CheckDiskSpace(mountPoint string) (uint64, error) {
+func CheckDiskSpace(mountPoint string, logger *zap.Logger) (uint64, error) {
 	var stat unix.Statfs_t
 	if err := statfsFunc(mountPoint, &stat); err != nil {
 		return 0, fmt.Errorf("failed to get disk stats for %q: %w", mountPoint, err)
@@ -163,7 +163,7 @@ func CheckDiskSpace(mountPoint string) (uint64, error) {
 	}
 
 	available := stat.Bavail * uint64(stat.Bsize)
-	zap.L().Debug("Disk space check",
+	logger.Debug("disk space check",
 		zap.String("mount_point", mountPoint),
 		zap.Uint64("available_bytes", available))
 
@@ -179,7 +179,7 @@ func ioctlGetUint64(fd int, req uint) (uint64, error) {
 	return value, nil
 }
 
-func GetVolumeSize(volumePath string) (uint64, error) {
+func GetVolumeSize(volumePath string, logger *zap.Logger) (uint64, error) {
 	fd, err := deviceFDCache.getFD(volumePath)
 	if err != nil {
 		return 0, err
@@ -202,7 +202,7 @@ func GetVolumeSize(volumePath string) (uint64, error) {
 		}
 	}
 
-	zap.L().Debug("Volume size retrieved",
+	logger.Debug("volume size retrieved",
 		zap.String("volume_path", volumePath),
 		zap.Uint64("size_bytes", size))
 
@@ -223,11 +223,11 @@ type VolumeAttributes struct {
 	Removable bool
 }
 
-func readUintAttr(sysfsPath, name string) (uint64, error) {
+func readUintAttr(sysfsPath, name string, logger *zap.Logger) (uint64, error) {
 	path := filepath.Join(sysfsPath, name)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		zap.L().Warn("Failed to read attribute",
+		logger.Warn("failed to read attribute",
 			zap.String("device", filepath.Base(sysfsPath)),
 			zap.String("attribute", name),
 			zap.Error(err))
@@ -236,7 +236,7 @@ func readUintAttr(sysfsPath, name string) (uint64, error) {
 
 	val, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 	if err != nil {
-		zap.L().Warn("Failed to parse attribute",
+		logger.Warn("failed to parse attribute",
 			zap.String("device", filepath.Base(sysfsPath)),
 			zap.String("attribute", name),
 			zap.Error(err))
@@ -245,8 +245,8 @@ func readUintAttr(sysfsPath, name string) (uint64, error) {
 	return val, nil
 }
 
-func readBoolAttr(sysfsPath, name string) (bool, error) {
-	val, err := readUintAttr(sysfsPath, name)
+func readBoolAttr(sysfsPath, name string, logger *zap.Logger) (bool, error) {
+	val, err := readUintAttr(sysfsPath, name, logger)
 	if err != nil {
 		return false, err
 	}
@@ -258,7 +258,7 @@ func readBoolAttr(sysfsPath, name string) (bool, error) {
 		return true, nil
 	default:
 		err := fmt.Errorf("invalid boolean value %d", val)
-		zap.L().Warn("Invalid boolean attribute",
+		logger.Warn("invalid boolean attribute",
 			zap.String("device", filepath.Base(sysfsPath)),
 			zap.String("attribute", name),
 			zap.Error(err))
@@ -266,7 +266,7 @@ func readBoolAttr(sysfsPath, name string) (bool, error) {
 	}
 }
 
-func GetVolumeAttributes(volumePath string) (*VolumeAttributes, error) {
+func GetVolumeAttributes(volumePath string, logger *zap.Logger) (*VolumeAttributes, error) {
 	devName := filepath.Base(volumePath)
 	sysfsPath := filepath.Join(sysBlockPath, devName)
 
@@ -290,31 +290,31 @@ func GetVolumeAttributes(volumePath string) (*VolumeAttributes, error) {
 			}
 		}
 	} else {
-		zap.L().Warn("Failed to read attribute",
+		logger.Warn("failed to read attribute",
 			zap.String("device", devName),
 			zap.String("attribute", "dev"),
 			zap.Error(err))
 	}
 
 	// size
-	if size, err := readUintAttr(sysfsPath, "size"); err == nil {
+	if size, err := readUintAttr(sysfsPath, "size", logger); err == nil {
 		attrs.Size = size
 	}
 
 	// read-only flag
-	if ro, err := readBoolAttr(sysfsPath, "ro"); err == nil {
+	if ro, err := readBoolAttr(sysfsPath, "ro", logger); err == nil {
 		attrs.ReadOnly = ro
 	}
 
 	// removable flag
-	if removable, err := readBoolAttr(sysfsPath, "removable"); err == nil {
+	if removable, err := readBoolAttr(sysfsPath, "removable", logger); err == nil {
 		attrs.Removable = removable
 	}
 
 	return attrs, nil
 }
 
-func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
+func ParseSnapshotSize(sizeStr, volumePath string, logger *zap.Logger) (uint64, error) {
 	sizeStr = strings.TrimSpace(sizeStr)
 
 	val, isPercent, err := sizeparse.Parse(sizeStr)
@@ -327,7 +327,7 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 			return 0, fmt.Errorf("percentage must be between 0 and 100, got %v", val)
 		}
 
-		volSize, err := GetVolumeSize(volumePath)
+		volSize, err := GetVolumeSize(volumePath, logger)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get volume size for %q: %w", volumePath, err)
 		}
@@ -338,7 +338,7 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 			return 0, fmt.Errorf("snapshot size %q overflows uint64", sizeStr)
 		}
 
-		zap.L().Debug("Parsed snapshot size from percentage",
+		logger.Debug("parsed snapshot size from percentage",
 			zap.String("input", sizeStr),
 			zap.Uint64("calculated_bytes", parsedSize))
 
@@ -350,16 +350,16 @@ func ParseSnapshotSize(sizeStr, volumePath string) (uint64, error) {
 		return 0, fmt.Errorf("snapshot size %q overflows uint64", sizeStr)
 	}
 
-	zap.L().Debug("Parsed snapshot size",
+	logger.Debug("parsed snapshot size",
 		zap.String("input", sizeStr),
 		zap.Uint64("bytes", parsedSize))
 
 	return parsedSize, nil
 }
 
-func GetSnapshotDevicePath(snapshotName, volumeGroup string) string {
+func GetSnapshotDevicePath(snapshotName, volumeGroup string, logger *zap.Logger) string {
 	path := fmt.Sprintf("/dev/%s/%s", volumeGroup, snapshotName)
-	zap.L().Debug("Constructed snapshot device path", zap.String("path", path))
+	logger.Debug("constructed snapshot device path", zap.String("path", path))
 	return path
 }
 

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestGetSnapshotDevicePath(t *testing.T) {
-	got := GetSnapshotDevicePath("snap", "vg0")
+	got := GetSnapshotDevicePath("snap", "vg0", zap.NewNop())
 	if got != "/dev/vg0/snap" {
 		t.Fatalf("unexpected path %s", got)
 	}
@@ -47,7 +49,7 @@ func TestParseSnapshotSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseSnapshotSize(tt.input, tmpFile)
+			got, err := ParseSnapshotSize(tt.input, tmpFile, zap.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ParseSnapshotSize error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -67,7 +69,7 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("failed to create temp volume: %v", err)
 		}
 
-		size, err := GetVolumeSize(tmpFile)
+		size, err := GetVolumeSize(tmpFile, zap.NewNop())
 		if err != nil {
 			t.Fatalf("GetVolumeSize failed: %v", err)
 		}
@@ -87,7 +89,7 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("truncate failed: %v", err)
 		}
 
-		size, err := GetVolumeSize(tmpFile)
+		size, err := GetVolumeSize(tmpFile, zap.NewNop())
 		if err != nil {
 			t.Fatalf("GetVolumeSize failed: %v", err)
 		}
@@ -113,7 +115,7 @@ func TestGetVolumeSizeIoctlLarge(t *testing.T) {
 	}
 	defer func() { ioctlGetUint64Func = orig }()
 
-	size, err := GetVolumeSize(tmpFile)
+	size, err := GetVolumeSize(tmpFile, zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetVolumeSize failed: %v", err)
 	}
@@ -147,7 +149,7 @@ func TestGetVolumeAttributes(t *testing.T) {
 		}
 	}
 
-	got, err := GetVolumeAttributes("/dev/testdev")
+	got, err := GetVolumeAttributes("/dev/testdev", zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetVolumeAttributes failed: %v", err)
 	}

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 type mockBackend struct{ calls []string }
@@ -53,11 +55,12 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 	snapName := "snap"
 	size := "1G"
 
-	if err := CreateSnapshot(context.Background(), lvPath, snapName, size); err != nil {
+	logger := zap.NewNop()
+	if err := CreateSnapshot(context.Background(), lvPath, snapName, size, logger); err != nil {
 		t.Fatalf("CreateSnapshot failed: %v", err)
 	}
 	snapPath := "/dev/vg0/" + snapName
-	if err := RemoveSnapshot(context.Background(), snapPath); err != nil {
+	if err := RemoveSnapshot(context.Background(), snapPath, logger); err != nil {
 		t.Fatalf("RemoveSnapshot failed: %v", err)
 	}
 
@@ -78,7 +81,7 @@ func TestCreateSnapshotPrivilegeError(t *testing.T) {
 	checkPrivs = func() error { return errPriv }
 	t.Cleanup(func() { checkPrivs = orig })
 
-	err := CreateSnapshot(context.Background(), "/dev/vg0/origin", "snap", "1G")
+	err := CreateSnapshot(context.Background(), "/dev/vg0/origin", "snap", "1G", zap.NewNop())
 	if !errors.Is(err, errPriv) {
 		t.Fatalf("expected privilege error, got %v", err)
 	}
@@ -100,7 +103,7 @@ func TestCreateSnapshotContextCancel(t *testing.T) {
 	snapName := "snap"
 	size := "1G"
 
-	err := CreateSnapshot(ctx, lvPath, snapName, size)
+	err := CreateSnapshot(ctx, lvPath, snapName, size, zap.NewNop())
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
 
@@ -33,7 +34,7 @@ func TestGetSnapshotUsage(t *testing.T) {
 	restore := SetBackend(fb)
 	t.Cleanup(restore)
 
-	usage, err := GetSnapshotUsage(context.Background(), "/dev/vg0/snap")
+	usage, err := GetSnapshotUsage(context.Background(), "/dev/vg0/snap", zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetSnapshotUsage failed: %v", err)
 	}
@@ -51,7 +52,7 @@ func TestMonitorSnapshot(t *testing.T) {
 	restore := SetBackend(fb)
 	t.Cleanup(restore)
 
-	err := MonitorSnapshot(context.Background(), "/dev/vg0/snap", 80, 10*time.Millisecond)
+	err := MonitorSnapshot(context.Background(), "/dev/vg0/snap", 80, 10*time.Millisecond, zap.NewNop())
 	if err == nil {
 		t.Fatalf("MonitorSnapshot expected error, got nil")
 	}
@@ -66,7 +67,7 @@ func TestCheckDiskSpace(t *testing.T) {
 	}
 	defer func() { statfsFunc = orig }()
 
-	available, err := CheckDiskSpace("/mnt")
+	available, err := CheckDiskSpace("/mnt", zap.NewNop())
 	if err != nil {
 		t.Fatalf("CheckDiskSpace failed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- pass explicit loggers into LVM snapshot helpers
- propagate logger through client snapshot preparation and signal handling
- update tests for explicit logging and snake_case fields

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689c3ed4b2cc8323b4490fe3c4f44234