### PR TITLE
feat: verify destination device identity and mount state

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	ConfigFile           string        `mapstructure:"config"`
 	ApplyMode            string        `mapstructure:"apply"`
 	StdoutMode           bool          `mapstructure:"stdout"`
+	Force                bool          `mapstructure:"force"`
 	Mode                 string        `mapstructure:"mode"`
 	Parallel             int           `mapstructure:"parallel"`
 	Concurrency          int           `mapstructure:"concurrency"`
@@ -87,6 +88,7 @@ type Config struct {
 	NumaPin              bool          `mapstructure:"numa_pin"`
 	MaxRetries           int           `mapstructure:"max_retries"`
 	ResumeState          string        `mapstructure:"resume"`
+	DeviceUUID           string        `mapstructure:"device_uuid"`
 	SSHHost              string        `mapstructure:"ssh_host"`
 	SSHUser              string        `mapstructure:"ssh_user"`
 	SSHKeyPath           string        `mapstructure:"ssh_key"`
@@ -400,6 +402,7 @@ func DefaultConfig() (*Config, error) {
 		Mode:                 "default",
 		ApplyMode:            "",
 		StdoutMode:           false,
+		Force:                false,
 		Parallel:             4,
 		Concurrency:          0,
 		ZeroCopy:             false,
@@ -407,6 +410,7 @@ func DefaultConfig() (*Config, error) {
 		NumaPin:              false,
 		MaxRetries:           3,
 		ResumeState:          "",
+		DeviceUUID:           "",
 		SSHHost:              "localhost",
 		SSHUser:              "root",
 		SSHKeyPath:           "",
@@ -473,6 +477,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("config", "", "Path to config YAML file")
 	fs.String("apply", cfg.ApplyMode, "Apply mode: read change dump from file ('-' for STDIN) and apply to destination device")
 	fs.Bool("stdout", cfg.StdoutMode, "Write change dump to STDOUT")
+	fs.Bool("force", cfg.Force, "Override safety checks and proceed on mounted destination")
 	fs.String("mode", cfg.Mode, "Preset mode: default or throughput")
 	fs.Int("parallel", cfg.Parallel, "Number of concurrent workers")
 	fs.Bool("zerocopy", cfg.ZeroCopy, "Enable zero-copy transfers")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -16,6 +16,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"config", ""},
 		{"apply", cfg.ApplyMode},
 		{"stdout", strconv.FormatBool(cfg.StdoutMode)},
+		{"force", strconv.FormatBool(cfg.Force)},
 		{"mode", cfg.Mode},
 		{"parallel", strconv.Itoa(cfg.Parallel)},
 		{"zerocopy", strconv.FormatBool(cfg.ZeroCopy)},

--- a/device/info.go
+++ b/device/info.go
@@ -1,0 +1,79 @@
+package device
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	uuidFunc  = defaultUUIDFunc
+	mountFunc = defaultMountFunc
+)
+
+// SetUUIDFunc allows tests to override the implementation used to lookup a
+// device's UUID or serial. It returns the previous function for restoration.
+func SetUUIDFunc(f func(string) (string, error)) func(string) (string, error) {
+	prev := uuidFunc
+	uuidFunc = f
+	return prev
+}
+
+// GetUUID returns the UUID or GPT serial of the device at path.
+func GetUUID(path string) (string, error) { return uuidFunc(path) }
+
+func defaultUUIDFunc(path string) (string, error) {
+	out, err := exec.Command("blkid", "-o", "value", "-s", "UUID", path).Output()
+	if err == nil && len(out) > 0 {
+		return strings.TrimSpace(string(out)), nil
+	}
+	out, err = exec.Command("blkid", "-o", "value", "-s", "PARTUUID", path).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// SetMountFunc allows tests to override the mount status checker. It returns
+// the previous function for restoration.
+func SetMountFunc(f func(string) (bool, error)) func(string) (bool, error) {
+	prev := mountFunc
+	mountFunc = f
+	return prev
+}
+
+// IsMountedRW reports whether the device at path is mounted read-write.
+func IsMountedRW(path string) (bool, error) { return mountFunc(path) }
+
+func defaultMountFunc(path string) (bool, error) {
+	real, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false, err
+	}
+	f, err := os.Open("/proc/self/mounts")
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 4 {
+			continue
+		}
+		if fields[0] == real {
+			for _, opt := range strings.Split(fields[3], ",") {
+				if opt == "rw" {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -1,0 +1,79 @@
+package transfer
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"lvmsync_go/common"
+	"lvmsync_go/config"
+	"lvmsync_go/device"
+
+	"go.uber.org/zap"
+)
+
+func minimalStream(t *testing.T) []byte {
+	var buf bytes.Buffer
+	if err := common.WriteHandshake(&buf, common.Handshake{Compress: "none", Checksum: true}); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestProcessDumpDataUUIDMismatch(t *testing.T) {
+	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "actual", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	prevMount := device.SetMountFunc(func(string) (bool, error) { return false, nil })
+	defer device.SetMountFunc(prevMount)
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected"}
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	f, err := os.Create(dest)
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	if err := f.Truncate(1024); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	if err == nil {
+		t.Fatalf("expected error for uuid mismatch")
+	}
+}
+
+func TestProcessDumpDataMountedDevice(t *testing.T) {
+	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "id", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	prevMount := device.SetMountFunc(func(string) (bool, error) { return true, nil })
+	defer device.SetMountFunc(prevMount)
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id"}
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	f, err := os.Create(dest)
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	if err := f.Truncate(1024); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	if err == nil {
+		t.Fatalf("expected error for mounted device")
+	}
+
+	cfg.Force = true
+	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	if err != nil {
+		t.Fatalf("unexpected error with force: %v", err)
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -21,6 +21,7 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	"lvmsync_go/internal/blocksize"
 )
 
@@ -684,6 +685,23 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 	}()
 
 	reader := bufio.NewReader(decReader)
+
+	if cfg.DeviceUUID != "" {
+		uuid, err2 := device.GetUUID(destPath)
+		if err2 != nil {
+			return fmt.Errorf("read destination uuid: %w", err2)
+		}
+		if uuid != cfg.DeviceUUID {
+			return fmt.Errorf("destination device uuid %s does not match expected %s", uuid, cfg.DeviceUUID)
+		}
+	}
+	mounted, err2 := device.IsMountedRW(destPath)
+	if err2 != nil {
+		return fmt.Errorf("check mount status: %w", err2)
+	}
+	if mounted && !cfg.Force {
+		return fmt.Errorf("destination device %s is mounted read-write", destPath)
+	}
 
 	var destFile *os.File
 	if cfg.ODirect {


### PR DESCRIPTION
## Summary
- ensure apply refuses to run on mismatched or mounted devices
- provide device helper for UUID lookup and mount checks
- add force flag and tests for safety validation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c71c52084832389d83180d9b1f40b