### PR TITLE
feat(grpc): implement advanced replication RPC handlers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -24,8 +24,8 @@ import (
 // Wrappers for external dependencies to enable test stubbing.
 var (
 	listen    = net.Listen
-	newServer = func(cfg grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
-		return grpcserver.New(cfg, agent)
+	newServer = func(cfg grpcserver.Config, agent lvmlib.Agent, logger *zap.Logger) (grpcServer, func(), error) {
+		return grpcserver.New(cfg, agent, logger)
 	}
 	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
 		return grpcclient.Dial(ctx, addr, conf)
@@ -68,7 +68,7 @@ func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger
 	if err != nil {
 		return nil, nil, fmt.Errorf("gRPC listen: %w", err)
 	}
-	srv, err := newServer(srvCfg, nil)
+	srv, srvCleanup, err := newServer(srvCfg, nil, logger)
 	if err != nil {
 		ln.Close()
 		return nil, nil, fmt.Errorf("gRPC server: %w", err)
@@ -87,6 +87,7 @@ func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger
 		errCh <- serveErr
 	}()
 	cleanup := func() {
+		srvCleanup()
 		srv.GracefulStop()
 		ln.Close()
 		close(errCh)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -44,7 +44,9 @@ func TestStartGRPCServerSuccess(t *testing.T) {
 	defer func() { listen = origListen; newServer = origNewServer }()
 	listen = func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil }
 	srv := &fakeServer{}
-	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) { return srv, nil }
+	newServer = func(conf grpcserver.Config, agent lvmlib.Agent, _ *zap.Logger) (grpcServer, func(), error) {
+		return srv, func() {}, nil
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cleanup, errCh, err := StartGRPCServer(ctx, cfg, logger)
@@ -85,8 +87,8 @@ func TestStartGRPCServerServeError(t *testing.T) {
 	defer func() { listen = origListen; newServer = origNewServer }()
 	listen = func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil }
 	srvErr := errors.New("serve boom")
-	newServer = func(conf grpcserver.Config, agent lvmlib.Agent) (grpcServer, error) {
-		return &failingServer{err: srvErr}, nil
+	newServer = func(conf grpcserver.Config, agent lvmlib.Agent, _ *zap.Logger) (grpcServer, func(), error) {
+		return &failingServer{err: srvErr}, func() {}, nil
 	}
 	cleanup, errCh, err := StartGRPCServer(context.Background(), cfg, logger)
 	if err != nil {

--- a/cmd/grpcd/cobra.go
+++ b/cmd/grpcd/cobra.go
@@ -35,7 +35,7 @@ var startFunc = func(ctx context.Context, opts Options, logger *zap.Logger) erro
 		CACert:        opts.CACert,
 		AllowInsecure: opts.AllowInsecure,
 	}
-	srv, err := grpcserver.New(cfg, nil)
+	srv, cleanup, err := grpcserver.New(cfg, nil, logger)
 	if err != nil {
 		ln.Close()
 		return fmt.Errorf("init gRPC server: %w", err)
@@ -48,6 +48,7 @@ var startFunc = func(ctx context.Context, opts Options, logger *zap.Logger) erro
 	<-ctx.Done()
 	srv.GracefulStop()
 	ln.Close()
+	cleanup()
 	return nil
 }
 

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -12,11 +12,13 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
 	servers "lvmsync_go/grpc/server"
+	lvmagent "lvmsync_go/internal/lvm"
 	"lvmsync_go/proto"
 )
 
@@ -31,7 +33,8 @@ func bufDialer(lis *bufconn.Listener) func(context.Context, string) (net.Conn, e
 func setupClient(t *testing.T) (proto.ReplicationClient, func()) {
 	t.Helper()
 	lis := bufconn.Listen(bufSize)
-	srv, err := servers.New(servers.Config{AllowInsecure: true}, nil)
+	agent := ackAgent{}
+	srv, srvCleanup, err := servers.New(servers.Config{AllowInsecure: true}, agent, zap.NewNop())
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -45,9 +48,23 @@ func setupClient(t *testing.T) (proto.ReplicationClient, func()) {
 		cancel()
 		conn.Close()
 		srv.Stop()
+		srvCleanup()
 	}
 	return proto.NewReplicationClient(conn), cleanup
 }
+
+type ackAgent struct{}
+
+func (ackAgent) Lock(context.Context, string, string) error   { return nil }
+func (ackAgent) Unlock(context.Context, string, string) error { return nil }
+func (ackAgent) GetMetadata(context.Context, string) (lvmagent.VolumeMetadata, error) {
+	return lvmagent.VolumeMetadata{}, nil
+}
+func (ackAgent) SendMetadata(context.Context, lvmagent.VolumeMetadata) error { return nil }
+func (ackAgent) StartTransferSession(context.Context, string, string) error  { return nil }
+func (ackAgent) FinalizeSync(context.Context, string, string) error          { return nil }
+func (ackAgent) GetStatus(context.Context, string, string) (string, error)   { return "", nil }
+func (ackAgent) Ack(ctx context.Context, ack *proto.Ack) (*proto.Ack, error) { return ack, nil }
 
 func TestHandshakeAndAck(t *testing.T) {
 	client, cleanup := setupClient(t)
@@ -74,12 +91,15 @@ func TestHandshakeAndAck(t *testing.T) {
 
 func TestDial(t *testing.T) {
 	lis := bufconn.Listen(bufSize)
-	srv, err := servers.New(servers.Config{AllowInsecure: true}, nil)
+	srv, srvCleanup, err := servers.New(servers.Config{AllowInsecure: true}, nil, zap.NewNop())
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
 	go srv.Serve(lis)
-	defer srv.Stop()
+	defer func() {
+		srv.Stop()
+		srvCleanup()
+	}()
 
 	cases := []struct {
 		name    string

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -27,7 +28,9 @@ type Config struct {
 	AllowInsecure bool
 }
 
-func New(conf Config, a lvmagent.Agent) (*grpc.Server, error) {
+// New constructs a gRPC server and returns it along with a cleanup function
+// that flushes logger buffers on shutdown.
+func New(conf Config, a lvmagent.Agent, logger *zap.Logger) (*grpc.Server, func(), error) {
 	opts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(authorizeInterceptor),
 		grpc.StreamInterceptor(authorizeStreamInterceptor),
@@ -35,19 +38,19 @@ func New(conf Config, a lvmagent.Agent) (*grpc.Server, error) {
 
 	if !conf.AllowInsecure {
 		if conf.TLSCert == "" || conf.TLSKey == "" || conf.CACert == "" {
-			return nil, fmt.Errorf("TLSCert, TLSKey, and CACert must be provided when AllowInsecure is false")
+			return nil, nil, fmt.Errorf("TLSCert, TLSKey, and CACert must be provided when AllowInsecure is false")
 		}
 		cert, err := tls.LoadX509KeyPair(conf.TLSCert, conf.TLSKey)
 		if err != nil {
-			return nil, fmt.Errorf("load TLS key pair: %w", err)
+			return nil, nil, fmt.Errorf("load TLS key pair: %w", err)
 		}
 		caPEM, err := os.ReadFile(conf.CACert)
 		if err != nil {
-			return nil, fmt.Errorf("read CA cert: %w", err)
+			return nil, nil, fmt.Errorf("read CA cert: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caPEM) {
-			return nil, fmt.Errorf("invalid CA cert")
+			return nil, nil, fmt.Errorf("invalid CA cert")
 		}
 		tlsCfg := &tls.Config{
 			Certificates: []tls.Certificate{cert},
@@ -59,9 +62,16 @@ func New(conf Config, a lvmagent.Agent) (*grpc.Server, error) {
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsCfg)))
 	}
 
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	srv := grpc.NewServer(opts...)
-	proto.RegisterReplicationServer(srv, &replicationServer{agent: a})
-	return srv, nil
+	proto.RegisterReplicationServer(srv, &replicationServer{agent: a, logger: logger})
+	cleanup := func() {
+		_ = logger.Sync()
+	}
+	return srv, cleanup, nil
 }
 
 func authorizeInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
@@ -94,7 +104,8 @@ func authorizeStreamInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamSer
 
 type replicationServer struct {
 	proto.UnimplementedReplicationServer
-	agent lvmagent.Agent
+	agent  lvmagent.Agent
+	logger *zap.Logger
 }
 
 func (s *replicationServer) agentAction(fn func(lvmagent.Agent) error) *proto.StatusResponse {
@@ -191,27 +202,95 @@ func (s *replicationServer) CreateSession(_ context.Context, req *proto.SessionR
 }
 
 func (s *replicationServer) SendResumeBitmap(stream proto.Replication_SendResumeBitmapServer) error {
+	if s.agent == nil {
+		return status.Error(codes.FailedPrecondition, "agent not configured")
+	}
+	a, ok := s.agent.(interface {
+		SendResumeBitmap(ctx context.Context, sessionID string, bitmap []byte) error
+	})
+	if !ok {
+		return status.Error(codes.Unimplemented, "SendResumeBitmap not supported")
+	}
+	ctx := stream.Context()
 	for {
-		_, err := stream.Recv()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		msg, err := stream.Recv()
 		if err == io.EOF {
 			return stream.SendAndClose(&proto.StatusResponse{Ok: true})
 		}
 		if err != nil {
 			return err
 		}
+		s.logger.Debug("resume_bitmap_recv",
+			zap.String("session_id", msg.GetSessionId()),
+			zap.Int("size_bytes", len(msg.GetBitmap())),
+		)
+		if err := a.SendResumeBitmap(ctx, msg.GetSessionId(), msg.GetBitmap()); err != nil {
+			return err
+		}
 	}
 }
 
 func (s *replicationServer) SendFinalManifest(ctx context.Context, m *proto.ManifestMessage) (*proto.StatusResponse, error) {
-	return &proto.StatusResponse{Ok: true, Message: "manifest received " + m.GetSessionId()}, nil
+	if s.agent == nil {
+		return &proto.StatusResponse{Ok: false, Message: "agent not configured"}, nil
+	}
+	a, ok := s.agent.(interface {
+		SendFinalManifest(ctx context.Context, sessionID string, manifest []byte) error
+	})
+	if !ok {
+		return &proto.StatusResponse{Ok: false, Message: "SendFinalManifest not supported"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.logger.Info("final_manifest_recv",
+		zap.String("session_id", m.GetSessionId()),
+		zap.Int("size_bytes", len(m.GetManifest())),
+	)
+	if err := a.SendFinalManifest(ctx, m.GetSessionId(), m.GetManifest()); err != nil {
+		return &proto.StatusResponse{Ok: false, Message: err.Error()}, nil
+	}
+	return &proto.StatusResponse{Ok: true}, nil
 }
 
-func (s *replicationServer) Finalize(_ context.Context, req *proto.FinalizeRequest) (*proto.StatusResponse, error) {
-	return &proto.StatusResponse{Ok: true, Message: "finalized " + req.GetSessionId()}, nil
+func (s *replicationServer) Finalize(ctx context.Context, req *proto.FinalizeRequest) (*proto.StatusResponse, error) {
+	if s.agent == nil {
+		return &proto.StatusResponse{Ok: false, Message: "agent not configured"}, nil
+	}
+	a, ok := s.agent.(interface {
+		Finalize(ctx context.Context, sessionID string) error
+	})
+	if !ok {
+		return &proto.StatusResponse{Ok: false, Message: "Finalize not supported"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.logger.Info("finalize_request", zap.String("session_id", req.GetSessionId()))
+	if err := a.Finalize(ctx, req.GetSessionId()); err != nil {
+		return &proto.StatusResponse{Ok: false, Message: err.Error()}, nil
+	}
+	return &proto.StatusResponse{Ok: true}, nil
 }
 
 func (s *replicationServer) AckStream(stream proto.Replication_AckStreamServer) error {
+	if s.agent == nil {
+		return status.Error(codes.FailedPrecondition, "agent not configured")
+	}
+	a, ok := s.agent.(interface {
+		Ack(ctx context.Context, ack *proto.Ack) (*proto.Ack, error)
+	})
+	if !ok {
+		return status.Error(codes.Unimplemented, "Ack not supported")
+	}
+	ctx := stream.Context()
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		msg, err := stream.Recv()
 		if err == io.EOF {
 			return nil
@@ -219,34 +298,147 @@ func (s *replicationServer) AckStream(stream proto.Replication_AckStreamServer) 
 		if err != nil {
 			return err
 		}
-		if err := stream.Send(msg); err != nil {
+		s.logger.Debug("ack_recv",
+			zap.String("session_id", msg.GetSessionId()),
+			zap.Bool("ok", msg.GetOk()),
+		)
+		resp, err := a.Ack(ctx, msg)
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(resp); err != nil {
 			return err
 		}
 	}
 }
 
-func (s *replicationServer) Probe(_ context.Context, req *proto.ProbeRequest) (*proto.StatusResponse, error) {
-	return &proto.StatusResponse{Ok: true, Message: "probe " + req.GetVolumeName()}, nil
+func (s *replicationServer) Probe(ctx context.Context, req *proto.ProbeRequest) (*proto.StatusResponse, error) {
+	if s.agent == nil {
+		return &proto.StatusResponse{Ok: false, Message: "agent not configured"}, nil
+	}
+	a, ok := s.agent.(interface {
+		Probe(ctx context.Context, volume string) error
+	})
+	if !ok {
+		return &proto.StatusResponse{Ok: false, Message: "Probe not supported"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.logger.Info("probe_request", zap.String("volume_name", req.GetVolumeName()))
+	if err := a.Probe(ctx, req.GetVolumeName()); err != nil {
+		return &proto.StatusResponse{Ok: false, Message: err.Error()}, nil
+	}
+	return &proto.StatusResponse{Ok: true}, nil
 }
 
 func (s *replicationServer) StartSync(ctx context.Context, req *proto.StartSyncRequest) (*proto.StatusResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.logger.Info("start_sync",
+		zap.String("volume_name", req.GetVolumeName()),
+		zap.String("requester", req.GetRequester()),
+	)
 	return s.agentAction(func(a lvmagent.Agent) error {
 		return a.StartTransferSession(ctx, req.GetVolumeName(), req.GetRequester())
 	}), nil
 }
 
-func (s *replicationServer) Cancel(_ context.Context, req *proto.CancelRequest) (*proto.StatusResponse, error) {
-	return &proto.StatusResponse{Ok: true, Message: "cancelled " + req.GetSessionId()}, nil
+func (s *replicationServer) Cancel(ctx context.Context, req *proto.CancelRequest) (*proto.StatusResponse, error) {
+	if s.agent == nil {
+		return &proto.StatusResponse{Ok: false, Message: "agent not configured"}, nil
+	}
+	a, ok := s.agent.(interface {
+		Cancel(ctx context.Context, sessionID string) error
+	})
+	if !ok {
+		return &proto.StatusResponse{Ok: false, Message: "Cancel not supported"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.logger.Info("cancel_request", zap.String("session_id", req.GetSessionId()))
+	if err := a.Cancel(ctx, req.GetSessionId()); err != nil {
+		return &proto.StatusResponse{Ok: false, Message: err.Error()}, nil
+	}
+	return &proto.StatusResponse{Ok: true}, nil
 }
 
 func (s *replicationServer) ProgressStream(req *proto.ProgressRequest, stream proto.Replication_ProgressStreamServer) error {
-	return stream.Send(&proto.Progress{SessionId: req.GetSessionId(), Completed: 1, Total: 1})
+	if s.agent == nil {
+		return status.Error(codes.FailedPrecondition, "agent not configured")
+	}
+	a, ok := s.agent.(interface {
+		Progress(ctx context.Context, sessionID string) (<-chan *proto.Progress, error)
+	})
+	if !ok {
+		return status.Error(codes.Unimplemented, "Progress not supported")
+	}
+	ctx := stream.Context()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	ch, err := a.Progress(ctx, req.GetSessionId())
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case p, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			s.logger.Debug("progress_update",
+				zap.String("session_id", p.GetSessionId()),
+				zap.Uint64("completed", p.GetCompleted()),
+				zap.Uint64("total", p.GetTotal()),
+			)
+			if err := stream.Send(p); err != nil {
+				return err
+			}
+		}
+	}
 }
 
-func (s *replicationServer) BuildManifest(_ context.Context, req *proto.BuildManifestRequest) (*proto.StatusResponse, error) {
-	return &proto.StatusResponse{Ok: true, Message: "manifest built " + req.GetSessionId()}, nil
+func (s *replicationServer) BuildManifest(ctx context.Context, req *proto.BuildManifestRequest) (*proto.StatusResponse, error) {
+	if s.agent == nil {
+		return &proto.StatusResponse{Ok: false, Message: "agent not configured"}, nil
+	}
+	a, ok := s.agent.(interface {
+		BuildManifest(ctx context.Context, sessionID string) error
+	})
+	if !ok {
+		return &proto.StatusResponse{Ok: false, Message: "BuildManifest not supported"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.logger.Info("build_manifest", zap.String("session_id", req.GetSessionId()))
+	if err := a.BuildManifest(ctx, req.GetSessionId()); err != nil {
+		return &proto.StatusResponse{Ok: false, Message: err.Error()}, nil
+	}
+	return &proto.StatusResponse{Ok: true}, nil
 }
 
-func (s *replicationServer) Verify(_ context.Context, req *proto.VerifyRequest) (*proto.StatusResponse, error) {
-	return &proto.StatusResponse{Ok: true, Message: "verified " + req.GetSessionId()}, nil
+func (s *replicationServer) Verify(ctx context.Context, req *proto.VerifyRequest) (*proto.StatusResponse, error) {
+	if s.agent == nil {
+		return &proto.StatusResponse{Ok: false, Message: "agent not configured"}, nil
+	}
+	a, ok := s.agent.(interface {
+		Verify(ctx context.Context, sessionID string) error
+	})
+	if !ok {
+		return &proto.StatusResponse{Ok: false, Message: "Verify not supported"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.logger.Info("verify_request", zap.String("session_id", req.GetSessionId()))
+	if err := a.Verify(ctx, req.GetSessionId()); err != nil {
+		return &proto.StatusResponse{Ok: false, Message: err.Error()}, nil
+	}
+	return &proto.StatusResponse{Ok: true}, nil
 }

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -19,6 +19,7 @@ import (
 	lvmagent "lvmsync_go/internal/lvm"
 	"lvmsync_go/proto"
 
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -39,6 +40,16 @@ type mockAgent struct {
 	startSess func(ctx context.Context, volume, requester string) error
 	finalize  func(ctx context.Context, volume, requester string) error
 	status    func(ctx context.Context, volume, requester string) (string, error)
+
+	sendBitmap    func(ctx context.Context, sessionID string, bitmap []byte) error
+	sendManifest  func(ctx context.Context, sessionID string, manifest []byte) error
+	finalizeSess  func(ctx context.Context, sessionID string) error
+	ack           func(ctx context.Context, ack *proto.Ack) (*proto.Ack, error)
+	probe         func(ctx context.Context, volume string) error
+	cancel        func(ctx context.Context, sessionID string) error
+	progress      func(ctx context.Context, sessionID string) (<-chan *proto.Progress, error)
+	buildManifest func(ctx context.Context, sessionID string) error
+	verify        func(ctx context.Context, sessionID string) error
 }
 
 func (m *mockAgent) Lock(ctx context.Context, volume, requester string) error {
@@ -84,10 +95,75 @@ func (m *mockAgent) GetStatus(ctx context.Context, volume, requester string) (st
 	return "", nil
 }
 
+func (m *mockAgent) SendResumeBitmap(ctx context.Context, sessionID string, bitmap []byte) error {
+	if m.sendBitmap != nil {
+		return m.sendBitmap(ctx, sessionID, bitmap)
+	}
+	return nil
+}
+
+func (m *mockAgent) SendFinalManifest(ctx context.Context, sessionID string, manifest []byte) error {
+	if m.sendManifest != nil {
+		return m.sendManifest(ctx, sessionID, manifest)
+	}
+	return nil
+}
+
+func (m *mockAgent) Finalize(ctx context.Context, sessionID string) error {
+	if m.finalizeSess != nil {
+		return m.finalizeSess(ctx, sessionID)
+	}
+	return nil
+}
+
+func (m *mockAgent) Ack(ctx context.Context, ack *proto.Ack) (*proto.Ack, error) {
+	if m.ack != nil {
+		return m.ack(ctx, ack)
+	}
+	return ack, nil
+}
+
+func (m *mockAgent) Probe(ctx context.Context, volume string) error {
+	if m.probe != nil {
+		return m.probe(ctx, volume)
+	}
+	return nil
+}
+
+func (m *mockAgent) Cancel(ctx context.Context, sessionID string) error {
+	if m.cancel != nil {
+		return m.cancel(ctx, sessionID)
+	}
+	return nil
+}
+
+func (m *mockAgent) Progress(ctx context.Context, sessionID string) (<-chan *proto.Progress, error) {
+	if m.progress != nil {
+		return m.progress(ctx, sessionID)
+	}
+	ch := make(chan *proto.Progress)
+	close(ch)
+	return ch, nil
+}
+
+func (m *mockAgent) BuildManifest(ctx context.Context, sessionID string) error {
+	if m.buildManifest != nil {
+		return m.buildManifest(ctx, sessionID)
+	}
+	return nil
+}
+
+func (m *mockAgent) Verify(ctx context.Context, sessionID string) error {
+	if m.verify != nil {
+		return m.verify(ctx, sessionID)
+	}
+	return nil
+}
+
 func newClient(t *testing.T, cfg Config, agent lvmagent.Agent, creds credentials.TransportCredentials) (proto.ReplicationClient, func()) {
 	t.Helper()
 	lis := bufconn.Listen(bufSize)
-	srv, err := New(cfg, agent)
+	srv, srvCleanup, err := New(cfg, agent, zap.NewNop())
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -107,6 +183,7 @@ func newClient(t *testing.T, cfg Config, agent lvmagent.Agent, creds credentials
 			t.Errorf("conn.Close: %v", err)
 		}
 		srv.Stop()
+		srvCleanup()
 	}
 	return proto.NewReplicationClient(conn), cleanup
 }
@@ -262,6 +339,239 @@ func TestGetStatus(t *testing.T) {
 	})
 }
 
+func TestSendFinalManifest(t *testing.T) {
+	cases := []testCase{
+		{"success", &mockAgent{sendManifest: func(_ context.Context, id string, m []byte) error { return nil }}, true, ""},
+		{"agent error", &mockAgent{sendManifest: func(_ context.Context, _ string, _ []byte) error { return errors.New("fail") }}, false, "fail"},
+		{"no agent", nil, false, "agent not configured"},
+	}
+	runAgentTest(t, cases, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+		return client.SendFinalManifest(ctxWithRole("replicator"), &proto.ManifestMessage{SessionId: "s", Manifest: []byte("{}")})
+	})
+}
+
+func TestFinalize(t *testing.T) {
+	cases := []testCase{
+		{"success", &mockAgent{finalizeSess: func(_ context.Context, _ string) error { return nil }}, true, ""},
+		{"agent error", &mockAgent{finalizeSess: func(_ context.Context, _ string) error { return errors.New("fail") }}, false, "fail"},
+		{"no agent", nil, false, "agent not configured"},
+	}
+	runAgentTest(t, cases, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+		return client.Finalize(ctxWithRole("replicator"), &proto.FinalizeRequest{SessionId: "s"})
+	})
+}
+
+func TestProbe(t *testing.T) {
+	cases := []testCase{
+		{"success", &mockAgent{probe: func(_ context.Context, _ string) error { return nil }}, true, ""},
+		{"agent error", &mockAgent{probe: func(_ context.Context, _ string) error { return errors.New("fail") }}, false, "fail"},
+		{"no agent", nil, false, "agent not configured"},
+	}
+	runAgentTest(t, cases, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+		return client.Probe(ctxWithRole("replicator"), &proto.ProbeRequest{VolumeName: "vol"})
+	})
+}
+
+func TestStartSync(t *testing.T) {
+	cases := []testCase{
+		{"success", &mockAgent{startSess: func(_ context.Context, _, _ string) error { return nil }}, true, ""},
+		{"agent error", &mockAgent{startSess: func(_ context.Context, _, _ string) error { return errors.New("fail") }}, false, "fail"},
+		{"no agent", nil, false, "agent not configured"},
+	}
+	runAgentTest(t, cases, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+		return client.StartSync(ctxWithRole("replicator"), &proto.StartSyncRequest{VolumeName: "vol", Requester: "req"})
+	})
+}
+
+func TestCancel(t *testing.T) {
+	cases := []testCase{
+		{"success", &mockAgent{cancel: func(_ context.Context, _ string) error { return nil }}, true, ""},
+		{"agent error", &mockAgent{cancel: func(_ context.Context, _ string) error { return errors.New("fail") }}, false, "fail"},
+		{"no agent", nil, false, "agent not configured"},
+	}
+	runAgentTest(t, cases, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+		return client.Cancel(ctxWithRole("replicator"), &proto.CancelRequest{SessionId: "s"})
+	})
+}
+
+func TestBuildManifest(t *testing.T) {
+	cases := []testCase{
+		{"success", &mockAgent{buildManifest: func(_ context.Context, _ string) error { return nil }}, true, ""},
+		{"agent error", &mockAgent{buildManifest: func(_ context.Context, _ string) error { return errors.New("fail") }}, false, "fail"},
+		{"no agent", nil, false, "agent not configured"},
+	}
+	runAgentTest(t, cases, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+		return client.BuildManifest(ctxWithRole("replicator"), &proto.BuildManifestRequest{SessionId: "s"})
+	})
+}
+
+func TestVerify(t *testing.T) {
+	cases := []testCase{
+		{"success", &mockAgent{verify: func(_ context.Context, _ string) error { return nil }}, true, ""},
+		{"agent error", &mockAgent{verify: func(_ context.Context, _ string) error { return errors.New("fail") }}, false, "fail"},
+		{"no agent", nil, false, "agent not configured"},
+	}
+	runAgentTest(t, cases, func(client proto.ReplicationClient) (*proto.StatusResponse, error) {
+		return client.Verify(ctxWithRole("replicator"), &proto.VerifyRequest{SessionId: "s"})
+	})
+}
+
+func TestSendResumeBitmap(t *testing.T) {
+	ctx := ctxWithRole("replicator")
+	t.Run("success", func(t *testing.T) {
+		agent := &mockAgent{sendBitmap: func(_ context.Context, id string, _ []byte) error {
+			if id != "s" {
+				t.Fatalf("unexpected id %s", id)
+			}
+			return nil
+		}}
+		client, cleanup := newInsecureClient(t, agent)
+		defer cleanup()
+		stream, err := client.SendResumeBitmap(ctx)
+		if err != nil {
+			t.Fatalf("SendResumeBitmap: %v", err)
+		}
+		if err := stream.Send(&proto.ResumeBitmap{SessionId: "s", Bitmap: []byte{1}}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		if _, err := stream.CloseAndRecv(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	})
+
+	t.Run("agent error", func(t *testing.T) {
+		agent := &mockAgent{sendBitmap: func(_ context.Context, _ string, _ []byte) error { return errors.New("fail") }}
+		client, cleanup := newInsecureClient(t, agent)
+		defer cleanup()
+		stream, err := client.SendResumeBitmap(ctx)
+		if err != nil {
+			t.Fatalf("SendResumeBitmap: %v", err)
+		}
+		if err := stream.Send(&proto.ResumeBitmap{SessionId: "s", Bitmap: []byte{1}}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		if _, err := stream.CloseAndRecv(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("no agent", func(t *testing.T) {
+		client, cleanup := newInsecureClient(t, nil)
+		defer cleanup()
+		stream, err := client.SendResumeBitmap(ctx)
+		if err != nil {
+			t.Fatalf("SendResumeBitmap: %v", err)
+		}
+		if err := stream.Send(&proto.ResumeBitmap{SessionId: "s", Bitmap: []byte{1}}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		if _, err := stream.CloseAndRecv(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestAckStream(t *testing.T) {
+	ctx := ctxWithRole("replicator")
+	t.Run("success", func(t *testing.T) {
+		agent := &mockAgent{ack: func(_ context.Context, ack *proto.Ack) (*proto.Ack, error) { return ack, nil }}
+		client, cleanup := newInsecureClient(t, agent)
+		defer cleanup()
+		stream, err := client.AckStream(ctx)
+		if err != nil {
+			t.Fatalf("AckStream: %v", err)
+		}
+		if err := stream.Send(&proto.Ack{SessionId: "s", Ok: true}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		if _, err := stream.Recv(); err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+	})
+
+	t.Run("agent error", func(t *testing.T) {
+		agent := &mockAgent{ack: func(_ context.Context, _ *proto.Ack) (*proto.Ack, error) { return nil, errors.New("fail") }}
+		client, cleanup := newInsecureClient(t, agent)
+		defer cleanup()
+		stream, err := client.AckStream(ctx)
+		if err != nil {
+			t.Fatalf("AckStream: %v", err)
+		}
+		if err := stream.Send(&proto.Ack{SessionId: "s"}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		if _, err := stream.Recv(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("no agent", func(t *testing.T) {
+		client, cleanup := newInsecureClient(t, nil)
+		defer cleanup()
+		stream, err := client.AckStream(ctx)
+		if err != nil {
+			t.Fatalf("AckStream: %v", err)
+		}
+		if err := stream.Send(&proto.Ack{SessionId: "s"}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		if _, err := stream.Recv(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestProgressStream(t *testing.T) {
+	ctx := ctxWithRole("replicator")
+	t.Run("success", func(t *testing.T) {
+		ch := make(chan *proto.Progress, 1)
+		ch <- &proto.Progress{SessionId: "s", Completed: 1, Total: 2}
+		close(ch)
+		agent := &mockAgent{progress: func(_ context.Context, id string) (<-chan *proto.Progress, error) {
+			if id != "s" {
+				t.Fatalf("unexpected id %s", id)
+			}
+			return ch, nil
+		}}
+		client, cleanup := newInsecureClient(t, agent)
+		defer cleanup()
+		stream, err := client.ProgressStream(ctx, &proto.ProgressRequest{SessionId: "s"})
+		if err != nil {
+			t.Fatalf("ProgressStream: %v", err)
+		}
+		if _, err := stream.Recv(); err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+	})
+
+	t.Run("agent error", func(t *testing.T) {
+		agent := &mockAgent{progress: func(_ context.Context, _ string) (<-chan *proto.Progress, error) {
+			return nil, errors.New("fail")
+		}}
+		client, cleanup := newInsecureClient(t, agent)
+		defer cleanup()
+		stream, err := client.ProgressStream(ctx, &proto.ProgressRequest{SessionId: "s"})
+		if err != nil {
+			t.Fatalf("ProgressStream: %v", err)
+		}
+		if _, err := stream.Recv(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("no agent", func(t *testing.T) {
+		client, cleanup := newInsecureClient(t, nil)
+		defer cleanup()
+		stream, err := client.ProgressStream(ctx, &proto.ProgressRequest{SessionId: "s"})
+		if err != nil {
+			t.Fatalf("ProgressStream: %v", err)
+		}
+		if _, err := stream.Recv(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
 func generateTLS(t *testing.T) (Config, *tls.Config, *tls.Config) {
 	ca := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
@@ -370,7 +680,8 @@ func TestMTLSValidation(t *testing.T) {
 }
 
 func TestSessionFlow(t *testing.T) {
-	client, cleanup := newInsecureClient(t, nil)
+	agent := &mockAgent{sendBitmap: func(_ context.Context, _ string, _ []byte) error { return nil }, sendManifest: func(_ context.Context, _ string, _ []byte) error { return nil }, finalizeSess: func(_ context.Context, _ string) error { return nil }, ack: func(_ context.Context, a *proto.Ack) (*proto.Ack, error) { return a, nil }}
+	client, cleanup := newInsecureClient(t, agent)
 	defer cleanup()
 	ctx := ctxWithRole("replicator")
 	hsResp, err := client.Handshake(ctx, &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: 1})
@@ -422,10 +733,9 @@ func TestHandshakeFailure(t *testing.T) {
 }
 
 func TestNewRPCPermissions(t *testing.T) {
-	client, cleanup := newInsecureClient(t, nil)
-	defer cleanup()
-
 	t.Run("probe", func(t *testing.T) {
+		client, cleanup := newInsecureClient(t, nil)
+		defer cleanup()
 		if _, err := client.Probe(ctxWithRole("replicator"), &proto.ProbeRequest{VolumeName: "vol"}); err != nil {
 			t.Fatalf("Probe: %v", err)
 		}
@@ -452,6 +762,8 @@ func TestNewRPCPermissions(t *testing.T) {
 	})
 
 	t.Run("cancel", func(t *testing.T) {
+		client, cleanup := newInsecureClient(t, nil)
+		defer cleanup()
 		if _, err := client.Cancel(ctxWithRole("replicator"), &proto.CancelRequest{SessionId: "s"}); err != nil {
 			t.Fatalf("Cancel: %v", err)
 		}
@@ -461,6 +773,14 @@ func TestNewRPCPermissions(t *testing.T) {
 	})
 
 	t.Run("progress", func(t *testing.T) {
+		agent := &mockAgent{progress: func(_ context.Context, _ string) (<-chan *proto.Progress, error) {
+			ch := make(chan *proto.Progress, 1)
+			ch <- &proto.Progress{SessionId: "s"}
+			close(ch)
+			return ch, nil
+		}}
+		client, cleanup := newInsecureClient(t, agent)
+		defer cleanup()
 		stream, err := client.ProgressStream(ctxWithRole("replicator"), &proto.ProgressRequest{SessionId: "s"})
 		if err != nil {
 			t.Fatalf("ProgressStream: %v", err)
@@ -477,6 +797,8 @@ func TestNewRPCPermissions(t *testing.T) {
 	})
 
 	t.Run("buildmanifest", func(t *testing.T) {
+		client, cleanup := newInsecureClient(t, nil)
+		defer cleanup()
 		if _, err := client.BuildManifest(ctxWithRole("replicator"), &proto.BuildManifestRequest{SessionId: "s"}); err != nil {
 			t.Fatalf("BuildManifest: %v", err)
 		}
@@ -486,6 +808,8 @@ func TestNewRPCPermissions(t *testing.T) {
 	})
 
 	t.Run("verify", func(t *testing.T) {
+		client, cleanup := newInsecureClient(t, nil)
+		defer cleanup()
 		if _, err := client.Verify(ctxWithRole("replicator"), &proto.VerifyRequest{SessionId: "s"}); err != nil {
 			t.Fatalf("Verify: %v", err)
 		}
@@ -497,7 +821,13 @@ func TestNewRPCPermissions(t *testing.T) {
 
 func TestNewRPCsMTLS(t *testing.T) {
 	cfg, good, bad := generateTLS(t)
-	client, cleanup := newClient(t, cfg, nil, credentials.NewTLS(good))
+	agent := &mockAgent{progress: func(_ context.Context, _ string) (<-chan *proto.Progress, error) {
+		ch := make(chan *proto.Progress, 1)
+		ch <- &proto.Progress{SessionId: "s"}
+		close(ch)
+		return ch, nil
+	}}
+	client, cleanup := newClient(t, cfg, agent, credentials.NewTLS(good))
 	defer cleanup()
 	ctx := ctxWithRole("replicator")
 	if _, err := client.Probe(ctx, &proto.ProbeRequest{VolumeName: "vol"}); err != nil {
@@ -533,7 +863,7 @@ func TestNewRPCsMTLS(t *testing.T) {
 func TestPlaintextRejected(t *testing.T) {
 	cfg, _, _ := generateTLS(t)
 	lis := bufconn.Listen(bufSize)
-	srv, err := New(cfg, nil)
+	srv, srvCleanup, err := New(cfg, nil, zap.NewNop())
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -549,6 +879,7 @@ func TestPlaintextRejected(t *testing.T) {
 	}
 	conn.Close()
 	srv.Stop()
+	srvCleanup()
 }
 
 func dummyCert(t *testing.T) []byte {
@@ -571,7 +902,7 @@ func TestNewTLSFailures(t *testing.T) {
 	t.Run("missing cert", func(t *testing.T) {
 		bad := cfg
 		bad.TLSCert = ""
-		if _, err := New(bad, nil); err == nil {
+		if _, _, err := New(bad, nil, zap.NewNop()); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -579,7 +910,7 @@ func TestNewTLSFailures(t *testing.T) {
 	t.Run("missing key", func(t *testing.T) {
 		bad := cfg
 		bad.TLSKey = ""
-		if _, err := New(bad, nil); err == nil {
+		if _, _, err := New(bad, nil, zap.NewNop()); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -587,7 +918,7 @@ func TestNewTLSFailures(t *testing.T) {
 	t.Run("missing CA", func(t *testing.T) {
 		bad := cfg
 		bad.CACert = ""
-		if _, err := New(bad, nil); err == nil {
+		if _, _, err := New(bad, nil, zap.NewNop()); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -599,7 +930,7 @@ func TestNewTLSFailures(t *testing.T) {
 			t.Fatalf("WriteFile: %v", err)
 		}
 		bad.CACert = invalid
-		if _, err := New(bad, nil); err == nil {
+		if _, _, err := New(bad, nil, zap.NewNop()); err == nil {
 			t.Fatalf("expected error")
 		}
 	})


### PR DESCRIPTION
## Summary
- wire replication RPC handlers to underlying agent with context-aware streaming and logging
- add zap-based server initialization with cleanup
- expand test coverage for replication RPCs across success and error paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e130be8fc83238d58f103a84cdf60