### PR TITLE
refactor(lvm): inject logger into fd cache

### DIFF
--- a/lvm/fd_cache.go
+++ b/lvm/fd_cache.go
@@ -42,6 +42,14 @@ func NewFDCache(size int, logger *zap.Logger) *FDCache {
 	}
 }
 
+// SetLogger updates the logger used by the cache.
+func (c *FDCache) SetLogger(logger *zap.Logger) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	c.logger = logger
+}
+
 // getFD retrieves an open file descriptor for the specified device path.
 // It reuses descriptors when possible and evicts the least recently used entry
 // when the cache reaches its capacity.
@@ -99,4 +107,4 @@ func (c *FDCache) Close() {
 }
 
 // deviceFDCache is the global cache used by volume operations.
-var deviceFDCache = NewFDCache(fdCacheSize, zap.L())
+var deviceFDCache = NewFDCache(fdCacheSize, zap.NewNop())

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -180,6 +180,7 @@ func ioctlGetUint64(fd int, req uint) (uint64, error) {
 }
 
 func GetVolumeSize(volumePath string, logger *zap.Logger) (uint64, error) {
+	deviceFDCache.SetLogger(logger)
 	fd, err := deviceFDCache.getFD(volumePath)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary
- allow FDCache to accept and update a zap logger
- ensure volume size queries use the caller's logger

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c758fec648323b343c3001dc6161f