### PR TITLE
fix(main): handle zap logger creation errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,8 +14,14 @@ var (
 	runFunc           = rootcmd.Run
 	syncLoggerFunc    = rootcmd.SyncLogger
 	exitFunc          = os.Exit
-	exampleLoggerFunc = func() *zap.Logger { return zap.NewProduction() }
-	runtimeGOOS       = runtime.GOOS
+	exampleLoggerFunc = func() *zap.Logger {
+		logger, err := zap.NewProduction()
+		if err != nil {
+			return zap.NewNop()
+		}
+		return logger
+	}
+	runtimeGOOS = runtime.GOOS
 )
 
 func syncLogger(logger *zap.Logger) { syncLoggerFunc(logger) }


### PR DESCRIPTION
## Summary
- handle zap.NewProduction error when constructing fallback logger

## Testing
- `go build ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `go test -coverprofile=coverage.out ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `golangci-lint run` *(fails: reading go.mod: open go.mod: no such file or directory)*
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_689c5d33888c832383c66966dcfbf0bf