### PR TITLE
feat(cmd): document cobra tree and support env flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,10 +658,10 @@ journalctl -u lvmsync-grpcd
 ### Basic Syntax
 
 ```sh
-lvmsync run [options] <snapshot|lvm device> <destination>
+lvmsync run [--dry-run] [--transport tcp+tls,ssh] <snapshot|lvm device> <destination>
 ```
 
-The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps.
+The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps. Use `--dry-run` to print planned actions without executing and `--transport` to provide an ordered list of transports to try.
 
 ### Manifest Operations
 
@@ -669,6 +669,14 @@ Rebuild a manifest index for an existing device:
 
 ```sh
 lvmsync manifest rebuild /dev/vg0/lv0
+```
+
+### Verification
+
+Verify that a source and destination match:
+
+```sh
+lvmsync verify /dev/vg0/source /dev/vg1/target
 ```
 
 ### Options
@@ -689,6 +697,8 @@ lvmsync manifest rebuild /dev/vg0/lv0
 | `--verify_checksum` | Enable checksum verification for data integrity                                                         | `false`   |
 | `--progress`        | Show progress percentage during the transfer                                                            | `true`    |
 | `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
+| `--dry-run`         | Print actions without executing | `false`   |
+| `--transport`       | Ordered transports to try (e.g., `tcp+tls,ssh`) | `""`      |
 
 #### SSH Options
 

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -1,6 +1,8 @@
 package lvmsync
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -22,6 +24,7 @@ var (
 func newViper() *viper.Viper {
 	v := viper.New()
 	v.SetEnvPrefix("LVMSYNC")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 	return v
 }

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -25,6 +25,27 @@ func TestRunCommandFlags(t *testing.T) {
 	}
 }
 
+func TestRunCommandEnv(t *testing.T) {
+	t.Setenv("LVMSYNC_DRY_RUN", "true")
+	t.Setenv("LVMSYNC_TRANSPORT", "ssh")
+	var opts RunOptions
+	runCommand = func(src, dst string, o RunOptions) error {
+		opts = o
+		return nil
+	}
+	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
+
+	if err := Execute([]string{"run", "src", "dst"}); err != nil {
+		t.Fatalf("execute run with env: %v", err)
+	}
+	if !opts.DryRun {
+		t.Fatalf("expected dry-run from env")
+	}
+	if opts.Transport != "ssh" {
+		t.Fatalf("unexpected transport %q", opts.Transport)
+	}
+}
+
 func TestManifestRebuildRoutes(t *testing.T) {
 	var gotDevice string
 	var dry bool

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@
 # and apply to destination device
 apply: ""
 stdout: false  # Write change dump to STDOUT
-dry_run: false  # Print actions without executing
+dry_run: false  # Print actions without executing (same as --dry-run)
 parallel: 4  # Number of concurrent workers
 # Enable zero-copy transfers (only in sequential mode)
 zerocopy: false
@@ -86,6 +86,6 @@ progress: true  # Enable progress display during transfer
 block_size: "auto"
 
 # Transport Options
-transport: "tcp+tls,ssh"  # Ordered transports to try
+transport: "tcp+tls,ssh"  # Ordered transports to try (comma-separated)
 concurrency: 0  # Stream concurrency (0 to autotune)
 tcp_port: 0  # TCP+TLS port


### PR DESCRIPTION
## Summary
- document Cobra command tree and run/manifest/verify subcommands
- add environment variable key mapping for Cobra flags
- cover flag parsing from environment in tests and docs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestSSHManagerGetClientRefresh expected 1 connection, got 0)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689c758eacc8832392726c9c786ab33f