### PR TITLE
feat(device): add device detection and type flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,26 @@ Recent refactors added several configuration options:
 - `--sync_interval` sets how many bytes are written between `fdatasync` calls.
 - `--numa_pin` pins worker goroutines to CPUs local to the source device's NUMA node.
 
+### Device types
+
+LVMSync works with three kinds of source and destination devices. Auto-detection
+examines the path to select the correct handling:
+
+| Type | Detection | Notes |
+|------|-----------|-------|
+| `lvm` | `/dev/<vg>/<lv>` or `/dev/mapper/<vg>-<lv>` | A snapshot is created and removed automatically |
+| `raw` | Other block devices | Require `--skip_snapshot_creation` or external freeze hooks |
+| `file` | Regular files | Used as-is with no snapshot |
+
+Override detection with `--source-type` and `--dest-type` when necessary.
+
+Examples:
+
+```sh
+lvmsync --source-type lvm /dev/vg0/origin /tmp/dump
+lvmsync --dest-type raw dumpfile /dev/sdb
+```
+
 ### Configuration sources and precedence
 
 LVMSync uses [`pflag`](https://github.com/spf13/pflag) and [`viper`](https://github.com/spf13/viper) so every option can be
@@ -269,6 +289,8 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--config` | `LVMSYNC_CONFIG` | `config` | Path to config YAML file |
 | `--apply` | `LVMSYNC_APPLY` | `apply` | Apply mode: read change dump from file ('-' for STDIN) and apply to destination device |
 | `--stdout` | `LVMSYNC_STDOUT` | `stdout` | Write change dump to STDOUT |
+| `--source-type` | `LVMSYNC_SOURCE_TYPE` | `source-type` | Source device type: `auto`, `file`, `raw`, or `lvm` |
+| `--dest-type` | `LVMSYNC_DEST_TYPE` | `dest-type` | Destination device type: `auto`, `file`, `raw`, or `lvm` |
 | `--mode` | `LVMSYNC_MODE` | `mode` | Configuration preset: `default` or `throughput`; unknown modes fail validation |
 | `--parallel` | `LVMSYNC_PARALLEL` | `parallel` | Number of concurrent workers |
 | `--concurrency` | `LVMSYNC_CONCURRENCY` | `concurrency` | Stream concurrency (0 to autotune based on BDP) |

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	"lvmsync_go/transfer"
 )
 
@@ -23,5 +24,22 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 		return fmt.Errorf("no destination device specified for apply mode")
 	}
 	destDevice := args[0]
+	if cfg.DestType == "auto" {
+		if dev, err := device.Detect(destDevice); err == nil {
+			switch dev.(type) {
+			case *device.RawDevice:
+				if !cfg.SkipSnapshotCreation {
+					dev.Close()
+					return fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
+				}
+				cfg.DestType = "raw"
+			case *device.LVMDevice:
+				cfg.DestType = "lvm"
+			case *device.FileDevice:
+				cfg.DestType = "file"
+			}
+			dev.Close()
+		}
+	}
 	return applyFunc(cfg, applyFile, destDevice, logger)
 }

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -14,6 +14,7 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	"lvmsync_go/remote"
 	"lvmsync_go/transfer"
 	"lvmsync_go/transport"
@@ -107,6 +108,23 @@ func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, l
 
 // RunLocalDump dumps changes to a local destination device.
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
+	if cfg.DestType == "auto" {
+		if dev, err := device.Detect(dest); err == nil {
+			switch dev.(type) {
+			case *device.RawDevice:
+				if !cfg.SkipSnapshotCreation {
+					dev.Close()
+					return fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
+				}
+				cfg.DestType = "raw"
+			case *device.LVMDevice:
+				cfg.DestType = "lvm"
+			case *device.FileDevice:
+				cfg.DestType = "file"
+			}
+			dev.Close()
+		}
+	}
 	destFile, err := openFile(dest, os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("failed to open destination device %s: %w", dest, err)

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()
@@ -43,7 +44,7 @@ func TestRunOutputFlag(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -14,6 +14,7 @@ import (
 	dumpcmd "lvmsync_go/cmd/dump"
 	manifestcmd "lvmsync_go/cmd/manifest"
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privilege"
 	"lvmsync_go/lvm"
@@ -171,10 +172,40 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		destPath = args[1]
 	}
 
-	var monitorErrCh chan error
-	snapshotPath, monitorErrCh, cleanup, err := PrepareSnapshot(ctx, cfg, originalVolume, logger)
-	if err != nil {
-		return err
+	snapshotPath = originalVolume
+	var (
+		monitorErrCh chan error
+		cleanup      = func() {}
+	)
+
+	if cfg.SourceType == "" || cfg.SourceType == "auto" {
+		if dev, err := device.Detect(originalVolume); err == nil {
+			switch dev.(type) {
+			case *device.LVMDevice:
+				cfg.SourceType = "lvm"
+			case *device.RawDevice:
+				cfg.SourceType = "raw"
+			case *device.FileDevice:
+				cfg.SourceType = "file"
+			}
+			dev.Close()
+		} else {
+			cfg.SourceType = "file"
+		}
+	}
+	switch cfg.SourceType {
+	case "lvm":
+		snapshotPath, monitorErrCh, cleanup, err = PrepareSnapshot(ctx, cfg, originalVolume, logger)
+		if err != nil {
+			return err
+		}
+	case "raw":
+		if !cfg.SkipSnapshotCreation {
+			return fmt.Errorf("raw sources require --skip_snapshot_creation or external freeze hooks")
+		}
+	case "file":
+	default:
+		return fmt.Errorf("unknown source type %q", cfg.SourceType)
 	}
 	defer cleanup()
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -26,6 +26,8 @@ var (
 )
 
 type Config struct {
+	SourceType           string        `mapstructure:"source-type"`
+	DestType             string        `mapstructure:"dest-type"`
 	ConfigFile           string        `mapstructure:"config"`
 	ApplyMode            string        `mapstructure:"apply"`
 	StdoutMode           bool          `mapstructure:"stdout"`
@@ -173,6 +175,8 @@ func DefaultConfig() (*Config, error) {
 		SkipSnapshotCreation: false,
 		SkipDiskCheck:        false,
 		SnapshotSize:         "20%",
+		SourceType:           "auto",
+		DestType:             "auto",
 		VolumeGroup:          "",
 		TargetVolumeGroup:    "",
 		TargetVGCandidates:   []string{},

--- a/config/flags.go
+++ b/config/flags.go
@@ -53,6 +53,8 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("stdout", cfg.StdoutMode, "Write change dump to STDOUT")
 	fs.Bool("dry_run", cfg.DryRun, "Print actions without executing")
 	fs.Bool("force", cfg.Force, "Override safety checks and proceed on mounted destination")
+	fs.String("source-type", cfg.SourceType, "Source device type (auto,file,raw,lvm)")
+	fs.String("dest-type", cfg.DestType, "Destination device type (auto,file,raw,lvm)")
 	fs.String("mode", cfg.Mode, "Preset mode: default or throughput")
 	fs.Int("parallel", cfg.Parallel, "Number of concurrent workers")
 	fs.Bool("zerocopy", cfg.ZeroCopy, "Enable zero-copy transfers")

--- a/config/validation.go
+++ b/config/validation.go
@@ -15,6 +15,12 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.Mode != "default" && c.Mode != "throughput" {
 		return fmt.Errorf("invalid mode %q: must be \"default\" or \"throughput\"", c.Mode)
 	}
+	if c.SourceType != "" && c.SourceType != "auto" && c.SourceType != "file" && c.SourceType != "raw" && c.SourceType != "lvm" {
+		return fmt.Errorf("invalid source type %q", c.SourceType)
+	}
+	if c.DestType != "" && c.DestType != "auto" && c.DestType != "file" && c.DestType != "raw" && c.DestType != "lvm" {
+		return fmt.Errorf("invalid dest type %q", c.DestType)
+	}
 	if c.SSHKeepAliveInterval <= 0 {
 		return fmt.Errorf("ssh keepalive interval must be > 0")
 	}

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -234,13 +234,15 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")
 	v.AddConfigPath(".")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	v.SetEnvPrefix("LVMSYNC")
 	v.AutomaticEnv()
 	keys := []string{
 		"transport",
 		"concurrency",
 		"tcp_port",
+		"source-type",
+		"dest-type",
 	}
 	for _, k := range keys {
 		if err := v.BindEnv(k); err != nil {

--- a/device/detect.go
+++ b/device/detect.go
@@ -1,0 +1,28 @@
+package device
+
+import (
+	"fmt"
+	"os"
+
+	"lvmsync_go/lvm"
+)
+
+// Detect inspects the path and returns the appropriate Device implementation.
+// Regular files return FileDevice, block devices are classified as either LVM
+// logical volumes or raw devices based on LVM metadata.
+func Detect(path string) (Device, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode().IsRegular() {
+		return OpenFile(path)
+	}
+	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
+		if _, err := lvm.GetVolumeGroupName(path); err == nil {
+			return OpenLVM(path)
+		}
+		return OpenRaw(path)
+	}
+	return nil, fmt.Errorf("unsupported path type: %s", path)
+}

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -1,0 +1,86 @@
+package device
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupLoop(t *testing.T, size int64) (string, func()) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "loopback")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if err := f.Truncate(size); err != nil {
+		f.Close()
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	out, err := exec.Command("losetup", "--show", "-f", f.Name()).Output()
+	if err != nil {
+		t.Skipf("losetup: %v", err)
+	}
+	loop := strings.TrimSpace(string(out))
+	loop = filepath.Clean(loop)
+	cleanup := func() { exec.Command("losetup", "-d", loop).Run() }
+	return loop, cleanup
+}
+
+func TestDetectFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "file")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	dev, err := Detect(f.Name())
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if _, ok := dev.(*FileDevice); !ok {
+		t.Fatalf("expected FileDevice, got %T", dev)
+	}
+	dev.Close()
+}
+
+func TestDetectRaw(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+	dev, err := Detect(loop)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if _, ok := dev.(*RawDevice); !ok {
+		t.Fatalf("expected RawDevice, got %T", dev)
+	}
+	dev.Close()
+}
+
+func TestDetectLVM(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+	vgDir := filepath.Join("/dev", "testvg")
+	lvPath := filepath.Join(vgDir, "testlv")
+	os.MkdirAll(vgDir, 0o755)
+	os.Symlink(loop, lvPath)
+	defer os.Remove(lvPath)
+	defer os.Remove(vgDir)
+
+	dev, err := Detect(lvPath)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if _, ok := dev.(*LVMDevice); !ok {
+		t.Fatalf("expected LVMDevice, got %T", dev)
+	}
+	dev.Close()
+}

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -1,0 +1,49 @@
+package device
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"lvmsync_go/lvm"
+)
+
+// LVMDevice represents a logical volume managed by LVM.
+type LVMDevice struct {
+	f         *os.File
+	size      uint64
+	blockSize uint64
+}
+
+// OpenLVM opens an LVM logical volume and queries its size and block size.
+// Size information is obtained through the lvm package helpers.
+func OpenLVM(path string) (*LVMDevice, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	bs, err := unix.IoctlGetInt(int(f.Fd()), unix.BLKSSZGET)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	size, err := lvm.GetVolumeSize(path, zap.NewNop())
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &LVMDevice{f: f, size: size, blockSize: uint64(bs)}, nil
+}
+
+// Path returns the underlying device path.
+func (d *LVMDevice) Path() string { return d.f.Name() }
+
+// SizeBytes returns the logical volume size in bytes.
+func (d *LVMDevice) SizeBytes() uint64 { return d.size }
+
+// BlockSize returns the logical block size in bytes.
+func (d *LVMDevice) BlockSize() uint64 { return d.blockSize }
+
+// Close closes the device.
+func (d *LVMDevice) Close() error { return d.f.Close() }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -109,7 +109,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	file.Close()
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "uuid-test", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeonce.man")
 	prevHook := closeHook


### PR DESCRIPTION
## Summary
- add LVM-aware device implementation and detection for file, raw, and LVM paths
- introduce source/dest type flags and config entries with auto-detection
- document supported device matrix and usage examples

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689c97146e388323a2b76f6f537945d0