### PR TITLE
feat(manifest): record device identity during rebuild

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -10,6 +10,8 @@ import (
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
 	"golang.org/x/sys/unix"
+
+	"lvmsync_go/device"
 )
 
 const (
@@ -191,9 +193,9 @@ func (i *Index) Entry(idx int) (offset uint64, length uint32, xxh uint64, digest
 }
 
 // Rebuild creates a manifest index for device at output path.
-// DeviceID is set to the device path. The device is read sequentially using blockSize-sized chunks.
-func Rebuild(device, output string) error {
-	f, err := os.Open(device)
+// DeviceID is determined via device.GetUUID. The device is read sequentially using blockSize-sized chunks.
+func Rebuild(devicePath, output string) error {
+	f, err := os.Open(devicePath)
 	if err != nil {
 		return err
 	}
@@ -204,7 +206,11 @@ func Rebuild(device, output string) error {
 	}
 	blockSize := uint32(4096)
 	size := uint64(st.Size())
-	idx, err := Create(output, device, size, blockSize)
+	id, err := device.GetUUID(devicePath)
+	if err != nil {
+		return err
+	}
+	idx, err := Create(output, id, size, blockSize)
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"bytes"
 	"crypto/rand"
 	"os"
 	"path/filepath"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
+
+	"lvmsync_go/device"
 )
 
 func TestIndexCRUD(t *testing.T) {
@@ -62,6 +65,8 @@ func TestRebuild(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	file.Close()
+	prev := device.SetUUIDFunc(func(string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "rebuild.man")
 	if err := Rebuild(file.Name(), manPath); err != nil {
 		t.Fatalf("rebuild: %v", err)
@@ -72,6 +77,9 @@ func TestRebuild(t *testing.T) {
 	}
 	if idx.hdr.BlockSize != 4096 || idx.hdr.ChunkCount != 2 || idx.hdr.SizeBytes != 8192 {
 		t.Fatalf("header mismatch: %+v", idx.hdr)
+	}
+	if id := string(bytes.TrimRight(idx.hdr.DeviceID[:], "\x00")); id != "uuid-test" {
+		t.Fatalf("device id mismatch: %s", id)
 	}
 	_, l1, xx1, b31 := idx.Entry(0)
 	if l1 != 4096 || xx1 != xxh3.Hash(data1) || b31 != blake3.Sum256(data1) {

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	manifestpkg "lvmsync_go/manifest"
 )
 
@@ -28,6 +29,8 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	dev.Close()
+	prev := device.SetUUIDFunc(func(string) (string, error) { return "id", nil })
+	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "dev.man")
 	if err := manifestpkg.Rebuild(dev.Name(), manPath); err != nil {
 		t.Fatalf("rebuild: %v", err)


### PR DESCRIPTION
## Summary
- capture device UUID when rebuilding manifest index
- test manifest rebuild stores device ID
- stub UUID in transfer manifest integration test

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c758a07708323a245d07b5d8b12f1