### PR TITLE
fix(manifest): close index once

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -41,6 +41,8 @@ type Index struct {
 	hdr  Header
 }
 
+var closeHook = func() {}
+
 func headerMAC(h *Header) [32]byte {
 	var buf [headerSize - 32]byte
 	binary.LittleEndian.PutUint32(buf[0:4], h.Version)
@@ -82,6 +84,7 @@ func (i *Index) readHeader() error {
 
 // Close flushes the mmap and closes the underlying file.
 func (i *Index) Close() error {
+	defer closeHook()
 	if i.data != nil {
 		if err := unix.Msync(i.data, unix.MS_SYNC); err != nil {
 			_ = unix.Munmap(i.data)
@@ -232,5 +235,5 @@ func Rebuild(devicePath, output string) error {
 			break
 		}
 	}
-	return idx.Close()
+	return nil
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -93,3 +93,32 @@ func TestRebuild(t *testing.T) {
 		t.Fatalf("close manifest: %v", err)
 	}
 }
+
+func TestRebuildCloseOnce(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	data := make([]byte, 4096)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	manPath := filepath.Join(dir, "closeonce.man")
+	prevHook := closeHook
+	count := 0
+	closeHook = func() { count++ }
+	defer func() { closeHook = prevHook }()
+	if err := Rebuild(file.Name(), manPath); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected close called once, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure manifest index closes exactly once during rebuild
- add regression test to verify Rebuild closes index only once

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c86a82c04832398e55f8243385b6b