### PR TITLE
feat(transfer): persist dedup mode and CDC boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Recent refactors added several configuration options:
 - `--tcp_lowat` sets TCP_NOTSENT_LOWAT to limit unsent bytes.
 - `--sync_interval` controls how many bytes are written between `fdatasync` calls.
 - `--checkpoint_interval` sets how often resume state is persisted.
+- `--checkpoint_bytes` sets how many bytes are written between resume checkpoints.
 - `--block_size` sets the transfer block size (use `auto` for detection).
 
 ### I/O tuning
@@ -276,9 +277,10 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--odirect` | `LVMSYNC_ODIRECT` | `odirect` | Use O_DIRECT for device I/O when possible |
 | `--numa_pin` | `LVMSYNC_NUMA_PIN` | `numa_pin` | Pin worker goroutines to device NUMA node |
 | `--max_retries` | `LVMSYNC_MAX_RETRIES` | `max_retries` | Maximum number of retries per block |
-| `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file (checkpointed every 1 GiB or 10 s) |
+| `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file (records dedup mode and last chunk boundary) |
 | `--speed` | `LVMSYNC_SPEED` | `speed` | Transfer speed limit |
 | `--sync_interval` | `LVMSYNC_SYNC_INTERVAL` | `sync_interval` | Bytes between fdatasync calls |
+| `--checkpoint_bytes` | `LVMSYNC_CHECKPOINT_BYTES` | `checkpoint_bytes` | Bytes between resume checkpoints |
 | `--checkpoint_interval` | `LVMSYNC_CHECKPOINT_INTERVAL` | `checkpoint_interval` | Duration between checkpoints |
 | `--block_size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
 | `--verbose` | `LVMSYNC_VERBOSE` | `verbose` | Verbosity level |
@@ -836,7 +838,7 @@ lvmsync run --speed 50MB /dev/vg0/snap0 /dev/vg0/data
 
 #### Resuming a Transfer
 
