### PR TITLE
feat(config): unify flag parsing across subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
 | `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
 | `--target_vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
-| `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Print actions without executing |
+  | `--dry_run` | `LVMSYNC_DRY_RUN` | `dry_run` | Print actions without executing |
 | `--transport` | `LVMSYNC_TRANSPORT` | `transport` | Ordered transports to try (e.g., `tcp+tls,ssh`) |
 | `--tcp_port` | `LVMSYNC_TCP_PORT` | `tcp_port` | TCP+TLS port |
 | `--tcp_parallel` | `LVMSYNC_TCP_PARALLEL` | `tcp_parallel` | Number of parallel TCP connections |
@@ -658,10 +658,10 @@ journalctl -u lvmsync-grpcd
 ### Basic Syntax
 
 ```sh
-lvmsync run [--dry-run] [--transport tcp+tls,ssh] <snapshot|lvm device> <destination>
+lvmsync run [--dry_run] [--transport tcp+tls,ssh] <snapshot|lvm device> <destination>
 ```
 
-The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps. Use `--dry-run` to print planned actions without executing and `--transport` to provide an ordered list of transports to try.
+The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps. Use `--dry_run` to print planned actions without executing and `--transport` to provide an ordered list of transports to try.
 
 ### Manifest Operations
 
@@ -697,7 +697,7 @@ lvmsync verify /dev/vg0/source /dev/vg1/target
 | `--verify_checksum` | Enable checksum verification for data integrity                                                         | `false`   |
 | `--progress`        | Show progress percentage during the transfer                                                            | `true`    |
 | `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
-| `--dry-run`         | Print actions without executing | `false`   |
+| `--dry_run`         | Print actions without executing | `false`   |
 | `--transport`       | Ordered transports to try (e.g., `tcp+tls,ssh`) | `""`      |
 
 #### SSH Options

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -1,10 +1,12 @@
 package lvmsync
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/spf13/pflag"
+
+	"lvmsync_go/config"
 )
 
 // RunOptions collects flags for the run command.
@@ -21,51 +23,66 @@ var (
 )
 
 // NewRootCmd creates the root cobra command with all subcommands wired.
-func newViper() *viper.Viper {
-	v := viper.New()
-	v.SetEnvPrefix("LVMSYNC")
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	v.AutomaticEnv()
-	return v
-}
-
 func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "lvmsync",
 		Short: "LVMSync command line tool",
 	}
-	runV := newViper()
+
 	runCmd := &cobra.Command{
-		Use:   "run <source> <dest>",
-		Short: "Synchronize source to destination",
-		Args:  cobra.ExactArgs(2),
+		Use:                "run [flags] <source> <dest>",
+		Short:              "Synchronize source to destination",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := RunOptions{
-				DryRun:    runV.GetBool("dry-run"),
-				Transport: runV.GetString("transport"),
+			defaults, err := config.DefaultConfig()
+			if err != nil {
+				return err
 			}
-			return runCommand(args[0], args[1], opts)
+			fs := pflag.NewFlagSet("run", pflag.ContinueOnError)
+			flagSets := config.NewFlagSets(defaults)
+			cfg, remaining, err := config.LoadConfig(flagSets, defaults, fs, args)
+			if err != nil {
+				return err
+			}
+			if len(remaining) != 2 {
+				fs.Usage()
+				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
+			}
+			opts := RunOptions{
+				DryRun:    cfg.DryRun,
+				Transport: cfg.Transport,
+			}
+			return runCommand(remaining[0], remaining[1], opts)
 		},
 	}
-	runCmd.Flags().Bool("dry-run", false, "print actions without executing")
-	runCmd.Flags().String("transport", "", "ordered transports to try (e.g. 'tcp+tls,ssh')")
-	runV.BindPFlags(runCmd.Flags())
 
 	manifestCmd := &cobra.Command{
 		Use:   "manifest",
 		Short: "Manage manifests",
 	}
-	rebuildV := newViper()
+
 	rebuildCmd := &cobra.Command{
-		Use:   "rebuild <device>",
-		Short: "Rebuild manifest for device",
-		Args:  cobra.ExactArgs(1),
+		Use:                "rebuild [flags] <device>",
+		Short:              "Rebuild manifest for device",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return manifestRebuild(args[0], rebuildV.GetBool("dry-run"))
+			defaults, err := config.DefaultConfig()
+			if err != nil {
+				return err
+			}
+			fs := pflag.NewFlagSet("rebuild", pflag.ContinueOnError)
+			flagSets := config.NewFlagSets(defaults)
+			cfg, remaining, err := config.LoadConfig(flagSets, defaults, fs, args)
+			if err != nil {
+				return err
+			}
+			if len(remaining) != 1 {
+				fs.Usage()
+				return fmt.Errorf("usage: lvmsync manifest rebuild [flags] <device>")
+			}
+			return manifestRebuild(remaining[0], cfg.DryRun)
 		},
 	}
