### PR TITLE
feat(cli): estimate dry-run transfer using manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ for `run` and `verify` are provided as positional arguments after any flags:
 lvmsync run [flags] <source> <dest>
 ```
 
+When run with `--dry-run`, LVMSync loads any manifest at `--manifest_path` and samples up to 100 blocks to estimate the bytes that would be transmitted. The estimate and ETA are logged without sending data.
+
 ### Examples
 
 Set the `parallel` worker count using any configuration source:

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -2,15 +2,19 @@ package lvmsync
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
 	"go.uber.org/zap"
 
 	verifycmd "lvmsync_go/cmd/verify"
 	"lvmsync_go/config"
+	"lvmsync_go/manifest"
 )
 
 // RunOptions collects flags for the run command.
@@ -53,7 +57,9 @@ func NewRootCmd() *cobra.Command {
 				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
 			}
 			if cfg.DryRun {
-				if err := estimateTransfer(remaining[0], cfg); err != nil {
+				logger := zap.NewExample()
+				defer logger.Sync()
+				if err := estimateTransfer(remaining[0], cfg, logger); err != nil {
 					return err
 				}
 				return nil
@@ -118,18 +124,76 @@ func Execute(args []string) error {
 	return cmd.Execute()
 }
 
-func estimateTransfer(src string, cfg *config.Config) error {
+func estimateTransfer(src string, cfg *config.Config, logger *zap.Logger) error {
 	info, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("stat source: %w", err)
 	}
 	size := info.Size()
+	// No manifest provided; estimate full size.
+	if cfg.ManifestPath == "" {
+		var eta time.Duration
+		if cfg.SpeedLimit > 0 {
+			eta = time.Duration(size/int64(cfg.SpeedLimit)) * time.Second
+		}
+		logger.Info("dry run", zap.Int64("size_bytes", size), zap.Int64("estimated_tx_bytes", size), zap.Duration("eta", eta))
+		return nil
+	}
+
+	idx, err := manifest.Open(cfg.ManifestPath)
+	if err != nil {
+		return fmt.Errorf("open manifest: %w", err)
+	}
+	defer idx.Close()
+
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer f.Close()
+
+	chunks := idx.ChunkCount()
+	samples := chunks
+	if samples > 100 {
+		samples = 100
+	}
+	step := 1
+	if samples > 0 && chunks > samples {
+		step = chunks / samples
+	}
+
+	changed := 0
+	for i := 0; i < samples; i++ {
+		idxPos := i * step
+		if idxPos >= chunks {
+			idxPos = chunks - 1
+		}
+		off, length, _, _ := idx.Entry(idxPos)
+		buf := make([]byte, length)
+		n, err := f.ReadAt(buf, int64(off))
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("read source: %w", err)
+		}
+		data := buf[:n]
+		xx := xxh3.Hash(data)
+		digest := blake3.Sum256(data)
+		if !idx.Match(off, uint32(n), xx, func() [32]byte { return digest }) {
+			changed++
+		}
+		if err == io.EOF {
+			break
+		}
+	}
+
+	ratio := float64(changed)
+	if samples > 0 {
+		ratio /= float64(samples)
+	}
+	est := int64(ratio * float64(size))
 	var eta time.Duration
 	if cfg.SpeedLimit > 0 {
-		eta = time.Duration(size/int64(cfg.SpeedLimit)) * time.Second
+		eta = time.Duration(est/int64(cfg.SpeedLimit)) * time.Second
 	}
-	logger := zap.NewExample()
-	defer logger.Sync()
-	logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
+	logger.Info("dry run", zap.Int64("size_bytes", size), zap.Int("sampled_blocks", samples), zap.Int("changed_blocks", changed), zap.Int64("estimated_tx_bytes", est), zap.Duration("eta", eta))
 	return nil
 }

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -5,6 +5,13 @@ import (
 	"testing"
 
 	verifycmd "lvmsync_go/cmd/verify"
+	"lvmsync_go/config"
+	"lvmsync_go/manifest"
+
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestRunCommandExecutes(t *testing.T) {
@@ -105,5 +112,52 @@ func TestVerifyRoutes(t *testing.T) {
 	}
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Fatalf("unexpected args %v", got)
+	}
+}
+
+func TestEstimateTransferWithManifest(t *testing.T) {
+	dir := t.TempDir()
+	src := dir + "/src"
+	// two 4-byte blocks; second block differs from manifest
+	if err := os.WriteFile(src, []byte("aaaacccc"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	manifestPath := dir + "/manifest"
+	idx, err := manifest.Create(manifestPath, "id", 8, 4)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+	xx0 := xxh3.Hash([]byte("aaaa"))
+	d0 := blake3.Sum256([]byte("aaaa"))
+	idx.Set(0, 4, xx0, d0)
+	xx1 := xxh3.Hash([]byte("bbbb"))
+	d1 := blake3.Sum256([]byte("bbbb"))
+	idx.Set(4, 4, xx1, d1)
+	idx.Close()
+
+	cfg := &config.Config{ManifestPath: manifestPath}
+	core, obs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	if err := estimateTransfer(src, cfg, logger); err != nil {
+		t.Fatalf("estimate transfer: %v", err)
+	}
+	logs := obs.All()
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+	v := logs[0].ContextMap()["estimated_tx_bytes"].(int64)
+	if v != 4 {
+		t.Fatalf("expected 4 estimated bytes, got %d", v)
+	}
+}
+
+func TestEstimateTransferMissingManifest(t *testing.T) {
+	src := t.TempDir() + "/src"
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	cfg := &config.Config{ManifestPath: src + "-missing"}
+	if err := estimateTransfer(src, cfg, zap.NewNop()); err == nil {
+		t.Fatalf("expected error for missing manifest")
 	}
 }


### PR DESCRIPTION
## Summary
- sample existing manifest blocks to estimate transfer size during dry-run
- accept a zap logger for transfer estimation
- document manifest-based dry-run behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e233a69f88323a21eb06e070320b4