### PR TITLE
feat(device): add snapshot lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,13 @@ examines the path to select the correct handling:
 
 Override detection with `--source-type` and `--dest-type` when necessary.
 
+Snapshots provide a crash-consistent view of a device. LVM volumes are
+snapshotted automatically and removed after transfer. Raw block devices and
+regular files do not have a snapshot mechanism; to avoid inconsistent reads you
+must either take them offline with `--offline` or freeze the filesystem with
+`--fs-freeze-command`. Snapshot creation requires root privileges, so non-root
+invocations must permit escalation via `sudo -n`.
+
 Examples:
 
 ```sh

--- a/device/device.go
+++ b/device/device.go
@@ -1,5 +1,7 @@
 package device
 
+import "context"
+
 // Device describes a block device capable of reporting size information.
 type Device interface {
 	// Path returns the device path.
@@ -8,6 +10,11 @@ type Device interface {
 	SizeBytes() uint64
 	// BlockSize returns the logical block size of the device in bytes.
 	BlockSize() uint64
+	// Snapshot prepares the device for a consistent read, returning a
+	// handle that should be closed after use.
+	Snapshot(ctx context.Context) (Device, error)
+	// Cleanup releases any snapshot resources held by the device.
+	Cleanup(ctx context.Context) error
 	// Close releases any resources associated with the device.
 	Close() error
 }

--- a/device/file.go
+++ b/device/file.go
@@ -1,6 +1,7 @@
 package device
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -50,3 +51,9 @@ func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 
 // Close closes the underlying file descriptor.
 func (d *FileDevice) Close() error { return d.f.Close() }
+
+// Snapshot returns the device itself for regular files.
+func (d *FileDevice) Snapshot(context.Context) (Device, error) { return d, nil }
+
+// Cleanup is a no-op for regular files.
+func (d *FileDevice) Cleanup(context.Context) error { return nil }

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -1,7 +1,12 @@
 package device
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
+	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -11,9 +16,11 @@ import (
 
 // LVMDevice represents a logical volume managed by LVM.
 type LVMDevice struct {
-	f         *os.File
-	size      uint64
-	blockSize uint64
+	f           *os.File
+	path        string
+	size        uint64
+	blockSize   uint64
+	cleanupPath string
 }
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
@@ -33,11 +40,11 @@ func OpenLVM(path string) (*LVMDevice, error) {
 		f.Close()
 		return nil, err
 	}
-	return &LVMDevice{f: f, size: size, blockSize: uint64(bs)}, nil
+	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs)}, nil
 }
 
 // Path returns the underlying device path.
-func (d *LVMDevice) Path() string { return d.f.Name() }
+func (d *LVMDevice) Path() string { return d.path }
 
 // SizeBytes returns the logical volume size in bytes.
 func (d *LVMDevice) SizeBytes() uint64 { return d.size }
@@ -46,4 +53,65 @@ func (d *LVMDevice) SizeBytes() uint64 { return d.size }
 func (d *LVMDevice) BlockSize() uint64 { return d.blockSize }
 
 // Close closes the device.
-func (d *LVMDevice) Close() error { return d.f.Close() }
+func (d *LVMDevice) Close() error {
+	if d.f != nil {
+		return d.f.Close()
+	}
+	return nil
+}
+
+var (
+	execCommand      = exec.CommandContext
+	generateSnapshot = func() string { return fmt.Sprintf("lvmsync_%d", time.Now().UnixNano()) }
+	geteuid          = os.Geteuid
+	openLVMFunc      = OpenLVM
+)
+
+func runLVM(ctx context.Context, name string, args ...string) error {
+	if geteuid() != 0 {
+		args = append([]string{"-n", name}, args...)
+		name = "sudo"
+	}
+	cmd := execCommand(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// Snapshot creates, activates, and opens an LVM snapshot of the device.
+func (d *LVMDevice) Snapshot(ctx context.Context) (Device, error) {
+	vg, err := lvm.GetVolumeGroupName(d.path)
+	if err != nil {
+		return nil, err
+	}
+	snapName := generateSnapshot()
+	if err := runLVM(ctx, "lvcreate", "-s", "-n", snapName, "-L", "1G", d.path); err != nil {
+		return nil, err
+	}
+	snapPath := lvm.GetSnapshotDevicePath(snapName, vg, zap.NewNop())
+	if err := runLVM(ctx, "lvchange", "-ay", snapPath); err != nil {
+		_ = runLVM(ctx, "lvremove", "-f", snapPath)
+		return nil, err
+	}
+	snapDev, err := openLVMFunc(snapPath)
+	if err != nil {
+		_ = runLVM(ctx, "lvremove", "-f", snapPath)
+		return nil, err
+	}
+	snapDev.cleanupPath = snapPath
+	return snapDev, nil
+}
+
+// Cleanup removes the snapshot if one was created.
+func (d *LVMDevice) Cleanup(ctx context.Context) error {
+	if d.cleanupPath == "" {
+		return nil
+	}
+	if err := runLVM(ctx, "lvremove", "-f", d.cleanupPath); err != nil {
+		return err
+	}
+	d.cleanupPath = ""
+	return nil
+}

--- a/device/raw.go
+++ b/device/raw.go
@@ -1,6 +1,7 @@
 package device
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -63,6 +64,12 @@ func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
 
 // Close closes the underlying file descriptor.
 func (d *RawDevice) Close() error { return d.f.Close() }
+
+// Snapshot returns the device itself for raw block devices.
+func (d *RawDevice) Snapshot(context.Context) (Device, error) { return d, nil }
+
+// Cleanup is a no-op for raw block devices.
+func (d *RawDevice) Cleanup(context.Context) error { return nil }
 
 // ioctlGetUint64 performs an ioctl call expecting a 64-bit unsigned result.
 func ioctlGetUint64(fd int, req uint) (uint64, error) {

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -1,0 +1,95 @@
+package device
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSnapshotLifecycle(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("root required")
+	}
+	ctx := context.Background()
+
+	// File device snapshot is a no-op.
+	f, err := os.CreateTemp(t.TempDir(), "file")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	fd, err := OpenFile(f.Name())
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	fsnap, err := fd.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("file snapshot: %v", err)
+	}
+	if fsnap.Path() != fd.Path() {
+		t.Fatalf("file snapshot path mismatch")
+	}
+	if err := fsnap.Cleanup(ctx); err != nil {
+		t.Fatalf("file cleanup: %v", err)
+	}
+
+	// Raw device snapshot is also a no-op.
+	rd := &RawDevice{f: os.NewFile(uintptr(0), "/dev/sda")}
+	rsnap, err := rd.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("raw snapshot: %v", err)
+	}
+	if rsnap.Path() != rd.Path() {
+		t.Fatalf("raw snapshot path mismatch")
+	}
+	if err := rsnap.Cleanup(ctx); err != nil {
+		t.Fatalf("raw cleanup: %v", err)
+	}
+
+	// LVM device snapshot creates and removes snapshots via sudo when non-root.
+	var cmds []string
+	origCmd := execCommand
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmds = append(cmds, name+" "+strings.Join(args, " "))
+		return exec.CommandContext(ctx, "true")
+	}
+	defer func() { execCommand = origCmd }()
+
+	origName := generateSnapshot
+	generateSnapshot = func() string { return "snap" }
+	defer func() { generateSnapshot = origName }()
+
+	origOpen := openLVMFunc
+	openLVMFunc = func(p string) (*LVMDevice, error) {
+		return &LVMDevice{path: p, cleanupPath: p}, nil
+	}
+	defer func() { openLVMFunc = origOpen }()
+
+	origEuid := geteuid
+	geteuid = func() int { return 1 }
+	defer func() { geteuid = origEuid }()
+
+	lvd := &LVMDevice{path: "/dev/vg0/origin"}
+	snap, err := lvd.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("lvm snapshot: %v", err)
+	}
+	if snap.Path() != "/dev/vg0/snap" {
+		t.Fatalf("lvm snapshot path = %s", snap.Path())
+	}
+	if err := snap.Cleanup(ctx); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+
+	want := []string{
+		"sudo -n lvcreate -s -n snap -L 1G /dev/vg0/origin",
+		"sudo -n lvchange -ay /dev/vg0/snap",
+		"sudo -n lvremove -f /dev/vg0/snap",
+	}
+	if !reflect.DeepEqual(cmds, want) {
+		t.Fatalf("commands = %v, want %v", cmds, want)
+	}
+}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -20,10 +20,12 @@ type mockDevice struct {
 	blockSize uint64
 }
 
-func (m *mockDevice) Path() string      { return m.path }
-func (m *mockDevice) SizeBytes() uint64 { return m.size }
-func (m *mockDevice) BlockSize() uint64 { return m.blockSize }
-func (m *mockDevice) Close() error      { return nil }
+func (m *mockDevice) Path() string                                    { return m.path }
+func (m *mockDevice) SizeBytes() uint64                               { return m.size }
+func (m *mockDevice) BlockSize() uint64                               { return m.blockSize }
+func (m *mockDevice) Close() error                                    { return nil }
+func (m *mockDevice) Snapshot(context.Context) (device.Device, error) { return m, nil }
+func (m *mockDevice) Cleanup(context.Context) error                   { return nil }
 
 func TestIndexCRUD(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- extend device interface with snapshot and cleanup hooks
- add LVM snapshot create/activate/remove logic with sudo escalation
- document snapshot requirements and add lifecycle tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestSSHManagerGetClientReuse in remote package)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_689e1038cd4c8323ae9c335a15da9005