### PR TITLE
fix(remote): zero private key buffer after parsing

### DIFF
--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -16,6 +16,9 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
+// parsePrivateKey is a variable to allow test stubbing.
+var parsePrivateKey = ssh.ParsePrivateKey
+
 // SSHManager maintains SSH client connections for reuse and ensures
 // consistent host key verification.
 //
@@ -154,7 +157,12 @@ func loadPrivateKey(keyPath string) (ssh.Signer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key: %w", err)
 	}
-	return ssh.ParsePrivateKey(keyData)
+	signer, err := parsePrivateKey(keyData)
+	// Zero the key material to avoid leaving it in memory.
+	for i := range keyData {
+		keyData[i] = 0
+	}
+	return signer, err
 }
 
 func sshAgentAuth(ctx context.Context, timeout time.Duration, logger *zap.Logger) (ssh.AuthMethod, error) {

--- a/remote/ssh_manager_test.go
+++ b/remote/ssh_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
 	"lvmsync_go/remote/testutil"
@@ -93,5 +94,28 @@ func TestSSHAgentAuthSuccess(t *testing.T) {
 	}
 	if auth == nil {
 		t.Fatal("expected auth method")
+	}
+}
+
+func TestLoadPrivateKeyZeroesSlice(t *testing.T) {
+	keyPath := testutil.CreateTempKey(t)
+	var captured []byte
+	parsePrivateKey = func(data []byte) (ssh.Signer, error) {
+		captured = data
+		return ssh.ParsePrivateKey(data)
+	}
+	t.Cleanup(func() { parsePrivateKey = ssh.ParsePrivateKey })
+
+	signer, err := loadPrivateKey(keyPath)
+	if err != nil {
+		t.Fatalf("loadPrivateKey: %v", err)
+	}
+	if signer == nil {
+		t.Fatal("expected signer")
+	}
+	for _, b := range captured {
+		if b != 0 {
+			t.Fatal("key data not zeroed")
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- wipe private key bytes in memory after parsing
- add test verifying key material is cleared

## Testing
- `go build ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `go test -coverprofile=coverage.out ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `golangci-lint run` *(fails: reading go.mod: open go.mod: no such file or directory)*
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c56eb6c008323b83e597d79b2d388