### PR TITLE
feat(transport): require tls roots or allow insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,9 @@ lvmsync run --config config.yaml /dev/vg0/snap0 /mnt/backup
 Transport selection is controlled by the `--transport` flag, which accepts a comma-separated ordered list of
 transports to attempt (for example `quic,h2,tcp+tls,ssh`). The `quic` transport runs over TLS 1.3 with mutual
 authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional streams and datagrams. Provide
-certificates via `--tls_cert`, `--tls_key`, and `--ca_cert`. The flags below configure transport behavior.
+certificates via `--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and
+will refuse connections when no roots are provided unless `--allow_insecure` (or the `AllowInsecure` configuration
+flag) is set. The flags below configure transport behavior.
 
 ### Flags and environment variables
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -15,6 +15,10 @@ TLS based transports enable mutual TLS by default and restrict cipher suites to
 `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, and
 `TLS_CHACHA20_POLY1305_SHA256`.
 
+TLS transports require an explicit set of trusted CA roots. Connections are
+rejected if no roots are provided unless the transport configuration sets
+`AllowInsecure` to skip verification.
+
 ## QUIC
 
 - Uses [quic-go](https://github.com/quic-go/quic-go)

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -210,7 +210,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 	writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
 
 	ctx := context.Background()
-	tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop()})
+	tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("get transport: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 			writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
 
 			ctx := context.Background()
-			tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop()})
+			tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
 			if err != nil {
 				t.Fatalf("get transport: %v", err)
 			}
@@ -468,7 +468,11 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 			writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
 
 			ctx := context.Background()
-			tr, err := transport.Get(transportName, transport.Config{Logger: zap.NewNop()})
+			tcfg := transport.Config{Logger: zap.NewNop()}
+			if transportName == "tcp+tls" {
+				tcfg.AllowInsecure = true
+			}
+			tr, err := transport.Get(transportName, tcfg)
 			if err != nil {
 				t.Fatalf("get transport: %v", err)
 			}

--- a/transport/config.go
+++ b/transport/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 // Config carries shared transport configuration such as TLS roots,
-// client certificates, and logger.
+// client certificates, logger, and security policy.
 // Fields may be nil/zero when not applicable to a transport.
 type Config struct {
-	Roots      *x509.CertPool
-	ClientCert tls.Certificate
-	Logger     *zap.Logger
+	Roots         *x509.CertPool
+	ClientCert    tls.Certificate
+	Logger        *zap.Logger
+	AllowInsecure bool
 }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -49,6 +49,9 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
 		return nil, fmt.Errorf("logger is required")
 	}
+	if cfg.Roots == nil && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")
+	}
 	cert := cfg.ClientCert
 	if len(cert.Certificate) == 0 {
 		var err error
@@ -58,7 +61,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		}
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
-	if cfg.Roots == nil {
+	if cfg.AllowInsecure {
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverTLS := &tls.Config{
@@ -71,7 +74,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	clientTLS := &tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		RootCAs:            cfg.Roots,
-		InsecureSkipVerify: cfg.Roots == nil,
+		InsecureSkipVerify: cfg.AllowInsecure,
 		MinVersion:         tls.VersionTLS13,
 		NextProtos:         []string{alpn},
 	}

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -26,7 +26,7 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 
 func TestQUICTransportHandshake(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	trIface, err := New(transport.Config{Logger: zap.New(core), AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestQUICTransportHandshake(t *testing.T) {
 
 func TestQUICTransportHandshakeError(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	trIface, err := New(transport.Config{Logger: zap.New(core), AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}
@@ -133,5 +133,14 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 func TestQUICTransportRequiresLogger(t *testing.T) {
 	if _, err := New(transport.Config{}); err == nil {
 		t.Fatalf("expected error when logger is nil")
+	}
+}
+
+func TestQUICTransportRequiresRootsOrAllowInsecure(t *testing.T) {
+	if _, err := New(transport.Config{Logger: zap.NewNop()}); err == nil {
+		t.Fatalf("expected error when roots are nil without AllowInsecure")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing roots: %v", err)
 	}
 }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -30,6 +30,9 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
 		return nil, fmt.Errorf("logger is required")
 	}
+	if cfg.Roots == nil && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")
+	}
 	cert := cfg.ClientCert
 	if len(cert.Certificate) == 0 {
 		var err error
@@ -38,16 +41,20 @@ func New(cfg transport.Config) (transport.Interface, error) {
 			return nil, err
 		}
 	}
+	clientAuth := tls.RequireAndVerifyClientCert
+	if cfg.AllowInsecure {
+		clientAuth = tls.RequireAnyClientCert
+	}
 	serverConf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    cfg.Roots,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientAuth:   clientAuth,
 		MinVersion:   tls.VersionTLS13,
 	}
 	clientConf := &tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		RootCAs:            cfg.Roots,
-		InsecureSkipVerify: cfg.Roots == nil,
+		InsecureSkipVerify: cfg.AllowInsecure,
 		MinVersion:         tls.VersionTLS13,
 	}
 	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -180,3 +180,12 @@ func TestTCPTLSTransportRequiresLogger(t *testing.T) {
 		t.Fatalf("expected error when logger is nil")
 	}
 }
+
+func TestTCPTLSTransportRequiresRootsOrAllowInsecure(t *testing.T) {
+	if _, err := New(transport.Config{Logger: zap.NewNop()}); err == nil {
+		t.Fatalf("expected error when roots are nil without AllowInsecure")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing roots: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce explicit CA roots for QUIC and TCP+TLS transports unless `AllowInsecure` is set
- add `AllowInsecure` to transport.Config and update tests for the new security requirement
- document CA root requirement for TLS transports

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestSSHManagerGetClientReuse expected 1 connection, got 0)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e234270188323ae11dcc40d6ac23b