### PR TITLE
fix(privilege): guard capability checks on non-linux

### DIFF
--- a/internal/privilege/caps_linux.go
+++ b/internal/privilege/caps_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 // Package privilege implements capability detection to avoid unnecessary sudo
 // usage. Only the capabilities required for LVM and direct I/O operations are
 // checked.

--- a/internal/privilege/caps_stub.go
+++ b/internal/privilege/caps_stub.go
@@ -1,0 +1,19 @@
+//go:build !linux
+// +build !linux
+
+// Package privilege provides stubs for capability checks on non-Linux systems.
+package privilege
+
+// HasCaps reports whether the required capabilities are present.
+// Non-Linux platforms do not support these capabilities, so HasCaps always
+// returns false.
+var HasCaps = realHasCaps
+
+// RealHasCaps returns false on non-Linux platforms.
+func RealHasCaps() bool { return realHasCaps() }
+
+func realHasCaps() bool { return false }
+
+// checkCaps is a no-op on non-Linux platforms since capabilities are
+// unsupported and sudo will be required.
+func checkCaps() error { return nil }


### PR DESCRIPTION
## Summary
- restrict capability probing to linux builds
- provide non-linux stubs that always report missing caps

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689c4d01a4e4832390fc0c320f742e69