### PR TITLE
fix(transport): conditional error logging

### DIFF
--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -94,26 +94,29 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	qconn, err := quic.DialAddr(ctx, address, t.clientTLS, t.qconf)
 	if err != nil {
-		t.logger.Info("dial_end",
+		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
-		)
+		}
+		fields = append(fields, zap.Error(err))
+		t.logger.Info("dial_end", fields...)
 		return nil, err
 	}
 	stream, err := qconn.OpenStreamSync(ctx)
-	t.logger.Info("dial_end",
+	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", errString(err)),
-	)
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	t.logger.Info("dial_end", fields...)
 	if err != nil {
 		qconn.CloseWithError(0, err.Error())
 		return nil, err
@@ -128,16 +131,18 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	ql, err := quic.ListenAddr(address, t.serverTLS, t.qconf)
-	t.logger.Info("listen_end",
+	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", errString(err)),
-	)
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	t.logger.Info("listen_end", fields...)
 	if err != nil {
 		return nil, err
 	}
@@ -170,16 +175,18 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		zap.String("address", address),
 		zap.String("role", roleStr),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	defer func() {
-		t.logger.Info("negotiate_end",
+		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", roleStr),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
-		)
+		}
+		if err != nil {
+			fields = append(fields, zap.Error(err))
+		}
+		t.logger.Info("negotiate_end", fields...)
 	}()
 
 	hs.Version = common.ProtocolVersion
@@ -245,13 +252,6 @@ func (c *Conn) SetDeadline(t time.Time) error {
 }
 func (c *Conn) SetReadDeadline(t time.Time) error  { return c.stream.SetReadDeadline(t) }
 func (c *Conn) SetWriteDeadline(t time.Time) error { return c.stream.SetWriteDeadline(t) }
-
-func errString(err error) string {
-	if err == nil {
-		return ""
-	}
-	return err.Error()
-}
 
 func roleString(r transport.Role) string {
 	switch r {

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -11,16 +11,21 @@ import (
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
 	}
 	ctx := entries[0].ContextMap()
-	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+	for _, k := range []string{"address", "role", "duration_ms"} {
 		if _, ok := ctx[k]; !ok {
 			t.Fatalf("expected field %q in %s log", k, msg)
 		}
+	}
+	if _, ok := ctx["error"]; wantErr && !ok {
+		t.Fatalf("expected error field in %s log", msg)
+	} else if !wantErr && ok {
+		t.Fatalf("unexpected error field in %s log", msg)
 	}
 }
 
@@ -76,12 +81,12 @@ func TestQUICTransportHandshake(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 2)
-	checkLogFields(t, logs, "negotiate_end", 2)
+	checkLogFields(t, logs, "dial_start", 1, false)
+	checkLogFields(t, logs, "dial_end", 1, false)
+	checkLogFields(t, logs, "listen_start", 1, false)
+	checkLogFields(t, logs, "listen_end", 1, false)
+	checkLogFields(t, logs, "negotiate_start", 2, false)
+	checkLogFields(t, logs, "negotiate_end", 2, false)
 }
 
 func TestQUICTransportHandshakeError(t *testing.T) {
@@ -122,12 +127,12 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 1)
-	checkLogFields(t, logs, "negotiate_end", 1)
+	checkLogFields(t, logs, "dial_start", 1, false)
+	checkLogFields(t, logs, "dial_end", 1, false)
+	checkLogFields(t, logs, "listen_start", 1, false)
+	checkLogFields(t, logs, "listen_end", 1, false)
+	checkLogFields(t, logs, "negotiate_start", 1, false)
+	checkLogFields(t, logs, "negotiate_end", 1, true)
 }
 
 func TestQUICTransportRequiresLogger(t *testing.T) {

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -67,17 +67,19 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	d := net.Dialer{}
 	conn, err := tls.DialWithDialer(&d, "tcp", address, t.clientConf)
-	t.logger.Info("dial_end",
+	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", errString(err)),
-	)
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	t.logger.Info("dial_end", fields...)
 	return conn, err
 }
 
@@ -87,19 +89,21 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	ln, err := net.Listen("tcp", address)
 	if err == nil {
 		ln = tls.NewListener(ln, t.serverConf)
 	}
-	t.logger.Info("listen_end",
+	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", errString(err)),
-	)
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	t.logger.Info("listen_end", fields...)
 	return ln, err
 }
 
@@ -110,16 +114,18 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		zap.String("address", address),
 		zap.String("role", roleStr),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	defer func() {
-		t.logger.Info("negotiate_end",
+		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", roleStr),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
-		)
+		}
+		if err != nil {
+			fields = append(fields, zap.Error(err))
+		}
+		t.logger.Info("negotiate_end", fields...)
 	}()
 
 	hs.Version = common.ProtocolVersion
@@ -154,13 +160,6 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	default:
 		return peer, nil
 	}
-}
-
-func errString(err error) string {
-	if err == nil {
-		return ""
-	}
-	return err.Error()
 }
 
 func roleString(r transport.Role) string {

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -13,16 +13,21 @@ import (
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
 	}
 	ctx := entries[0].ContextMap()
-	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+	for _, k := range []string{"address", "role", "duration_ms"} {
 		if _, ok := ctx[k]; !ok {
 			t.Fatalf("expected field %q in %s log", k, msg)
 		}
+	}
+	if _, ok := ctx["error"]; wantErr && !ok {
+		t.Fatalf("expected error field in %s log", msg)
+	} else if !wantErr && ok {
+		t.Fatalf("unexpected error field in %s log", msg)
 	}
 }
 
@@ -91,12 +96,12 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 2)
-	checkLogFields(t, logs, "negotiate_end", 2)
+	checkLogFields(t, logs, "dial_start", 1, false)
+	checkLogFields(t, logs, "dial_end", 1, false)
+	checkLogFields(t, logs, "listen_start", 1, false)
+	checkLogFields(t, logs, "listen_end", 1, false)
+	checkLogFields(t, logs, "negotiate_start", 2, false)
+	checkLogFields(t, logs, "negotiate_end", 2, false)
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {
@@ -140,12 +145,12 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 1)
-	checkLogFields(t, logs, "negotiate_end", 1)
+	checkLogFields(t, logs, "dial_start", 1, false)
+	checkLogFields(t, logs, "dial_end", 1, false)
+	checkLogFields(t, logs, "listen_start", 1, false)
+	checkLogFields(t, logs, "listen_end", 1, false)
+	checkLogFields(t, logs, "negotiate_start", 1, false)
+	checkLogFields(t, logs, "negotiate_end", 1, true)
 }
 
 func TestTCPTLSCertValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
- log `zap.Error` only when non-nil in QUIC and TCP+TLS transports
- remove placeholder error fields from start logs
- add tests verifying presence of error field only on failures

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e233f2f9083238042d155eac6ad10