### PR TITLE
test(verify): use manifest_path flag in success test

### DIFF
--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -121,7 +121,7 @@ func TestVerifyManifestSuccess(t *testing.T) {
 	if err := manifest.Rebuild(src, manPath); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
-	if err := Run([]string{"--manifest", manPath, src, src}, zap.NewNop()); err != nil {
+	if err := Run([]string{"--manifest_path", manPath, src, src}, zap.NewNop()); err != nil {
 		t.Fatalf("verify manifest success: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- fix TestVerifyManifestSuccess to reference manifest_path flag

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`
- `go test ./cmd/verify`


------
https://chatgpt.com/codex/tasks/task_e_689e1ab5a0ac8323991f32ed2b7042c3