### PR TITLE
feat: require explicit TLS certificates for gRPC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_
 
 The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel. Plaintext connections are rejected unless `--allow-insecure` is explicitly set.
 
+TLS mode requires explicit certificates. Provide `--tls-cert`, `--tls-key`, and `--ca-cert`; the daemon fails to start if any are missing and does not generate self-signed certificates.
+
 `StartGRPCServer` accepts a `context.Context` and runs the server in a goroutine, returning a buffered error channel. Cancel the context or invoke the cleanup function to stop the server and wait on the channel during shutdown to surface any serve errors.
 
 1. **Handshake** – clients advertise `sector_size`, `alignment`, `max_concurrency`, and whether deduplication and compression are supported.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -18,6 +18,10 @@ LVMSync runs on Linux only and is validated on the `amd64` and `arm64` architect
 
 The planned `serve` subcommand will expose a QUIC listener for incoming replication requests. It follows an argument simplification philosophy, surfacing only essential flags while relying on configuration binding for advanced tuning. All logging for this command must use the structured `zap` logger.
 
+### gRPC Certificate Configuration
+
+The gRPC server requires externally supplied certificates. When TLS is enabled (the default), `TLSCert`, `TLSKey`, and `CACert` must all be configured; the daemon fails to start if any are missing and does not generate self-signed certificates automatically. Use `AllowInsecure` only for development.
+
 ## Identified Gaps
 
 1. **Deduplication State Loading** – deduplication strategies save state but never load existing state files on startup.

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -3,16 +3,12 @@ package server
 import (
 	"context"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"fmt"
 	"io"
-	"math/big"
 	"os"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -38,6 +34,9 @@ func New(conf Config, a lvmagent.Agent) (*grpc.Server, error) {
 	}
 
 	if !conf.AllowInsecure {
+		if conf.TLSCert == "" || conf.TLSKey == "" || conf.CACert == "" {
+			return nil, fmt.Errorf("TLSCert, TLSKey, and CACert must be provided when AllowInsecure is false")
+		}
 		cert, err := tls.LoadX509KeyPair(conf.TLSCert, conf.TLSKey)
 		if err != nil {
 			return nil, fmt.Errorf("load TLS key pair: %w", err)
@@ -188,16 +187,7 @@ func (s *replicationServer) CreateSession(_ context.Context, req *proto.SessionR
 	h.Write([]byte(req.GetDeviceUuid()))
 	h.Write(seed)
 	psk := h.Sum(nil)
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, err
-	}
-	tmpl := &x509.Certificate{SerialNumber: big.NewInt(time.Now().UnixNano()), Subject: pkix.Name{CommonName: sessionID}, NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour)}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		return nil, err
-	}
-	return &proto.SessionResponse{SessionId: sessionID, Psk: psk, ServerCert: der}, nil
+	return &proto.SessionResponse{SessionId: sessionID, Psk: psk}, nil
 }
 
 func (s *replicationServer) SendResumeBitmap(stream proto.Replication_SendResumeBitmapServer) error {

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -381,8 +381,8 @@ func TestSessionFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	if len(sess.GetPsk()) == 0 || len(sess.GetServerCert()) == 0 {
-		t.Fatalf("expected psk and cert in session response")
+	if len(sess.GetPsk()) == 0 {
+		t.Fatalf("expected psk in session response")
 	}
 	bmp, err := client.SendResumeBitmap(ctx)
 	if err != nil {
@@ -566,28 +566,40 @@ func dummyCert(t *testing.T) []byte {
 }
 
 func TestNewTLSFailures(t *testing.T) {
-	t.Run("missing key pair", func(t *testing.T) {
-		if _, err := New(Config{TLSCert: "nope", TLSKey: "nope", CACert: "nope"}, nil); err == nil {
+	cfg, _, _ := generateTLS(t)
+
+	t.Run("missing cert", func(t *testing.T) {
+		bad := cfg
+		bad.TLSCert = ""
+		if _, err := New(bad, nil); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		bad := cfg
+		bad.TLSKey = ""
+		if _, err := New(bad, nil); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("missing CA", func(t *testing.T) {
-		cfg, _, _ := generateTLS(t)
-		cfg.CACert = "nope"
-		if _, err := New(cfg, nil); err == nil {
+		bad := cfg
+		bad.CACert = ""
+		if _, err := New(bad, nil); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalid CA", func(t *testing.T) {
-		cfg, _, _ := generateTLS(t)
-		badCA := filepath.Join(t.TempDir(), "bad.pem")
-		if err := os.WriteFile(badCA, []byte("invalid"), 0600); err != nil {
+		bad := cfg
+		invalid := filepath.Join(t.TempDir(), "bad.pem")
+		if err := os.WriteFile(invalid, []byte("invalid"), 0600); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
-		cfg.CACert = badCA
-		if _, err := New(cfg, nil); err == nil {
+		bad.CACert = invalid
+		if _, err := New(bad, nil); err == nil {
 			t.Fatalf("expected error")
 		}
 	})


### PR DESCRIPTION
## Summary
- remove self-signed certificate generation in CreateSession
- enforce TLSCert, TLSKey, and CACert requirement when TLS is enabled
- document mandatory gRPC certificate configuration

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e0489cbbc8323b13da3869a8e1b5f