### PR TITLE
feat(grpc): add setup timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_
 | `--grpc_connect` | `LVMSYNC_GRPC_CONNECT` | `grpc_connect` | gRPC server address to connect to |
 | `--grpc_port` | `LVMSYNC_GRPC_PORT` | `grpc_port` | gRPC port to listen on |
 | `--grpc_dial_timeout` | `LVMSYNC_GRPC_DIAL_TIMEOUT` | `grpc_dial_timeout` | gRPC dial timeout |
+| `--grpc_setup_timeout` | `LVMSYNC_GRPC_SETUP_TIMEOUT` | `grpc_setup_timeout` | gRPC setup timeout |
 | `--grpc_heartbeat_interval` | `LVMSYNC_GRPC_HEARTBEAT_INTERVAL` | `grpc_heartbeat_interval` | gRPC heartbeat interval |
 | `--grpc_heartbeat_send_timeout` | `LVMSYNC_GRPC_HEARTBEAT_SEND_TIMEOUT` | `grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout |
 | `--tls_cert` | `LVMSYNC_TLS_CERT` | `tls_cert` | TLS certificate file |
@@ -802,6 +803,7 @@ timeouts or cancellations are reported separately.
 | ------------------ | ---------------------------- | --------------- |
 | `--grpc_port`      | gRPC port to listen on       | `8443`          |
 | `--grpc_dial_timeout` | gRPC dial timeout          | `5s`            |
+| `--grpc_setup_timeout` | gRPC setup timeout        | `10s`           |
 | `--grpc_heartbeat_interval` | gRPC heartbeat interval | `30s`          |
 | `--grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout | `5s` |
 | `--tls_cert`       | TLS certificate file         | `""`            |

--- a/app/app.go
+++ b/app/app.go
@@ -95,11 +95,11 @@ func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger
 }
 
 // ClientHandshake performs the gRPC client handshake and returns a cleanup function and heartbeat error channel.
