### PR TITLE
fix: log estimated transfer bytes when manifest used

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -194,6 +194,11 @@ func estimateTransfer(src string, cfg *config.Config, logger *zap.Logger) error 
 	if cfg.SpeedLimit > 0 {
 		eta = time.Duration(est/int64(cfg.SpeedLimit)) * time.Second
 	}
-	logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
+	logger.Info(
+		"dry run",
+		zap.Int64("size_bytes", size),
+		zap.Int64("estimated_tx_bytes", est),
+		zap.Duration("eta", eta),
+	)
 	return nil
 }


### PR DESCRIPTION
## Summary
- log estimated transfer bytes in dry-run manifest path

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689e2ac263588323adbdf8eed72eb5e9