### PR TITLE
Inject logger into dry-run estimation

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -53,7 +53,9 @@ func NewRootCmd() *cobra.Command {
 				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
 			}
 			if cfg.DryRun {
-				if err := estimateTransfer(remaining[0], cfg); err != nil {
+				logger := zap.NewExample()
+				defer logger.Sync()
+				if err := estimateTransfer(remaining[0], cfg, logger); err != nil {
 					return err
 				}
 				return nil
@@ -118,7 +120,7 @@ func Execute(args []string) error {
 	return cmd.Execute()
 }
 
-func estimateTransfer(src string, cfg *config.Config) error {
+func estimateTransfer(src string, cfg *config.Config, logger *zap.Logger) error {
 	info, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("stat source: %w", err)
@@ -128,8 +130,6 @@ func estimateTransfer(src string, cfg *config.Config) error {
 	if cfg.SpeedLimit > 0 {
 		eta = time.Duration(size/int64(cfg.SpeedLimit)) * time.Second
 	}
-	logger := zap.NewExample()
-	defer logger.Sync()
 	logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
 	return nil
 }

--- a/cmd/lvmsync/estimate_test.go
+++ b/cmd/lvmsync/estimate_test.go
@@ -1,0 +1,49 @@
+package lvmsync
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/config"
+)
+
+func TestEstimateTransferSuccess(t *testing.T) {
+	src := t.TempDir() + "/src"
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	defer logger.Sync()
+	cfg := &config.Config{}
+	if err := estimateTransfer(src, cfg, logger); err != nil {
+		t.Fatalf("estimate transfer: %v", err)
+	}
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", logs.Len())
+	}
+	entry := logs.All()[0]
+	if entry.Message != "dry run" {
+		t.Fatalf("unexpected log message %q", entry.Message)
+	}
+	if size := entry.ContextMap()["size_bytes"]; size != int64(4) {
+		t.Fatalf("unexpected size %v", size)
+	}
+}
+
+func TestEstimateTransferInvalidPath(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	defer logger.Sync()
+	err := estimateTransfer("/does/not/exist", &config.Config{}, logger)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "stat source") {
+		t.Fatalf("unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow dry-run estimation to accept a logger
- test dry-run estimate success and invalid path

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e233bad048323aa62fd13d4f8909f