-	rebuildCmd.Flags().Bool("dry-run", false, "print actions without executing")
-	rebuildV.BindPFlags(rebuildCmd.Flags())
 	manifestCmd.AddCommand(rebuildCmd)
 
 	verifyCmd := &cobra.Command{

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -11,7 +11,7 @@ func TestRunCommandFlags(t *testing.T) {
 	}
 	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
 
-	if err := Execute([]string{"run", "--dry-run", "--transport", "tcp,ssh", "src", "dst"}); err != nil {
+	if err := Execute([]string{"run", "--dry_run", "--transport", "tcp,ssh", "src", "dst"}); err != nil {
 		t.Fatalf("execute run: %v", err)
 	}
 	if gotSrc != "src" || gotDst != "dst" {
@@ -55,7 +55,7 @@ func TestManifestRebuildRoutes(t *testing.T) {
 	}
 	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool) error { return nil } })
 
-	if err := Execute([]string{"manifest", "rebuild", "--dry-run", "/dev/vg0"}); err != nil {
+	if err := Execute([]string{"manifest", "rebuild", "--dry_run", "/dev/vg0"}); err != nil {
 		t.Fatalf("execute rebuild: %v", err)
 	}
 	if gotDevice != "/dev/vg0" {

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
@@ -13,25 +12,35 @@ import (
 
 // Run executes manifest subcommands. Currently only "rebuild" is supported.
 func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
-	fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)
-	output := fs.String("output", "", "manifest output file")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	v := viper.New()
-	_ = v.BindPFlags(fs)
-	remaining := fs.Args()
-	if len(remaining) < 2 || remaining[0] != "rebuild" {
+	if len(args) == 0 || args[0] != "rebuild" {
+		fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)
 		fs.Usage()
 		return fmt.Errorf("usage: lvmsync manifest rebuild <device>")
 	}
-	device := remaining[1]
+	flagSets := config.NewFlagSets(cfg)
+	fs := pflag.NewFlagSet("manifest rebuild", pflag.ContinueOnError)
+	output := fs.String("output", "", "manifest output file")
+	conf, remaining, err := config.LoadConfig(flagSets, cfg, fs, args[1:])
+	if err != nil {
+		return err
+	}
+	if len(remaining) != 1 {
+		fs.Usage()
+		return fmt.Errorf("usage: lvmsync manifest rebuild <device>")
+	}
+	device := remaining[0]
 	path := *output
 	if path == "" {
 		path = device + ".manifest"
 	}
 	if logger != nil {
 		logger.Info("rebuilding manifest", zap.String("device", device), zap.String("output", path))
+	}
+	if conf.DryRun {
+		if logger != nil {
+			logger.Info("dry run - skipping rebuild")
+		}
+		return nil
 	}
 	if err := manifestpkg.Rebuild(device, path); err != nil {
 		if logger != nil {

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@
 # and apply to destination device
 apply: ""
 stdout: false  # Write change dump to STDOUT
-dry_run: false  # Print actions without executing (same as --dry-run)
+dry_run: false  # Print actions without executing (same as --dry_run)
 parallel: 4  # Number of concurrent workers
 # Enable zero-copy transfers (only in sequential mode)
 zerocopy: false

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	ConfigFile           string        `mapstructure:"config"`
 	ApplyMode            string        `mapstructure:"apply"`
 	StdoutMode           bool          `mapstructure:"stdout"`
+	DryRun               bool          `mapstructure:"dry_run"`
 	Force                bool          `mapstructure:"force"`
 	Mode                 string        `mapstructure:"mode"`
 	Parallel             int           `mapstructure:"parallel"`
@@ -403,6 +404,7 @@ func DefaultConfig() (*Config, error) {
 		Mode:                 "default",
 		ApplyMode:            "",
 		StdoutMode:           false,
+		DryRun:               false,
 		Force:                false,
 		Parallel:             4,
 		Concurrency:          0,
@@ -478,6 +480,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("config", "", "Path to config YAML file")
 	fs.String("apply", cfg.ApplyMode, "Apply mode: read change dump from file ('-' for STDIN) and apply to destination device")
 	fs.Bool("stdout", cfg.StdoutMode, "Write change dump to STDOUT")
+	fs.Bool("dry_run", cfg.DryRun, "Print actions without executing")
 	fs.Bool("force", cfg.Force, "Override safety checks and proceed on mounted destination")
 	fs.String("mode", cfg.Mode, "Preset mode: default or throughput")
 	fs.Int("parallel", cfg.Parallel, "Number of concurrent workers")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -16,6 +16,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"config", ""},
 		{"apply", cfg.ApplyMode},
 		{"stdout", strconv.FormatBool(cfg.StdoutMode)},
+		{"dry_run", strconv.FormatBool(cfg.DryRun)},
 		{"force", strconv.FormatBool(cfg.Force)},
 		{"mode", cfg.Mode},
 		{"parallel", strconv.Itoa(cfg.Parallel)},


### PR DESCRIPTION
## Summary
- add `dry_run` to central config and expose `--dry_run` flag
- use `config.NewFlagSets` in `lvmsync` and `manifest` commands for unified parsing
- document `--dry_run` flag with underscore style

## Testing
- `go build ./...` *(fails: common/handshake.go syntax error)*
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake.go build errors)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`
- `go test ./cmd/lvmsync`


------
https://chatgpt.com/codex/tasks/task_e_689c8179895c8323a2ab62a609d8ed48