-func ClientHandshake(cfg *config.Config, logger *zap.Logger) (func(), chan error, error) {
+func ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), chan error, error) {
 	if cfg.GRPCConnect == "" {
 		return func() {}, nil, nil
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	conn, err := dial(ctx, cfg.GRPCConnect, grpcclient.Config{
 		TLSCert:       cfg.TLSCert,
 		TLSKey:        cfg.TLSKey,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -148,7 +148,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 	}
 	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
 
-	cleanup, hbErrCh, err := ClientHandshake(cfg, logger)
+	cleanup, hbErrCh, err := ClientHandshake(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestClientHandshakeDialError(t *testing.T) {
 		return nil, errors.New("dial fail")
 	}
 
-	if _, _, err := ClientHandshake(cfg, logger); err == nil {
+	if _, _, err := ClientHandshake(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -202,7 +202,7 @@ func TestClientHandshakeHeartbeatFailure(t *testing.T) {
 	}
 	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
 
-	cleanup, hbErrCh, err := ClientHandshake(cfg, logger)
+	cleanup, hbErrCh, err := ClientHandshake(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestClientHandshakeHeartbeatTimeout(t *testing.T) {
 	}
 	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
 
-	cleanup, hbErrCh, err := ClientHandshake(cfg, logger)
+	cleanup, hbErrCh, err := ClientHandshake(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -93,7 +93,7 @@ func SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (fun
 		}
 	default:
 	}
-	cleanupClient, hbErrCh, err := clientHandshake(cfg, logger)
+	cleanupClient, hbErrCh, err := clientHandshake(ctx, cfg, logger)
 	if err != nil {
 		cleanupSrv()
 		<-srvErrCh
@@ -139,7 +139,7 @@ func Run(cfg *config.Config, logger *zap.Logger) error {
 		return fmt.Errorf("select transport: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.GRPCSetupTimeout)
 	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(ctx, cfg, logger)
 	if err != nil {
 		cancel()

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -32,7 +32,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		return func() { srvCleanCalled = true }, srvErrCh, nil
 	}
-	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	clientHandshake = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return func() { clientCleanCalled = true }, make(chan error), nil
 	}
 
@@ -88,7 +88,7 @@ func TestSetupGRPCClientError(t *testing.T) {
 	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		return func() { srvCleanupCalled = true }, srvErrCh, nil
 	}
-	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	clientHandshake = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return nil, nil, errors.New("client fail")
 	}
 	done := make(chan struct{})
@@ -111,6 +111,35 @@ func TestSetupGRPCClientError(t *testing.T) {
 	}
 }
 
+func TestSetupGRPCTimeout(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	srvCleanupCalled := false
+	origStart := startGRPCServer
+	origClient := clientHandshake
+	defer func() {
+		startGRPCServer = origStart
+		clientHandshake = origClient
+	}()
+	startGRPCServer = func(ctx context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+		ch := make(chan error, 1)
+		go func() { <-ctx.Done(); ch <- ctx.Err() }()
+		return func() { srvCleanupCalled = true }, ch, nil
+	}
+	clientHandshake = func(ctx context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+		<-ctx.Done()
+		return func() {}, nil, ctx.Err()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if _, _, _, err := SetupGRPC(ctx, cfg, logger); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if !srvCleanupCalled {
+		t.Fatalf("server cleanup not called on timeout")
+	}
+}
+
 func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
@@ -126,7 +155,7 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 		errCh <- errors.New("serve boom")
 		return func() { srvCleanupCalled = true; close(errCh) }, errCh, nil
 	}
-	clientHandshake = func(_ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	clientHandshake = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		t.Fatalf("client handshake should not be called")
 		return nil, nil, nil
 	}
@@ -186,7 +215,7 @@ func TestExecuteClient(t *testing.T) {
 }
 
 func TestRunHeartbeatError(t *testing.T) {
-	cfg := &config.Config{StdoutMode: true}
+	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second}
 	logger := zap.NewNop()
 
 	origStart := startGRPCServer
@@ -212,7 +241,7 @@ func TestRunHeartbeatError(t *testing.T) {
 		close(ch)
 		return func() {}, ch, nil
 	}
-	clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
+	clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
 	}
 	selectTransport = func(*config.Config, *zap.Logger) error { return nil }
@@ -251,7 +280,7 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
-			cfg := &config.Config{StdoutMode: true, GRPCConnect: tc.grpcConnect}
+			cfg := &config.Config{StdoutMode: true, GRPCConnect: tc.grpcConnect, GRPCSetupTimeout: time.Second}
 			logger := zap.NewNop()
 
 			origStart := startGRPCServer
@@ -277,11 +306,11 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 
 			if tc.hbChannel {
 				hbErrCh := make(chan error)
-				clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
+				clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 					return func() { close(hbErrCh) }, hbErrCh, nil
 				}
 			} else {
-				clientHandshake = func(*config.Config, *zap.Logger) (func(), chan error, error) {
+				clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 					return func() {}, nil, nil
 				}
 			}

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,7 @@ sync_interval: "1GB"  # Bytes between fdatasync calls
 # gRPC Options
 grpc_port: 8443  # gRPC port to listen on
 grpc_dial_timeout: 5s  # gRPC dial timeout
+grpc_setup_timeout: 10s  # gRPC setup timeout
 grpc_heartbeat_interval: 30s  # gRPC heartbeat interval
 grpc_heartbeat_send_timeout: 5s  # gRPC heartbeat send timeout
 tls_cert: ""  # TLS certificate file

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,7 @@ type Config struct {
 	GRPCListen           string        `mapstructure:"grpc_listen"`
 	GRPCConnect          string        `mapstructure:"grpc_connect"`
 	GRPCDialTimeout      time.Duration `mapstructure:"grpc_dial_timeout"` // gRPC dial timeout
+	GRPCSetupTimeout     time.Duration `mapstructure:"grpc_setup_timeout"`
 	HeartbeatInterval    time.Duration `mapstructure:"grpc_heartbeat_interval"`
 	HeartbeatSendTimeout time.Duration `mapstructure:"grpc_heartbeat_send_timeout"`
 	TLSCert              string        `mapstructure:"tls_cert"`
@@ -461,6 +462,7 @@ func DefaultConfig() (*Config, error) {
 		GRPCListen:           "",
 		GRPCConnect:          "",
 		GRPCDialTimeout:      5 * time.Second,
+		GRPCSetupTimeout:     10 * time.Second,
 		HeartbeatInterval:    30 * time.Second,
 		HeartbeatSendTimeout: 5 * time.Second,
 		TLSCert:              "",
@@ -571,6 +573,7 @@ func initGRPCFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("grpc_listen", cfg.GRPCListen, "gRPC listen address")
 	fs.String("grpc_connect", cfg.GRPCConnect, "gRPC server address to connect to")
 	fs.Duration("grpc_dial_timeout", cfg.GRPCDialTimeout, "gRPC dial timeout")
+	fs.Duration("grpc_setup_timeout", cfg.GRPCSetupTimeout, "gRPC setup timeout")
 	fs.Duration("grpc_heartbeat_interval", cfg.HeartbeatInterval, "gRPC heartbeat interval")
 	fs.Duration("grpc_heartbeat_send_timeout", cfg.HeartbeatSendTimeout, "gRPC heartbeat send timeout")
 	fs.String("tls_cert", cfg.TLSCert, "TLS certificate file")
@@ -693,6 +696,9 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	}
 	if c.GRPCDialTimeout <= 0 {
 		return fmt.Errorf("grpc dial timeout must be > 0")
+	}
+	if c.GRPCSetupTimeout <= 0 {
+		return fmt.Errorf("grpc setup timeout must be > 0")
 	}
 	if c.HeartbeatInterval <= 0 {
 		return fmt.Errorf("grpc heartbeat interval must be > 0")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -328,6 +328,7 @@ func TestConfigValidate(t *testing.T) {
 			SSHKeepAliveInterval: time.Second,
 			LVMTimeout:           time.Second,
 			GRPCDialTimeout:      time.Second,
+			GRPCSetupTimeout:     time.Second,
 			HeartbeatInterval:    time.Second,
 			HeartbeatSendTimeout: time.Second,
 			TCPParallel:          1,
@@ -350,35 +351,42 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalidKeepalive", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+		cfg := &Config{SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatInterval", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatSendTimeout", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0, TCPParallel: 1}
+		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0, TCPParallel: 1}
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("invalidGRPCSetupTimeout", func(t *testing.T) {
+		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: 0, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPParallel", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 5}
+		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 5}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPLowat", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, TCPNotSentLowAt: -1}
+		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, TCPNotSentLowAt: -1}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -452,7 +460,7 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{Mode: "default", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+	cfg := &Config{Mode: "default", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
 	if err := cfg.ValidateWith(geteuid); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -182,6 +182,7 @@ func TestInitGRPCFlags(t *testing.T) {
 		{"grpc_listen", cfg.GRPCListen},
 		{"grpc_connect", cfg.GRPCConnect},
 		{"grpc_dial_timeout", cfg.GRPCDialTimeout.String()},
+		{"grpc_setup_timeout", cfg.GRPCSetupTimeout.String()},
 		{"grpc_heartbeat_interval", cfg.HeartbeatInterval.String()},
 		{"grpc_heartbeat_send_timeout", cfg.HeartbeatSendTimeout.String()},
 		{"tls_cert", cfg.TLSCert},


### PR DESCRIPTION
## Summary
- add `GRPCSetupTimeout` to configuration with a 10s default and CLI flag
- use timeout-based context during gRPC setup and propagate through handshake
- document the new gRPC setup timeout option

## Testing
- `GO111MODULE=off go build ./...` *(fails: cannot find packages)*
- `GO111MODULE=off go test -coverprofile=coverage.out ./...` *(fails: cannot find packages)*
- `golangci-lint run` *(fails: open go.mod: no such file or directory)*
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_689c56ec732083238ea8d0cd3fa0a0d8