### PR TITLE
feat(manifest): enforce device id length

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,9 @@ Rebuild a manifest index for an existing device:
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
 
+Manifests embed a persistent device identifier in a fixed 64-byte field. The
+`manifest rebuild` command fails if the identifier exceeds this limit.
+
 Verify that a source and destination match:
 
 ```sh

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -30,6 +30,9 @@ Each subsequent entry describes one chunk and also uses little‑endian encoding
 The header `version` field allows future format changes without breaking
 backwards compatibility.
 
+Device identifiers are stored in a fixed 64-byte field; creation fails if the
+ID exceeds this limit.
+
 ## Resume Tokens
 
 During a transfer handshake the sender may advertise a `resume:<token>` token.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -106,6 +106,9 @@ func (i *Index) Close() error {
 
 // Create initializes a new manifest index at path for the given device.
 func Create(path, deviceID string, size uint64, blockSize uint32) (*Index, error) {
+	if len(deviceID) > 64 {
+		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
+	}
 	chunkCount := (size + uint64(blockSize) - 1) / uint64(blockSize)
 	total := headerSize + entrySize*chunkCount
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/zeebo/blake3"
@@ -58,6 +59,20 @@ func TestIndexCRUD(t *testing.T) {
 	}
 	if err := idx2.Close(); err != nil {
 		t.Fatalf("close2: %v", err)
+	}
+}
+
+func TestDeviceIDLength(t *testing.T) {
+	dir := t.TempDir()
+	good := strings.Repeat("a", 64)
+	goodPath := filepath.Join(dir, "good.man")
+	if _, err := Create(goodPath, good, 4096, 4096); err != nil {
+		t.Fatalf("expected success for 64-byte id: %v", err)
+	}
+	bad := strings.Repeat("b", 65)
+	badPath := filepath.Join(dir, "bad.man")
+	if _, err := Create(badPath, bad, 4096, 4096); err == nil {
+		t.Fatalf("expected error for id >64 bytes")
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate that manifest creation fails when device id exceeds 64 bytes
- test device id length limits
- document 64 byte device id limit

## Testing
- `go build ./... && echo build-ok`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e2f0d6f7c83239c770df4c75975b0