### PR TITLE
perf(manifest): short-circuit BLAKE3 digest on XXH3 mismatch

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -2,6 +2,8 @@
 
 LVMSync records transfer metadata in a manifest file. Each entry stores the chunk offset, length, and BLAKE3 digest so transfers can resume and destinations can be verified.
 
+For quicker comparisons, an additional XXH3 hash is stored alongside each entry. When checking a chunk, the XXH3 value is compared first and the more expensive BLAKE3 digest is only computed if the XXH3 hashes match.
+
 ## Index Format
 
 Manifests are JSON lines with one object per chunk:

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -172,8 +172,10 @@ func (i *Index) Set(offset uint64, length uint32, xxh uint64, digest [32]byte) {
 	copy(i.data[off+24:off+56], digest[:])
 }
 
-// Match reports whether the manifest already has a record for the chunk at offset matching length and digest.
-func (i *Index) Match(offset uint64, length uint32, digest [32]byte) bool {
+// Match reports whether the manifest already has a record for the chunk at the
+// given offset and length. The provided digestFn is invoked to compute the
+// BLAKE3 digest only if the stored XXH3 hash matches the supplied xxh.
+func (i *Index) Match(offset uint64, length uint32, xxh uint64, digestFn func() [32]byte) bool {
 	idx := int(offset / uint64(i.hdr.BlockSize))
 	if idx < 0 || idx >= int(i.hdr.ChunkCount) {
 		return false
@@ -187,6 +189,11 @@ func (i *Index) Match(offset uint64, length uint32, digest [32]byte) bool {
 	if storedOffset != offset || storedLen != length {
 		return false
 	}
+	storedXXH := binary.LittleEndian.Uint64(i.data[off+16 : off+24])
+	if storedXXH != xxh {
+		return false
+	}
+	digest := digestFn()
 	return bytes.Equal(i.data[off+24:off+56], digest[:])
 }
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -39,7 +39,7 @@ func TestIndexCRUD(t *testing.T) {
 	xx := xxh3.Hash(data)
 	b3 := blake3.Sum256(data)
 	idx.Set(0, 4096, xx, b3)
-	if !idx.Match(0, 4096, b3) {
+	if !idx.Match(0, 4096, xx, func() [32]byte { return b3 }) {
 		t.Fatalf("Match failed")
 	}
 	if err := idx.Close(); err != nil {
@@ -56,6 +56,38 @@ func TestIndexCRUD(t *testing.T) {
 	}
 	if err := idx2.Close(); err != nil {
 		t.Fatalf("close2: %v", err)
+	}
+}
+
+func TestMatchXXHShortcut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shortcut.man")
+	idx, err := Create(path, "dev", 4096, 4096)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	data := make([]byte, 4096)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	xx := xxh3.Hash(data)
+	b3 := blake3.Sum256(data)
+	idx.Set(0, 4096, xx, b3)
+
+	other := make([]byte, 4096)
+	if _, err := rand.Read(other); err != nil {
+		t.Fatalf("rand other: %v", err)
+	}
+	xxOther := xxh3.Hash(other)
+	called := false
+	if idx.Match(0, 4096, xxOther, func() [32]byte {
+		called = true
+		return blake3.Sum256(other)
+	}) {
+		t.Fatalf("unexpected match")
+	}
+	if called {
+		t.Fatalf("digest function called despite XXH3 mismatch")
 	}
 }
 

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -51,8 +51,17 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 		if err != nil {
 			return totalBytes, skippedBlocks, manifest, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
 		}
-		sum := blake3.Sum256(data)
-		if idx != nil && idx.Match(r.Start, blockSize, sum) {
+		xx := hashutil.SumXXH3(data)
+		var sum [32]byte
+		sumComputed := false
+		sumFn := func() [32]byte {
+			if !sumComputed {
+				sum = blake3.Sum256(data)
+				sumComputed = true
+			}
+			return sum
+		}
+		if idx != nil && idx.Match(r.Start, blockSize, xx, sumFn) {
 			skippedBlocks++
 			putBlockBuffer(data)
 			continue
@@ -66,7 +75,6 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 			dedup.RecordTransfer(offset, data)
 		}
 
-		xx := hashutil.SumXXH3(data)
 		binary.BigEndian.PutUint64(header[0:8], r.Start)
 		if isAllZero(data) {
 			binary.BigEndian.PutUint32(header[8:12], 0)
@@ -77,12 +85,13 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 			zh := zeroHash(int(blockSize))
 			saveResumeState(cfg, r.Start, zh, int64(blockSize), logger)
 			if idx != nil {
-				idx.Set(r.Start, blockSize, xx, sum)
+				idx.Set(r.Start, blockSize, xx, zh)
 			}
 			putBlockBuffer(data)
 			totalBytes += int64(blockSize)
 			continue
 		}
+		sum = sumFn()
 		binary.BigEndian.PutUint32(header[8:12], blockSize)
 		if _, err := bufOut.Write(header[:]); err != nil {
 			putBlockBuffer(data)
@@ -161,9 +170,12 @@ func processParallelResults(
 		if res.Err != nil {
 			return totalBytesTransferred, manifest, fmt.Errorf("error in block %d: %w", res.Index, res.Err)
 		}
-		if idx != nil && res.Data != nil && idx.Match(res.Offset, res.Size, res.ChunkID) {
-			putBlockBuffer(res.Data)
-			continue
+		if idx != nil && res.Data != nil {
+			xx := hashutil.SumXXH3(res.Data)
+			if idx.Match(res.Offset, res.Size, xx, func() [32]byte { return res.ChunkID }) {
+				putBlockBuffer(res.Data)
+				continue
+			}
 		}
 
 		n := prepareResultHeader(cfg, checksum, res, header)


### PR DESCRIPTION
## Summary
- Compare stored XXH3 hashes before invoking BLAKE3 in manifest.Match
- Lazily compute BLAKE3 digests when matching chunks to avoid unnecessary work
- Document manifest hashing optimization

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e01975e608323b43b05ea46232534