### PR TITLE
test(grpc): expect send error without agent

### DIFF
--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -462,11 +462,16 @@ func TestSendResumeBitmap(t *testing.T) {
 		if err != nil {
 			t.Fatalf("SendResumeBitmap: %v", err)
 		}
-		if err := stream.Send(&proto.ResumeBitmap{SessionId: "s", Bitmap: []byte{1}}); err != nil {
-			t.Fatalf("send: %v", err)
-		}
-		if _, err := stream.CloseAndRecv(); err == nil {
+		// The server should close immediately when no agent is configured.
+		// The send should therefore return a non-nil error without needing to
+		// call CloseAndRecv.
+		time.Sleep(50 * time.Millisecond)
+		err = stream.Send(&proto.ResumeBitmap{SessionId: "s", Bitmap: []byte{1}})
+		if err == nil {
 			t.Fatalf("expected error")
+		}
+		if status.Code(err) == codes.OK {
+			t.Fatalf("unexpected OK code")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- ensure SendResumeBitmap returns an error when no agent is configured

## Testing
- `go build ./...`
- `go test ./grpc/server`
- `go test -coverprofile=coverage.out ./...` *(fails: unknown flag: --manifest in cmd/verify)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e1ac745948323bfbebb631d358558