### PR TITLE
feat: group manifest and gRPC flags with precedence tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Flags are grouped in the CLI help:
 - **LVM Options** – snapshot management and privilege escalation.
 - **gRPC Options** – parameters for the optional gRPC daemon.
 - **Transport Options** – configure data transports (QUIC, HTTP/2, TCP+TLS, SSH).
+- **Manifest Options** – manifest path overrides and related settings.
 
 Internally, each group is set up through a dedicated helper such as
 `initGeneralFlags`, `initSSHFlags`, or `initCompressionFlags`, keeping flag
@@ -338,6 +339,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
 | `--checksum_algorithm` | `LVMSYNC_CHECKSUM_ALGORITHM` | `checksum_algorithm` | Checksum algorithm: `auto`, `sha256`, `blake3`, or `blake3-512` |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
+| `--manifest_path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
 | `--ssh_host` | `LVMSYNC_SSH_HOST` | `ssh_host` | SSH host |
 | `--ssh_user` | `LVMSYNC_SSH_USER` | `ssh_user` | SSH username |
 | `--ssh_key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key or use agent |

--- a/cmd/grpcd/cobra.go
+++ b/cmd/grpcd/cobra.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
@@ -51,14 +52,20 @@ var startFunc = func(ctx context.Context, opts Options, logger *zap.Logger) erro
 	return nil
 }
 
-func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
+	general := pflag.NewFlagSet("General Options", pflag.ExitOnError)
+	general.String("config", "", "config file")
+
+	grpc := pflag.NewFlagSet("gRPC Options", pflag.ExitOnError)
+	grpc.Int("grpc-port", 9443, "gRPC listen port")
+	grpc.String("tls-cert", "", "TLS certificate file")
+	grpc.String("tls-key", "", "TLS key file")
+	grpc.String("ca-cert", "", "CA certificate file")
+	grpc.Bool("allow-insecure", false, "allow plaintext gRPC")
+
 	fs := cmd.Flags()
-	fs.Int("grpc-port", 9443, "gRPC listen port")
-	fs.String("tls-cert", "", "TLS certificate file")
-	fs.String("tls-key", "", "TLS key file")
-	fs.String("ca-cert", "", "CA certificate file")
-	fs.Bool("allow-insecure", false, "allow plaintext gRPC")
-	fs.String("config", "", "config file")
+	fs.AddFlagSet(general)
+	fs.AddFlagSet(grpc)
 
 	v.BindPFlags(fs)
 	v.SetEnvPrefix("LVMSYNC_GRPC")
@@ -106,7 +113,7 @@ func NewCmd(logger *zap.Logger) *cobra.Command {
 			return startFunc(ctx, opts, logger)
 		},
 	}
-	bindFlags(cmd, v)
+	bindFlagSets(cmd, v)
 	return cmd
 }
 

--- a/cmd/grpcd/cobra_test.go
+++ b/cmd/grpcd/cobra_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"go.uber.org/zap"
@@ -30,4 +32,44 @@ func TestFlagParsing(t *testing.T) {
 	if got != want {
 		t.Fatalf("got %+v want %+v", got, want)
 	}
+}
+
+func TestGRPCPortPrecedence(t *testing.T) {
+	logger := zap.NewNop()
+	cfgPath := writeTempConfig(t, "grpc-port: 1111\n")
+	t.Setenv("LVMSYNC_GRPC_GRPC_PORT", "2222")
+
+	var got Options
+	orig := startFunc
+	startFunc = func(ctx context.Context, opts Options, _ *zap.Logger) error {
+		got = opts
+		return nil
+	}
+	defer func() { startFunc = orig }()
+
+	args := []string{"--config", cfgPath, "--grpc-port", "3333"}
+	if err := Execute(args, logger); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.GRPCPort != 3333 {
+		t.Fatalf("expected 3333, got %d", got.GRPCPort)
+	}
+
+	got = Options{}
+	if err := Execute([]string{"--config", cfgPath}, logger); err != nil {
+		t.Fatalf("Execute env: %v", err)
+	}
+	if got.GRPCPort != 2222 {
+		t.Fatalf("expected 2222, got %d", got.GRPCPort)
+	}
+}
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
 }

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -19,7 +19,6 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	}
 	flagSets := config.NewFlagSets(cfg)
 	fs := pflag.NewFlagSet("manifest rebuild", pflag.ContinueOnError)
-	output := fs.String("output", "", "manifest output file")
 	conf, remaining, err := config.LoadConfig(flagSets, cfg, fs, args[1:])
 	if err != nil {
 		return err
@@ -29,7 +28,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		return fmt.Errorf("usage: lvmsync manifest rebuild <device>")
 	}
 	device := remaining[0]
-	path := *output
+	path := conf.ManifestPath
 	if path == "" {
 		path = device + ".manifest"
 	}

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -37,7 +37,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 	}
 }
 
