### PR TITLE
feat(cli): add dry-run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
 | `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
 | `--target_vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
-  | `--dry_run` | `LVMSYNC_DRY_RUN` | `dry_run` | Print actions without executing |
+| `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Print actions without executing |
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | `transport` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) |
 | `--tcp_port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |
 | `--tcp_parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | `tcp_parallel` | Number of parallel TCP connections |
@@ -716,10 +716,10 @@ journalctl -u lvmsync-grpcd
 ### Basic Syntax
 
 ```sh
-lvmsync run [--dry_run] [--transport quic,h2,tcp+tls,ssh] <snapshot|lvm device> <destination>
+lvmsync run [--dry-run] [--transport quic,h2,tcp+tls,ssh] <snapshot|lvm device> <destination>
 ```
 
-The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps. Use `--dry_run` to print planned actions without executing and `--transport` to provide an ordered list of transports to try.
+The tool supports both local and remote transfers, as well as an "apply mode" for applying change dumps. Use `--dry-run` to print planned actions without executing and `--transport` to provide an ordered list of transports to try.
 
 ## Resume, Manifest, and Verify
 
@@ -741,9 +741,13 @@ Verify that a source and destination match:
 lvmsync verify /dev/vg0/source /dev/vg1/target
 ```
 
-Supply options such as block size or deduplication mode to control how data is
-compared. For example, to verify using 4 KiB blocks and a manifest generated
-earlier:
+Supply options such as block size or deduplication mode to control how data is compared. For example, to estimate verification without reading data:
+
+```sh
+lvmsync verify --dry-run /dev/vg0/source /dev/vg1/target
+```
+
+To verify using 4 KiB blocks and a manifest generated earlier:
 
 ```sh
 lvmsync verify --block_size 4K --manifest snapshot.manifest /dev/vg0/source /dev/vg1/target
@@ -770,7 +774,7 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--verify_checksum` | Enable checksum verification for data integrity                                                         | `false`   |
 | `--progress`        | Show progress percentage during the transfer                                                            | `true`    |
 | `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
-| `--dry_run`         | Print actions without executing | `false`   |
+| `--dry-run`         | Print actions without executing | `false`   |
 | `--transport`       | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) | `""`      |
 
 #### SSH Options

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -2,9 +2,12 @@ package lvmsync
 
 import (
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.uber.org/zap"
 
 	verifycmd "lvmsync_go/cmd/verify"
 	"lvmsync_go/config"
@@ -48,6 +51,12 @@ func NewRootCmd() *cobra.Command {
 			if len(remaining) != 2 {
 				fs.Usage()
 				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
+			}
+			if cfg.DryRun {
+				if err := estimateTransfer(remaining[0], cfg); err != nil {
+					return err
+				}
+				return nil
 			}
 			opts := RunOptions{
 				DryRun:    cfg.DryRun,
@@ -107,4 +116,20 @@ func Execute(args []string) error {
 		cmd.SetArgs(args)
 	}
 	return cmd.Execute()
+}
+
+func estimateTransfer(src string, cfg *config.Config) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+	size := info.Size()
+	var eta time.Duration
+	if cfg.SpeedLimit > 0 {
+		eta = time.Duration(size/int64(cfg.SpeedLimit)) * time.Second
+	}
+	logger := zap.NewExample()
+	defer logger.Sync()
+	logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
+	return nil
 }

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -1,12 +1,14 @@
 package lvmsync
 
 import (
+	"os"
 	"testing"
 
 	verifycmd "lvmsync_go/cmd/verify"
 )
 
-func TestRunCommandFlags(t *testing.T) {
+func TestRunCommandExecutes(t *testing.T) {
+	t.Setenv("LVMSYNC_TRANSPORT_TRANSPORT", "ssh")
 	var gotSrc, gotDst string
 	var gotOpts RunOptions
 	runCommand = func(src, dst string, opts RunOptions) error {
@@ -15,38 +17,58 @@ func TestRunCommandFlags(t *testing.T) {
 	}
 	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
 
-	if err := Execute([]string{"run", "--dry_run", "--transport", "tcp,ssh", "src", "dst"}); err != nil {
+	if err := Execute([]string{"run", "src", "dst"}); err != nil {
 		t.Fatalf("execute run: %v", err)
 	}
 	if gotSrc != "src" || gotDst != "dst" {
 		t.Fatalf("unexpected args %q %q", gotSrc, gotDst)
 	}
-	if !gotOpts.DryRun {
-		t.Fatalf("expected dry-run true")
+	if gotOpts.DryRun {
+		t.Fatalf("expected dry-run false")
 	}
-	if gotOpts.Transport != "tcp,ssh" {
+	if gotOpts.Transport != "ssh" {
 		t.Fatalf("unexpected transport %q", gotOpts.Transport)
 	}
 }
 
-func TestRunCommandEnv(t *testing.T) {
-	t.Setenv("LVMSYNC_DRY_RUN", "true")
-	t.Setenv("LVMSYNC_TRANSPORT_TRANSPORT", "ssh")
-	var opts RunOptions
-	runCommand = func(src, dst string, o RunOptions) error {
-		opts = o
+func TestRunCommandDryRun(t *testing.T) {
+	src := t.TempDir() + "/src"
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	called := false
+	runCommand = func(src, dst string, opts RunOptions) error {
+		called = true
 		return nil
 	}
 	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
 
-	if err := Execute([]string{"run", "src", "dst"}); err != nil {
+	if err := Execute([]string{"run", "--dry-run", src, "dst"}); err != nil {
+		t.Fatalf("execute run dry-run: %v", err)
+	}
+	if called {
+		t.Fatalf("runCommand should not be called in dry-run")
+	}
+}
+
+func TestRunCommandDryRunEnv(t *testing.T) {
+	src := t.TempDir() + "/src"
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	t.Setenv("LVMSYNC_DRY_RUN", "true")
+	called := false
+	runCommand = func(src, dst string, o RunOptions) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
+
+	if err := Execute([]string{"run", src, "dst"}); err != nil {
 		t.Fatalf("execute run with env: %v", err)
 	}
-	if !opts.DryRun {
-		t.Fatalf("expected dry-run from env")
-	}
-	if opts.Transport != "ssh" {
-		t.Fatalf("unexpected transport %q", opts.Transport)
+	if called {
+		t.Fatalf("runCommand should not be called when dry-run env set")
 	}
 }
 
@@ -59,7 +81,7 @@ func TestManifestRebuildRoutes(t *testing.T) {
 	}
 	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool) error { return nil } })
 
-	if err := Execute([]string{"manifest", "rebuild", "--dry_run", "/dev/vg0"}); err != nil {
+	if err := Execute([]string{"manifest", "rebuild", "--dry-run", "/dev/vg0"}); err != nil {
 		t.Fatalf("execute rebuild: %v", err)
 	}
 	if gotDevice != "/dev/vg0" {

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -44,6 +45,19 @@ func Run(args []string, logger *zap.Logger) error {
 			if len(remaining) != 2 {
 				fs.Usage()
 				return fmt.Errorf("usage: lvmsync verify [flags] <source> <dest>")
+			}
+			if cfg.DryRun {
+				info, err := os.Stat(remaining[0])
+				if err != nil {
+					return fmt.Errorf("stat source: %w", err)
+				}
+				size := info.Size()
+				var eta time.Duration
+				if cfg.SpeedLimit > 0 {
+					eta = time.Duration(size/int64(cfg.SpeedLimit)) * time.Second
+				}
+				logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
+				return nil
 			}
 			return verifyDevices(cfg, remaining[0], remaining[1], manifest, logger)
 		},

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -48,6 +48,29 @@ func TestVerifyMismatch(t *testing.T) {
 	}
 }
 
+func TestVerifyDryRun(t *testing.T) {
+	srcData := []byte{1}
+	dstData := []byte{2}
+	src := writeTempFile(t, srcData)
+	dst := writeTempFile(t, dstData)
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	if err := Run([]string{"--dry-run", src, dst}, logger); err != nil {
+		t.Fatalf("dry run verify: %v", err)
+	}
+	entries := logs.All()
+	found := false
+	for _, e := range entries {
+		if e.Message == "dry run" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected dry run log entry")
+	}
+}
+
 func TestVerifyManifestMismatch(t *testing.T) {
 	srcData := make([]byte, 4096)
 	srcData[0] = 1

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@
 # and apply to destination device
 apply: ""
 stdout: false  # Write change dump to STDOUT
-dry_run: false  # Print actions without executing (same as --dry_run)
+dry-run: false  # Print actions without executing (same as --dry-run)
 parallel: 4  # Number of concurrent workers
 # Enable zero-copy transfers (only in sequential mode)
 zerocopy: false

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -31,7 +31,7 @@ type Config struct {
 	ConfigFile           string        `mapstructure:"config"`
 	ApplyMode            string        `mapstructure:"apply"`
 	StdoutMode           bool          `mapstructure:"stdout"`
-	DryRun               bool          `mapstructure:"dry_run"`
+	DryRun               bool          `mapstructure:"dry-run"`
 	Force                bool          `mapstructure:"force"`
 	Mode                 string        `mapstructure:"mode"`
 	Parallel             int           `mapstructure:"parallel"`

--- a/config/flags.go
+++ b/config/flags.go
@@ -53,7 +53,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("config", "", "Path to config YAML file")
 	fs.String("apply", cfg.ApplyMode, "Apply mode: read change dump from file ('-' for STDIN) and apply to destination device")
 	fs.Bool("stdout", cfg.StdoutMode, "Write change dump to STDOUT")
-	fs.Bool("dry_run", cfg.DryRun, "Print actions without executing")
+	fs.Bool("dry-run", cfg.DryRun, "Print actions without executing")
 	fs.Bool("force", cfg.Force, "Override safety checks and proceed on mounted destination")
 	fs.String("source-type", cfg.SourceType, "Source device type (auto,file,raw,lvm)")
 	fs.String("dest-type", cfg.DestType, "Destination device type (auto,file,raw,lvm)")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -16,7 +16,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"config", ""},
 		{"apply", cfg.ApplyMode},
 		{"stdout", strconv.FormatBool(cfg.StdoutMode)},
-		{"dry_run", strconv.FormatBool(cfg.DryRun)},
+		{"dry-run", strconv.FormatBool(cfg.DryRun)},
 		{"force", strconv.FormatBool(cfg.Force)},
 		{"mode", cfg.Mode},
 		{"parallel", strconv.Itoa(cfg.Parallel)},


### PR DESCRIPTION
## Summary
- expose `--dry-run` flag via config and CLI
- skip transfer/verification work when `--dry-run` is set and print estimated size/ETA
- document dry-run usage for run and verify commands

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestQUICTransportHandshake: unexpected response "\x00\x00\x00\x00")*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689dee1f34d483238801d38a5c08aea0