### PR TITLE
docs: replace manifest flag with manifest_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ lvmsync verify --dry-run /dev/vg0/source /dev/vg1/target
 To verify using 4 KiB blocks and a manifest generated earlier:
 
 ```sh
-lvmsync verify --block_size 4K --manifest snapshot.manifest /dev/vg0/source /dev/vg1/target
+lvmsync verify --block_size 4K --manifest_path snapshot.manifest /dev/vg0/source /dev/vg1/target
 ```
 
 Flags are parsed via Viper, so the same settings can be provided through

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -121,7 +121,7 @@ func TestVerifyManifestSuccess(t *testing.T) {
 	if err := manifest.Rebuild(src, manPath); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
-	if err := Run([]string{"--manifest", manPath, src, src}, zap.NewNop()); err != nil {
-		t.Fatalf("verify manifest success: %v", err)
-	}
+        if err := Run([]string{"--manifest_path", manPath, src, src}, zap.NewNop()); err != nil {
+                t.Fatalf("verify manifest success: %v", err)
+        }
 }

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -50,7 +50,7 @@ lvmsync manifest rebuild /dev/vg0/lv0
 Use a manifest to verify that a source and destination match:
 
 ```sh
-lvmsync verify --manifest snapshot.manifest /dev/vg0/snap0 /dev/null
+lvmsync verify --manifest_path snapshot.manifest /dev/vg0/snap0 /dev/null
 ```
 
 ### Flags

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -15,7 +15,7 @@ lvmsync verify /dev/vg0/source /dev/vg1/target
 Restrict verification to ranges recorded in a manifest and use 4 KiB blocks:
 
 ```sh
-lvmsync verify --block_size 4K --manifest snapshot.manifest /dev/vg0/source /dev/vg1/target
+lvmsync verify --block_size 4K --manifest_path snapshot.manifest /dev/vg0/source /dev/vg1/target
 ```
 
 All flags can also be provided via `LVMSYNC_*` environment variables or a


### PR DESCRIPTION
## Summary
- use `--manifest_path` in README and docs examples
- adjust verify test to match new flag name

## Testing
- `go build -v ./...`
- `go test -count=1 -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`
- `npx -y markdownlint-cli README.md docs/manifest.md docs/verify.md` *(fails: README lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e1adcef488323b82ded69e11d9abc