### PR TITLE
feat(grpcd): add mTLS daemon and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@
 FROM golang:1.24-alpine AS build
 ARG BIN
 ARG BUILD_PATH=.
+# To build the gRPC daemon instead of the CLI, set:
+#   --build-arg BIN=lvmsync_grpcd --build-arg BUILD_PATH=./cmd/grpcd
 ARG GIT_SHA=unknown
 
 RUN apk add --no-cache \

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ proto:
 	protoc --go_out=. --go-grpc_out=. --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative proto/replication.proto
 
 build:
-	mkdir -p bin
-	go build -o bin/lvmsync .
-	go build -o bin/grpcd ./cmd/grpcd
+        mkdir -p bin
+        go build -o bin/lvmsync .
+        go build -o bin/lvmsync_grpcd ./cmd/grpcd
 
 test:
 	go test -coverprofile=coverage.out ./...

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_
 
 ## gRPC Control Plane
 
-The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel.
+The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel. Plaintext connections are rejected unless `--allow-insecure` is explicitly set.
 
 `StartGRPCServer` accepts a `context.Context` and runs the server in a goroutine, returning a buffered error channel. Cancel the context or invoke the cleanup function to stop the server and wait on the channel during shutdown to surface any serve errors.
 
@@ -371,11 +371,15 @@ The optional gRPC daemon exposes snapshot management and replication over a mutu
 4. **Ack/Ping Stream** – a bidirectional stream of `Ack` messages per session provides keep-alives and progress confirmation.
 5. **Finalization** – the client requests completion using the session ID when replication is done.
 
