### PR TITLE
fix(remote): enforce private key permissions

### DIFF
--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -167,6 +167,14 @@ func dialSSH(ctx context.Context, addr string, sshConfig *ssh.ClientConfig, time
 }
 
 func loadPrivateKey(keyPath string) (ssh.Signer, error) {
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat private key: %w", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		return nil, fmt.Errorf("private key permissions %o are too open, want 0600", info.Mode().Perm())
+	}
+
 	keyData, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key: %w", err)

--- a/remote/ssh_manager_test.go
+++ b/remote/ssh_manager_test.go
@@ -164,3 +164,37 @@ func TestLoadPrivateKeyZeroesSlice(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadPrivateKeyPermissions(t *testing.T) {
+	goodKey := testutil.CreateTempKey(t)
+	openKey := testutil.CreateTempKey(t)
+	if err := os.Chmod(openKey, 0o644); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	missingKey := filepath.Join(t.TempDir(), "missing")
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "correct", path: goodKey, wantErr: false},
+		{name: "too_open", path: openKey, wantErr: true},
+		{name: "missing", path: missingKey, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadPrivateKey(tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %s", tt.name)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error for %s: %v", tt.name, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- verify SSH private key files are mode 0600
- error on overly permissive key files
- test key permission handling

## Testing
- `go build ./...` *(fails: common/handshake.go:138:6: syntax error: unexpected name ReadHandshake, expected ()*
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake.go:138:6: syntax error: unexpected name ReadHandshake, expected ()*
- `go test -coverprofile=coverage.out ./remote`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689c81784ee48323a26433a8cd7f75e4