### PR TITLE
fix(logging): use production logger and report sync errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ This structure allows individual packages to be developed and tested in isolatio
 
 LVMSync emits structured logs using [zap](https://github.com/uber-go/zap). Errors are logged with
 structured fields instead of being written to stderr, and the logger is flushed on shutdown to
-ensure all entries are persisted. Even configuration failures during startup are reported through a
-temporary zap logger for uniform structured output. When `--progress` is enabled, progress updates
-are emitted as structured log entries, allowing external tooling to track transfer completion.
+ensure all entries are persisted. A production logger is initialized immediately so even
+configuration failures during startup are reported through the same structured format. When
+`--progress` is enabled, progress updates are emitted as structured log entries, allowing external
+tooling to track transfer completion.
 
 ### Expectations
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var (
 	runFunc           = rootcmd.Run
 	syncLoggerFunc    = rootcmd.SyncLogger
 	exitFunc          = os.Exit
-	exampleLoggerFunc = func() *zap.Logger { return zap.NewExample() }
+	exampleLoggerFunc = func() *zap.Logger { return zap.NewProduction() }
 	runtimeGOOS       = runtime.GOOS
 )
 
@@ -24,7 +24,9 @@ func main() {
 	if runtimeGOOS != "linux" {
 		tmpLogger := exampleLoggerFunc()
 		tmpLogger.Error("unsupported platform", zap.String("goos", runtimeGOOS))
-		_ = tmpLogger.Sync()
+		if err := tmpLogger.Sync(); err != nil {
+			tmpLogger.Error("Logger sync error", zap.Error(err))
+		}
 		exitFunc(1)
 		return
 	}
@@ -33,7 +35,9 @@ func main() {
 	if err != nil {
 		tmpLogger := exampleLoggerFunc()
 		tmpLogger.Error("configuration failed", zap.Error(err))
-		_ = tmpLogger.Sync()
+		if err := tmpLogger.Sync(); err != nil {
+			tmpLogger.Error("Logger sync error", zap.Error(err))
+		}
 		exitFunc(1)
 		return
 	}

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -14,10 +14,14 @@ import (
 type syncCheckCore struct {
 	zapcore.Core
 	synced *bool
+	err    error
 }
 
 func (c *syncCheckCore) Sync() error {
 	*c.synced = true
+	if c.err != nil {
+		return c.err
+	}
 	return c.Core.Sync()
 }
 
@@ -33,9 +37,10 @@ func TestMainLogsStructuredError(t *testing.T) {
 	exitFunc = func(c int) { code = c }
 	defer func() { exitFunc = oldExit }()
 
+	syncErr := errors.New("sync fail")
 	core, logs := observer.New(zap.ErrorLevel)
 	synced := false
-	logger := zap.New(&syncCheckCore{Core: core, synced: &synced})
+	logger := zap.New(&syncCheckCore{Core: core, synced: &synced, err: syncErr})
 
 	oldConfigure := configureFunc
 	configureFunc = func() (*config.Config, *zap.Logger, error) { return &config.Config{}, logger, nil }
@@ -50,6 +55,15 @@ func TestMainLogsStructuredError(t *testing.T) {
 	entries := logs.FilterMessage("run failed").All()
 	if len(entries) != 1 {
 		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+
+	syncEntries := logs.FilterMessage("Logger sync error").All()
+	if len(syncEntries) != 1 {
+		t.Fatalf("expected logger sync error entry, got %d", len(syncEntries))
+	}
+	errStr, ok := syncEntries[0].ContextMap()["error"].(string)
+	if !ok || errStr != syncErr.Error() {
+		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), syncEntries[0].ContextMap()["error"])
 	}
 
 	if !synced {
@@ -69,9 +83,10 @@ func TestMainLogsConfigError(t *testing.T) {
 	exitFunc = func(c int) { code = c }
 	defer func() { exitFunc = oldExit }()
 
+	syncErr := errors.New("sync fail")
 	core, logs := observer.New(zap.ErrorLevel)
 	synced := false
-	tmpLogger := zap.New(&syncCheckCore{Core: core, synced: &synced})
+	tmpLogger := zap.New(&syncCheckCore{Core: core, synced: &synced, err: syncErr})
 
 	oldExample := exampleLoggerFunc
 	exampleLoggerFunc = func() *zap.Logger { return tmpLogger }
@@ -86,6 +101,15 @@ func TestMainLogsConfigError(t *testing.T) {
 	entries := logs.FilterMessage("configuration failed").All()
 	if len(entries) != 1 {
 		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+
+	syncEntries := logs.FilterMessage("Logger sync error").All()
+	if len(syncEntries) != 1 {
+		t.Fatalf("expected logger sync error entry, got %d", len(syncEntries))
+	}
+	errStr, ok := syncEntries[0].ContextMap()["error"].(string)
+	if !ok || errStr != syncErr.Error() {
+		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), syncEntries[0].ContextMap()["error"])
 	}
 
 	if !synced {
@@ -103,9 +127,10 @@ func TestMainErrorsOnNonLinux(t *testing.T) {
 	exitFunc = func(c int) { code = c }
 	defer func() { exitFunc = oldExit }()
 
+	syncErr := errors.New("sync fail")
 	core, logs := observer.New(zap.ErrorLevel)
 	synced := false
-	tmpLogger := zap.New(&syncCheckCore{Core: core, synced: &synced})
+	tmpLogger := zap.New(&syncCheckCore{Core: core, synced: &synced, err: syncErr})
 
 	oldExample := exampleLoggerFunc
 	exampleLoggerFunc = func() *zap.Logger { return tmpLogger }
@@ -120,6 +145,15 @@ func TestMainErrorsOnNonLinux(t *testing.T) {
 	entries := logs.FilterMessage("unsupported platform").All()
 	if len(entries) != 1 {
 		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+
+	syncEntries := logs.FilterMessage("Logger sync error").All()
+	if len(syncEntries) != 1 {
+		t.Fatalf("expected logger sync error entry, got %d", len(syncEntries))
+	}
+	errStr, ok := syncEntries[0].ContextMap()["error"].(string)
+	if !ok || errStr != syncErr.Error() {
+		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), syncEntries[0].ContextMap()["error"])
 	}
 
 	if !synced {


### PR DESCRIPTION
## Summary
- ensure startup uses a production zap logger
- log sync failures in main before exiting
- document startup structured logging and tighten tests

## Testing
- `go build ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `go test -coverprofile=coverage.out ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `golangci-lint run` *(fails: reading go.mod: open go.mod: no such file or directory)*
- `go tool cover -func=coverage.out` *(fails: total 0.0%)*

------
https://chatgpt.com/codex/tasks/task_e_689c56eee3408323b2b29b46e1724867