### PR TITLE
fix(remote): refresh dead ssh connections

### DIFF
--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -22,9 +22,14 @@ import (
 // It caches established connections keyed by host and port so that
 // subsequent requests to the same destination reuse existing sessions.
 // The manager is safe for concurrent use.
+type sshClientEntry struct {
+	client *ssh.Client
+	done   chan error
+}
+
 type SSHManager struct {
 	mu        sync.Mutex
-	clients   map[string]*ssh.Client
+	clients   map[string]*sshClientEntry
 	sshConfig *ssh.ClientConfig
 	timeout   time.Duration
 	logger    *zap.Logger
@@ -59,7 +64,7 @@ func NewSSHManager(user, keyPath string, timeout time.Duration, knownHostsPath s
 	}
 
 	return &SSHManager{
-		clients:   make(map[string]*ssh.Client),
+		clients:   make(map[string]*sshClientEntry),
 		sshConfig: sshConfig,
 		timeout:   timeout,
 		logger:    logger,
@@ -74,8 +79,15 @@ func (s *SSHManager) GetClient(ctx context.Context, host string, port int) (*ssh
 	defer s.mu.Unlock()
 
 	addr := fmt.Sprintf("%s:%d", host, port)
-	if client, exists := s.clients[addr]; exists {
-		return client, nil
+	if entry, exists := s.clients[addr]; exists {
+		select {
+		case err := <-entry.done:
+			s.logger.Debug("ssh connection closed", zap.String("addr", addr), zap.Error(err))
+			entry.client.Close() //nolint:errcheck
+			delete(s.clients, addr)
+		default:
+			return entry.client, nil
+		}
 	}
 
 	client, err := dialSSH(ctx, addr, s.sshConfig, s.timeout)
@@ -83,7 +95,9 @@ func (s *SSHManager) GetClient(ctx context.Context, host string, port int) (*ssh
 		return nil, fmt.Errorf("failed to establish SSH connection: %w", err)
 	}
 
-	s.clients[addr] = client
+	done := make(chan error, 1)
+	go func(c *ssh.Client) { done <- c.Conn.Wait() }(client)
+	s.clients[addr] = &sshClientEntry{client: client, done: done}
 	return client, nil
 }
 
@@ -94,8 +108,8 @@ func (s *SSHManager) CloseAll() error {
 	defer s.mu.Unlock()
 
 	var errs error
-	for addr, client := range s.clients {
-		if err := client.Close(); err != nil {
+	for addr, entry := range s.clients {
+		if err := entry.client.Close(); err != nil {
 			s.logger.Warn("client close error", zap.String("addr", addr), zap.Error(err))
 			errs = multierr.Append(errs, fmt.Errorf("%s: %w", addr, err))
 		}

--- a/remote/ssh_manager_test.go
+++ b/remote/ssh_manager_test.go
@@ -53,6 +53,50 @@ func TestSSHManagerGetClientReuse(t *testing.T) {
 	}
 }
 
+func TestSSHManagerGetClientRefresh(t *testing.T) {
+	server := testutil.NewMockSSHServer(t, func(string) int { return 0 })
+	defer server.Close()
+	knownHosts := testutil.CreateKnownHostsFile(t, server)
+	keyPath := testutil.CreateTempKey(t)
+
+	mgr, err := NewSSHManager("user", keyPath, time.Second, knownHosts, zaptest.NewLogger(t))
+	if err != nil {
+		t.Fatalf("NewSSHManager: %v", err)
+	}
+
+	host, portStr, err := net.SplitHostPort(server.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, _ := strconv.Atoi(portStr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	c1, err := mgr.GetClient(ctx, host, port)
+	if err != nil {
+		t.Fatalf("GetClient first: %v", err)
+	}
+	if server.ConnectionCount() != 1 {
+		t.Fatalf("expected 1 connection, got %d", server.ConnectionCount())
+	}
+
+	c1.Close()
+
+	c2, err := mgr.GetClient(ctx, host, port)
+	if err != nil {
+		t.Fatalf("GetClient second: %v", err)
+	}
+	if c1 == c2 {
+		t.Fatal("expected new connection after close")
+	}
+	if server.ConnectionCount() != 2 {
+		t.Fatalf("expected 2 connections, got %d", server.ConnectionCount())
+	}
+	if err := mgr.CloseAll(); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+}
+
 func TestSSHAgentAuthTimeout(t *testing.T) {
 	tmpSock := filepath.Join(t.TempDir(), "agent.sock")
 	os.Setenv("SSH_AUTH_SOCK", tmpSock)


### PR DESCRIPTION
## Summary
- ensure cached SSH clients are still alive before reuse
- reconnect when a cached SSH connection has closed
- test SSHManager reuse and automatic refresh

## Testing
- `go build ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `go test -coverprofile=coverage.out ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `golangci-lint run` *(fails: reading go.mod: open go.mod: no such file or directory)*
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c56ea7b3483239bc756bbd045f92d