### PR TITLE
transport: validate handshake parameters and extend negotiation tests

### DIFF
--- a/common/handshake_validate.go
+++ b/common/handshake_validate.go
@@ -1,0 +1,38 @@
+package common
+
+import "fmt"
+
+// ValidateHandshake ensures peer and local handshakes agree on critical parameters.
+func ValidateHandshake(local, peer Handshake) error {
+	if peer.Endianness != "" && local.Endianness != "" && peer.Endianness != local.Endianness {
+		return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+	}
+	if peer.DedupMode != "" && local.DedupMode != "" && peer.DedupMode != local.DedupMode {
+		return fmt.Errorf("dedup mode mismatch: %s", peer.DedupMode)
+	}
+	if peer.CDCMin > 0 && local.CDCMin > 0 && peer.CDCMin != local.CDCMin {
+		return fmt.Errorf("cdc min mismatch: %d", peer.CDCMin)
+	}
+	if peer.CDCAvg > 0 && local.CDCAvg > 0 && peer.CDCAvg != local.CDCAvg {
+		return fmt.Errorf("cdc avg mismatch: %d", peer.CDCAvg)
+	}
+	if peer.CDCMax > 0 && local.CDCMax > 0 && peer.CDCMax != local.CDCMax {
+		return fmt.Errorf("cdc max mismatch: %d", peer.CDCMax)
+	}
+	if peer.Compress != "" && local.Compress != "" && peer.Compress != local.Compress {
+		return fmt.Errorf("compression mismatch: %s", peer.Compress)
+	}
+	if peer.CompressLevel != 0 && local.CompressLevel != 0 && peer.CompressLevel != local.CompressLevel {
+		return fmt.Errorf("compression level mismatch: %d", peer.CompressLevel)
+	}
+	if peer.ODirect != local.ODirect {
+		return fmt.Errorf("o_direct mismatch: %v", peer.ODirect)
+	}
+	if peer.ResumeToken != "" && local.ResumeToken != "" && peer.ResumeToken != local.ResumeToken {
+		return fmt.Errorf("resume token mismatch: %s", peer.ResumeToken)
+	}
+	if peer.MaxInFlight > 0 && local.MaxInFlight > 0 && peer.MaxInFlight != local.MaxInFlight {
+		return fmt.Errorf("max in-flight mismatch: %d", peer.MaxInFlight)
+	}
+	return nil
+}

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -1,0 +1,16 @@
+package common
+
+import "testing"
+
+func TestValidateHandshake(t *testing.T) {
+        local := Handshake{DedupMode: "fixed", CDCMin: 64, CDCAvg: 128, CDCMax: 256, Compress: "zstd", CompressLevel: 1, ODirect: true, ResumeToken: "tok", MaxInFlight: 8, Endianness: "little"}
+        peer := local
+        if err := ValidateHandshake(local, peer); err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        peer.DedupMode = "cdc"
+        if err := ValidateHandshake(local, peer); err == nil {
+                t.Fatal("expected dedup mismatch error")
+        }
+}
+

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -106,8 +106,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		return peer, nil
 	case transport.Server:
@@ -115,8 +115,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err

