### PR TITLE
refactor: inject logger into transports

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -295,12 +295,13 @@ func SelectTransport(cfg *config.Config, logger *zap.Logger) (transport.Interfac
 	}
 	for _, name := range strings.Split(cfg.Transport, ",") {
 		name = strings.TrimSpace(name)
-		tr, err := transport.Get(name)
+		trLogger := logger.Named(name)
+		tr, err := transport.Get(name, trLogger)
 		if err != nil {
-			logger.Warn("unsupported transport", zap.String("transport", name))
+			trLogger.Warn("unsupported transport", zap.String("transport", name))
 			continue
 		}
-		logger.Info("selected transport", zap.String("transport", name))
+		trLogger.Info("selected transport", zap.String("transport", name))
 		return tr, nil
 	}
 	return nil, fmt.Errorf("no supported transports: %s", cfg.Transport)

--- a/cmd/dump/select_transport_test.go
+++ b/cmd/dump/select_transport_test.go
@@ -7,12 +7,13 @@ import (
 	"lvmsync_go/config"
 	_ "lvmsync_go/transport/ssh"
 
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestSelectTransportNoConfig(t *testing.T) {
 	cfg := &config.Config{}
-	logger := zap.NewNop()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
 	tr, err := SelectTransport(cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -24,7 +25,8 @@ func TestSelectTransportNoConfig(t *testing.T) {
 
 func TestSelectTransportError(t *testing.T) {
 	cfg := &config.Config{Transport: "bogus"}
-	logger := zap.NewNop()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
 	_, err := SelectTransport(cfg, logger)
 	if err == nil || !strings.Contains(err.Error(), "no supported") {
 		t.Fatalf("expected transport error, got %v", err)
@@ -33,7 +35,8 @@ func TestSelectTransportError(t *testing.T) {
 
 func TestSelectTransportOrder(t *testing.T) {
 	cfg := &config.Config{Transport: "bogus,ssh"}
-	logger := zap.NewNop()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
 	tr, err := SelectTransport(cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"net"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
 // Transport is a placeholder HTTP/2 transport using plain TCP.
-type Transport struct{}
+type Transport struct{ logger *zap.Logger }
 
 // New returns a new Transport.
-func New() transport.Interface { return &Transport{} }
+func New(logger *zap.Logger) transport.Interface { return &Transport{logger: logger} }
 
 func init() {
 	if err := transport.Register("h2", New); err != nil {
@@ -25,11 +27,13 @@ func init() {
 func (t *Transport) Name() string { return "h2" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
+	t.logger.Info("dial", zap.String("address", address))
 	d := net.Dialer{}
 	return d.DialContext(ctx, "tcp", address)
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
+	t.logger.Info("listen", zap.String("address", address))
 	return net.Listen("tcp", address)
 }
 
@@ -45,6 +49,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return nil
@@ -54,6 +59,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -6,10 +6,14 @@ import (
 	"testing"
 
 	"lvmsync_go/transport"
+
+	"go.uber.org/zap/zaptest"
 )
 
 func TestH2TransportHandshake(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
@@ -55,7 +59,9 @@ func TestH2TransportHandshake(t *testing.T) {
 }
 
 func TestH2TransportHandshakeError(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {

--- a/transport/negotiation_integration_test.go
+++ b/transport/negotiation_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"lvmsync_go/transport"
 	_ "lvmsync_go/transport/ssh"
 	_ "lvmsync_go/transport/tcp_tls"
+
+	"go.uber.org/zap/zaptest"
 )
 
 func handshakeRoundTrip(t transport.Interface, tname string) error {
@@ -73,7 +75,9 @@ func handshakeRoundTrip(t transport.Interface, tname string) error {
 func TestNegotiationTCPAndSSH(t *testing.T) {
 	names := []string{"tcp+tls", "ssh"}
 	for _, name := range names {
-		tr, err := transport.Get(name)
+		logger := zaptest.NewLogger(t)
+		defer logger.Sync()
+		tr, err := transport.Get(name, logger)
 		if err != nil {
 			t.Fatalf("get transport %s: %v", name, err)
 		}

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"net"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
 // Transport is a placeholder QUIC transport using plain TCP.
-type Transport struct{}
+type Transport struct{ logger *zap.Logger }
 
 // New returns a new Transport.
-func New() transport.Interface { return &Transport{} }
+func New(logger *zap.Logger) transport.Interface { return &Transport{logger: logger} }
 
 func init() {
 	if err := transport.Register("quic", New); err != nil {
@@ -25,11 +27,13 @@ func init() {
 func (t *Transport) Name() string { return "quic" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
+	t.logger.Info("dial", zap.String("address", address))
 	d := net.Dialer{}
 	return d.DialContext(ctx, "tcp", address)
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
+	t.logger.Info("listen", zap.String("address", address))
 	return net.Listen("tcp", address)
 }
 
@@ -45,6 +49,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return nil
@@ -54,6 +59,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -6,10 +6,14 @@ import (
 	"testing"
 
 	"lvmsync_go/transport"
+
+	"go.uber.org/zap/zaptest"
 )
 
 func TestQUICTransportHandshake(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
@@ -55,7 +59,9 @@ func TestQUICTransportHandshake(t *testing.T) {
 }
 
 func TestQUICTransportHandshakeError(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -3,10 +3,12 @@ package transport
 import (
 	"fmt"
 	"sync"
+
+	"go.uber.org/zap"
 )
 
 // Factory creates a transport implementation.
-type Factory func() Interface
+type Factory func(*zap.Logger) Interface
 
 var (
 	registry = map[string]Factory{}
@@ -24,12 +26,12 @@ func Register(name string, f Factory) error {
 	return nil
 }
 
-// Get returns a transport from the registry by name.
-func Get(name string) (Interface, error) {
+// Get returns a transport from the registry by name, constructing it with the provided logger.
+func Get(name string, logger *zap.Logger) (Interface, error) {
 	regMu.RLock()
 	defer regMu.RUnlock()
 	if f, ok := registry[name]; ok {
-		return f(), nil
+		return f(logger), nil
 	}
 	return nil, fmt.Errorf("transport %q not registered", name)
 }

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestConcurrentRegister(t *testing.T) {
@@ -14,7 +17,7 @@ func TestConcurrentRegister(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			name := fmt.Sprintf("test-%d", i)
-			if err := Register(name, func() Interface { return nil }); err != nil {
+			if err := Register(name, func(*zap.Logger) Interface { return nil }); err != nil {
 				t.Errorf("register %s: %v", name, err)
 			}
 		}(i)
@@ -22,18 +25,20 @@ func TestConcurrentRegister(t *testing.T) {
 	wg.Wait()
 	for i := 0; i < goroutines; i++ {
 		name := fmt.Sprintf("test-%d", i)
-		if _, err := Get(name); err != nil {
+		logger := zaptest.NewLogger(t)
+		if _, err := Get(name, logger); err != nil {
 			t.Errorf("get %s: %v", name, err)
 		}
+		logger.Sync()
 	}
 }
 
 func TestDuplicateRegister(t *testing.T) {
 	name := "dupe-test"
-	if err := Register(name, func() Interface { return nil }); err != nil {
+	if err := Register(name, func(*zap.Logger) Interface { return nil }); err != nil {
 		t.Fatalf("first register: %v", err)
 	}
-	if err := Register(name, func() Interface { return nil }); err == nil {
+	if err := Register(name, func(*zap.Logger) Interface { return nil }); err == nil {
 		t.Fatalf("expected duplicate registration error")
 	}
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"net"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
 // Transport implements the transport.Interface over plain TCP for now.
-type Transport struct{}
+type Transport struct{ logger *zap.Logger }
 
 // New returns a new Transport.
-func New() transport.Interface { return &Transport{} }
+func New(logger *zap.Logger) transport.Interface { return &Transport{logger: logger} }
 
 func init() {
 	if err := transport.Register("ssh", New); err != nil {
@@ -25,11 +27,13 @@ func init() {
 func (t *Transport) Name() string { return "ssh" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
+	t.logger.Info("dial", zap.String("address", address))
 	d := net.Dialer{}
 	return d.DialContext(ctx, "tcp", address)
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
+	t.logger.Info("listen", zap.String("address", address))
 	return net.Listen("tcp", address)
 }
 
@@ -45,6 +49,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return nil
@@ -54,6 +59,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -6,10 +6,14 @@ import (
 	"testing"
 
 	"lvmsync_go/transport"
+
+	"go.uber.org/zap/zaptest"
 )
 
 func TestSSHTransportHandshake(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
@@ -55,7 +59,9 @@ func TestSSHTransportHandshake(t *testing.T) {
 }
 
 func TestSSHTransportHandshakeError(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"time"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
@@ -20,14 +22,16 @@ import (
 type Transport struct {
 	serverConf *tls.Config
 	clientConf *tls.Config
+	logger     *zap.Logger
 }
 
 // New creates a Transport with a self-signed certificate for tests.
-func New() transport.Interface {
+func New(logger *zap.Logger) transport.Interface {
 	cert, _ := generateSelfSignedCert()
 	return &Transport{
 		serverConf: &tls.Config{Certificates: []tls.Certificate{cert}},
 		clientConf: &tls.Config{InsecureSkipVerify: true},
+		logger:     logger,
 	}
 }
 
@@ -40,11 +44,13 @@ func init() {
 func (t *Transport) Name() string { return "tcp+tls" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
+	t.logger.Info("dial", zap.String("address", address))
 	d := net.Dialer{}
 	return tls.DialWithDialer(&d, "tcp", address, t.clientConf)
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
+	t.logger.Info("listen", zap.String("address", address))
 	ln, err := net.Listen("tcp", address)
 	if err != nil {
 		return nil, err
@@ -64,6 +70,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return nil
@@ -73,6 +80,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
+			t.logger.Warn("endianness_mismatch", zap.String("peer_endianness", peer.Endianness), zap.String("local_endianness", hs.Endianness))
 			return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return common.WriteHandshake(conn, hs)

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -6,10 +6,14 @@ import (
 	"testing"
 
 	"lvmsync_go/transport"
+
+	"go.uber.org/zap/zaptest"
 )
 
 func TestTCPTLSTransportHandshake(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
@@ -55,7 +59,9 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {
-	tr := New()
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	tr := New(logger)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
## Summary
- require scoped zap loggers for transport factories
- pass transport-specific loggers during selection
- replace transport fmt prints with structured logs and zaptest in unit tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/manifest, manifest, remote)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c971d32808323a7737acce03daa51