### PR TITLE
feat(manifest): detect device block size

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -44,6 +44,8 @@ type Index struct {
 
 var closeHook = func() {}
 
+var detectDevice = device.Detect
+
 func headerMAC(h *Header) [32]byte {
 	var buf [headerSize - 32]byte
 	binary.LittleEndian.PutUint32(buf[0:4], h.Version)
@@ -199,21 +201,22 @@ func (i *Index) Entry(idx int) (offset uint64, length uint32, xxh uint64, digest
 // Rebuild creates a manifest index for device at output path.
 // DeviceID is determined via device.GetUUID. The device is read sequentially using blockSize-sized chunks.
 func Rebuild(devicePath, output string) error {
-	f, err := os.Open(devicePath)
+	dev, err := detectDevice(devicePath)
+	if err != nil {
+		return err
+	}
+	defer dev.Close()
+	blockSize := uint32(dev.BlockSize())
+	size := dev.SizeBytes()
+	id, err := device.GetUUID(context.Background(), dev.Path())
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(dev.Path())
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	st, err := f.Stat()
-	if err != nil {
-		return err
-	}
-	blockSize := uint32(4096)
-	size := uint64(st.Size())
-	id, err := device.GetUUID(context.Background(), devicePath)
-	if err != nil {
-		return err
-	}
 	idx, err := Create(output, id, size, blockSize)
 	if err != nil {
 		return err

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -14,6 +14,17 @@ import (
 	"lvmsync_go/device"
 )
 
+type mockDevice struct {
+	path      string
+	size      uint64
+	blockSize uint64
+}
+
+func (m *mockDevice) Path() string      { return m.path }
+func (m *mockDevice) SizeBytes() uint64 { return m.size }
+func (m *mockDevice) BlockSize() uint64 { return m.blockSize }
+func (m *mockDevice) Close() error      { return nil }
+
 func TestIndexCRUD(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.man")
@@ -121,5 +132,55 @@ func TestRebuildCloseOnce(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected close called once, got %d", count)
+	}
+}
+
+func TestRebuildNonDefaultBlockSize(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	bs := 2048
+	data1 := make([]byte, bs)
+	data2 := make([]byte, bs)
+	if _, err := rand.Read(data1); err != nil {
+		t.Fatalf("rand1: %v", err)
+	}
+	if _, err := rand.Read(data2); err != nil {
+		t.Fatalf("rand2: %v", err)
+	}
+	if _, err := file.Write(append(data1, data2...)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-bs", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	prevDetect := detectDevice
+	detectDevice = func(string) (device.Device, error) {
+		return &mockDevice{path: file.Name(), size: uint64(2 * bs), blockSize: uint64(bs)}, nil
+	}
+	defer func() { detectDevice = prevDetect }()
+	manPath := filepath.Join(dir, "rebuildbs.man")
+	if err := Rebuild(file.Name(), manPath); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	idx, err := Open(manPath)
+	if err != nil {
+		t.Fatalf("open manifest: %v", err)
+	}
+	if idx.hdr.BlockSize != uint32(bs) || idx.hdr.ChunkCount != 2 || idx.hdr.SizeBytes != uint64(2*bs) {
+		t.Fatalf("header mismatch: %+v", idx.hdr)
+	}
+	_, l1, xx1, b31 := idx.Entry(0)
+	if l1 != uint32(bs) || xx1 != xxh3.Hash(data1) || b31 != blake3.Sum256(data1) {
+		t.Fatalf("chunk1 mismatch")
+	}
+	_, l2, xx2, b32 := idx.Entry(1)
+	if l2 != uint32(bs) || xx2 != xxh3.Hash(data2) || b32 != blake3.Sum256(data2) {
+		t.Fatalf("chunk2 mismatch")
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close manifest: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- determine block size with `device.Detect` instead of a fixed constant
- cover manifest rebuild with non-default block sizes in tests

## Testing
- `go build ./manifest`
- `go build -v ./...` *(fails: cmd/dump/client.go:318:4: undefined: trLogger)*
- `go test -coverprofile=coverage.out ./manifest`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/dump/client.go:318:4: undefined: trLogger)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689dd9853f748323b7dcbfed0295bb17