--- a/transport/negotiation_params_test.go
+++ b/transport/negotiation_params_test.go
@@ -1,0 +1,194 @@
+package transport_test
+
+import (
+        "context"
+        "crypto/rand"
+        "crypto/rsa"
+        "crypto/tls"
+        "crypto/x509"
+        "math/big"
+        "net"
+        "testing"
+        "time"
+
+        "go.uber.org/zap"
+
+        "lvmsync_go/common"
+        "lvmsync_go/transport"
+       _ "lvmsync_go/transport/h2"
+       _ "lvmsync_go/transport/quic"
+       _ "lvmsync_go/transport/ssh"
+       _ "lvmsync_go/transport/tcp_tls"
+)
+
+func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+        t.Helper()
+        key, err := rsa.GenerateKey(rand.Reader, 2048)
+        if err != nil {
+                t.Fatalf("generate key: %v", err)
+        }
+        tmpl := x509.Certificate{
+                SerialNumber: big.NewInt(1),
+                NotBefore:    time.Now(),
+                NotAfter:     time.Now().Add(time.Hour),
+                IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+        }
+        der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+        if err != nil {
+                t.Fatalf("create cert: %v", err)
+        }
+        cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+        parsed, err := x509.ParseCertificate(der)
+        if err != nil {
+                t.Fatalf("parse cert: %v", err)
+        }
+        pool := x509.NewCertPool()
+        pool.AddCert(parsed)
+        return cert, pool
+}
+
+func newTransport(t *testing.T, name string) transport.Interface {
+        t.Helper()
+        cfg := transport.Config{Logger: zap.NewNop()}
+        if name == "tcp+tls" || name == "quic" {
+                cert, pool := generateSelfSignedCert(t)
+                cfg.ClientCert = cert
+                cfg.Roots = pool
+        }
+        tr, err := transport.Get(name, cfg)
+        if err != nil {
+                t.Fatalf("get transport %s: %v", name, err)
+        }
+        return tr
+}
+
+type result struct {
+        peer common.Handshake
+        err  error
+}
+
+func runNegotiation(t *testing.T, tr transport.Interface, serverHS, clientHS common.Handshake) (result, result) {
+        t.Helper()
+        ctx := context.Background()
+        ln, err := tr.Listen(ctx, "127.0.0.1:0")
+        if err != nil {
+                t.Fatalf("listen: %v", err)
+        }
+        defer ln.Close()
+        addr := ln.Addr().String()
+        srvCh := make(chan result)
+        done := make(chan struct{})
+        go func() {
+                conn, err := ln.Accept()
+                if err != nil {
+                        srvCh <- result{err: err}
+                        return
+                }
+                peer, err := tr.Negotiate(ctx, conn, transport.Server, serverHS)
+                if err != nil {
+                        conn.Close()
+                        srvCh <- result{peer: peer, err: err}
+                        return
+                }
+                <-done
+                conn.Close()
+                srvCh <- result{peer: peer, err: err}
+        }()
+        conn, err := tr.Dial(ctx, addr)
+        if err != nil {
+                t.Fatalf("dial: %v", err)
+        }
+        peer, err := tr.Negotiate(ctx, conn, transport.Client, clientHS)
+        conn.Close()
+        close(done)
+        srvRes := <-srvCh
+        return srvRes, result{peer: peer, err: err}
+}
+
+func TestTransportNegotiationMatrix(t *testing.T) {
+        transports := []string{"ssh", "tcp+tls", "h2", "quic"}
+        for _, name := range transports {
+                t.Run(name, func(t *testing.T) {
+                        tr := newTransport(t, name)
+                        base := common.Handshake{
+                                DedupMode:     "fixed",
+                                CDCMin:        64,
+                                CDCAvg:        128,
+                                CDCMax:        256,
+                                Compress:      "zstd",
+                                CompressLevel: 1,
+                                ODirect:       true,
+                                ResumeToken:   "tok",
+                                MaxInFlight:   8,
+                                Endianness:    common.NativeEndianness(),
+                        }
+                        modes := []string{"fixed", "cdc", "hybrid"}
+                        for _, m := range modes {
+                                serverHS := base
+                                clientHS := base
+                                serverHS.DedupMode = m
+                                clientHS.DedupMode = m
+                                srv, cli := runNegotiation(t, tr, serverHS, clientHS)
+                                if srv.err != nil || cli.err != nil {
+                                        t.Fatalf("expected success: server %v client %v", srv.err, cli.err)
+                                }
+                                if cli.peer.DedupMode != m || cli.peer.Compress != "zstd" || cli.peer.ODirect != true {
+                                        t.Fatalf("unexpected peer handshake: %+v", cli.peer)
+                                }
+                        }
+                        // mismatch cases
+                        // dedup mode
+                        serverHS := base
+                        clientHS := base
+                        clientHS.DedupMode = "cdc"
+                        if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+                                t.Fatalf("expected dedup mismatch error")
+                        }
+                        // cdc bounds
+                        serverHS = base
+                        serverHS.DedupMode = "cdc"
+                        clientHS = serverHS
+                        clientHS.CDCMin = 128
+                        if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+                                t.Fatalf("expected cdc bounds mismatch error")
+                        }
+                        // compression algorithm
+                        serverHS = base
+                        clientHS = base
+                        clientHS.Compress = "lz4"
+                        clientHS.CompressLevel = 0
+                        if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+                                t.Fatalf("expected compression mismatch error")
+                        }
+                        // compression level
+                        serverHS = base
+                        clientHS = base
+                        clientHS.CompressLevel = 2
+                        if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+                                t.Fatalf("expected compression level mismatch error")
+                        }
+                        // O_DIRECT
+                        serverHS = base
+                        clientHS = base
+                        clientHS.ODirect = false
+                        if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+                                t.Fatalf("expected o_direct mismatch error")
+                        }
+                        // resume token
+                        serverHS = base
+                        clientHS = base
+                        clientHS.ResumeToken = "other"
+                        if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+                                t.Fatalf("expected resume token mismatch error")
+                        }
+                        // max in-flight
+                        serverHS = base
+                        clientHS = base
+                        clientHS.MaxInFlight = 4
+                        if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+                                t.Fatalf("expected max in-flight mismatch error")
+                        }
+                })
+        }
+}
+

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -195,8 +195,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		return peer, nil
 	case transport.Server:
@@ -204,8 +204,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -106,8 +106,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		return peer, nil
 	case transport.Server:
@@ -115,8 +115,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -135,8 +135,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		return peer, nil
 	case transport.Server:
@@ -144,8 +144,8 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
-		if peer.Endianness != "" && peer.Endianness != hs.Endianness {
-			return peer, fmt.Errorf("endianness mismatch: %s", peer.Endianness)
+		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
 			return peer, err


### PR DESCRIPTION
## Summary
- validate key handshake parameters (dedup mode, CDC bounds, compression, O_DIRECT, resume token, max in-flight)
- use validation in ssh, tcp+tls, h2, and quic transports
- add transport negotiation test matrix covering parameter combinations and mismatches

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e1073ff7083239ad65a540922d1e8