### PR TITLE
refactor(transport): add logger field and test h2 logging

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -14,11 +14,18 @@ import (
 
 // Transport is a placeholder HTTP/2 transport using plain TCP.
 type Transport struct {
-	cfg transport.Config
+	cfg    transport.Config
+	logger *zap.Logger
 }
 
 // New returns a new Transport.
-func New(cfg transport.Config) (transport.Interface, error) { return &Transport{cfg: cfg}, nil }
+func New(cfg transport.Config) (transport.Interface, error) {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Transport{cfg: cfg, logger: logger}, nil
+}
 
 func init() {
 	if err := transport.Register("h2", New); err != nil {

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
 func TestH2TransportHandshake(t *testing.T) {
-	trIface, _ := New(transport.Config{Logger: zap.NewNop()})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, _ := New(transport.Config{Logger: zap.New(core)})
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -56,10 +58,26 @@ func TestH2TransportHandshake(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	dialLogs := logs.FilterMessage("dial").All()
+	if len(dialLogs) != 1 {
+		t.Fatalf("expected one dial log, got %d", len(dialLogs))
+	}
+	if _, ok := dialLogs[0].ContextMap()["address"].(string); !ok {
+		t.Fatalf("expected snake_case field 'address' in dial log")
+	}
+	listenLogs := logs.FilterMessage("listen").All()
+	if len(listenLogs) != 1 {
+		t.Fatalf("expected one listen log, got %d", len(listenLogs))
+	}
+	if _, ok := listenLogs[0].ContextMap()["address"].(string); !ok {
+		t.Fatalf("expected snake_case field 'address' in listen log")
+	}
 }
 
 func TestH2TransportHandshakeError(t *testing.T) {
-	trIface, _ := New(transport.Config{Logger: zap.NewNop()})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, _ := New(transport.Config{Logger: zap.New(core)})
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -90,4 +108,19 @@ func TestH2TransportHandshakeError(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	dialLogs := logs.FilterMessage("dial").All()
+	if len(dialLogs) != 1 {
+		t.Fatalf("expected one dial log, got %d", len(dialLogs))
+	}
+	if _, ok := dialLogs[0].ContextMap()["address"].(string); !ok {
+		t.Fatalf("expected snake_case field 'address' in dial log")
+	}
+	listenLogs := logs.FilterMessage("listen").All()
+	if len(listenLogs) != 1 {
+		t.Fatalf("expected one listen log, got %d", len(listenLogs))
+	}
+	if _, ok := listenLogs[0].ContextMap()["address"].(string); !ok {
+		t.Fatalf("expected snake_case field 'address' in listen log")
+	}
 }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -14,11 +14,18 @@ import (
 
 // Transport is a placeholder QUIC transport using plain TCP.
 type Transport struct {
-	cfg transport.Config
+	cfg    transport.Config
+	logger *zap.Logger
 }
 
 // New returns a new Transport.
-func New(cfg transport.Config) (transport.Interface, error) { return &Transport{cfg: cfg}, nil }
+func New(cfg transport.Config) (transport.Interface, error) {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Transport{cfg: cfg, logger: logger}, nil
+}
 
 func init() {
 	if err := transport.Register("quic", New); err != nil {

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -14,12 +14,17 @@ import (
 
 // Transport implements the transport.Interface over plain TCP for now.
 type Transport struct {
-	cfg transport.Config
+	cfg    transport.Config
+	logger *zap.Logger
 }
 
 // New returns a new Transport.
 func New(cfg transport.Config) (transport.Interface, error) {
-	return &Transport{cfg: cfg}, nil
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Transport{cfg: cfg, logger: logger}, nil
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- inject `*zap.Logger` into HTTP/2, QUIC and SSH transports
- assert `snake_case` dial/listen fields are logged for H2 handshake success and failure

## Testing
- `go build ./transport/h2`
- `go build ./transport/quic`
- `go build ./transport/ssh`
- `go test -coverprofile=coverage.out ./transport/h2`
- `golangci-lint run ./transport/h2`
- `go tool cover -func=coverage.out | tail -n 1`
- `go build ./...` *(fails: cmd/dump/client.go:318:4: undefined: trLogger)*

------
https://chatgpt.com/codex/tasks/task_e_689dd3a3358c8323aa2e3f6d6668bc6c