### PR TITLE
feat(transport): add registry mutex and duplicate checks

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -16,7 +16,11 @@ type Transport struct{}
 // New returns a new Transport.
 func New() transport.Interface { return &Transport{} }
 
-func init() { transport.Register("h2", New) }
+func init() {
+	if err := transport.Register("h2", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "h2" }
 

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -16,7 +16,11 @@ type Transport struct{}
 // New returns a new Transport.
 func New() transport.Interface { return &Transport{} }
 
-func init() { transport.Register("quic", New) }
+func init() {
+	if err := transport.Register("quic", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "quic" }
 

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -1,19 +1,33 @@
 package transport
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // Factory creates a transport implementation.
 type Factory func() Interface
 
-var registry = map[string]Factory{}
+var (
+	registry = map[string]Factory{}
+	regMu    sync.RWMutex
+)
 
 // Register adds a transport factory to the registry.
-func Register(name string, f Factory) {
+func Register(name string, f Factory) error {
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, exists := registry[name]; exists {
+		return fmt.Errorf("transport %q already registered", name)
+	}
 	registry[name] = f
+	return nil
 }
 
 // Get returns a transport from the registry by name.
 func Get(name string) (Interface, error) {
+	regMu.RLock()
+	defer regMu.RUnlock()
 	if f, ok := registry[name]; ok {
 		return f(), nil
 	}

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -1,0 +1,39 @@
+package transport
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestConcurrentRegister(t *testing.T) {
+	const goroutines = 50
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := fmt.Sprintf("test-%d", i)
+			if err := Register(name, func() Interface { return nil }); err != nil {
+				t.Errorf("register %s: %v", name, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < goroutines; i++ {
+		name := fmt.Sprintf("test-%d", i)
+		if _, err := Get(name); err != nil {
+			t.Errorf("get %s: %v", name, err)
+		}
+	}
+}
+
+func TestDuplicateRegister(t *testing.T) {
+	name := "dupe-test"
+	if err := Register(name, func() Interface { return nil }); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if err := Register(name, func() Interface { return nil }); err == nil {
+		t.Fatalf("expected duplicate registration error")
+	}
+}

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -16,7 +16,11 @@ type Transport struct{}
 // New returns a new Transport.
 func New() transport.Interface { return &Transport{} }
 
-func init() { transport.Register("ssh", New) }
+func init() {
+	if err := transport.Register("ssh", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "ssh" }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -31,7 +31,11 @@ func New() transport.Interface {
 	}
 }
 
-func init() { transport.Register("tcp+tls", New) }
+func init() {
+	if err := transport.Register("tcp+tls", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "tcp+tls" }
 


### PR DESCRIPTION
## Summary
- protect transport registry with sync.RWMutex
- return error on duplicate registrations
- test concurrent and duplicate registration handling

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689c86ac52348323b8fc4f7c89ed1e8e