-func TestRunOutputFlag(t *testing.T) {
+func TestRunManifestPathFlag(t *testing.T) {
 	dir := t.TempDir()
 	devicePath := filepath.Join(dir, "dev.img")
 	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {
@@ -53,7 +53,7 @@ func TestRunOutputFlag(t *testing.T) {
 	}
 
 	outputPath := filepath.Join(dir, "custom.manifest")
-	args := []string{"rebuild", "--output", outputPath, devicePath}
+	args := []string{"rebuild", "--manifest_path", outputPath, devicePath}
 	if err := Run(cfg, args, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -33,11 +33,6 @@ func Run(args []string, logger *zap.Logger) error {
 			}
 			flagSets := config.NewFlagSets(defaults)
 			fs := pflag.NewFlagSet("verify", pflag.ContinueOnError)
-			for _, set := range flagSets.All() {
-				fs.AddFlagSet(set)
-			}
-			var manifest string
-			fs.StringVar(&manifest, "manifest", "", "Manifest file providing range hints")
 			cfg, remaining, err := config.LoadConfig(flagSets, defaults, fs, argv)
 			if err != nil {
 				return err
@@ -59,7 +54,7 @@ func Run(args []string, logger *zap.Logger) error {
 				logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
 				return nil
 			}
-			return verifyDevices(cfg, remaining[0], remaining[1], manifest, logger)
+			return verifyDevices(cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)
 		},
 	}
 	cmd.SetArgs(args)

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -85,7 +85,7 @@ func TestVerifyManifestMismatch(t *testing.T) {
 	}
 	core, observed := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
-	if err := Run([]string{"--manifest", manPath, src, dst}, logger); err == nil {
+	if err := Run([]string{"--manifest_path", manPath, src, dst}, logger); err == nil {
 		t.Fatalf("expected mismatch error")
 	}
 	logs := observed.All()

--- a/config/flags.go
+++ b/config/flags.go
@@ -18,6 +18,7 @@ type FlagSets struct {
 	LVM         *pflag.FlagSet
 	GRPC        *pflag.FlagSet
 	Transport   *pflag.FlagSet
+	Manifest    *pflag.FlagSet
 }
 
 // NewFlagSets constructs grouped flag sets using the provided defaults.
@@ -31,6 +32,7 @@ func NewFlagSets(cfg *Config) *FlagSets {
 		LVM:         initLVMFlags(cfg),
 		GRPC:        initGRPCFlags(cfg),
 		Transport:   initTransportFlags(cfg),
+		Manifest:    initManifestFlags(cfg),
 	}
 }
 
@@ -45,6 +47,7 @@ func (f *FlagSets) All() []*pflag.FlagSet {
 		f.LVM,
 		f.GRPC,
 		f.Transport,
+		f.Manifest,
 	}
 }
 
@@ -75,6 +78,12 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("verify_checksum", cfg.VerifyChecksum, "Enable checksum verification")
 	fs.String("checksum_algorithm", cfg.ChecksumAlgorithm, fmt.Sprintf("Checksum algorithm: %v", SupportedChecksumAlgorithms))
 	fs.Bool("progress", cfg.Progress, "Show progress during transfer")
+	return fs
+}
+
+func initManifestFlags(cfg *Config) *pflag.FlagSet {
+	fs := pflag.NewFlagSet("Manifest Options", pflag.ExitOnError)
+	fs.String("manifest_path", cfg.ManifestPath, "Path to manifest file")
 	return fs
 }
 

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -206,6 +206,21 @@ func TestInitGRPCFlags(t *testing.T) {
 	}
 }
 
+func TestInitManifestFlags(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := initManifestFlags(cfg)
+	f := fs.Lookup("manifest_path")
+	if f == nil {
+		t.Fatalf("missing manifest_path flag")
+	}
+	if f.DefValue != cfg.ManifestPath {
+		t.Fatalf("manifest_path default %s want %s", f.DefValue, cfg.ManifestPath)
+	}
+}
+
 func TestInitTransportFlags(t *testing.T) {
 	cfg, err := DefaultConfig()
 	if err != nil {

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -410,3 +410,119 @@ func TestTCPPortEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("expected tcp_port 2222, got %d", conf.TCPPort)
 	}
 }
+
+func TestGRPCPortCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "grpc_port: 1111\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--grpc_port", "3333"})
+	t.Setenv("LVMSYNC_GRPC_PORT", "2222")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.GRPCPort != 3333 {
+		t.Fatalf("expected grpc_port 3333, got %d", conf.GRPCPort)
+	}
+}
+
+func TestGRPCPortEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "grpc_port: 1111\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_GRPC_PORT", "2222")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.GRPCPort != 2222 {
+		t.Fatalf("expected grpc_port 2222, got %d", conf.GRPCPort)
+	}
+}
+
+func TestManifestPathCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "manifest_path: cfg.manifest\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest_path", "cli.manifest"})
+	t.Setenv("LVMSYNC_MANIFEST_PATH", "env.manifest")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.ManifestPath != "cli.manifest" {
+		t.Fatalf("expected manifest_path cli.manifest, got %s", conf.ManifestPath)
+	}
+}
+
+func TestManifestPathEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "manifest_path: cfg.manifest\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_MANIFEST_PATH", "env.manifest")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.ManifestPath != "env.manifest" {
+		t.Fatalf("expected manifest_path env.manifest, got %s", conf.ManifestPath)
+	}
+}


### PR DESCRIPTION
## Summary
- group manifest flags into dedicated FlagSet bound to viper
- refactor gRPC daemon to use grouped flag sets
- verify configuration precedence for manifest and gRPC options

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e104a32c483239cf587e7a0bec940