### PR TITLE
feat(device): add raw block device abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Compression**: Samples 8 KiB per chunk, skipping compression when the ratio exceeds a threshold. Auto mode selects LZ4 for chunks <256 KiB and Zstd level 1 for larger chunks on CPUs with AVX2, AVX-512, or NEON support.
 - **Checksum Verification**: Ensures data integrity using SHA-256 or BLAKE3, automatically selecting BLAKE3 on CPUs with AES-NI, AVX2/AVX-512, or NEON.
 - **Native LVM2 Integration**: Uses Go bindings to `liblvm2cmd` instead of shelling out.
+- **Generic Block Device Support**: Access raw `/dev/*` paths and loopback images through a unified device abstraction.
 - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or a Bloom filter with optional FastCDC content-defined chunking and mmap-backed index.
 - **Hashing**: Hardware-accelerated XXH3 provides fast deduplication hints while BLAKE3 digests are stored in manifests for integrity.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
@@ -53,6 +54,7 @@ See AGENTS.md for contributor tasks and design guidelines.
 LVMSync is organized into modular packages to keep concerns separated:
 
 - `lvm` – manages snapshot creation, monitoring, and cleanup.
+- `device` – opens and queries generic block devices such as raw `/dev/*` paths.
 - `transfer` – performs block-level synchronization, compression, deduplication, and resume logic.
   - Internally split into focused modules: `progress.go`, `handshake.go`, and `block_writer.go` for clearer responsibilities.
 - `remote` – wraps SSH functionality for running commands on remote hosts and coordinating transfers. Callers must provide a `context.Context` with a timeout when starting the privileged helper to allow cancellation if the remote command fails to launch.

--- a/device/device.go
+++ b/device/device.go
@@ -1,0 +1,13 @@
+package device
+
+// Device describes a block device capable of reporting size information.
+type Device interface {
+	// Path returns the device path.
+	Path() string
+	// SizeBytes returns the total size of the device in bytes.
+	SizeBytes() uint64
+	// BlockSize returns the logical block size of the device in bytes.
+	BlockSize() uint64
+	// Close releases any resources associated with the device.
+	Close() error
+}

--- a/device/raw.go
+++ b/device/raw.go
@@ -1,0 +1,53 @@
+package device
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// RawDevice represents a generic block device opened from /dev.
+type RawDevice struct {
+	f         *os.File
+	size      uint64
+	blockSize uint64
+}
+
+// OpenRaw opens a block device at the given path and queries its size and block size.
+func OpenRaw(path string) (*RawDevice, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
+		return nil, fmt.Errorf("%s is not a block device", path)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	size, err := unix.IoctlGetUint64(int(f.Fd()), unix.BLKGETSIZE64)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	bs, err := unix.IoctlGetInt(int(f.Fd()), unix.BLKSSZGET)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &RawDevice{f: f, size: size, blockSize: uint64(bs)}, nil
+}
+
+// Path returns the device path.
+func (d *RawDevice) Path() string { return d.f.Name() }
+
+// SizeBytes returns the total size of the device in bytes.
+func (d *RawDevice) SizeBytes() uint64 { return d.size }
+
+// BlockSize returns the logical block size of the device in bytes.
+func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
+
+// Close closes the underlying file descriptor.
+func (d *RawDevice) Close() error { return d.f.Close() }

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -1,0 +1,27 @@
+package device
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOpenRawRejectsRegularFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "file")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	if _, err := OpenRaw(f.Name()); err == nil {
+		t.Fatalf("expected error for regular file")
+	}
+}
+
+func TestOpenRawRejectsCharDevice(t *testing.T) {
+	if _, err := os.Stat("/dev/null"); err == nil {
+		if _, err := OpenRaw("/dev/null"); err == nil {
+			t.Fatalf("expected error for char device")
+		}
+	} else if os.IsNotExist(err) {
+		t.Skip("/dev/null not found")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce device package with generic Device interface
- add RawDevice implementation using ioctl to query size and block size
- document generic block device support in README

## Testing
- `go build ./...` *(fails: directory prefix . does not contain main module)*
- `go test -coverprofile=coverage.out ./...` *(fails: directory prefix . does not contain main module)*
- `golangci-lint run` *(fails: reading go.mod: open go.mod: no such file or directory)*
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c69a809808323bed5f4fab478fb86