### PR TITLE
docs: document device matrix and transports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,10 @@ Run these commands locally before opening a pull request:
 - [ ] Remove stray `fmt.Print*` calls in favor of structured logs.
 - [ ] Monitor elimination of `fmt.Print*` calls to keep progress logging fully structured.
 - [ ] Review QUIC constructor refactor and expand tests for sender/receiver coverage.
+- [ ] LVM device support: plumb snapshot creation through the device abstraction, allow raw device fallbacks, and unit test LVM vs. file paths.
+- [ ] Transport logging: emit connection handshake and teardown events with `snake_case` fields and ensure callers `defer logger.Sync()`.
+- [ ] Manifest rebuild: add a subcommand to regenerate chunk digests when manifests are missing or out of date, exercising rebuild logic in tests.
+- [ ] Verify command: compare source and destination devices against manifest entries and surface mismatched digests with structured logs.
 - [x] Refactor `cmd/grpcd` to defer `syncLogger` for structured log flushing.
 - [x] Expand unit test coverage for remote execution and client signal handling, and run coverage reports (transports coverage ≥50%).
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Flexible Configuration**: Flags, environment variables, or `config.yaml`. See [Configuration](#configuration).
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.
 
+## Device Support Matrix
+
+| Device type     | Source | Destination |
+|-----------------|:------:|:-----------:|
+| LVM snapshot    |   ✅   |      ❌      |
+| Raw block device|   ✅   |      ✅      |
+| Regular file    |   ✅   |      ✅      |
+
 ## Supported Platforms
 
 LVMSync targets Linux systems only. Builds are tested on the `amd64` and `arm64` architectures.
@@ -459,14 +467,17 @@ transports to attempt (for example `tcp+tls,ssh`). The flags below configure tra
 
 ### Flags and environment variables
 
-| Flag | Environment variable | Description |
-|------|----------------------|-------------|
-| `--transport` | `LVMSYNC_TRANSPORT` | Ordered transports to try (e.g., `tcp+tls,ssh`) |
-| `--concurrency` | `LVMSYNC_CONCURRENCY` | Stream concurrency (0 to autotune based on BDP) |
-| `--tcp_port` | `LVMSYNC_TCP_PORT` | TCP+TLS port |
-| `--tcp_parallel` | `LVMSYNC_TCP_PARALLEL` | Number of parallel TCP connections |
-| `--tcp_lowat` | `LVMSYNC_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes |
-| `--ssh_port` | `LVMSYNC_SSH_PORT` | SSH port |
+| Flag | Environment variable | Description | mTLS |
+|------|----------------------|-------------|------|
+| `--transport` | `LVMSYNC_TRANSPORT` | Ordered transports to try (e.g., `tcp+tls,ssh`) | n/a |
+| `--concurrency` | `LVMSYNC_CONCURRENCY` | Stream concurrency (0 to autotune based on BDP) | n/a |
+| `--tcp_port` | `LVMSYNC_TCP_PORT` | TCP+TLS port | ✅ |
+| `--ssh_port` | `LVMSYNC_SSH_PORT` | SSH port | ❌ |
+| `--tls_cert` | `LVMSYNC_TLS_CERT` | TLS certificate file | ✅ |
+| `--tls_key` | `LVMSYNC_TLS_KEY` | TLS key file | ✅ |
+| `--ca_cert` | `LVMSYNC_CA_CERT` | CA certificate file | ✅ |
+| `--tcp_parallel` | `LVMSYNC_TCP_PARALLEL` | Number of parallel TCP connections | n/a |
+| `--tcp_lowat` | `LVMSYNC_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes | n/a |
 
 ### Usage examples
 
@@ -488,7 +499,13 @@ LVMSYNC_TRANSPORT=ssh LVMSYNC_SSH_PORT=2222 lvmsync run backup@host:/dev/vg1/tar
 
 ## Hybrid Deduplication and Adaptive Compression
 
-Hybrid dedup combines fixed-size and content-defined chunking. Enable it with `--dedup hybrid` and tune the CDC window with `--cdc_min`, `--cdc_avg`, and `--cdc_max`.
+Hybrid dedup combines fixed-size and content-defined chunking. Enable it with `--dedup hybrid` and tune FastCDC with `--cdc-min`, `--cdc-avg`, and `--cdc-max` (flags use underscores in the CLI: `--cdc_min`, `--cdc_avg`, `--cdc_max`).
+
+| Flag (`--cdc-*`) | Environment variable | Config key | Description |
+|------------------|----------------------|------------|-------------|
+| `--cdc-min`      | `LVMSYNC_CDC_MIN`    | `cdc_min`  | Minimum chunk size |
+| `--cdc-avg`      | `LVMSYNC_CDC_AVG`    | `cdc_avg`  | Target average chunk size |
+| `--cdc-max`      | `LVMSYNC_CDC_MAX`    | `cdc_max`  | Maximum chunk size |
 
 The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom_entries` and desired false positive rate via `--bloom_fp_rate`. For an mmap-backed index, `--bloom_mbits` controls the bitmap size in megabits.
 
@@ -663,15 +680,19 @@ lvmsync run [--dry_run] [--transport tcp+tls,ssh] <snapshot|lvm device> <destina
 
 The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps. Use `--dry_run` to print planned actions without executing and `--transport` to provide an ordered list of transports to try.
 
-### Manifest Operations
+## Resume, Manifest, and Verify
+
+Resume an interrupted transfer using a checkpointed state file:
+
+```sh
+lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data
+```
 
 Rebuild a manifest index for an existing device:
 
 ```sh
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
-
-### Verification
 
 Verify that a source and destination match:
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,36 @@
+# Manifest Format
+
+LVMSync records transfer metadata in a manifest file. Each entry stores the chunk offset, length, and BLAKE3 digest so transfers can resume and destinations can be verified.
+
+## Index Format
+
+Manifests are JSON lines with one object per chunk:
+
+```json
+{"offset":0,"size_bytes":4096,"digest":"<hex blake3>"}
+```
+
+The final line carries a SHA-256 digest of all chunk digests to validate completeness.
+
+## Rebuilding
+
+Regenerate a manifest for an existing device when the index is missing or out of date:
+
+```sh
+lvmsync manifest rebuild /dev/vg0/lv0
+```
+
+## Verification
+
+Use manifests to verify that a source and destination match:
+
+```sh
+lvmsync verify /dev/vg0/snap0 /mnt/backup
+```
+
+### Flags
+
+| Flag | Environment variable | Config key | Description |
+|------|----------------------|------------|-------------|
+| `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file |
+| `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -1,0 +1,33 @@
+# Transports
+
+LVMSync supports multiple transports selected with the `--transport` flag.
+
+## Handshake Negotiation
+
+During connection setup the sender and receiver exchange:
+
+- `sector_size`
+- `alignment`
+- `max_concurrency`
+- deduplication and compression capabilities
+
+This negotiation ensures both sides agree on block sizes and enabled features before data moves.
+
+## Security Defaults
+
+- `tcp+tls` requires mutual TLS with `--tls_cert`, `--tls_key`, and a trusted `--ca_cert`.
+- `ssh` relies on user keys and host key verification; mTLS does not apply.
+
+## Flags
+
+| Flag | Environment variable | Description | mTLS |
+|------|----------------------|-------------|------|
+| `--transport` | `LVMSYNC_TRANSPORT` | Ordered transports to try (e.g., `tcp+tls,ssh`) | n/a |
+| `--concurrency` | `LVMSYNC_CONCURRENCY` | Stream concurrency (0 to autotune based on BDP) | n/a |
+| `--tcp_port` | `LVMSYNC_TCP_PORT` | TCP+TLS port | ✅ |
+| `--ssh_port` | `LVMSYNC_SSH_PORT` | SSH port | ❌ |
+| `--tls_cert` | `LVMSYNC_TLS_CERT` | TLS certificate file | ✅ |
+| `--tls_key` | `LVMSYNC_TLS_KEY` | TLS key file | ✅ |
+| `--ca_cert` | `LVMSYNC_CA_CERT` | CA certificate file | ✅ |
+| `--tcp_parallel` | `LVMSYNC_TCP_PARALLEL` | Number of parallel TCP connections | n/a |
+| `--tcp_lowat` | `LVMSYNC_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes | n/a |


### PR DESCRIPTION
## Summary
- note device, logging, manifest, and verify tasks in AGENTS.md
- expand README with device matrix, mTLS flag table, CDC tunables, and resume/manifest/verify examples
- add manifest and transport docs covering index format, handshake, and security defaults

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cannot use func(string) as func(context.Context,string))*
- `golangci-lint run`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689c971e94d0832399377adda1a5f322