### PR TITLE
test(transport): add handshake error tests

### DIFF
--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -53,3 +53,36 @@ func TestH2TransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 }
+
+func TestH2TransportHandshakeError(t *testing.T) {
+	tr := New()
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		// send invalid handshake to trigger failure
+		conn.Write([]byte("bad\n"))
+		conn.Close()
+		close(done)
+	}()
+
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := tr.Negotiate(ctx, conn, transport.Client); err == nil {
+		t.Fatalf("expected negotiate error")
+	}
+	conn.Close()
+	<-done
+}

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -53,3 +53,36 @@ func TestQUICTransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 }
+
+func TestQUICTransportHandshakeError(t *testing.T) {
+	tr := New()
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		// send invalid handshake and close
+		conn.Write([]byte("bad\n"))
+		conn.Close()
+		close(done)
+	}()
+
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := tr.Negotiate(ctx, conn, transport.Client); err == nil {
+		t.Fatalf("expected negotiate error")
+	}
+	conn.Close()
+	<-done
+}

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -53,3 +53,36 @@ func TestSSHTransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 }
+
+func TestSSHTransportHandshakeError(t *testing.T) {
+	tr := New()
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		// send an invalid handshake to trigger negotiation failure
+		conn.Write([]byte("bad\n"))
+		conn.Close()
+		close(done)
+	}()
+
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := tr.Negotiate(ctx, conn, transport.Client); err == nil {
+		t.Fatalf("expected negotiate error")
+	}
+	conn.Close()
+	<-done
+}

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -53,3 +53,36 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 }
+
+func TestTCPTLSTransportHandshakeError(t *testing.T) {
+	tr := New()
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		// send invalid handshake without negotiation
+		conn.Write([]byte("bad\n"))
+		conn.Close()
+		close(done)
+	}()
+
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := tr.Negotiate(ctx, conn, transport.Client); err == nil {
+		t.Fatalf("expected negotiate error")
+	}
+	conn.Close()
+	<-done
+}


### PR DESCRIPTION
## Summary
- add negative handshake tests for ssh, tcp+tls, h2 and quic transports

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c7588457c8323807270bca1233328