### PR TITLE
feat(config): add offline and freeze hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 | Device type     | Source | Destination |
 |-----------------|:------:|:-----------:|
 | LVM snapshot    |   ✅   |      ❌      |
-| Raw block device|   ✅   |      ✅      |
+| Raw block device|   ✅*  |      ✅      |
 | Regular file    |   ✅   |      ✅      |
+
+*Requires `--offline` or `--fs-freeze-command` when used as a source.*
 
 ## Supported Platforms
 
@@ -246,7 +248,7 @@ examines the path to select the correct handling:
 | Type | Detection | Notes |
 |------|-----------|-------|
 | `lvm` | `/dev/<vg>/<lv>` or `/dev/mapper/<vg>-<lv>` | A snapshot is created and removed automatically |
-| `raw` | Other block devices | Require `--skip_snapshot_creation` or external freeze hooks |
+| `raw` | Other block devices | Require `--skip_snapshot_creation` and either `--offline` or `--fs-freeze-command` |
 | `file` | Regular files | Used as-is with no snapshot |
 
 Override detection with `--source-type` and `--dest-type` when necessary.
@@ -256,6 +258,8 @@ Examples:
 ```sh
 lvmsync --source-type lvm /dev/vg0/origin /tmp/dump
 lvmsync --dest-type raw dumpfile /dev/sdb
+lvmsync --source-type raw --offline /dev/sdb /tmp/dump
+lvmsync --source-type raw --fs-freeze-command "fsfreeze -f /mnt && fsfreeze -u /mnt" /dev/sdb /tmp/dump
 ```
 
 ### Configuration sources and precedence

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -25,7 +25,7 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	}
 	destDevice := args[0]
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(destDevice); err == nil {
+		if dev, err := device.Detect(destDevice, true, ""); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -109,7 +109,7 @@ func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, l
 // RunLocalDump dumps changes to a local destination device.
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(dest); err == nil {
+		if dev, err := device.Detect(dest, true, ""); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -188,19 +188,19 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	)
 
 	if cfg.SourceType == "" || cfg.SourceType == "auto" {
-		if dev, err := device.Detect(originalVolume); err == nil {
-			switch dev.(type) {
-			case *device.LVMDevice:
-				cfg.SourceType = "lvm"
-			case *device.RawDevice:
-				cfg.SourceType = "raw"
-			case *device.FileDevice:
-				cfg.SourceType = "file"
-			}
-			dev.Close()
-		} else {
+		dev, err := device.Detect(originalVolume, cfg.Offline, cfg.FSFreezeCommand)
+		if err != nil {
+			return err
+		}
+		switch dev.(type) {
+		case *device.LVMDevice:
+			cfg.SourceType = "lvm"
+		case *device.RawDevice:
+			cfg.SourceType = "raw"
+		case *device.FileDevice:
 			cfg.SourceType = "file"
 		}
+		dev.Close()
 	}
 	switch cfg.SourceType {
 	case "lvm":
@@ -210,7 +210,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		}
 	case "raw":
 		if !cfg.SkipSnapshotCreation {
-			return fmt.Errorf("raw sources require --skip_snapshot_creation or external freeze hooks")
+			return fmt.Errorf("raw sources require --skip_snapshot_creation and either --offline or --fs-freeze-command")
 		}
 	case "file":
 	default:

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestSetupGRPCSuccess(t *testing.T) {
-	cfg := &config.Config{}
+	cfg := &config.Config{SourceType: "file"}
 	logger := zap.NewNop()
 	srvCleanCalled := false
 	clientCleanCalled := false
@@ -61,7 +61,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 }
 
 func TestSetupGRPCServerError(t *testing.T) {
-	cfg := &config.Config{}
+	cfg := &config.Config{SourceType: "file"}
 	logger := zap.NewNop()
 	origStart := startGRPCServer
 	defer func() { startGRPCServer = origStart }()
@@ -74,7 +74,7 @@ func TestSetupGRPCServerError(t *testing.T) {
 }
 
 func TestSetupGRPCClientError(t *testing.T) {
-	cfg := &config.Config{}
+	cfg := &config.Config{SourceType: "file"}
 	logger := zap.NewNop()
 	srvCleanupCalled := false
 	origStart := startGRPCServer
@@ -214,7 +214,7 @@ func TestExecuteClient(t *testing.T) {
 }
 
 func TestRunHeartbeatError(t *testing.T) {
-	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second}
+	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second, SourceType: "file"}
 	logger := zap.NewNop()
 
 	origStart := startGRPCServer
@@ -276,7 +276,7 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
-			cfg := &config.Config{StdoutMode: true, GRPCConnect: tc.grpcConnect, GRPCSetupTimeout: time.Second}
+			cfg := &config.Config{StdoutMode: true, GRPCConnect: tc.grpcConnect, GRPCSetupTimeout: time.Second, SourceType: "file"}
 			logger := zap.NewNop()
 
 			origStart := startGRPCServer

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -33,6 +33,8 @@ type Config struct {
 	StdoutMode           bool          `mapstructure:"stdout"`
 	DryRun               bool          `mapstructure:"dry-run"`
 	Force                bool          `mapstructure:"force"`
+	Offline              bool          `mapstructure:"offline"`
+	FSFreezeCommand      string        `mapstructure:"fs-freeze-command"`
 	Mode                 string        `mapstructure:"mode"`
 	Parallel             int           `mapstructure:"parallel"`
 	Concurrency          int           `mapstructure:"concurrency"`
@@ -146,6 +148,8 @@ func DefaultConfig() (*Config, error) {
 		StdoutMode:           false,
 		DryRun:               false,
 		Force:                false,
+		Offline:              false,
+		FSFreezeCommand:      "",
 		Parallel:             4,
 		Concurrency:          0,
 		ZeroCopy:             false,

--- a/config/flags.go
+++ b/config/flags.go
@@ -55,6 +55,8 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("stdout", cfg.StdoutMode, "Write change dump to STDOUT")
 	fs.Bool("dry-run", cfg.DryRun, "Print actions without executing")
 	fs.Bool("force", cfg.Force, "Override safety checks and proceed on mounted destination")
+	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")
+	fs.String("fs-freeze-command", cfg.FSFreezeCommand, "Command to freeze filesystem before reading raw source")
 	fs.String("source-type", cfg.SourceType, "Source device type (auto,file,raw,lvm)")
 	fs.String("dest-type", cfg.DestType, "Destination device type (auto,file,raw,lvm)")
 	fs.String("mode", cfg.Mode, "Preset mode: default or throughput")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -18,6 +18,8 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"stdout", strconv.FormatBool(cfg.StdoutMode)},
 		{"dry-run", strconv.FormatBool(cfg.DryRun)},
 		{"force", strconv.FormatBool(cfg.Force)},
+		{"offline", strconv.FormatBool(cfg.Offline)},
+		{"fs-freeze-command", cfg.FSFreezeCommand},
 		{"mode", cfg.Mode},
 		{"parallel", strconv.Itoa(cfg.Parallel)},
 		{"zerocopy", strconv.FormatBool(cfg.ZeroCopy)},

--- a/device/detect.go
+++ b/device/detect.go
@@ -10,7 +10,7 @@ import (
 // Detect inspects the path and returns the appropriate Device implementation.
 // Regular files return FileDevice, block devices are classified as either LVM
 // logical volumes or raw devices based on LVM metadata.
-func Detect(path string) (Device, error) {
+func Detect(path string, offline bool, fsFreezeCmd string) (Device, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func Detect(path string) (Device, error) {
 		if _, err := lvm.GetVolumeGroupName(path); err == nil {
 			return OpenLVM(path)
 		}
-		return OpenRaw(path)
+		return OpenRaw(path, offline, fsFreezeCmd)
 	}
 	return nil, fmt.Errorf("unsupported path type: %s", path)
 }

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -36,7 +36,7 @@ func TestDetectFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	dev, err := Detect(f.Name())
+	dev, err := Detect(f.Name(), true, "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestDetectRaw(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	dev, err := Detect(loop)
+	dev, err := Detect(loop, true, "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestDetectLVM(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(lvPath)
+	dev, err := Detect(lvPath, true, "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -16,7 +17,17 @@ type RawDevice struct {
 }
 
 // OpenRaw opens a block device at the given path and queries its size and block size.
-func OpenRaw(path string) (*RawDevice, error) {
+// If offline is false, fsFreezeCmd must be a command that successfully freezes the
+// filesystem before accessing the device.
+func OpenRaw(path string, offline bool, fsFreezeCmd string) (*RawDevice, error) {
+	if !offline {
+		if fsFreezeCmd == "" {
+			return nil, fmt.Errorf("raw sources require --offline or --fs-freeze-command")
+		}
+		if err := exec.Command("sh", "-c", fsFreezeCmd).Run(); err != nil {
+			return nil, fmt.Errorf("freeze command failed: %w", err)
+		}
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -11,17 +11,29 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(f.Name()); err == nil {
+	if _, err := OpenRaw(f.Name(), true, ""); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw("/dev/null"); err == nil {
+		if _, err := OpenRaw("/dev/null", true, ""); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
 		t.Skip("/dev/null not found")
+	}
+}
+
+func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
+	if _, err := OpenRaw("/dev/null", false, ""); err == nil {
+		t.Fatalf("expected offline or freeze command error")
+	}
+}
+
+func TestOpenRawFreezeCommandFailure(t *testing.T) {
+	if _, err := OpenRaw("/dev/null", false, "false"); err == nil {
+		t.Fatalf("expected freeze command failure")
 	}
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -44,7 +44,9 @@ type Index struct {
 
 var closeHook = func() {}
 
-var detectDevice = device.Detect
+var detectDevice = func(path string) (device.Device, error) {
+	return device.Detect(path, true, "")
+}
 
 func headerMAC(h *Header) [32]byte {
 	var buf [headerSize - 32]byte


### PR DESCRIPTION
## Summary
- add `--offline` and `--fs-freeze-command` configuration flags
- require offline mode or a successful freeze command before reading raw devices
- document raw device safety requirements and usage examples

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689df8d52c0883239e9e062996fb4d09