### PR TITLE
feat(cmd): add verify subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,17 @@ Verify that a source and destination match:
 lvmsync verify /dev/vg0/source /dev/vg1/target
 ```
 
+Supply options such as block size or deduplication mode to control how data is
+compared. For example, to verify using 4 KiB blocks and a manifest generated
+earlier:
+
+```sh
+lvmsync verify --block_size 4K --manifest snapshot.manifest /dev/vg0/source /dev/vg1/target
+```
+
+Flags are parsed via Viper, so the same settings can be provided through
+`LVMSYNC_*` environment variables or a `config.yaml` file.
+
 ### Options
 
 #### General Options

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	verifycmd "lvmsync_go/cmd/verify"
 	"lvmsync_go/config"
 )
 
@@ -19,7 +20,7 @@ var (
 	// These function variables allow tests to stub command behavior.
 	runCommand      = func(src, dst string, opts RunOptions) error { return nil }
 	manifestRebuild = func(device string, dryRun bool) error { return nil }
-	verifyCommand   = func(src, dst string) error { return nil }
+	verifyRun       = func(args []string) error { return verifycmd.Run(args, nil) }
 )
 
 // NewRootCmd creates the root cobra command with all subcommands wired.
@@ -86,11 +87,11 @@ func NewRootCmd() *cobra.Command {
 	manifestCmd.AddCommand(rebuildCmd)
 
 	verifyCmd := &cobra.Command{
-		Use:   "verify <source> <dest>",
-		Short: "Verify that source and destination match",
-		Args:  cobra.ExactArgs(2),
+		Use:                "verify [flags] <source> <dest>",
+		Short:              "Verify that source and destination match",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return verifyCommand(args[0], args[1])
+			return verifyRun(args)
 		},
 	}
 

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -1,6 +1,10 @@
 package lvmsync
 
-import "testing"
+import (
+	"testing"
+
+	verifycmd "lvmsync_go/cmd/verify"
+)
 
 func TestRunCommandFlags(t *testing.T) {
 	var gotSrc, gotDst string
@@ -67,17 +71,17 @@ func TestManifestRebuildRoutes(t *testing.T) {
 }
 
 func TestVerifyRoutes(t *testing.T) {
-	var src, dst string
-	verifyCommand = func(s, d string) error {
-		src, dst = s, d
+	var got []string
+	verifyRun = func(a []string) error {
+		got = append([]string{}, a...)
 		return nil
 	}
-	t.Cleanup(func() { verifyCommand = func(src, dst string) error { return nil } })
+	t.Cleanup(func() { verifyRun = func(args []string) error { return verifycmd.Run(args, nil) } })
 
 	if err := Execute([]string{"verify", "a", "b"}); err != nil {
 		t.Fatalf("execute verify: %v", err)
 	}
-	if src != "a" || dst != "b" {
-		t.Fatalf("unexpected args %q %q", src, dst)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("unexpected args %v", got)
 	}
 }

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()
@@ -43,7 +44,7 @@ func TestRunOutputFlag(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -13,6 +13,7 @@ import (
 	applycmd "lvmsync_go/cmd/apply"
 	dumpcmd "lvmsync_go/cmd/dump"
 	manifestcmd "lvmsync_go/cmd/manifest"
+	verifycmd "lvmsync_go/cmd/verify"
 	"lvmsync_go/config"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privilege"
@@ -121,8 +122,13 @@ func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPa
 func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	defer lvm.Cleanup()
 
-	if len(args) > 0 && args[0] == "manifest" {
-		return manifestcmd.Run(cfg, args[1:], logger)
+	if len(args) > 0 {
+		switch args[0] {
+		case "manifest":
+			return manifestcmd.Run(cfg, args[1:], logger)
+		case "verify":
+			return verifycmd.Run(args[1:], logger)
+		}
 	}
 
 	if cfg.ApplyMode != "" {

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -1,0 +1,153 @@
+package verify
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+	"lvmsync_go/transfer"
+)
+
+// Run executes the verify command with the provided arguments and logger.
+// Args should exclude the "verify" subcommand itself.
+func Run(args []string, logger *zap.Logger) error {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	cmd := &cobra.Command{
+		Use:                "verify [flags] <source> <dest>",
+		Short:              "Verify that source and destination contain identical data",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, argv []string) error {
+			defaults, err := config.DefaultConfig()
+			if err != nil {
+				return err
+			}
+			flagSets := config.NewFlagSets(defaults)
+			fs := pflag.NewFlagSet("verify", pflag.ContinueOnError)
+			for _, set := range flagSets.All() {
+				fs.AddFlagSet(set)
+			}
+			var manifest string
+			fs.StringVar(&manifest, "manifest", "", "Manifest file providing range hints")
+			cfg, remaining, err := config.LoadConfig(flagSets, defaults, fs, argv)
+			if err != nil {
+				return err
+			}
+			if len(remaining) != 2 {
+				fs.Usage()
+				return fmt.Errorf("usage: lvmsync verify [flags] <source> <dest>")
+			}
+			return verifyDevices(cfg, remaining[0], remaining[1], manifest, logger)
+		},
+	}
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func verifyDevices(cfg *config.Config, src, dst, manifest string, logger *zap.Logger) error {
+	if manifest != "" {
+		return verifyWithManifest(src, dst, manifest, logger)
+	}
+	return verifyFull(cfg, src, dst, logger)
+}
+
+func verifyFull(cfg *config.Config, src, dst string, logger *zap.Logger) error {
+	blockSize := cfg.BlockSize
+	if blockSize == 0 {
+		blockSize = 8 * 1024 * 1024
+	}
+	fSrc, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer fSrc.Close()
+	fDst, err := os.Open(dst)
+	if err != nil {
+		return fmt.Errorf("open dest: %w", err)
+	}
+	defer fDst.Close()
+
+	infoSrc, err := fSrc.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+	infoDst, err := fDst.Stat()
+	if err != nil {
+		return fmt.Errorf("stat dest: %w", err)
+	}
+	if infoSrc.Size() != infoDst.Size() {
+		logger.Error("size mismatch", zap.Int64("source_bytes", infoSrc.Size()), zap.Int64("dest_bytes", infoDst.Size()))
+		return fmt.Errorf("size mismatch")
+	}
+
+	total := infoSrc.Size()
+	mismatches := 0
+	for off := int64(0); off < total; off += int64(blockSize) {
+		bufSrc, err := transfer.ReadBlock(fSrc, off, blockSize)
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("read source: %w", err)
+		}
+		bufDst, err := transfer.ReadBlock(fDst, off, blockSize)
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("read dest: %w", err)
+		}
+		if blake3.Sum256(bufSrc) != blake3.Sum256(bufDst) {
+			mismatches++
+			logger.Error("mismatched_block", zap.Int64("offset_bytes", off))
+		}
+	}
+	if mismatches > 0 {
+		return fmt.Errorf("%d blocks differ", mismatches)
+	}
+	logger.Info("verification complete")
+	return nil
+}
+
+func verifyWithManifest(src, dst, manifest string, logger *zap.Logger) error {
+	data, err := os.ReadFile(manifest)
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+	m, err := transfer.UnmarshalManifest(data)
+	if err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+	fSrc, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer fSrc.Close()
+	fDst, err := os.Open(dst)
+	if err != nil {
+		return fmt.Errorf("open dest: %w", err)
+	}
+	defer fDst.Close()
+
+	mismatches := 0
+	for _, ch := range m.Chunks {
+		bufSrc := make([]byte, ch.Length)
+		if _, err := fSrc.ReadAt(bufSrc, ch.Offset); err != nil {
+			return fmt.Errorf("read source: %w", err)
+		}
+		bufDst := make([]byte, ch.Length)
+		if _, err := fDst.ReadAt(bufDst, ch.Offset); err != nil {
+			return fmt.Errorf("read dest: %w", err)
+		}
+		if blake3.Sum256(bufSrc) != blake3.Sum256(bufDst) {
+			mismatches++
+			logger.Error("mismatched_block", zap.Int64("offset_bytes", ch.Offset))
+		}
+	}
+	if mismatches > 0 {
+		return fmt.Errorf("%d blocks differ", mismatches)
+	}
+	logger.Info("verification complete")
+	return nil
+}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -1,0 +1,43 @@
+package verify
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func writeTempFile(t *testing.T, data []byte) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "verify")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close temp: %v", err)
+	}
+	return f.Name()
+}
+
+func TestVerifySuccess(t *testing.T) {
+	data := make([]byte, 8192)
+	src := writeTempFile(t, data)
+	dst := writeTempFile(t, data)
+	if err := Run([]string{"--block_size", "8K", src, dst}, zap.NewNop()); err != nil {
+		t.Fatalf("verify success: %v", err)
+	}
+}
+
+func TestVerifyMismatch(t *testing.T) {
+	srcData := make([]byte, 8192)
+	dstData := make([]byte, 8192)
+	dstData[0] = 1
+	src := writeTempFile(t, srcData)
+	dst := writeTempFile(t, dstData)
+	if err := Run([]string{"--block_size", "8K", src, dst}, zap.NewNop()); err == nil {
+		t.Fatalf("expected mismatch error")
+	}
+}

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -1,0 +1,22 @@
+# Verify
+
+`lvmsync verify` compares two devices and reports any blocks that differ.
+It reads both paths in chunks, computing BLAKE3 digests for each block. A
+non-zero exit status is returned when mismatches are detected.
+
+## Examples
+
+Verify that two logical volumes match:
+
+```sh
+lvmsync verify /dev/vg0/source /dev/vg1/target
+```
+
+Restrict verification to ranges recorded in a manifest and use 4 KiB blocks:
+
+```sh
+lvmsync verify --block_size 4K --manifest snapshot.manifest /dev/vg0/source /dev/vg1/target
+```
+
+All flags can also be provided via `LVMSYNC_*` environment variables or a
+`config.yaml` file thanks to Viper binding.

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -109,7 +109,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	file.Close()
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "uuid-test", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeonce.man")
 	prevHook := closeHook


### PR DESCRIPTION
## Summary
- add `lvmsync verify` command with Cobra and Viper flag binding
- compare devices block-by-block and optionally from manifest
- document verification usage

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c9718d4988323906714834d083bbd