### PR TITLE
feat(transport): add lifecycle logging and require logger

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -315,10 +315,10 @@ func SelectTransport(cfg *config.Config, logger *zap.Logger) (transport.Interfac
 		name = strings.TrimSpace(name)
 		tr, err := transport.Get(name, transport.Config{Logger: logger})
 		if err != nil {
-			trLogger.Warn("unsupported transport", zap.String("transport", name))
+			logger.Warn("unsupported transport", zap.String("transport", name))
 			continue
 		}
-		trLogger.Info("selected transport", zap.String("transport", name))
+		logger.Info("selected transport", zap.String("transport", name))
 		return tr, nil
 	}
 	return nil, fmt.Errorf("no supported transports: %s", cfg.Transport)

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -20,11 +21,10 @@ type Transport struct {
 
 // New returns a new Transport.
 func New(cfg transport.Config) (transport.Interface, error) {
-	logger := cfg.Logger
-	if logger == nil {
-		logger = zap.NewNop()
+	if cfg.Logger == nil {
+		return nil, fmt.Errorf("logger is required")
 	}
-	return &Transport{cfg: cfg, logger: logger}, nil
+	return &Transport{cfg: cfg, logger: cfg.Logger}, nil
 }
 
 func init() {
@@ -36,47 +36,111 @@ func init() {
 func (t *Transport) Name() string { return "h2" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
-	t.logger.Info("dial", zap.String("address", address))
+	role := "client"
+	t.logger.Info("dial_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
 	d := net.Dialer{}
-	return d.DialContext(ctx, "tcp", address)
+	conn, err := d.DialContext(ctx, "tcp", address)
+	t.logger.Info("dial_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return conn, err
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
-	t.logger.Info("listen", zap.String("address", address))
-	return net.Listen("tcp", address)
+	role := "server"
+	t.logger.Info("listen_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
+	ln, err := net.Listen("tcp", address)
+	t.logger.Info("listen_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return ln, err
 }
 
-func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (common.Handshake, error) {
+func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
+	roleStr := roleString(role)
+	address := conn.RemoteAddr().String()
+	t.logger.Info("negotiate_start",
+		zap.String("address", address),
+		zap.String("role", roleStr),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
+	defer func() {
+		t.logger.Info("negotiate_end",
+			zap.String("address", address),
+			zap.String("role", roleStr),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.String("error", errString(err)),
+		)
+	}()
+
 	hs.Version = common.ProtocolVersion
 	if hs.Endianness == "" {
 		hs.Endianness = common.NativeEndianness()
 	}
 	switch role {
 	case transport.Client:
-		if err := common.WriteHandshake(conn, hs); err != nil {
-			return common.Handshake{}, err
+		if err = common.WriteHandshake(conn, hs); err != nil {
+			return peer, err
 		}
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return peer, nil
 	case transport.Server:
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
-		if err := common.WriteHandshake(conn, hs); err != nil {
+		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err
 		}
 		return peer, nil
 	default:
-		return common.Handshake{}, nil
+		return peer, nil
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func roleString(r transport.Role) string {
+	switch r {
+	case transport.Client:
+		return "client"
+	case transport.Server:
+		return "server"
+	default:
+		return ""
 	}
 }

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -12,9 +12,25 @@ import (
 	"lvmsync_go/transport"
 )
 
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+		if _, ok := ctx[k]; !ok {
+			t.Fatalf("expected field %q in %s log", k, msg)
+		}
+	}
+}
+
 func TestH2TransportHandshake(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, _ := New(transport.Config{Logger: zap.New(core)})
+	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -59,25 +75,20 @@ func TestH2TransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 
-	dialLogs := logs.FilterMessage("dial").All()
-	if len(dialLogs) != 1 {
-		t.Fatalf("expected one dial log, got %d", len(dialLogs))
-	}
-	if _, ok := dialLogs[0].ContextMap()["address"].(string); !ok {
-		t.Fatalf("expected snake_case field 'address' in dial log")
-	}
-	listenLogs := logs.FilterMessage("listen").All()
-	if len(listenLogs) != 1 {
-		t.Fatalf("expected one listen log, got %d", len(listenLogs))
-	}
-	if _, ok := listenLogs[0].ContextMap()["address"].(string); !ok {
-		t.Fatalf("expected snake_case field 'address' in listen log")
-	}
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 2)
+	checkLogFields(t, logs, "negotiate_end", 2)
 }
 
 func TestH2TransportHandshakeError(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, _ := New(transport.Config{Logger: zap.New(core)})
+	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -93,7 +104,6 @@ func TestH2TransportHandshakeError(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		// send invalid handshake to trigger failure
 		conn.Write([]byte("bad\n"))
 		conn.Close()
 		close(done)
@@ -109,18 +119,16 @@ func TestH2TransportHandshakeError(t *testing.T) {
 	conn.Close()
 	<-done
 
-	dialLogs := logs.FilterMessage("dial").All()
-	if len(dialLogs) != 1 {
-		t.Fatalf("expected one dial log, got %d", len(dialLogs))
-	}
-	if _, ok := dialLogs[0].ContextMap()["address"].(string); !ok {
-		t.Fatalf("expected snake_case field 'address' in dial log")
-	}
-	listenLogs := logs.FilterMessage("listen").All()
-	if len(listenLogs) != 1 {
-		t.Fatalf("expected one listen log, got %d", len(listenLogs))
-	}
-	if _, ok := listenLogs[0].ContextMap()["address"].(string); !ok {
-		t.Fatalf("expected snake_case field 'address' in listen log")
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 1)
+	checkLogFields(t, logs, "negotiate_end", 1)
+}
+
+func TestH2TransportRequiresLogger(t *testing.T) {
+	if _, err := New(transport.Config{}); err == nil {
+		t.Fatalf("expected error when logger is nil")
 	}
 }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -20,11 +21,10 @@ type Transport struct {
 
 // New returns a new Transport.
 func New(cfg transport.Config) (transport.Interface, error) {
-	logger := cfg.Logger
-	if logger == nil {
-		logger = zap.NewNop()
+	if cfg.Logger == nil {
+		return nil, fmt.Errorf("logger is required")
 	}
-	return &Transport{cfg: cfg, logger: logger}, nil
+	return &Transport{cfg: cfg, logger: cfg.Logger}, nil
 }
 
 func init() {
@@ -36,47 +36,111 @@ func init() {
 func (t *Transport) Name() string { return "quic" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
-	t.logger.Info("dial", zap.String("address", address))
+	role := "client"
+	t.logger.Info("dial_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
 	d := net.Dialer{}
-	return d.DialContext(ctx, "tcp", address)
+	conn, err := d.DialContext(ctx, "tcp", address)
+	t.logger.Info("dial_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return conn, err
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
-	t.logger.Info("listen", zap.String("address", address))
-	return net.Listen("tcp", address)
+	role := "server"
+	t.logger.Info("listen_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
+	ln, err := net.Listen("tcp", address)
+	t.logger.Info("listen_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return ln, err
 }
 
-func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (common.Handshake, error) {
+func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
+	roleStr := roleString(role)
+	address := conn.RemoteAddr().String()
+	t.logger.Info("negotiate_start",
+		zap.String("address", address),
+		zap.String("role", roleStr),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
+	defer func() {
+		t.logger.Info("negotiate_end",
+			zap.String("address", address),
+			zap.String("role", roleStr),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.String("error", errString(err)),
+		)
+	}()
+
 	hs.Version = common.ProtocolVersion
 	if hs.Endianness == "" {
 		hs.Endianness = common.NativeEndianness()
 	}
 	switch role {
 	case transport.Client:
-		if err := common.WriteHandshake(conn, hs); err != nil {
-			return common.Handshake{}, err
+		if err = common.WriteHandshake(conn, hs); err != nil {
+			return peer, err
 		}
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return peer, nil
 	case transport.Server:
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
-		if err := common.WriteHandshake(conn, hs); err != nil {
+		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err
 		}
 		return peer, nil
 	default:
-		return common.Handshake{}, nil
+		return peer, nil
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func roleString(r transport.Role) string {
+	switch r {
+	case transport.Client:
+		return "client"
+	case transport.Server:
+		return "server"
+	default:
+		return ""
 	}
 }

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -6,13 +6,31 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+		if _, ok := ctx[k]; !ok {
+			t.Fatalf("expected field %q in %s log", k, msg)
+		}
+	}
+}
+
 func TestQUICTransportHandshake(t *testing.T) {
-	trIface, _ := New(transport.Config{Logger: zap.NewNop()})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -56,10 +74,21 @@ func TestQUICTransportHandshake(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 2)
+	checkLogFields(t, logs, "negotiate_end", 2)
 }
 
 func TestQUICTransportHandshakeError(t *testing.T) {
-	trIface, _ := New(transport.Config{Logger: zap.NewNop()})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -75,7 +104,6 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		// send invalid handshake and close
 		conn.Write([]byte("bad\n"))
 		conn.Close()
 		close(done)
@@ -90,4 +118,17 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 1)
+	checkLogFields(t, logs, "negotiate_end", 1)
+}
+
+func TestQUICTransportRequiresLogger(t *testing.T) {
+	if _, err := New(transport.Config{}); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
 }

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -22,13 +22,14 @@ func TestConcurrentRegister(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+	logger := zap.NewNop()
 	for i := 0; i < goroutines; i++ {
 		name := fmt.Sprintf("test-%d", i)
-		if _, err := Get(name, Config{Logger: zap.NewNop()}); err != nil {
+		if _, err := Get(name, Config{Logger: logger}); err != nil {
 			t.Errorf("get %s: %v", name, err)
 		}
-		logger.Sync()
 	}
+	logger.Sync()
 }
 
 func TestDuplicateRegister(t *testing.T) {

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -20,11 +21,10 @@ type Transport struct {
 
 // New returns a new Transport.
 func New(cfg transport.Config) (transport.Interface, error) {
-	logger := cfg.Logger
-	if logger == nil {
-		logger = zap.NewNop()
+	if cfg.Logger == nil {
+		return nil, fmt.Errorf("logger is required")
 	}
-	return &Transport{cfg: cfg, logger: logger}, nil
+	return &Transport{cfg: cfg, logger: cfg.Logger}, nil
 }
 
 func init() {
@@ -36,47 +36,111 @@ func init() {
 func (t *Transport) Name() string { return "ssh" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
-	t.logger.Info("dial", zap.String("address", address))
+	role := "client"
+	t.logger.Info("dial_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
 	d := net.Dialer{}
-	return d.DialContext(ctx, "tcp", address)
+	conn, err := d.DialContext(ctx, "tcp", address)
+	t.logger.Info("dial_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return conn, err
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
-	t.logger.Info("listen", zap.String("address", address))
-	return net.Listen("tcp", address)
+	role := "server"
+	t.logger.Info("listen_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
+	ln, err := net.Listen("tcp", address)
+	t.logger.Info("listen_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return ln, err
 }
 
-func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (common.Handshake, error) {
+func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
+	roleStr := roleString(role)
+	address := conn.RemoteAddr().String()
+	t.logger.Info("negotiate_start",
+		zap.String("address", address),
+		zap.String("role", roleStr),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
+	defer func() {
+		t.logger.Info("negotiate_end",
+			zap.String("address", address),
+			zap.String("role", roleStr),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.String("error", errString(err)),
+		)
+	}()
+
 	hs.Version = common.ProtocolVersion
 	if hs.Endianness == "" {
 		hs.Endianness = common.NativeEndianness()
 	}
 	switch role {
 	case transport.Client:
-		if err := common.WriteHandshake(conn, hs); err != nil {
-			return common.Handshake{}, err
+		if err = common.WriteHandshake(conn, hs); err != nil {
+			return peer, err
 		}
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return peer, nil
 	case transport.Server:
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
-		if err := common.WriteHandshake(conn, hs); err != nil {
+		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err
 		}
 		return peer, nil
 	default:
-		return common.Handshake{}, nil
+		return peer, nil
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func roleString(r transport.Role) string {
+	switch r {
+	case transport.Client:
+		return "client"
+	case transport.Server:
+		return "server"
+	default:
+		return ""
 	}
 }

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -6,13 +6,31 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+		if _, ok := ctx[k]; !ok {
+			t.Fatalf("expected field %q in %s log", k, msg)
+		}
+	}
+}
+
 func TestSSHTransportHandshake(t *testing.T) {
-	trIface, _ := New(transport.Config{Logger: zap.NewNop()})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -56,10 +74,21 @@ func TestSSHTransportHandshake(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 2)
+	checkLogFields(t, logs, "negotiate_end", 2)
 }
 
 func TestSSHTransportHandshakeError(t *testing.T) {
-	trIface, _ := New(transport.Config{Logger: zap.NewNop()})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -75,7 +104,6 @@ func TestSSHTransportHandshakeError(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		// send an invalid handshake to trigger negotiation failure
 		conn.Write([]byte("bad\n"))
 		conn.Close()
 		close(done)
@@ -90,4 +118,17 @@ func TestSSHTransportHandshakeError(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 1)
+	checkLogFields(t, logs, "negotiate_end", 1)
+}
+
+func TestSSHTransportRequiresLogger(t *testing.T) {
+	if _, err := New(transport.Config{}); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
 }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -27,6 +27,9 @@ type Transport struct {
 
 // New creates a Transport using provided TLS roots and client certificate.
 func New(cfg transport.Config) (transport.Interface, error) {
+	if cfg.Logger == nil {
+		return nil, fmt.Errorf("logger is required")
+	}
 	cert := cfg.ClientCert
 	if len(cert.Certificate) == 0 {
 		var err error
@@ -47,7 +50,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		InsecureSkipVerify: cfg.Roots == nil,
 		MinVersion:         tls.VersionTLS13,
 	}
-	return &Transport{serverConf: serverConf, clientConf: clientConf}, nil
+	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil
 }
 
 func init() {
@@ -59,52 +62,115 @@ func init() {
 func (t *Transport) Name() string { return "tcp+tls" }
 
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
-	t.logger.Info("dial", zap.String("address", address))
+	role := "client"
+	t.logger.Info("dial_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
 	d := net.Dialer{}
-	return tls.DialWithDialer(&d, "tcp", address, t.clientConf)
+	conn, err := tls.DialWithDialer(&d, "tcp", address, t.clientConf)
+	t.logger.Info("dial_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return conn, err
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
-	t.logger.Info("listen", zap.String("address", address))
+	role := "server"
+	t.logger.Info("listen_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
 	ln, err := net.Listen("tcp", address)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		ln = tls.NewListener(ln, t.serverConf)
 	}
-	return tls.NewListener(ln, t.serverConf), nil
+	t.logger.Info("listen_end",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", errString(err)),
+	)
+	return ln, err
 }
 
-func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (common.Handshake, error) {
+func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
+	roleStr := roleString(role)
+	address := conn.RemoteAddr().String()
+	t.logger.Info("negotiate_start",
+		zap.String("address", address),
+		zap.String("role", roleStr),
+		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
+	)
+	start := time.Now()
+	defer func() {
+		t.logger.Info("negotiate_end",
+			zap.String("address", address),
+			zap.String("role", roleStr),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.String("error", errString(err)),
+		)
+	}()
+
 	hs.Version = common.ProtocolVersion
 	if hs.Endianness == "" {
 		hs.Endianness = common.NativeEndianness()
 	}
 	switch role {
 	case transport.Client:
-		if err := common.WriteHandshake(conn, hs); err != nil {
-			return common.Handshake{}, err
+		if err = common.WriteHandshake(conn, hs); err != nil {
+			return peer, err
 		}
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
 		return peer, nil
 	case transport.Server:
-		peer, err := common.ReadHandshake(bufio.NewReader(conn))
+		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
-			return common.Handshake{}, err
+			return peer, err
 		}
 		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
 			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 		}
-		if err := common.WriteHandshake(conn, hs); err != nil {
+		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err
 		}
 		return peer, nil
 	default:
-		return common.Handshake{}, nil
+		return peer, nil
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func roleString(r transport.Role) string {
+	switch r {
+	case transport.Client:
+		return "client"
+	case transport.Server:
+		return "server"
+	default:
+		return ""
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -7,10 +7,24 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
+
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+		if _, ok := ctx[k]; !ok {
+			t.Fatalf("expected field %q in %s log", k, msg)
+		}
+	}
+}
 
 func TestTCPTLSTransportHandshake(t *testing.T) {
 	cert, _ := generateSelfSignedCert()
@@ -20,7 +34,11 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 			root.AddCert(c)
 		}
 	}
-	trIface, _ := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -64,6 +82,13 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 2)
+	checkLogFields(t, logs, "negotiate_end", 2)
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {
@@ -72,7 +97,11 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 	if c, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
 		root.AddCert(c)
 	}
-	trIface, _ := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
 	tr := trIface.(*Transport)
 	ctx := context.Background()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
@@ -88,7 +117,6 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		// send invalid handshake without negotiation
 		conn.Write([]byte("bad\n"))
 		conn.Close()
 		close(done)
@@ -103,10 +131,16 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 	}
 	conn.Close()
 	<-done
+
+	checkLogFields(t, logs, "dial_start", 1)
+	checkLogFields(t, logs, "dial_end", 1)
+	checkLogFields(t, logs, "listen_start", 1)
+	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "negotiate_start", 1)
+	checkLogFields(t, logs, "negotiate_end", 1)
 }
 
 func TestTCPTLSCertValidation(t *testing.T) {
-	// client with empty root CA should fail to verify server certificate
 	root := x509.NewCertPool()
 	cert, _ := generateSelfSignedCert()
 	trIface, _ := New(transport.Config{Roots: root, ClientCert: cert, Logger: zap.NewNop()})
@@ -129,4 +163,12 @@ func TestTCPTLSCertValidation(t *testing.T) {
 		t.Fatalf("expected cert validation error")
 	}
 	<-done
+}
+
+func TestTCPTLSTransportRequiresLogger(t *testing.T) {
+	cert, _ := generateSelfSignedCert()
+	root := x509.NewCertPool()
+	if _, err := New(transport.Config{Roots: root, ClientCert: cert}); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
 }


### PR DESCRIPTION
## Summary
- add start/end lifecycle logs to transport Dial, Listen, and Negotiate
- require non-nil logger in transport constructors
- test logging fields and constructor failures

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689ddbcd6e8c83239f8775e6dd81109f