### PR TITLE
refactor(remote): accept context in SSH manager constructor

### DIFF
--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -16,7 +16,9 @@ import (
 
 func TestNewSSHManagerInvalidKey(t *testing.T) {
 	knownHosts := remotetest.CreateEmptyKnownHosts(t)
-	_, err := NewSSHManager("root", "no_such_key", time.Second, knownHosts, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := NewSSHManager(ctx, "root", "no_such_key", time.Second, knownHosts, zap.NewNop())
 	if err == nil {
 		t.Fatal("expected error for missing key")
 	}
@@ -27,7 +29,9 @@ func TestNewSSHManagerNoAgent(t *testing.T) {
 		t.Fatalf("Unsetenv: %v", err)
 	}
 	knownHosts := remotetest.CreateEmptyKnownHosts(t)
-	_, err := NewSSHManager("root", "", time.Second, knownHosts, zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := NewSSHManager(ctx, "root", "", time.Second, knownHosts, zap.NewNop())
 	if err == nil {
 		t.Fatal("expected error when SSH_AUTH_SOCK not set")
 	}

--- a/remote/ssh_keepalive_test.go
+++ b/remote/ssh_keepalive_test.go
@@ -75,7 +75,9 @@ func TestNewSSHClient(t *testing.T) {
 func TestSSHManager(t *testing.T) {
 	server, host, port, knownHosts := newSSHServer(t, func(_ string) int { return 0 }) // cmd is unused
 	keyPath := remotetest.CreateTempKey(t)
-	mgr, err := NewSSHManager("test", keyPath, time.Second, knownHosts, zap.NewNop())
+	initCtx, initCancel := context.WithTimeout(context.Background(), time.Second)
+	defer initCancel()
+	mgr, err := NewSSHManager(initCtx, "test", keyPath, time.Second, knownHosts, zap.NewNop())
 	if err != nil {
 		t.Fatalf("NewSSHManager error: %v", err)
 	}

--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -42,13 +42,14 @@ type SSHManager struct {
 // specifies a private key to use for authentication; if empty, the SSH agent
 // will be consulted. All host keys are verified against the provided
 // knownHostsPath. The timeout applies to establishing new connections.
-func NewSSHManager(user, keyPath string, timeout time.Duration, knownHostsPath string, logger *zap.Logger) (*SSHManager, error) {
+//
+// The provided ctx controls cancellation for initialization steps such as
+// retrieving authentication methods. It should include a deadline.
+func NewSSHManager(ctx context.Context, user, keyPath string, timeout time.Duration, knownHostsPath string, logger *zap.Logger) (*SSHManager, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 	authMethods, err := getSSHAuthMethods(ctx, keyPath, timeout, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize authentication: %w", err)

--- a/remote/ssh_manager_test.go
+++ b/remote/ssh_manager_test.go
@@ -22,7 +22,9 @@ func TestSSHManagerGetClientReuse(t *testing.T) {
 	knownHosts := testutil.CreateKnownHostsFile(t, server)
 	keyPath := testutil.CreateTempKey(t)
 
-	mgr, err := NewSSHManager("user", keyPath, time.Second, knownHosts, zaptest.NewLogger(t))
+	initCtx, initCancel := context.WithTimeout(context.Background(), time.Second)
+	defer initCancel()
+	mgr, err := NewSSHManager(initCtx, "user", keyPath, time.Second, knownHosts, zaptest.NewLogger(t))
 	if err != nil {
 		t.Fatalf("NewSSHManager: %v", err)
 	}
@@ -60,7 +62,9 @@ func TestSSHManagerGetClientRefresh(t *testing.T) {
 	knownHosts := testutil.CreateKnownHostsFile(t, server)
 	keyPath := testutil.CreateTempKey(t)
 
-	mgr, err := NewSSHManager("user", keyPath, time.Second, knownHosts, zaptest.NewLogger(t))
+	initCtx, initCancel := context.WithTimeout(context.Background(), time.Second)
+	defer initCancel()
+	mgr, err := NewSSHManager(initCtx, "user", keyPath, time.Second, knownHosts, zaptest.NewLogger(t))
 	if err != nil {
 		t.Fatalf("NewSSHManager: %v", err)
 	}


### PR DESCRIPTION
## Summary
- accept context in `NewSSHManager` and rely on caller deadlines
- pass explicit deadline contexts in SSH manager tests

## Testing
- `go build ./...` *(fails: common/handshake.go:138:6: syntax error: unexpected name ReadHandshake, expected ()*
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake.go:138:6: syntax error: unexpected name ReadHandshake, expected ()*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_689c81776ee8832390a861152c1623c7