### PR TITLE
feat(device): add context-aware UUID lookup

### DIFF
--- a/device/info.go
+++ b/device/info.go
@@ -2,11 +2,15 @@ package device
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const uuidTimeout = 5 * time.Second
 
 var (
 	uuidFunc  = defaultUUIDFunc
@@ -15,21 +19,32 @@ var (
 
 // SetUUIDFunc allows tests to override the implementation used to lookup a
 // device's UUID or serial. It returns the previous function for restoration.
-func SetUUIDFunc(f func(string) (string, error)) func(string) (string, error) {
+func SetUUIDFunc(f func(context.Context, string) (string, error)) func(context.Context, string) (string, error) {
 	prev := uuidFunc
 	uuidFunc = f
 	return prev
 }
 
 // GetUUID returns the UUID or GPT serial of the device at path.
-func GetUUID(path string) (string, error) { return uuidFunc(path) }
+// If ctx has no deadline, a default timeout is applied.
+func GetUUID(ctx context.Context, path string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, uuidTimeout)
+		defer cancel()
+	}
+	return uuidFunc(ctx, path)
+}
 
-func defaultUUIDFunc(path string) (string, error) {
-	out, err := exec.Command("blkid", "-o", "value", "-s", "UUID", path).Output()
+func defaultUUIDFunc(ctx context.Context, path string) (string, error) {
+	out, err := exec.CommandContext(ctx, "blkid", "-o", "value", "-s", "UUID", path).Output()
 	if err == nil && len(out) > 0 {
 		return strings.TrimSpace(string(out)), nil
 	}
-	out, err = exec.Command("blkid", "-o", "value", "-s", "PARTUUID", path).Output()
+	out, err = exec.CommandContext(ctx, "blkid", "-o", "value", "-s", "PARTUUID", path).Output()
 	if err != nil {
 		return "", err
 	}

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -1,0 +1,15 @@
+package device
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGetUUIDCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := GetUUID(ctx, "/dev/null"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -206,7 +207,7 @@ func Rebuild(devicePath, output string) error {
 	}
 	blockSize := uint32(4096)
 	size := uint64(st.Size())
-	id, err := device.GetUUID(devicePath)
+	id, err := device.GetUUID(context.Background(), devicePath)
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"os"
 	"path/filepath"
@@ -65,7 +66,7 @@ func TestRebuild(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	file.Close()
-	prev := device.SetUUIDFunc(func(string) (string, error) { return "uuid-test", nil })
+	prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "rebuild.man")
 	if err := Rebuild(file.Name(), manPath); err != nil {

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -23,7 +24,7 @@ func minimalStream(t *testing.T) []byte {
 }
 
 func TestProcessDumpDataUUIDMismatch(t *testing.T) {
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "actual", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "actual", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	prevMount := device.SetMountFunc(func(string) (bool, error) { return false, nil })
 	defer device.SetMountFunc(prevMount)
@@ -48,7 +49,7 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 }
 
 func TestProcessDumpDataMountedDevice(t *testing.T) {
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "id", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	prevMount := device.SetMountFunc(func(string) (bool, error) { return true, nil })
 	defer device.SetMountFunc(prevMount)
@@ -79,7 +80,7 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 }
 
 func TestApplyDataUUIDMismatch(t *testing.T) {
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "actual", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "actual", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	prevMount := device.SetMountFunc(func(string) (bool, error) { return false, nil })
 	defer device.SetMountFunc(prevMount)
@@ -104,7 +105,7 @@ func TestApplyDataUUIDMismatch(t *testing.T) {
 }
 
 func TestApplyDataMountedDevice(t *testing.T) {
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "id", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	prevMount := device.SetMountFunc(func(string) (bool, error) { return true, nil })
 	defer device.SetMountFunc(prevMount)

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"os"
 	"path/filepath"
@@ -29,7 +30,7 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	dev.Close()
-	prev := device.SetUUIDFunc(func(string) (string, error) { return "id", nil })
+	prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
 	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "dev.man")
 	if err := manifestpkg.Rebuild(dev.Name(), manPath); err != nil {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -4,6 +4,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/gob"
@@ -720,7 +721,7 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 	reader := bufio.NewReader(decReader)
 
 	if cfg.DeviceUUID != "" {
-		uuid, err2 := device.GetUUID(destPath)
+		uuid, err2 := device.GetUUID(context.Background(), destPath)
 		if err2 != nil {
 			return fmt.Errorf("read destination uuid: %w", err2)
 		}
@@ -799,7 +800,7 @@ func openApplyReader(applyFile string) (io.ReadCloser, error) {
 
 func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string) error {
 	if cfg.DeviceUUID != "" {
-		uuid, err := device.GetUUID(destDevice)
+		uuid, err := device.GetUUID(context.Background(), destDevice)
 		if err != nil {
 			return fmt.Errorf("read destination uuid: %w", err)
 		}


### PR DESCRIPTION
## Summary
- allow querying device UUIDs with context-based timeout
- update call sites to pass context
- add cancellation test for GetUUID

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c86aaedf08323bb87068fdc9de4c2