-Resume an interrupted transfer using a resume state file. The file stores the last successful CDC chunk digest and is checkpointed every 1 GiB or 10 s:
+Resume an interrupted transfer using a resume state file. The file records the deduplication mode, the digest of the last successful chunk, and its CDC boundaries. Progress is checkpointed every `--checkpoint-bytes` or `--checkpoint-interval`, and the resume file is removed on successful completion:
 
 ```sh
 lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()
@@ -43,7 +44,7 @@ func TestRunOutputFlag(t *testing.T) {
 		t.Fatalf("write device: %v", err)
 	}
 
-	restore := device.SetUUIDFunc(func(string) (string, error) { return "uuid", nil })
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
 	defer device.SetUUIDFunc(restore)
 
 	cfg, err := config.DefaultConfig()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -442,6 +442,9 @@ func TestApplyThroughputMode(t *testing.T) {
 	if conf.SyncIntervalBytes != 1000000000 {
 		t.Fatalf("sync interval bytes %d", conf.SyncIntervalBytes)
 	}
+	if conf.CheckpointBytes != 1000000000 {
+		t.Fatalf("checkpoint bytes %d", conf.CheckpointBytes)
+	}
 	if conf.CheckpointInterval != 10*time.Second {
 		t.Fatalf("checkpoint interval %v", conf.CheckpointInterval)
 	}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -100,7 +100,9 @@ type Config struct {
 	TCPNotSentLowAt      int           `mapstructure:"tcp_lowat"`
 	SyncInterval         string        `mapstructure:"sync_interval"`
 	CheckpointInterval   time.Duration `mapstructure:"checkpoint_interval"`
+	CheckpointBytesRaw   string        `mapstructure:"checkpoint_bytes"`
 	SyncIntervalBytes    int           `mapstructure:"-"`
+	CheckpointBytes      int           `mapstructure:"-"`
 }
 
 func FormatBlockSize(blockSize int) (string, error) {
@@ -207,6 +209,8 @@ func DefaultConfig() (*Config, error) {
 		TCPNotSentLowAt:      0,
 		SyncInterval:         "1GB",
 		CheckpointInterval:   0,
+		CheckpointBytesRaw:   "1GB",
 		SyncIntervalBytes:    1000000000,
+		CheckpointBytes:      1000000000,
 	}, nil
 }

--- a/config/flags.go
+++ b/config/flags.go
@@ -62,6 +62,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("resume", cfg.ResumeState, "Path to resume state file")
 	fs.String("speed", cfg.Speed, "Transfer speed limit")
 	fs.String("sync_interval", cfg.SyncInterval, "Bytes between fdatasync calls")
+	fs.String("checkpoint_bytes", cfg.CheckpointBytesRaw, "Bytes between resume checkpoints")
 	fs.Duration("checkpoint_interval", cfg.CheckpointInterval, "Duration between checkpoints")
 	fs.String("block_size", cfg.BlockSizeRaw, "Block size for data transfer; specify 'auto' or 0 for automatic detection")
 	fs.CountP("verbose", "v", "Verbosity level")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -27,6 +27,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"resume", cfg.ResumeState},
 		{"speed", cfg.Speed},
 		{"sync_interval", cfg.SyncInterval},
+		{"checkpoint_bytes", cfg.CheckpointBytesRaw},
 		{"checkpoint_interval", cfg.CheckpointInterval.String()},
 		{"block_size", cfg.BlockSizeRaw},
 		{"verbose", "0"},

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -80,6 +80,15 @@ func (b *Builder) applyDefaults(conf *Config) error {
 		conf.SyncInterval = b.defaults.SyncInterval
 	}
 
+	cb, err := b.parseBytesOrFallback("checkpoint_bytes", b.defaults.CheckpointBytesRaw)
+	if err != nil {
+		return err
+	}
+	conf.CheckpointBytes = cb
+	if conf.CheckpointBytesRaw == "" {
+		conf.CheckpointBytesRaw = b.defaults.CheckpointBytesRaw
+	}
+
 	if conf.CompressConcurrency <= 0 {
 		conf.CompressConcurrency = runtime.GOMAXPROCS(0)
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -109,7 +109,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	file.Close()
-	prevUUID := device.SetUUIDFunc(func(string) (string, error) { return "uuid-test", nil })
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeonce.man")
 	prevHook := closeHook

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -75,7 +75,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 				return totalBytes, skippedBlocks, manifest, fmt.Errorf("failed to write header: %w", err)
 			}
 			zh := zeroHash(int(blockSize))
-			saveResumeState(cfg, zh, int64(blockSize), logger)
+			saveResumeState(cfg, r.Start, zh, int64(blockSize), logger)
 			if idx != nil {
 				idx.Set(r.Start, blockSize, xx, sum)
 			}
@@ -98,7 +98,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		if idx != nil {
 			idx.Set(r.Start, blockSize, xx, sum)
 		}
-		saveResumeState(cfg, sum, int64(blockSize), logger)
+		saveResumeState(cfg, r.Start, sum, int64(blockSize), logger)
 
 		putBlockBuffer(data)
 
@@ -180,14 +180,14 @@ func processParallelResults(
 				xx := hashutil.SumXXH3(res.Data)
 				idx.Set(res.Offset, res.Size, xx, res.ChunkID)
 			}
-			saveResumeState(cfg, res.ChunkID, int64(res.Size), logger)
+			saveResumeState(cfg, res.Offset, res.ChunkID, int64(res.Size), logger)
 			putBlockBuffer(res.Data)
 		} else {
 			if idx != nil {
 				xx := hashutil.SumXXH3(nil)
 				idx.Set(res.Offset, res.Size, xx, res.ChunkID)
 			}
-			saveResumeState(cfg, res.ChunkID, 0, logger)
+			saveResumeState(cfg, res.Offset, res.ChunkID, 0, logger)
 		}
 
 		totalBytesTransferred += int64(res.Size)

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -52,11 +52,11 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	tmp := t.TempDir()
 	stateFile := filepath.Join(tmp, "resume")
 	digest := blake3.Sum256([]byte("data"))
-	cfg := &config.Config{ResumeState: stateFile, Compress: "none", ChecksumAlgorithm: "blake3"}
-	writeResumeState(cfg, logger, stateFile, digest)
+	cfg := &config.Config{ResumeState: stateFile, Compress: "none", ChecksumAlgorithm: "blake3", DedupMode: "fixed"}
+	writeResumeState(cfg, logger, stateFile, 0, 0, digest)
 
-	val := readResumeDigest(cfg, logger)
-	if val != digest {
+	val := readResumeState(cfg, logger)
+	if val.Chunk != digest {
 		t.Fatalf("expected digest match")
 	}
 

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -1,104 +1,31 @@
 package transfer
 
 import (
-	"bytes"
-	"io"
-	"reflect"
+	"path/filepath"
 	"testing"
 
-	"lvmsync_go/dedup"
-	hashutil "lvmsync_go/hash"
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
 )
 
-func collectCDCDigests(data []byte, min, avg, max int) ([][32]byte, error) {
-	ch := dedup.NewChunker(min, avg, max)
-	rdr := bytes.NewReader(data)
-	var out [][32]byte
-	for {
-		c, err := ch.NextChunk(rdr)
-		if err == io.EOF && c.Length == 0 {
-			break
-		}
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-		out = append(out, hashutil.SumBLAKE3(c.Data))
-		if err == io.EOF {
-			break
-		}
-	}
-	return out, nil
-}
+func TestResumeCDCOffset(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	state := filepath.Join(dir, "resume")
 
-func resumeCDCFromDigest(data []byte, min, avg, max int, resume [32]byte) ([][32]byte, error) {
-	ch := dedup.NewChunker(min, avg, max)
-	rdr := bytes.NewReader(data)
-	var out [][32]byte
-	found := false
-	for {
-		c, err := ch.NextChunk(rdr)
-		if err == io.EOF && c.Length == 0 {
-			break
-		}
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-		digest := hashutil.SumBLAKE3(c.Data)
-		if !found {
-			if digest == resume {
-				found = true
-			}
-		} else {
-			out = append(out, digest)
-		}
-		if err == io.EOF {
-			break
-		}
-	}
-	if !found {
-		return nil, io.EOF
-	}
-	return out, nil
-}
+	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
+	digest := blake3.Sum256([]byte("chunk"))
+	writeResumeState(cfg, logger, state, 80, 40, digest)
 
-func TestResumeCDC(t *testing.T) {
-	// Use identical parameters for CDC and hybrid to make the first chunk
-	// boundary deterministic and consistent across modes.
-	min, avg, max := 64, 64, 64
-	fixed := 64
-	data := bytes.Repeat([]byte("a"), 512)
-
-	cdcAll, err := collectCDCDigests(data, min, avg, max)
-	if err != nil {
-		t.Fatalf("collect CDC digests: %v", err)
+	chk := readResumeState(cfg, logger)
+	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
+	idx := findResumeIndex(cfg, nil, ranges, chk, logger)
+	if idx != 1 {
+		t.Fatalf("expected index 1, got %d", idx)
 	}
-	hybridAll, err := collectHybridDigests(data, fixed, min, avg, max)
-	if err != nil {
-		t.Fatalf("collect hybrid digests: %v", err)
-	}
-	if len(cdcAll) < 2 || len(hybridAll) < 2 {
-		t.Fatalf("expected at least two chunks per mode")
-	}
-
-	// The resume checkpoint should be identical regardless of dedup mode.
-	resume := cdcAll[0]
-	if resume != hybridAll[0] {
-		t.Fatalf("resume digest mismatch: %x vs %x", resume, hybridAll[0])
-	}
-
-	resumedCDC, err := resumeCDCFromDigest(data, min, avg, max, resume)
-	if err != nil {
-		t.Fatalf("resume CDC: %v", err)
-	}
-	if !reflect.DeepEqual(resumedCDC, cdcAll[1:]) {
-		t.Fatalf("CDC resumed digests %v, expected %v", resumedCDC, cdcAll[1:])
-	}
-
-	resumedHybrid, err := resumeHybridFromDigest(data, fixed, min, avg, max, resume)
-	if err != nil {
-		t.Fatalf("resume hybrid: %v", err)
-	}
-	if !reflect.DeepEqual(resumedHybrid, hybridAll[1:]) {
-		t.Fatalf("hybrid resumed digests %v, expected %v", resumedHybrid, hybridAll[1:])
+	if ranges[1].Start != 120 {
+		t.Fatalf("expected range start 120, got %d", ranges[1].Start)
 	}
 }

--- a/transfer/resume_checksum_test.go
+++ b/transfer/resume_checksum_test.go
@@ -16,7 +16,7 @@ func TestResumeFinalChecksum(t *testing.T) {
 	logger := zap.NewNop()
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "sha256")
-	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "sha256", Transport: "ssh"}
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "sha256", Transport: "ssh", DedupMode: "fixed"}
 	ranges, err := gatherChangedRanges(snapshot, blockSize, logger)
 	if err != nil {
 		t.Fatalf("gather ranges: %v", err)
@@ -26,8 +26,8 @@ func TestResumeFinalChecksum(t *testing.T) {
 		t.Fatalf("open src: %v", err)
 	}
 	defer srcFile.Close()
-	resumeDigest := readResumeDigest(cfg, logger)
-	start := findResumeIndex(cfg, srcFile, ranges, resumeDigest, logger)
+	checkpoint := readResumeState(cfg, logger)
+	start := findResumeIndex(cfg, srcFile, ranges, checkpoint, logger)
 	w := bufio.NewWriter(io.Discard)
 	_, _, manifest, err := iterateBlocks(cfg, ranges[start:], srcFile, w, nil, [2]int{-1, -1}, logger)
 	if err != nil {

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -1,101 +1,31 @@
 package transfer
 
 import (
-	"bytes"
-	"io"
-	"reflect"
+	"path/filepath"
 	"testing"
 
-	"lvmsync_go/dedup"
-	hashutil "lvmsync_go/hash"
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
 )
 
-func collectHybridDigests(data []byte, fixed, min, avg, max int) ([][32]byte, error) {
-	h := dedup.NewHybridChunker(fixed, min, avg, max)
-	rdr := bytes.NewReader(data)
-	var out [][32]byte
-	for {
-		c, err := h.NextChunk(rdr)
-		if err == io.EOF && c.Length == 0 {
-			break
-		}
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-		out = append(out, hashutil.SumBLAKE3(c.Data))
-		if err == io.EOF {
-			break
-		}
-	}
-	return out, nil
-}
+func TestResumeHybridOffset(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	state := filepath.Join(dir, "resume")
 
-func resumeHybridFromDigest(data []byte, fixed, min, avg, max int, resume [32]byte) ([][32]byte, error) {
-	h := dedup.NewHybridChunker(fixed, min, avg, max)
-	rdr := bytes.NewReader(data)
-	var out [][32]byte
-	found := false
-	for {
-		c, err := h.NextChunk(rdr)
-		if err == io.EOF && c.Length == 0 {
-			break
-		}
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-		digest := hashutil.SumBLAKE3(c.Data)
-		if !found {
-			if digest == resume {
-				found = true
-			}
-		} else {
-			out = append(out, digest)
-		}
-		if err == io.EOF {
-			break
-		}
-	}
-	if !found {
-		return nil, io.EOF
-	}
-	return out, nil
-}
+	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
+	digest := blake3.Sum256([]byte("chunk"))
+	writeResumeState(cfg, logger, state, 80, 40, digest)
 
-func TestResumeHybrid(t *testing.T) {
-	fixed := 64
-	min, avg, max := 64, 64, 64
-	data := bytes.Repeat([]byte("b"), 512)
-
-	hybridAll, err := collectHybridDigests(data, fixed, min, avg, max)
-	if err != nil {
-		t.Fatalf("collect hybrid digests: %v", err)
+	chk := readResumeState(cfg, logger)
+	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
+	idx := findResumeIndex(cfg, nil, ranges, chk, logger)
+	if idx != 1 {
+		t.Fatalf("expected index 1, got %d", idx)
 	}
-	cdcAll, err := collectCDCDigests(data, min, avg, max)
-	if err != nil {
-		t.Fatalf("collect CDC digests: %v", err)
-	}
-	if len(hybridAll) < 2 || len(cdcAll) < 2 {
-		t.Fatalf("expected at least two chunks per mode")
-	}
-
-	resume := hybridAll[0]
-	if resume != cdcAll[0] {
-		t.Fatalf("resume digest mismatch: %x vs %x", resume, cdcAll[0])
-	}
-
-	resumedHybrid, err := resumeHybridFromDigest(data, fixed, min, avg, max, resume)
-	if err != nil {
-		t.Fatalf("resume hybrid: %v", err)
-	}
-	if !reflect.DeepEqual(resumedHybrid, hybridAll[1:]) {
-		t.Fatalf("hybrid resumed digests %v, expected %v", resumedHybrid, hybridAll[1:])
-	}
-
-	resumedCDC, err := resumeCDCFromDigest(data, min, avg, max, resume)
-	if err != nil {
-		t.Fatalf("resume CDC: %v", err)
-	}
-	if !reflect.DeepEqual(resumedCDC, cdcAll[1:]) {
-		t.Fatalf("CDC resumed digests %v, expected %v", resumedCDC, cdcAll[1:])
+	if ranges[1].Start != 120 {
+		t.Fatalf("expected range start 120, got %d", ranges[1].Start)
 	}
 }

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -38,8 +38,8 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int, algo string)
 	} else {
 		digest = blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
 	}
-	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: algo}
-	writeResumeState(cfg, zap.NewNop(), resumePath, digest)
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: algo, DedupMode: "fixed"}
+	writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest)
 	return srcPath, snapshot, resumePath
 }
 
@@ -77,7 +77,7 @@ func TestResumeSequential(t *testing.T) {
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
 
-	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh"}
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "fixed"}
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
@@ -101,7 +101,7 @@ func TestResumeParallel(t *testing.T) {
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
 
-	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 2, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh"}
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 2, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "fixed"}
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -242,8 +242,8 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	}
 	defer cleanupPipe()
 
-	resumeDigest := readResumeDigest(cfg, t.Logger)
-	startIdx := findResumeIndex(cfg, srcFile, ranges, resumeDigest, t.Logger)
+	checkpoint := readResumeState(cfg, t.Logger)
+	startIdx := findResumeIndex(cfg, srcFile, ranges, checkpoint, t.Logger)
 	if startIdx > 0 {
 		ranges = ranges[startIdx:]
 	}
@@ -317,24 +317,38 @@ func (t *Transfer) DumpChanges(cfg *config.Config, snapshot, source string, out 
 }
 
 var (
-	resumeMu    sync.Mutex
-	resumeBytes int64
-	resumeLast  time.Time
-	resumeChunk [32]byte
+	resumeMu     sync.Mutex
+	resumeBytes  int64
+	resumeLast   time.Time
+	resumeChunk  [32]byte
+	resumeOffset uint64
+	resumeLength uint32
 )
 
 type resumeState struct {
 	Transport         string `json:"transport"`
 	Compress          string `json:"compress"`
 	ChecksumAlgorithm string `json:"checksum_algorithm"`
+	DedupMode         string `json:"dedup_mode"`
+	Offset            uint64 `json:"offset"`
+	Length            uint32 `json:"length"`
 	Chunk             string `json:"chunk"`
 }
 
-func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunk [32]byte) {
+type resumeCheckpoint struct {
+	Chunk  [32]byte
+	Offset uint64
+	Length uint32
+}
+
+func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offset uint64, length uint32, chunk [32]byte) {
 	rs := resumeState{
 		Transport:         cfg.Transport,
 		Compress:          cfg.Compress,
 		ChecksumAlgorithm: cfg.ChecksumAlgorithm,
+		DedupMode:         cfg.DedupMode,
+		Offset:            offset,
+		Length:            length,
 		Chunk:             hex.EncodeToString(chunk[:]),
 	}
 	data, err := json.Marshal(rs)
@@ -351,7 +365,7 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunk
 	}
 }
 
-func saveResumeState(cfg *config.Config, chunk [32]byte, size int64, logger *zap.Logger) {
+func saveResumeState(cfg *config.Config, offset uint64, chunk [32]byte, size int64, logger *zap.Logger) {
 	if cfg.ResumeState == "" {
 		return
 	}
@@ -362,8 +376,11 @@ func saveResumeState(cfg *config.Config, chunk [32]byte, size int64, logger *zap
 	}
 	resumeBytes += size
 	resumeChunk = chunk
-	if resumeBytes >= 1<<30 || time.Since(resumeLast) >= 10*time.Second {
-		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunk)
+	resumeOffset = offset
+	resumeLength = uint32(size)
+	if (cfg.CheckpointBytes > 0 && resumeBytes >= int64(cfg.CheckpointBytes)) ||
+		(cfg.CheckpointInterval > 0 && time.Since(resumeLast) >= cfg.CheckpointInterval) {
+		writeResumeState(cfg, logger, cfg.ResumeState, resumeOffset, resumeLength, resumeChunk)
 		resumeBytes = 0
 		resumeLast = time.Now()
 	}
@@ -378,12 +395,17 @@ func finalizeResumeState(cfg *config.Config, logger *zap.Logger) {
 	if resumeLast.IsZero() {
 		return
 	}
-	writeResumeState(cfg, logger, cfg.ResumeState, resumeChunk)
+	if err := os.Remove(cfg.ResumeState); err != nil && !os.IsNotExist(err) {
+		if logger != nil {
+			logger.Warn("Failed to remove resume state", zap.Error(err))
+		}
+	}
 	resumeBytes = 0
+	resumeLast = time.Time{}
 }
 
-func readResumeDigest(cfg *config.Config, logger *zap.Logger) [32]byte {
-	var out [32]byte
+func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
+	var out resumeCheckpoint
 	if cfg.ResumeState == "" {
 		return out
 	}
@@ -395,22 +417,47 @@ func readResumeDigest(cfg *config.Config, logger *zap.Logger) [32]byte {
 	if err := json.Unmarshal(data, &rs); err != nil {
 		return out
 	}
-	if rs.Transport != cfg.Transport || rs.Compress != cfg.Compress || rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm {
+	if rs.Transport != cfg.Transport || rs.Compress != cfg.Compress ||
+		rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm || rs.DedupMode != cfg.DedupMode {
 		return out
 	}
 	b, err := hex.DecodeString(rs.Chunk)
 	if err != nil || len(b) != 32 {
 		return out
 	}
-	copy(out[:], b)
+	copy(out.Chunk[:], b)
+	out.Offset = rs.Offset
+	out.Length = rs.Length
 	if logger != nil {
-		logger.Info("Resuming from chunk", zap.String("resume_chunk", hex.EncodeToString(out[:])))
+		logger.Info("Resuming from chunk",
+			zap.String("resume_chunk", hex.EncodeToString(out.Chunk[:])),
+			zap.Uint64("resume_offset", out.Offset),
+			zap.Uint32("resume_length", out.Length))
 	}
 	return out
 }
 
-func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, digest [32]byte, logger *zap.Logger) int {
-	if cfg.ResumeState == "" || digest == [32]byte{} {
+func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+	if cfg.ResumeState == "" {
+		return 0
+	}
+	if cfg.DedupMode == "cdc" || cfg.DedupMode == "hybrid" {
+		next := chk.Offset + uint64(chk.Length)
+		for i := range ranges {
+			if next < ranges[i].Start {
+				return i
+			}
+			if next <= ranges[i].End {
+				ranges[i].Start = next
+				if logger != nil {
+					logger.Info("Resuming after offset", zap.Uint64("resume_offset", next))
+				}
+				return i
+			}
+		}
+		return len(ranges)
+	}
+	if chk.Chunk == [32]byte{} {
 		return 0
 	}
 	for i, r := range ranges {
@@ -430,7 +477,7 @@ func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, diges
 			sum = blake3.Sum256(data)
 		}
 		putBlockBuffer(data)
-		if sum == digest {
+		if sum == chk.Chunk {
 			if logger != nil {
 				logger.Info("Resuming after index", zap.Int("resume_index", i+1))
 			}
@@ -510,8 +557,8 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 	}
 	defer common.CloseWithErr(srcFile, &err, "close source file")
 
-	resumeDigest := readResumeDigest(cfg, t.Logger)
-	resumeStart := findResumeIndex(cfg, srcFile, ranges, resumeDigest, t.Logger)
+	checkpoint := readResumeState(cfg, t.Logger)
+	resumeStart := findResumeIndex(cfg, srcFile, ranges, checkpoint, t.Logger)
 	results := t.startParallelWorkers(cfg, srcFile, ranges, resumeStart, t.Logger)
 
 	startTime := time.Now()

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -42,8 +42,8 @@ func TestIterateBlocksOversizedBlockSize(t *testing.T) {
 
 func TestSaveResumeStatePermissions(t *testing.T) {
 	dir := t.TempDir()
-	cfg := &config.Config{ResumeState: filepath.Join(dir, "resume")}
-	saveResumeState(cfg, [32]byte{}, 1<<30, zap.NewNop())
+	cfg := &config.Config{ResumeState: filepath.Join(dir, "resume"), CheckpointBytes: 1}
+	saveResumeState(cfg, 0, [32]byte{}, 1, zap.NewNop())
 
 	info, err := os.Stat(cfg.ResumeState)
 	if err != nil {


### PR DESCRIPTION
## Summary
- include dedup mode and chunk boundaries in resume checkpoints
- use chunk offsets for CDC and hybrid resume
- expose checkpoint bytes flag and document resume semantics

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: expected 1 connection, got 0)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689c971ba93c8323aeac32fbc2fb9693