### PR TITLE
feat(transfer): validate destination device before apply

### DIFF
--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -29,7 +29,7 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 	defer device.SetMountFunc(prevMount)
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
-	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected"}
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected", DedupStrategy: "none", VerifyChecksum: true}
 
 	dest := filepath.Join(t.TempDir(), "dest")
 	f, err := os.Create(dest)
@@ -54,7 +54,7 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 	defer device.SetMountFunc(prevMount)
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
-	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id"}
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true}
 
 	dest := filepath.Join(t.TempDir(), "dest")
 	f, err := os.Create(dest)
@@ -75,5 +75,55 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err != nil {
 		t.Fatalf("unexpected error with force: %v", err)
+	}
+}
+
+func TestApplyDataUUIDMismatch(t *testing.T) {
+	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "actual", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	prevMount := device.SetMountFunc(func(string) (bool, error) { return false, nil })
+	defer device.SetMountFunc(prevMount)
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected"}
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	f, err := os.Create(dest)
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	if err := f.Truncate(1024); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	err = tr.applyData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	if err == nil {
+		t.Fatalf("expected error for uuid mismatch")
+	}
+}
+
+func TestApplyDataMountedDevice(t *testing.T) {
+	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "id", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	prevMount := device.SetMountFunc(func(string) (bool, error) { return true, nil })
+	defer device.SetMountFunc(prevMount)
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id"}
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	f, err := os.Create(dest)
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	if err := f.Truncate(1024); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	err = tr.applyData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	if err == nil {
+		t.Fatalf("expected error for mounted device")
 	}
 }

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -765,6 +765,22 @@ func openApplyReader(applyFile string) (io.ReadCloser, error) {
 }
 
 func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string) error {
+	if cfg.DeviceUUID != "" {
+		uuid, err := device.GetUUID(destDevice)
+		if err != nil {
+			return fmt.Errorf("read destination uuid: %w", err)
+		}
+		if uuid != cfg.DeviceUUID {
+			return fmt.Errorf("destination device uuid %s does not match expected %s", uuid, cfg.DeviceUUID)
+		}
+	}
+	mounted, err := device.IsMountedRW(destDevice)
+	if err != nil {
+		return fmt.Errorf("check mount status: %w", err)
+	}
+	if mounted && !cfg.Force {
+		return fmt.Errorf("destination device %s is mounted read-write", destDevice)
+	}
 	dedup := NewDeduplicationStrategy(cfg, t.Logger)
 	if dedup != nil {
 		if t.Logger != nil {


### PR DESCRIPTION
## Summary
- verify destination device UUID and mount status before applying dump
- exercise mismatched UUID and mounted device scenarios in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c75913c3c8323990c5a5f7fca3373