### PR TITLE
fix: use provided args and set gRPC timeout in tests

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -165,7 +165,6 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		}()
 	}
 
-	args := pflag.Args()
 	if (cfg.StdoutMode && len(args) < 1) || (!cfg.StdoutMode && len(args) < 2) {
 		pflag.Usage()
 		return fmt.Errorf("invalid arguments")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -476,6 +476,7 @@ func TestValidateMode(t *testing.T) {
 	base := Config{
 		SSHKeepAliveInterval: time.Second,
 		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
 		HeartbeatInterval:    time.Second,
 		HeartbeatSendTimeout: time.Second,
 		TCPParallel:          1,


### PR DESCRIPTION
## Summary
- remove redundant call to `pflag.Args()` in root command
- set `GRPCSetupTimeout` in ValidateMode test to satisfy validation

## Testing
- `go build ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `go test -coverprofile=coverage.out ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `golangci-lint run` *(fails: reading go.mod: no such file or directory)*
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c5bd71ccc8323af14ad3ba1e3ec61