### PR TITLE
chore: refresh prune candidates

### DIFF
--- a/.prune_candidates.txt
+++ b/.prune_candidates.txt
@@ -1,5 +1,0 @@
-grpc/auth
-internal/transport/h2
-internal/transport/quic
-internal/transport/ssh
-internal/transport/tcp

--- a/reports/pruning.md
+++ b/reports/pruning.md
@@ -3,3 +3,12 @@
 | cmd/grpcd | unused gRPC daemon command with broken tests | go vet compile errors | simpler binary; faster tests | `git rm -r cmd/grpcd` (restore: `git checkout -- cmd/grpcd`) |
 | internal/transport | package unused and contained merge conflicts | only imported by removed selectTransport | less dead code | `git rm -r internal/transport` (restore: `git checkout -- internal/transport`) |
 | transfer/compression_test.go | test file malformed and failing vet | go vet syntax error | clean test run | `git rm transfer/compression_test.go` (restore: `git checkout -- transfer/compression_test.go`) |
+
+## Regenerating prune candidates
+
+Run the reachmap tool to refresh `.prune_candidates.txt`:
+
+```sh
+go run ./cmd/reachmap > .prune_candidates.txt
+```
+


### PR DESCRIPTION
## Summary
- remove stale entries from `.prune_candidates.txt`
- document how to regenerate the list in `reports/pruning.md`

## Testing
- `go run ./cmd/reachmap` (fails: cannot find main module)
- `go build ./...` (fails: directory prefix . does not contain main module or its selected dependencies)
- `go test -coverprofile=coverage.out ./...` (fails: directory prefix . does not contain main module or its selected dependencies)
- `golangci-lint run` (fails: reading go.mod: open go.mod: no such file or directory)
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c56edb03c83238cffc1276ff5904a