### PR TITLE
fix(grpc): enforce dial timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,9 @@ timeouts or cancellations are reported separately.
 
 #### gRPC Options
 
+The client aborts dialing if a connection cannot be established within
+`--grpc_dial_timeout`, which defaults to `5s`.
+
 | Option             | Description                  | Default         |
 | ------------------ | ---------------------------- | --------------- |
 | `--grpc_port`      | gRPC port to listen on       | `8443`          |

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -56,11 +57,23 @@ func Dial(ctx context.Context, addr string, conf Config, opts ...grpc.DialOption
 	if !strings.Contains(addr, "://") {
 		target = "passthrough:///" + addr
 	}
+	ctx, cancel := context.WithTimeout(ctx, conf.DialTimeout)
+	defer cancel()
 	conn, err := grpc.NewClient(target, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return conn, nil
+	conn.Connect()
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return conn, nil
+		}
+		if !conn.WaitForStateChange(ctx, state) {
+			conn.Close()
+			return nil, ctx.Err()
+		}
+	}
 }
 
 func Handshake(ctx context.Context, c proto.ReplicationClient, hs *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -113,6 +113,20 @@ func TestDial(t *testing.T) {
 	}
 }
 
+func TestDialTimeoutExceeded(t *testing.T) {
+	slowDialer := func(ctx context.Context, s string) (net.Conn, error) {
+		time.Sleep(50 * time.Millisecond)
+		return nil, errors.New("no connection")
+	}
+	_, err := Dial(context.Background(), "slow", Config{AllowInsecure: true, DialTimeout: 10 * time.Millisecond}, grpc.WithContextDialer(slowDialer))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
 type fakeSessionClient struct {
 	stubClient
 	resp *proto.SessionResponse

--- a/reports/doc-updates.md
+++ b/reports/doc-updates.md
@@ -2,3 +2,4 @@
 - README.md: document `--transport` as reserved; examples note "transport not implemented" error.
 - README.md: clarified `--strict_host_key_checking` flag; disabling it now skips SSH host key verification.
 - README.md: documented SSH agent usage when `--ssh_key` is unset and that the connection respects `--ssh_timeout`.
+- README.md: describe gRPC dial timeout behavior and default.

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -1,6 +1,5 @@
 | Type | Component | Evidence | Impact | Fix | Priority |
 |------|-----------|----------|--------|-----|----------|
-| deprecated-api | grpc/client/client.go | used grpc.DialContext deprecated API | future gRPC releases could break dialing | replaced with grpc.NewClient | P1 |
 | unreachable | internal/transport | package unused and failing vet | dead code increased maintenance | removed package and callers | P1 |
 | doc-missing | README.md | `--transport` flag documented but not implemented | users misled about transport selection | docs note flag is ignored | P2 |
 | bug | remote/remote.go | `setupHostKeyCallback` ignored verify flag | users could not disable host key verification | respect flag and use `ssh.InsecureIgnoreHostKey` when false | P1 |

--- a/reports/machine/gaps.json
+++ b/reports/machine/gaps.json
@@ -1,13 +1,5 @@
 [
   {
-    "type": "deprecated-api",
-    "component": "grpc/client/client.go",
-    "evidence": "used grpc.DialContext deprecated API",
-    "impact": "future gRPC releases could break dialing",
-    "fix": "replaced with grpc.NewClient",
-    "priority": "P1"
-  },
-  {
     "type": "unreachable",
     "component": "internal/transport",
     "evidence": "package unused and failing vet",


### PR DESCRIPTION
## Summary
- enforce gRPC dial timeout and wait for connection readiness
- test gRPC client dial timeout
- document gRPC dial timeout and remove resolved gap entry

## Testing
- `go build ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `go test -coverprofile=coverage.out ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `golangci-lint run` *(fails: reading go.mod: open go.mod: no such file or directory)*
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c6122b2008323b8990e5d9a049bf4