### PR TITLE
docs: document raw device safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,23 @@ lvmsync --source-type raw --offline /dev/sdb /tmp/dump
 lvmsync --source-type raw --fs-freeze-command "fsfreeze -f /mnt && fsfreeze -u /mnt" /dev/sdb /tmp/dump
 ```
 
+### Raw device safety
+
+Reading from a live block device can corrupt data if writes occur during the transfer. Ensure a consistent view with one of the following options:
+
+- `--offline` – assert that no process will write to the source device.
+- `--fs-freeze-command` – run a command that freezes the filesystem and thaws it after the read.
+
+Example using the provided scripts:
+
+```sh
+lvmsync --source-type raw \
+  --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt && ./docs/fsfreeze-thaw.sh /mnt" \
+  /dev/sdb /tmp/dump
+```
+
+`docs/fsfreeze-freeze.sh` and `docs/fsfreeze-thaw.sh` demonstrate basic freeze and thaw operations.
+
 ### Configuration sources and precedence
 
 LVMSync uses [`pflag`](https://github.com/spf13/pflag) and [`viper`](https://github.com/spf13/viper) so every option can be

--- a/docs/fsfreeze-freeze.sh
+++ b/docs/fsfreeze-freeze.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Freeze the filesystem at the given mount point
+# Usage: ./fsfreeze-freeze.sh /mnt/data
+set -e
+mount_point="$1"
+fsfreeze -f "$mount_point"
+

--- a/docs/fsfreeze-thaw.sh
+++ b/docs/fsfreeze-thaw.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Thaw the filesystem at the given mount point
+# Usage: ./fsfreeze-thaw.sh /mnt/data
+set -e
+mount_point="$1"
+fsfreeze -u "$mount_point"
+

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -34,3 +34,21 @@ lvmsync verify /dev/vg0/snap0 /mnt/backup
 |------|----------------------|------------|-------------|
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file |
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
+
+## Raw Device Safety
+
+Working on a live block device can lead to inconsistent manifests if writes occur during the scan. To ensure a stable view:
+
+- `--offline` asserts that no process will modify the device while it is read.
+- `--fs-freeze-command` runs a command that freezes the filesystem and thaws it once the read completes.
+
+Example scripts in this repository:
+
+- [fsfreeze-freeze.sh](fsfreeze-freeze.sh)
+- [fsfreeze-thaw.sh](fsfreeze-thaw.sh)
+
+Use them together:
+
+```sh
+lvmsync manifest rebuild --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt && ./docs/fsfreeze-thaw.sh /mnt" /dev/sdb
+```


### PR DESCRIPTION
## Summary
- document --offline and --fs-freeze-command usage for raw devices
- add sample filesystem freeze/thaw scripts

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestQUICTransportHandshake unexpected response)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689dff502e8083238fb826981a1d6ff5