### PR TITLE
feat(common): expand handshake negotiation

### DIFF
--- a/common/handshake.go
+++ b/common/handshake.go
@@ -12,7 +12,9 @@ import (
 // Handshake describes protocol negotiation parameters exchanged at the start
 // of a transfer. The format is a single line of space separated tokens:
 //
-//	lvmsync PROTO[3] compress:<algo> [checksum|checksum-dedup]
+//	lvmsync PROTO[3] [endian:<little|big>] [block:<bytes>]
+//	        [dedup:<fixed|cdc|hybrid>] [resume:<token>] [odirect]
+//	        [checksum|checksum-dedup] compress:<algo> [level:<n>]
 //
 // Additional tokens may be added in the future while preserving backward
 // compatibility. The receiver must ignore unknown tokens to allow for
@@ -20,7 +22,10 @@ import (
 //
 // Compress specifies the compression algorithm in use. Checksum indicates
 // whether chunk checksums are included. When ChecksumDedup is true the
-// checksum list also doubles as a deduplication map.
+// checksum list also doubles as a deduplication map. Endianness advertises the
+// sender's byte order, BlockSize conveys the preferred chunk size, DedupMode
+// announces the deduplication strategy, ResumeToken resumes interrupted
+// transfers, and ODirect signals support for `O_DIRECT` I/O.
 //
 // Version will always be set to ProtocolVersion on successful parsing.
 //

--- a/common/handshake_test.go
+++ b/common/handshake_test.go
@@ -15,6 +15,7 @@ func TestHandshakeRoundTrip(t *testing.T) {
 		Compress:      "gzip",
 		CompressLevel: 2,
 		Checksum:      true,
+		ChecksumDedup: true,
 		Endianness:    common.NativeEndianness(),
 		BlockSize:     4096,
 		DedupMode:     "fixed",

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -3,6 +3,7 @@ package h2
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"net"
 
 	"lvmsync_go/common"
@@ -29,17 +30,27 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 }
 
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role) error {
-	hs := common.Handshake{Version: common.ProtocolVersion}
+	hs := common.Handshake{Version: common.ProtocolVersion, Endianness: common.NativeEndianness()}
 	switch role {
 	case transport.Client:
 		if err := common.WriteHandshake(conn, hs); err != nil {
 			return err
 		}
-		_, err := common.ReadHandshake(bufio.NewReader(conn))
-		return err
-	case transport.Server:
-		if _, err := common.ReadHandshake(bufio.NewReader(conn)); err != nil {
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
 			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		}
+		return nil
+	case transport.Server:
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
+			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)
 	default:

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -3,6 +3,7 @@ package quic
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"net"
 
 	"lvmsync_go/common"
@@ -29,17 +30,27 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 }
 
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role) error {
-	hs := common.Handshake{Version: common.ProtocolVersion}
+	hs := common.Handshake{Version: common.ProtocolVersion, Endianness: common.NativeEndianness()}
 	switch role {
 	case transport.Client:
 		if err := common.WriteHandshake(conn, hs); err != nil {
 			return err
 		}
-		_, err := common.ReadHandshake(bufio.NewReader(conn))
-		return err
-	case transport.Server:
-		if _, err := common.ReadHandshake(bufio.NewReader(conn)); err != nil {
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
 			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		}
+		return nil
+	case transport.Server:
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
+			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)
 	default:

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"net"
 
 	"lvmsync_go/common"
@@ -29,17 +30,27 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 }
 
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role) error {
-	hs := common.Handshake{Version: common.ProtocolVersion}
+	hs := common.Handshake{Version: common.ProtocolVersion, Endianness: common.NativeEndianness()}
 	switch role {
 	case transport.Client:
 		if err := common.WriteHandshake(conn, hs); err != nil {
 			return err
 		}
-		_, err := common.ReadHandshake(bufio.NewReader(conn))
-		return err
-	case transport.Server:
-		if _, err := common.ReadHandshake(bufio.NewReader(conn)); err != nil {
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
 			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		}
+		return nil
+	case transport.Server:
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
+			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)
 	default:

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"math/big"
 	"net"
 	"time"
@@ -48,17 +49,27 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 }
 
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role) error {
-	hs := common.Handshake{Version: common.ProtocolVersion}
+	hs := common.Handshake{Version: common.ProtocolVersion, Endianness: common.NativeEndianness()}
 	switch role {
 	case transport.Client:
 		if err := common.WriteHandshake(conn, hs); err != nil {
 			return err
 		}
-		_, err := common.ReadHandshake(bufio.NewReader(conn))
-		return err
-	case transport.Server:
-		if _, err := common.ReadHandshake(bufio.NewReader(conn)); err != nil {
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
 			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		}
+		return nil
+	case transport.Server:
+		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		if err != nil {
+			return err
+		}
+		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)
 	default:


### PR DESCRIPTION
## Summary
- document handshake tokens for endianness, block size, dedup mode, compression level, resume tokens and O_DIRECT support
- validate endianness in transport handshakes and send it to peers
- cover handshake round-trips including new fields

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c7592539c8323bf82b823466b0511