### PR TITLE
feat: add mmap-backed manifest and rebuild command

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,14 @@ lvmsync [options] <snapshot|lvm device> <destination>
 
 The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps.
 
+### Manifest Operations
+
+Rebuild a manifest index for an existing device:
+
+```sh
+lvmsync manifest rebuild /dev/vg0/lv0
+```
+
 ### Options
 
 #### General Options

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -1,0 +1,46 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+	manifestpkg "lvmsync_go/manifest"
+)
+
+// Run executes manifest subcommands. Currently only "rebuild" is supported.
+func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
+	fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)
+	output := fs.String("output", "", "manifest output file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	v := viper.New()
+	_ = v.BindPFlags(fs)
+	remaining := fs.Args()
+	if len(remaining) < 2 || remaining[0] != "rebuild" {
+		fs.Usage()
+		return fmt.Errorf("usage: lvmsync manifest rebuild <device>")
+	}
+	device := remaining[1]
+	path := *output
+	if path == "" {
+		path = device + ".manifest"
+	}
+	if logger != nil {
+		logger.Info("rebuilding manifest", zap.String("device", device), zap.String("output", path))
+	}
+	if err := manifestpkg.Rebuild(device, path); err != nil {
+		if logger != nil {
+			logger.Error("rebuild failed", zap.Error(err))
+		}
+		return err
+	}
+	if logger != nil {
+		logger.Info("rebuild complete")
+	}
+	return nil
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -12,6 +12,7 @@ import (
 	"lvmsync_go/app"
 	applycmd "lvmsync_go/cmd/apply"
 	dumpcmd "lvmsync_go/cmd/dump"
+	manifestcmd "lvmsync_go/cmd/manifest"
 	"lvmsync_go/config"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privilege"
@@ -119,6 +120,10 @@ func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPa
 // Run orchestrates the command execution.
 func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	defer lvm.Cleanup()
+
+	if len(args) > 0 && args[0] == "manifest" {
+		return manifestcmd.Run(cfg, args[1:], logger)
+	}
 
 	if cfg.ApplyMode != "" {
 		if err := applycmd.Run(cfg, cfg.ApplyMode, args, logger); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -129,6 +129,7 @@ type Config struct {
 	BloomEntries         int           `mapstructure:"bloom_entries"`
 	BloomFpRate          float64       `mapstructure:"bloom_fp_rate"`
 	BloomMBits           uint          `mapstructure:"bloom_mbits"`
+	ManifestPath         string        `mapstructure:"manifest_path"`
 	GRPCPort             int           `mapstructure:"grpc_port"`
 	GRPCListen           string        `mapstructure:"grpc_listen"`
 	GRPCConnect          string        `mapstructure:"grpc_connect"`

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,51 +1,230 @@
 package manifest
 
 import (
-	"encoding/json"
-	"errors"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
 	"os"
 
-	"github.com/bits-and-blooms/bitset"
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
+	"golang.org/x/sys/unix"
 )
 
-// Version is the manifest format version.
-const Version uint32 = 1
+const (
+	// Version identifies the manifest format.
+	Version uint32 = 1
 
-// Manifest tracks chunk completion and hashes for a logical volume.
-type Manifest struct {
-	LVUUID       string         `json:"lv_uuid"`
-	SizeBytes    uint64         `json:"size_bytes"`
-	ChunkSize    uint64         `json:"chunk_size"`
-	TotalChunks  uint64         `json:"total_chunks"`
-	Bitmap       *bitset.BitSet `json:"bitmap"`
-	PerChunkHash [][]byte       `json:"per_chunk_hash"`
-	Version      uint32         `json:"version"`
+	headerSize = 4 + 4 + 8 + 8 + 64 + 32 // 120 bytes
+	entrySize  = 8 + 4 + 4 + 8 + 32      // 56 bytes
+)
+
+// Header describes the device tracked by the manifest.
+// It is stored in little-endian binary form at the start of the file.
+// The MAC field is the BLAKE3 digest of the preceding header fields.
+type Header struct {
+	Version    uint32
+	BlockSize  uint32
+	SizeBytes  uint64
+	ChunkCount uint64
+	DeviceID   [64]byte
+	MAC        [32]byte
 }
 
-// Save writes the manifest to the given path in JSON format.
-func (m *Manifest) Save(path string) error {
-	if m == nil {
-		return errors.New("nil manifest")
+// Index is an mmap-backed manifest file containing chunk metadata.
+type Index struct {
+	f    *os.File
+	data []byte
+	hdr  Header
+}
+
+func headerMAC(h *Header) [32]byte {
+	var buf [headerSize - 32]byte
+	binary.LittleEndian.PutUint32(buf[0:4], h.Version)
+	binary.LittleEndian.PutUint32(buf[4:8], h.BlockSize)
+	binary.LittleEndian.PutUint64(buf[8:16], h.SizeBytes)
+	binary.LittleEndian.PutUint64(buf[16:24], h.ChunkCount)
+	copy(buf[24:], h.DeviceID[:])
+	sum := blake3.Sum256(buf[:])
+	return sum
+}
+
+func (i *Index) writeHeader() {
+	var buf [headerSize]byte
+	binary.LittleEndian.PutUint32(buf[0:4], i.hdr.Version)
+	binary.LittleEndian.PutUint32(buf[4:8], i.hdr.BlockSize)
+	binary.LittleEndian.PutUint64(buf[8:16], i.hdr.SizeBytes)
+	binary.LittleEndian.PutUint64(buf[16:24], i.hdr.ChunkCount)
+	copy(buf[24:88], i.hdr.DeviceID[:])
+	copy(buf[88:120], i.hdr.MAC[:])
+	copy(i.data[:headerSize], buf[:])
+}
+
+func (i *Index) readHeader() error {
+	if len(i.data) < headerSize {
+		return fmt.Errorf("manifest: file too small")
 	}
-	data, err := json.Marshal(m)
+	buf := i.data[:headerSize]
+	i.hdr.Version = binary.LittleEndian.Uint32(buf[0:4])
+	i.hdr.BlockSize = binary.LittleEndian.Uint32(buf[4:8])
+	i.hdr.SizeBytes = binary.LittleEndian.Uint64(buf[8:16])
+	i.hdr.ChunkCount = binary.LittleEndian.Uint64(buf[16:24])
+	copy(i.hdr.DeviceID[:], buf[24:88])
+	copy(i.hdr.MAC[:], buf[88:120])
+	if mac := headerMAC(&i.hdr); !bytes.Equal(mac[:], i.hdr.MAC[:]) {
+		return fmt.Errorf("manifest: header MAC mismatch")
+	}
+	return nil
+}
+
+// Close flushes the mmap and closes the underlying file.
+func (i *Index) Close() error {
+	if i.data != nil {
+		if err := unix.Msync(i.data, unix.MS_SYNC); err != nil {
+			_ = unix.Munmap(i.data)
+			_ = i.f.Close()
+			return err
+		}
+		_ = unix.Munmap(i.data)
+	}
+	if i.f != nil {
+		return i.f.Close()
+	}
+	return nil
+}
+
+// Create initializes a new manifest index at path for the given device.
+func Create(path, deviceID string, size uint64, blockSize uint32) (*Index, error) {
+	chunkCount := (size + uint64(blockSize) - 1) / uint64(blockSize)
+	total := headerSize + entrySize*chunkCount
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Truncate(int64(total)); err != nil {
+		f.Close()
+		return nil, err
+	}
+	data, err := unix.Mmap(int(f.Fd()), 0, int(total), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	idx := &Index{f: f, data: data}
+	idx.hdr = Header{
+		Version:    Version,
+		BlockSize:  blockSize,
+		SizeBytes:  size,
+		ChunkCount: chunkCount,
+	}
+	copy(idx.hdr.DeviceID[:], []byte(deviceID))
+	idx.hdr.MAC = headerMAC(&idx.hdr)
+	idx.writeHeader()
+	return idx, nil
+}
+
+// Open maps an existing manifest index file.
+func Open(path string) (*Index, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	st, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	size := int(st.Size())
+	data, err := unix.Mmap(int(f.Fd()), 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	idx := &Index{f: f, data: data}
+	if err := idx.readHeader(); err != nil {
+		idx.Close()
+		return nil, err
+	}
+	return idx, nil
+}
+
+func entryOffset(i int) int { return headerSize + i*entrySize }
+
+// Set records metadata for the chunk at the given offset.
+func (i *Index) Set(offset uint64, length uint32, xxh uint64, digest [32]byte) {
+	idx := int(offset / uint64(i.hdr.BlockSize))
+	off := entryOffset(idx)
+	binary.LittleEndian.PutUint64(i.data[off:off+8], offset)
+	binary.LittleEndian.PutUint32(i.data[off+8:off+12], length)
+	// 4 bytes padding at off+12:off+16
+	binary.LittleEndian.PutUint64(i.data[off+16:off+24], xxh)
+	copy(i.data[off+24:off+56], digest[:])
+}
+
+// Match reports whether the manifest already has a record for the chunk at offset matching length and digest.
+func (i *Index) Match(offset uint64, length uint32, digest [32]byte) bool {
+	idx := int(offset / uint64(i.hdr.BlockSize))
+	if idx < 0 || idx >= int(i.hdr.ChunkCount) {
+		return false
+	}
+	off := entryOffset(idx)
+	storedOffset := binary.LittleEndian.Uint64(i.data[off : off+8])
+	storedLen := binary.LittleEndian.Uint32(i.data[off+8 : off+12])
+	if storedLen == 0 {
+		return false
+	}
+	if storedOffset != offset || storedLen != length {
+		return false
+	}
+	return bytes.Equal(i.data[off+24:off+56], digest[:])
+}
+
+// Entry returns metadata for the chunk at idx.
+func (i *Index) Entry(idx int) (offset uint64, length uint32, xxh uint64, digest [32]byte) {
+	off := entryOffset(idx)
+	offset = binary.LittleEndian.Uint64(i.data[off : off+8])
+	length = binary.LittleEndian.Uint32(i.data[off+8 : off+12])
+	xxh = binary.LittleEndian.Uint64(i.data[off+16 : off+24])
+	copy(digest[:], i.data[off+24:off+56])
+	return
+}
+
+// Rebuild creates a manifest index for device at output path.
+// DeviceID is set to the device path. The device is read sequentially using blockSize-sized chunks.
+func Rebuild(device, output string) error {
+	f, err := os.Open(device)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
-}
-
-// Load reads a manifest from the given path.
-func Load(path string) (*Manifest, error) {
-	data, err := os.ReadFile(path)
+	defer f.Close()
+	st, err := f.Stat()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	var m Manifest
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, err
+	blockSize := uint32(4096)
+	size := uint64(st.Size())
+	idx, err := Create(output, device, size, blockSize)
+	if err != nil {
+		return err
 	}
-	if m.Bitmap == nil {
-		m.Bitmap = bitset.New(0)
+	defer idx.Close()
+	buf := make([]byte, blockSize)
+	for off := uint64(0); off < size; off += uint64(blockSize) {
+		n, err := f.ReadAt(buf, int64(off))
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if n == 0 {
+			break
+		}
+		data := buf[:n]
+		xx := xxh3.Hash(data)
+		b3 := blake3.Sum256(data)
+		idx.Set(off, uint32(n), xx, b3)
+		if err == io.EOF {
+			break
+		}
 	}
-	return &m, nil
+	return idx.Close()
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,101 +1,87 @@
 package manifest
 
 import (
+	"crypto/rand"
 	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/bits-and-blooms/bitset"
 	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
 )
 
-func TestSaveLoadRoundTrip(t *testing.T) {
-	m := &Manifest{
-		LVUUID:      "1234-5678",
-		SizeBytes:   1024,
-		ChunkSize:   256,
-		TotalChunks: 4,
-		Bitmap:      bitset.New(4),
-		Version:     Version,
+func TestIndexCRUD(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.man")
+	idx, err := Create(path, "dev", 8192, 4096)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	h0 := blake3.Sum256([]byte("chunk0"))
-	h2 := blake3.Sum256([]byte("chunk2"))
-	m.Bitmap.Set(0)
-	m.Bitmap.Set(2)
-	m.PerChunkHash = [][]byte{h0[:], nil, h2[:]}
+	data := make([]byte, 4096)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	xx := xxh3.Hash(data)
+	b3 := blake3.Sum256(data)
+	idx.Set(0, 4096, xx, b3)
+	if !idx.Match(0, 4096, b3) {
+		t.Fatalf("Match failed")
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
 
-	f, err := os.CreateTemp(t.TempDir(), "manifest-*.json")
+	idx2, err := Open(path)
 	if err != nil {
-		t.Fatalf("temp file: %v", err)
+		t.Fatalf("Open: %v", err)
 	}
-	f.Close()
-	if err := m.Save(f.Name()); err != nil {
-		t.Fatalf("save: %v", err)
+	off, length, xx2, b32 := idx2.Entry(0)
+	if off != 0 || length != 4096 || xx2 != xx || b32 != b3 {
+		t.Fatalf("entry mismatch")
 	}
-	loaded, err := Load(f.Name())
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if !loaded.Bitmap.Equal(m.Bitmap) {
-		t.Fatalf("bitmap mismatch")
-	}
-	if len(loaded.PerChunkHash) != len(m.PerChunkHash) {
-		t.Fatalf("per chunk hash length mismatch")
-	}
-	if string(loaded.PerChunkHash[0]) != string(h0[:]) || string(loaded.PerChunkHash[2]) != string(h2[:]) {
-		t.Fatalf("hashes mismatch")
-	}
-	if loaded.LVUUID != m.LVUUID || loaded.SizeBytes != m.SizeBytes || loaded.ChunkSize != m.ChunkSize || loaded.TotalChunks != m.TotalChunks || loaded.Version != m.Version {
-		t.Fatalf("fields mismatch")
+	if err := idx2.Close(); err != nil {
+		t.Fatalf("close2: %v", err)
 	}
 }
 
-func TestLoadPartialManifest(t *testing.T) {
-	m := &Manifest{
-		LVUUID:      "partial",
-		SizeBytes:   2048,
-		ChunkSize:   512,
-		TotalChunks: 4,
-		Bitmap:      bitset.New(4),
-		Version:     Version,
-	}
-	h0 := blake3.Sum256([]byte("chunk0"))
-	m.Bitmap.Set(0)
-	m.PerChunkHash = [][]byte{h0[:]}
-
-	f, err := os.CreateTemp(t.TempDir(), "manifest-partial-*.json")
+func TestRebuild(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
 	if err != nil {
 		t.Fatalf("temp file: %v", err)
 	}
-	f.Close()
-	if err := m.Save(f.Name()); err != nil {
-		t.Fatalf("save: %v", err)
+	data1 := make([]byte, 4096)
+	data2 := make([]byte, 4096)
+	if _, err := rand.Read(data1); err != nil {
+		t.Fatalf("rand1: %v", err)
 	}
-	loaded, err := Load(f.Name())
+	if _, err := rand.Read(data2); err != nil {
+		t.Fatalf("rand2: %v", err)
+	}
+	if _, err := file.Write(append(data1, data2...)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+	manPath := filepath.Join(dir, "rebuild.man")
+	if err := Rebuild(file.Name(), manPath); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	idx, err := Open(manPath)
 	if err != nil {
-		t.Fatalf("load: %v", err)
+		t.Fatalf("open manifest: %v", err)
 	}
-	if len(loaded.PerChunkHash) != 1 {
-		t.Fatalf("expected 1 hash, got %d", len(loaded.PerChunkHash))
+	if idx.hdr.BlockSize != 4096 || idx.hdr.ChunkCount != 2 || idx.hdr.SizeBytes != 8192 {
+		t.Fatalf("header mismatch: %+v", idx.hdr)
 	}
-	if !loaded.Bitmap.Test(0) {
-		t.Fatalf("expected bit 0 set")
+	_, l1, xx1, b31 := idx.Entry(0)
+	if l1 != 4096 || xx1 != xxh3.Hash(data1) || b31 != blake3.Sum256(data1) {
+		t.Fatalf("chunk1 mismatch")
 	}
-}
-
-func TestLoadCorruptManifest(t *testing.T) {
-	m := &Manifest{LVUUID: "bad", Bitmap: bitset.New(1), Version: Version}
-	f, err := os.CreateTemp(t.TempDir(), "manifest-corrupt-*.json")
-	if err != nil {
-		t.Fatalf("temp file: %v", err)
+	_, l2, xx2, b32 := idx.Entry(1)
+	if l2 != 4096 || xx2 != xxh3.Hash(data2) || b32 != blake3.Sum256(data2) {
+		t.Fatalf("chunk2 mismatch")
 	}
-	f.Close()
-	if err := m.Save(f.Name()); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-	if err := os.WriteFile(f.Name(), []byte("not json"), 0o600); err != nil {
-		t.Fatalf("corrupt: %v", err)
-	}
-	if _, err := Load(f.Name()); err == nil {
-		t.Fatalf("expected error on corrupt manifest")
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close manifest: %v", err)
 	}
 }

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	hashutil "lvmsync_go/hash"
+	manifestpkg "lvmsync_go/manifest"
 )
 
 func validateOffsetAndSize(offset uint64, size int) (int64, uint32, error) {
@@ -31,6 +33,15 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 	var header [12]byte
 	manifest := &Manifest{}
 	h := newDigestHasher(cfg.ChecksumAlgorithm)
+	var idx *manifestpkg.Index
+	if cfg.ManifestPath != "" {
+		var err error
+		idx, err = manifestpkg.Open(cfg.ManifestPath)
+		if err != nil {
+			return totalBytes, skippedBlocks, manifest, fmt.Errorf("open manifest: %w", err)
+		}
+		defer idx.Close()
+	}
 	for _, r := range ranges {
 		offset, blockSize, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
 		if err != nil {
@@ -39,6 +50,12 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, pipeFds, logger)
 		if err != nil {
 			return totalBytes, skippedBlocks, manifest, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
+		}
+		sum := blake3.Sum256(data)
+		if idx != nil && idx.Match(r.Start, blockSize, sum) {
+			skippedBlocks++
+			putBlockBuffer(data)
+			continue
 		}
 		if dedup != nil {
 			if !dedup.ShouldTransfer(offset, data) {
@@ -49,6 +66,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 			dedup.RecordTransfer(offset, data)
 		}
 
+		xx := hashutil.SumXXH3(data)
 		binary.BigEndian.PutUint64(header[0:8], r.Start)
 		if isAllZero(data) {
 			binary.BigEndian.PutUint32(header[8:12], 0)
@@ -58,6 +76,9 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 			}
 			zh := zeroHash(int(blockSize))
 			saveResumeState(cfg, zh, int64(blockSize), logger)
+			if idx != nil {
+				idx.Set(r.Start, blockSize, xx, sum)
+			}
 			putBlockBuffer(data)
 			totalBytes += int64(blockSize)
 			continue
@@ -73,8 +94,10 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		}
 
 		h.Write(data)
-		sum := blake3.Sum256(data)
 		manifest.Append(sum, int64(r.Start), int(blockSize))
+		if idx != nil {
+			idx.Set(r.Start, blockSize, xx, sum)
+		}
 		saveResumeState(cfg, sum, int64(blockSize), logger)
 
 		putBlockBuffer(data)
@@ -125,9 +148,22 @@ func processParallelResults(
 	var totalBytesTransferred int64
 	h := newDigestHasher(cfg.ChecksumAlgorithm)
 	manifest := &Manifest{}
+	var idx *manifestpkg.Index
+	if cfg.ManifestPath != "" {
+		var err error
+		idx, err = manifestpkg.Open(cfg.ManifestPath)
+		if err != nil {
+			return totalBytesTransferred, manifest, fmt.Errorf("open manifest: %w", err)
+		}
+		defer idx.Close()
+	}
 	for res := range results {
 		if res.Err != nil {
 			return totalBytesTransferred, manifest, fmt.Errorf("error in block %d: %w", res.Index, res.Err)
+		}
+		if idx != nil && res.Data != nil && idx.Match(res.Offset, res.Size, res.ChunkID) {
+			putBlockBuffer(res.Data)
+			continue
 		}
 
 		n := prepareResultHeader(cfg, checksum, res, header)
@@ -140,9 +176,17 @@ func processParallelResults(
 		if res.Data != nil {
 			h.Write(res.Data)
 			manifest.Append(res.ChunkID, int64(res.Offset), int(res.Size))
+			if idx != nil {
+				xx := hashutil.SumXXH3(res.Data)
+				idx.Set(res.Offset, res.Size, xx, res.ChunkID)
+			}
 			saveResumeState(cfg, res.ChunkID, int64(res.Size), logger)
 			putBlockBuffer(res.Data)
 		} else {
+			if idx != nil {
+				xx := hashutil.SumXXH3(nil)
+				idx.Set(res.Offset, res.Size, xx, res.ChunkID)
+			}
 			saveResumeState(cfg, res.ChunkID, 0, logger)
 		}
 

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -1,0 +1,52 @@
+package transfer
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+	manifestpkg "lvmsync_go/manifest"
+)
+
+func TestIterateBlocksUsesManifest(t *testing.T) {
+	dir := t.TempDir()
+	dev, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	data := make([]byte, 8192)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := dev.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	dev.Close()
+	manPath := filepath.Join(dir, "dev.man")
+	if err := manifestpkg.Rebuild(dev.Name(), manPath); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	src, err := os.Open(dev.Name())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	cfg := &config.Config{BlockSize: 4096, ChecksumAlgorithm: "sha256", ManifestPath: manPath, MaxRetries: 1}
+	ranges := []Range{{Start: 0, End: 4096}, {Start: 4096, End: 8192}}
+	buf := bufio.NewWriter(bytes.NewBuffer(nil))
+	total, skipped, _, err := iterateBlocks(cfg, ranges, src, buf, nil, [2]int{-1, -1}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("iterateBlocks: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("expected 0 bytes transferred, got %d", total)
+	}
+	if skipped != 2 {
+		t.Fatalf("expected 2 skipped blocks, got %d", skipped)
+	}
+}


### PR DESCRIPTION
## Summary
- redesign manifest as mmap-backed index with chunk hashes and device metadata
- add `lvmsync manifest rebuild` CLI command
- consult manifest during transfer to skip previously synced chunks

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689c71c296b883238158e29e9833c172