### PR TITLE
feat(verify): check source blocks against manifest

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/manifest"
 	"lvmsync_go/transfer"
 )
 
@@ -53,7 +54,7 @@ func Run(args []string, logger *zap.Logger) error {
 
 func verifyDevices(cfg *config.Config, src, dst, manifest string, logger *zap.Logger) error {
 	if manifest != "" {
-		return verifyWithManifest(src, dst, manifest, logger)
+		return verifyWithManifest(src, manifest, logger)
 	}
 	return verifyFull(cfg, src, dst, logger)
 }
@@ -110,39 +111,35 @@ func verifyFull(cfg *config.Config, src, dst string, logger *zap.Logger) error {
 	return nil
 }
 
-func verifyWithManifest(src, dst, manifest string, logger *zap.Logger) error {
-	data, err := os.ReadFile(manifest)
+func verifyWithManifest(src, manifestPath string, logger *zap.Logger) error {
+	idx, err := manifest.Open(manifestPath)
 	if err != nil {
-		return fmt.Errorf("read manifest: %w", err)
+		return fmt.Errorf("open manifest: %w", err)
 	}
-	m, err := transfer.UnmarshalManifest(data)
-	if err != nil {
-		return fmt.Errorf("parse manifest: %w", err)
-	}
+	defer idx.Close()
 	fSrc, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("open source: %w", err)
 	}
 	defer fSrc.Close()
-	fDst, err := os.Open(dst)
-	if err != nil {
-		return fmt.Errorf("open dest: %w", err)
-	}
-	defer fDst.Close()
 
 	mismatches := 0
-	for _, ch := range m.Chunks {
-		bufSrc := make([]byte, ch.Length)
-		if _, err := fSrc.ReadAt(bufSrc, ch.Offset); err != nil {
+	for i := 0; i < idx.ChunkCount(); i++ {
+		off, length, _, digest := idx.Entry(i)
+		if length == 0 {
+			continue
+		}
+		buf := make([]byte, length)
+		if _, err := fSrc.ReadAt(buf, int64(off)); err != nil {
 			return fmt.Errorf("read source: %w", err)
 		}
-		bufDst := make([]byte, ch.Length)
-		if _, err := fDst.ReadAt(bufDst, ch.Offset); err != nil {
-			return fmt.Errorf("read dest: %w", err)
-		}
-		if blake3.Sum256(bufSrc) != blake3.Sum256(bufDst) {
+		actual := blake3.Sum256(buf)
+		if actual != digest {
 			mismatches++
-			logger.Error("mismatched_block", zap.Int64("offset_bytes", ch.Offset))
+			logger.Error("digest_mismatch",
+				zap.Uint64("offset_bytes", off),
+				zap.String("expected_digest", fmt.Sprintf("%x", digest[:])),
+				zap.String("actual_digest", fmt.Sprintf("%x", actual[:])))
 		}
 	}
 	if mismatches > 0 {

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -1,10 +1,16 @@
 package verify
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/device"
+	"lvmsync_go/manifest"
 )
 
 func writeTempFile(t *testing.T, data []byte) string {
@@ -39,5 +45,46 @@ func TestVerifyMismatch(t *testing.T) {
 	dst := writeTempFile(t, dstData)
 	if err := Run([]string{"--block_size", "8K", src, dst}, zap.NewNop()); err == nil {
 		t.Fatalf("expected mismatch error")
+	}
+}
+
+func TestVerifyManifestMismatch(t *testing.T) {
+	srcData := make([]byte, 4096)
+	srcData[0] = 1
+	dstData := make([]byte, 4096)
+	src := writeTempFile(t, srcData)
+	dst := writeTempFile(t, dstData)
+	manPath := filepath.Join(t.TempDir(), "dst.man")
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	if err := manifest.Rebuild(dst, manPath); err != nil {
+		t.Fatalf("rebuild manifest: %v", err)
+	}
+	core, observed := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+	if err := Run([]string{"--manifest", manPath, src, dst}, logger); err == nil {
+		t.Fatalf("expected mismatch error")
+	}
+	logs := observed.All()
+	if len(logs) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(logs))
+	}
+	log := logs[0]
+	if log.Message != "digest_mismatch" {
+		t.Fatalf("unexpected log message %q", log.Message)
+	}
+	if _, ok := log.ContextMap()["offset_bytes"]; !ok {
+		t.Fatalf("missing offset_bytes field")
+	}
+	exp, ok := log.ContextMap()["expected_digest"].(string)
+	if !ok {
+		t.Fatalf("missing expected_digest field")
+	}
+	act, ok := log.ContextMap()["actual_digest"].(string)
+	if !ok {
+		t.Fatalf("missing actual_digest field")
+	}
+	if exp == act {
+		t.Fatalf("expected and actual digests should differ")
 	}
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -198,6 +198,9 @@ func (i *Index) Entry(idx int) (offset uint64, length uint32, xxh uint64, digest
 	return
 }
 
+// ChunkCount returns the number of chunks tracked by the manifest.
+func (i *Index) ChunkCount() int { return int(i.hdr.ChunkCount) }
+
 // Rebuild creates a manifest index for device at output path.
 // DeviceID is determined via device.GetUUID. The device is read sequentially using blockSize-sized chunks.
 func Rebuild(devicePath, output string) error {


### PR DESCRIPTION
## Summary
- compare source blocks with destination manifest digests
- expose manifest chunk count
- test manifest-based mismatch detection

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(warnings: Can't process result by diff processor)*

------
https://chatgpt.com/codex/tasks/task_e_689dde5a0de48323b8f05821f846c221