+Configuration comes from flags, `LVMSYNC_GRPC_*` environment variables, or a YAML file with flags taking precedence.
+
 Run the daemon with TLS:
 
 ```sh
 lvmsync-grpcd --grpc-port 9443 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
+
+Disabling TLS with `--allow-insecure` is supported for development but is unsafe for production deployments.
 
 On failure, `lvmsync-grpcd` logs the error and exits with status `1` so calling scripts can inspect `$?`.
 

--- a/cmd/grpcd/cobra.go
+++ b/cmd/grpcd/cobra.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	grpcserver "lvmsync_go/grpc/server"
+)
+
+// Options holds configuration for the gRPC daemon.
+type Options struct {
+	GRPCPort      int
+	TLSCert       string
+	TLSKey        string
+	CACert        string
+	AllowInsecure bool
+}
+
+// startFunc allows tests to stub server startup.
+var startFunc = func(ctx context.Context, opts Options, logger *zap.Logger) error {
+	addr := fmt.Sprintf(":%d", opts.GRPCPort)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	cfg := grpcserver.Config{
+		TLSCert:       opts.TLSCert,
+		TLSKey:        opts.TLSKey,
+		CACert:        opts.CACert,
+		AllowInsecure: opts.AllowInsecure,
+	}
+	srv, err := grpcserver.New(cfg, nil)
+	if err != nil {
+		ln.Close()
+		return fmt.Errorf("init gRPC server: %w", err)
+	}
+	go func() {
+		if err := srv.Serve(ln); err != nil {
+			logger.Error("grpc serve", zap.Error(err))
+		}
+	}()
+	<-ctx.Done()
+	srv.GracefulStop()
+	ln.Close()
+	return nil
+}
+
+func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+	fs := cmd.Flags()
+	fs.Int("grpc-port", 9443, "gRPC listen port")
+	fs.String("tls-cert", "", "TLS certificate file")
+	fs.String("tls-key", "", "TLS key file")
+	fs.String("ca-cert", "", "CA certificate file")
+	fs.Bool("allow-insecure", false, "allow plaintext gRPC")
+	fs.String("config", "", "config file")
+
+	v.BindPFlags(fs)
+	v.SetEnvPrefix("LVMSYNC_GRPC")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+}
+
+func loadConfig(v *viper.Viper) (Options, error) {
+	cfgFile := v.GetString("config")
+	if cfgFile != "" {
+		v.SetConfigFile(cfgFile)
+	} else {
+		v.SetConfigName("grpcd")
+		v.AddConfigPath(".")
+	}
+	if err := v.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok && cfgFile != "" {
+			return Options{}, err
+		}
+	}
+	return Options{
+		GRPCPort:      v.GetInt("grpc-port"),
+		TLSCert:       v.GetString("tls-cert"),
+		TLSKey:        v.GetString("tls-key"),
+		CACert:        v.GetString("ca-cert"),
+		AllowInsecure: v.GetBool("allow-insecure"),
+	}, nil
+}
+
+// NewCmd creates the root cobra command.
+func NewCmd(logger *zap.Logger) *cobra.Command {
+	v := viper.New()
+	cmd := &cobra.Command{
+		Use:   "lvmsync-grpcd",
+		Short: "LVMSync gRPC daemon",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := loadConfig(v)
+			if err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			return startFunc(ctx, opts, logger)
+		},
+	}
+	bindFlags(cmd, v)
+	return cmd
+}
+
+// Execute runs the command with provided args.
+func Execute(args []string, logger *zap.Logger) error {
+	cmd := NewCmd(logger)
+	if args != nil {
+		cmd.SetArgs(args)
+	}
+	return cmd.Execute()
+}

--- a/cmd/grpcd/cobra_test.go
+++ b/cmd/grpcd/cobra_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestFlagParsing(t *testing.T) {
+	logger := zap.NewNop()
+	var got Options
+	orig := startFunc
+	startFunc = func(ctx context.Context, opts Options, _ *zap.Logger) error {
+		got = opts
+		return nil
+	}
+	defer func() { startFunc = orig }()
+	args := []string{
+		"--grpc-port", "1234",
+		"--tls-cert", "cert",
+		"--tls-key", "key",
+		"--ca-cert", "ca",
+		"--allow-insecure",
+	}
+	if err := Execute(args, logger); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	want := Options{GRPCPort: 1234, TLSCert: "cert", TLSKey: "key", CACert: "ca", AllowInsecure: true}
+	if got != want {
+		t.Fatalf("got %+v want %+v", got, want)
+	}
+}

--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		os.Exit(1)
+	}
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			logger.Error("logger sync error", zap.Error(err))
+		}
+	}()
+	if err := Execute(nil, logger); err != nil {
+		logger.Error("run failed", zap.Error(err))
+		os.Exit(1)
+	}
+}

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()
@@ -43,7 +44,7 @@ func TestRunOutputFlag(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -530,6 +530,27 @@ func TestNewRPCsMTLS(t *testing.T) {
 	}
 }
 
+func TestPlaintextRejected(t *testing.T) {
+	cfg, _, _ := generateTLS(t)
+	lis := bufconn.Listen(bufSize)
+	srv, err := New(cfg, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	go srv.Serve(lis)
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	client := proto.NewReplicationClient(conn)
+	if _, err := client.Ping(ctxWithRole("replicator"), &proto.Empty{}); err == nil {
+		t.Fatalf("expected handshake failure")
+	}
+	conn.Close()
+	srv.Stop()
+}
+
 func dummyCert(t *testing.T) []byte {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -109,7 +109,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	file.Close()
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "uuid-test", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeonce.man")
 	prevHook := closeHook

--- a/packaging/systemd/lvmsync-grpcd.service
+++ b/packaging/systemd/lvmsync-grpcd.service
@@ -5,7 +5,7 @@ Description=LVMSync gRPC daemon
 
 [Service]
 User=lvmsync
-ExecStart=/usr/bin/lvmsync_grpcd --config /etc/lvmsync.yaml
+ExecStart=/usr/bin/lvmsync_grpcd --config /etc/grpcd.yaml
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Summary
- add `lvmsync-grpcd` command with TLS flags and viper integration
- document and package gRPC daemon build assets
- cover new flags and TLS rejection with unit tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c971669d88323a5155229dddc4ac7