### PR TITLE
refactor(config): parse flags from provided flag set

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,13 @@ func initConfig() *viper.Viper {
 This groups related flags once and lets Viper merge values from flags, `LVMSYNC_*` variables, and the
 `config.yaml` file.
 
-The overall loading flow works in three stages:
+The overall loading flow now passes an explicit `FlagSet` and argument slice:
 
-1. `registerFlags()` adds all flag groups to the command line.
-2. `buildViper()` binds flags, `LVMSYNC_*` environment variables, and an optional `config.yaml` into a single configuration source.
-3. `LoadConfig()` merges those values with built-in defaults and validates the result.
+1. `registerFlags(flagSets, fs)` adds all flag groups to the provided flag set.
+2. `LoadConfig(flagSets, defaults, fs, args)` parses the arguments, binds flags and `LVMSYNC_*` environment variables with Viper,
+   merges them with defaults, and returns the effective configuration along with any leftover positional arguments.
+
+`cmd/root.Configure` surfaces those leftover arguments so `Run` operates purely on provided inputs.
 
 ### New and updated flags
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -40,26 +40,27 @@ func SyncLogger(logger *zap.Logger) {
 }
 
 // Configure loads configuration, ensures privileges, validates, and sets up logging.
-func Configure() (*config.Config, *zap.Logger, error) {
+func Configure() (*config.Config, []string, *zap.Logger, error) {
 	defaults, err := config.DefaultConfig()
 	if err != nil {
-		return nil, nil, fmt.Errorf("configuration error: %w", err)
+		return nil, nil, nil, fmt.Errorf("configuration error: %w", err)
 	}
 	flagSets := config.NewFlagSets(defaults)
-	cfg, err := config.LoadConfig(flagSets, defaults)
+	fs := pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
+	cfg, args, err := config.LoadConfig(flagSets, defaults, fs, os.Args[1:])
 	if err != nil {
-		return nil, nil, fmt.Errorf("configuration error: %w", err)
+		return nil, nil, nil, fmt.Errorf("configuration error: %w", err)
 	}
 	esc := privilege.New()
 	if err = esc.Ensure(); err != nil {
-		return nil, nil, fmt.Errorf("privilege check failed: %w", err)
+		return nil, nil, nil, fmt.Errorf("privilege check failed: %w", err)
 	}
 	if err = cfg.Validate(); err != nil {
-		return nil, nil, fmt.Errorf("configuration validation error: %w", err)
+		return nil, nil, nil, fmt.Errorf("configuration validation error: %w", err)
 	}
 	logger, err := zap.NewProduction()
 	if err != nil {
-		return nil, nil, fmt.Errorf("logger initialization error: %w", err)
+		return nil, nil, nil, fmt.Errorf("logger initialization error: %w", err)
 	}
 	logger.Info("Effective configuration",
 		zap.String("block_size", cfg.HumanBlockSize()),
@@ -76,7 +77,7 @@ func Configure() (*config.Config, *zap.Logger, error) {
 		zap.String("grpc_listen", cfg.GRPCListen),
 		zap.String("grpc_connect", cfg.GRPCConnect),
 	)
-	return cfg, logger, nil
+	return cfg, args, logger, nil
 }
 
 // SetupGRPC starts the server and performs client handshake returning cleanup functions and heartbeat error channel.
@@ -119,7 +120,7 @@ func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPa
 }
 
 // Run orchestrates the command execution.
-func Run(cfg *config.Config, logger *zap.Logger) error {
+func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if cfg.Serve {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
@@ -129,7 +130,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 	defer lvm.Cleanup()
 
 	if cfg.ApplyMode != "" {
-		if err := applycmd.Run(cfg, cfg.ApplyMode, pflag.Args(), logger); err != nil {
+		if err := applycmd.Run(cfg, cfg.ApplyMode, args, logger); err != nil {
 			return fmt.Errorf("apply operation failed: %w", err)
 		}
 		return nil
@@ -187,11 +188,11 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 
 // Execute is a helper that configures and runs the root command.
 func Execute() error {
-	cfg, logger, err := Configure()
+	cfg, args, logger, err := Configure()
 	if err != nil {
 		return err
 	}
-	if err := Run(cfg, logger); err != nil {
+	if err := Run(cfg, args, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
 		SyncLogger(logger)
 		return err

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -9,8 +9,6 @@ import (
 
 	"lvmsync_go/config"
 
-	"github.com/spf13/pflag"
-
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 )
@@ -228,10 +226,7 @@ func TestRunHeartbeatError(t *testing.T) {
 		return <-sigErrCh
 	}
 
-	pflag.CommandLine = pflag.NewFlagSet("test", pflag.ContinueOnError)
-	pflag.CommandLine.Parse([]string{"vol"})
-
-	err := Run(cfg, logger)
+	err := Run(cfg, []string{"vol"}, logger)
 	if err == nil || err.Error() != "hb fail" {
 		t.Fatalf("expected heartbeat error, got %v", err)
 	}
@@ -300,10 +295,7 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 				return nil
 			}
 
-			pflag.CommandLine = pflag.NewFlagSet("test", pflag.ContinueOnError)
-			pflag.CommandLine.Parse([]string{"vol"})
-
-			if err := Run(cfg, logger); err != nil {
+			if err := Run(cfg, []string{"vol"}, logger); err != nil {
 				t.Fatalf("Run returned error: %v", err)
 			}
 

--- a/config/config.go
+++ b/config/config.go
@@ -612,19 +612,19 @@ func printFlagSetUsage(out io.Writer, fs *pflag.FlagSet) {
 	fmt.Fprintln(out)
 }
 
-func registerFlags(flagSets *FlagSets) {
-	for _, fs := range flagSets.All() {
-		pflag.CommandLine.AddFlagSet(fs)
+func registerFlags(flagSets *FlagSets, fs *pflag.FlagSet) {
+	for _, s := range flagSets.All() {
+		fs.AddFlagSet(s)
 	}
-	pflag.CommandLine.Usage = func() {
-		out := pflag.CommandLine.Output()
+	fs.Usage = func() {
+		out := fs.Output()
 		fmt.Fprintln(out, "Usage of", os.Args[0]+":")
 		fmt.Fprintln(out)
-		for _, fs := range flagSets.All() {
-			printFlagSetUsage(out, fs)
+		for _, s := range flagSets.All() {
+			printFlagSetUsage(out, s)
 		}
 	}
-	pflag.Usage = pflag.CommandLine.Usage
+	pflag.Usage = fs.Usage
 }
 
 func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
@@ -659,13 +659,15 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	return v, nil
 }
 
-func LoadConfig(flagSets *FlagSets, defaults *Config) (*Config, error) {
-	registerFlags(flagSets)
-	pflag.Parse()
+func LoadConfig(flagSets *FlagSets, defaults *Config, fs *pflag.FlagSet, args []string) (*Config, []string, error) {
+	registerFlags(flagSets, fs)
+	if err := fs.Parse(args); err != nil {
+		return nil, nil, err
+	}
 
 	v, err := buildViper(flagSets)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	builder := &Builder{
@@ -674,10 +676,10 @@ func LoadConfig(flagSets *FlagSets, defaults *Config) (*Config, error) {
 	}
 	conf, err := builder.Build()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return conf, nil
+	return conf, fs.Args(), nil
 }
 
 // Validate verifies configuration values using the real OS euid.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -724,14 +724,14 @@ func TestDefaultCDCTunables(t *testing.T) {
 
 func TestLoadConfigPrecedence(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
-	resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
 	t.Setenv("LVMSYNC_PARALLEL", "2")
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	conf, err := LoadConfig(fs, defaults)
+	conf, _, err := LoadConfig(fs, defaults, rootFS, args)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -742,14 +742,14 @@ func TestLoadConfigPrecedence(t *testing.T) {
 
 func TestLoadConfigInvalidPath(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing.yaml")
-	resetFlags([]string{"--config", missing})
+	rootFS, args := newFlagSet([]string{"--config", missing})
 
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	if _, err := LoadConfig(fs, defaults); err == nil || !strings.Contains(err.Error(), "error reading config file") {
+	if _, _, err := LoadConfig(fs, defaults, rootFS, args); err == nil || !strings.Contains(err.Error(), "error reading config file") {
 		t.Fatalf("expected config file error, got %v", err)
 	}
 }

--- a/config/loadconfig_test.go
+++ b/config/loadconfig_test.go
@@ -11,11 +11,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// resetFlags replaces the global command line flags and sets os.Args.
-func resetFlags(args []string) {
-	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
-	pflag.CommandLine.SetOutput(io.Discard)
-	os.Args = append([]string{"test"}, args...)
+func newFlagSet(args []string) (*pflag.FlagSet, []string) {
+	fs := pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	return fs, args
 }
 
 func writeTempConfig(t *testing.T, content string) string {
@@ -29,16 +28,16 @@ func writeTempConfig(t *testing.T, content string) string {
 }
 
 func TestRegisterFlags(t *testing.T) {
-	resetFlags(nil)
+	rootFS, _ := newFlagSet(nil)
 	cfg, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(cfg)
-	registerFlags(fs)
+	registerFlags(fs, rootFS)
 	names := []string{"parallel", "ssh_user", "grpc_port"}
 	for _, name := range names {
-		if f := pflag.CommandLine.Lookup(name); f == nil {
+		if f := rootFS.Lookup(name); f == nil {
 			t.Fatalf("missing %s flag", name)
 		}
 	}
@@ -48,14 +47,16 @@ func TestBuildViperPrecedence(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 
 	t.Run("config_overrides_defaults", func(t *testing.T) {
-		resetFlags([]string{"--config", cfgPath})
+		rootFS, args := newFlagSet([]string{"--config", cfgPath})
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
 		}
 		fs := NewFlagSets(cfg)
-		registerFlags(fs)
-		pflag.Parse()
+		registerFlags(fs, rootFS)
+		if err := rootFS.Parse(args); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
 		v, err := buildViper(fs)
 		if err != nil {
 			t.Fatalf("buildViper: %v", err)
@@ -66,15 +67,17 @@ func TestBuildViperPrecedence(t *testing.T) {
 	})
 
 	t.Run("env_overrides_config", func(t *testing.T) {
-		resetFlags([]string{"--config", cfgPath})
+		rootFS, args := newFlagSet([]string{"--config", cfgPath})
 		t.Setenv("LVMSYNC_PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
 		}
 		fs := NewFlagSets(cfg)
-		registerFlags(fs)
-		pflag.Parse()
+		registerFlags(fs, rootFS)
+		if err := rootFS.Parse(args); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
 		v, err := buildViper(fs)
 		if err != nil {
 			t.Fatalf("buildViper: %v", err)
@@ -85,15 +88,17 @@ func TestBuildViperPrecedence(t *testing.T) {
 	})
 
 	t.Run("flags_override_env", func(t *testing.T) {
-		resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
+		rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
 		t.Setenv("LVMSYNC_PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
 		}
 		fs := NewFlagSets(cfg)
-		registerFlags(fs)
-		pflag.Parse()
+		registerFlags(fs, rootFS)
+		if err := rootFS.Parse(args); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
 		v, err := buildViper(fs)
 		if err != nil {
 			t.Fatalf("buildViper: %v", err)
@@ -105,16 +110,16 @@ func TestBuildViperPrecedence(t *testing.T) {
 }
 
 func TestUsageOutput(t *testing.T) {
-	resetFlags(nil)
+	rootFS, _ := newFlagSet(nil)
 	cfg, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(cfg)
-	registerFlags(fs)
+	registerFlags(fs, rootFS)
 	buf := &bytes.Buffer{}
-	pflag.CommandLine.SetOutput(buf)
-	pflag.Usage()
+	rootFS.SetOutput(buf)
+	rootFS.Usage()
 	out := buf.String()
 	wants := []string{
 		"General Options:", "--config",

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -3,13 +3,11 @@ package config
 import (
 	"testing"
 	"time"
-
-	"github.com/spf13/pflag"
 )
 
 func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
-	resetFlags([]string{"--config", cfgPath, "--parallel", "3"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
 	t.Setenv("LVMSYNC_PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
@@ -17,8 +15,10 @@ func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -36,7 +36,7 @@ func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 
 func TestEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
-	resetFlags([]string{"--config", cfgPath})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
 	t.Setenv("LVMSYNC_PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
@@ -44,8 +44,10 @@ func TestEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -73,15 +75,17 @@ func TestFlagSetsBindToViper(t *testing.T) {
 		"--grpc_heartbeat_interval", "2s",
 		"--grpc_heartbeat_send_timeout", "1s",
 	}
-	resetFlags(args)
+	rootFS, parseArgs := newFlagSet(args)
 
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(parseArgs); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -119,7 +123,7 @@ func TestFlagSetsBindToViper(t *testing.T) {
 
 func TestSSHUserCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "ssh_user: config\n")
-	resetFlags([]string{"--config", cfgPath, "--ssh_user", "cli"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh_user", "cli"})
 	t.Setenv("LVMSYNC_SSH_USER", "env")
 
 	defaults, err := DefaultConfig()
@@ -127,8 +131,10 @@ func TestSSHUserCLIOverridesEnvAndConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -146,7 +152,7 @@ func TestSSHUserCLIOverridesEnvAndConfig(t *testing.T) {
 
 func TestSSHUserEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "ssh_user: config\n")
-	resetFlags([]string{"--config", cfgPath})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
 	t.Setenv("LVMSYNC_SSH_USER", "env")
 
 	defaults, err := DefaultConfig()
@@ -154,8 +160,10 @@ func TestSSHUserEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -173,7 +181,7 @@ func TestSSHUserEnvOverridesConfig(t *testing.T) {
 
 func TestSSHHostCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "ssh_host: config\n")
-	resetFlags([]string{"--config", cfgPath, "--ssh_host", "cli"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh_host", "cli"})
 	t.Setenv("LVMSYNC_SSH_HOST", "env")
 
 	defaults, err := DefaultConfig()
@@ -181,8 +189,10 @@ func TestSSHHostCLIOverridesEnvAndConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -200,7 +210,7 @@ func TestSSHHostCLIOverridesEnvAndConfig(t *testing.T) {
 
 func TestSSHHostEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "ssh_host: config\n")
-	resetFlags([]string{"--config", cfgPath})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
 	t.Setenv("LVMSYNC_SSH_HOST", "env")
 
 	defaults, err := DefaultConfig()
@@ -208,8 +218,10 @@ func TestSSHHostEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -227,7 +239,7 @@ func TestSSHHostEnvOverridesConfig(t *testing.T) {
 
 func TestTransportCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "transport: tcp+tls\n")
-	resetFlags([]string{"--config", cfgPath, "--transport", "ssh"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--transport", "ssh"})
 	t.Setenv("LVMSYNC_TRANSPORT", "tcp+tls")
 
 	defaults, err := DefaultConfig()
@@ -235,8 +247,10 @@ func TestTransportCLIOverridesEnvAndConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -254,7 +268,7 @@ func TestTransportCLIOverridesEnvAndConfig(t *testing.T) {
 
 func TestTransportEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "transport: tcp+tls\n")
-	resetFlags([]string{"--config", cfgPath})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
 	t.Setenv("LVMSYNC_TRANSPORT", "ssh")
 
 	defaults, err := DefaultConfig()
@@ -262,8 +276,10 @@ func TestTransportEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -281,7 +297,7 @@ func TestTransportEnvOverridesConfig(t *testing.T) {
 
 func TestConcurrencyCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "concurrency: 1\n")
-	resetFlags([]string{"--config", cfgPath, "--concurrency", "3"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--concurrency", "3"})
 	t.Setenv("LVMSYNC_CONCURRENCY", "2")
 
 	defaults, err := DefaultConfig()
@@ -289,8 +305,10 @@ func TestConcurrencyCLIOverridesEnvAndConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {
@@ -308,7 +326,7 @@ func TestConcurrencyCLIOverridesEnvAndConfig(t *testing.T) {
 
 func TestConcurrencyEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "concurrency: 1\n")
-	resetFlags([]string{"--config", cfgPath})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
 	t.Setenv("LVMSYNC_CONCURRENCY", "2")
 
 	defaults, err := DefaultConfig()
@@ -316,8 +334,10 @@ func TestConcurrencyEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	registerFlags(fs)
-	pflag.Parse()
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 
 	v, err := buildViper(fs)
 	if err != nil {

--- a/config/serve_flags_test.go
+++ b/config/serve_flags_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 func TestServeFlagParsing(t *testing.T) {
-	resetFlags([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--serve_accept_timeout", "5s"})
+	rootFS, args := newFlagSet([]string{"--serve", "--serve_listen", "localhost:9900", "--serve_protocol", "p", "--serve_algorithm", "a", "--serve_test_space", "t", "--serve_policy", "accept", "--serve_accept_timeout", "5s"})
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := NewFlagSets(defaults)
-	cfg, err := LoadConfig(fs, defaults)
+	cfg, _, err := LoadConfig(fs, defaults, rootFS, args)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 		return
 	}
 
-	cfg, logger, err := configureFunc()
+	cfg, args, logger, err := configureFunc()
 	if err != nil {
 		tmpLogger := exampleLoggerFunc()
 		tmpLogger.Error("configuration failed", zap.Error(err))
@@ -37,7 +37,7 @@ func main() {
 		exitFunc(1)
 		return
 	}
-	if err := runFunc(cfg, logger); err != nil {
+	if err := runFunc(cfg, args, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
 		syncLogger(logger)
 		exitFunc(1)

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -24,7 +24,7 @@ func (c *syncCheckCore) Sync() error {
 func TestMainLogsStructuredError(t *testing.T) {
 	// stub run to force an error
 	oldRun := runFunc
-	runFunc = func(_ *config.Config, _ *zap.Logger) error { return errors.New("boom") }
+	runFunc = func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("boom") }
 	defer func() { runFunc = oldRun }()
 
 	// capture exit code
@@ -38,7 +38,7 @@ func TestMainLogsStructuredError(t *testing.T) {
 	logger := zap.New(&syncCheckCore{Core: core, synced: &synced})
 
 	oldConfigure := configureFunc
-	configureFunc = func() (*config.Config, *zap.Logger, error) { return &config.Config{}, logger, nil }
+	configureFunc = func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil }
 	defer func() { configureFunc = oldConfigure }()
 
 	main()
@@ -60,7 +60,7 @@ func TestMainLogsStructuredError(t *testing.T) {
 func TestMainLogsConfigError(t *testing.T) {
 	// stub configure to return an error
 	oldConfigure := configureFunc
-	configureFunc = func() (*config.Config, *zap.Logger, error) { return nil, nil, errors.New("cfg fail") }
+	configureFunc = func() (*config.Config, []string, *zap.Logger, error) { return nil, nil, nil, errors.New("cfg fail") }
 	defer func() { configureFunc = oldConfigure }()
 
 	// capture exit code


### PR DESCRIPTION
## Summary
- decouple LoadConfig from global flags by accepting a FlagSet and args
- surface leftover CLI args from Configure and pass them through Run
- update tests and docs for explicit FlagSet parsing

## Testing
- `go build ./...` (fails: directory prefix . does not contain main module)
- `go test -coverprofile=coverage.out ./...` (fails: directory prefix . does not contain main module)
- `golangci-lint run` (fails: open go.mod: no such file or directory)
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c56e9f6048323b6d23e53216f85a1