### PR TITLE
feat(cmd/root): log block_size_bytes in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ tooling to track transfer completion.
 
 - Use `zap` for all logging and avoid `fmt.Print*` or `log.*` calls.
 - Log field keys in `snake_case` and include units where relevant (for example, `duration_ms`).
+- Provide raw byte values alongside human-readable sizes (for example, `block_size` and `block_size_bytes`).
 - Always defer `syncLogger(logger)` to flush buffers and log if the sync fails.
 
 The example below demonstrates these conventions:

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -64,6 +64,7 @@ func Configure() (*config.Config, []string, *zap.Logger, error) {
 	}
 	logger.Info("Effective configuration",
 		zap.String("block_size", cfg.HumanBlockSize()),
+		zap.Uint64("block_size_bytes", cfg.BlockSizeBytes()),
 		zap.Int("parallel", cfg.Parallel),
 		zap.String("transport", cfg.Transport),
 		zap.Int("concurrency", cfg.Concurrency),

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -1,13 +1,18 @@
 package root
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"lvmsync_go/config"
+	privilege "lvmsync_go/internal/privilege"
 	"lvmsync_go/transport"
 
 	"go.uber.org/goleak"
@@ -57,6 +62,62 @@ func TestSetupGRPCSuccess(t *testing.T) {
 	}
 	if !srvCleanCalled || !clientCleanCalled {
 		t.Fatalf("cleanup functions not called")
+	}
+}
+
+func TestConfigureLogsBlockSizeBytes(t *testing.T) {
+	origArgs := os.Args
+	os.Args = []string{origArgs[0], "--block_size", "4KB"}
+	defer func() { os.Args = origArgs }()
+
+	origCaps := privilege.HasCaps
+	privilege.HasCaps = func() bool { return true }
+	defer func() { privilege.HasCaps = origCaps }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	cfg, _, logger, err := Configure()
+	if err != nil {
+		t.Fatalf("Configure error: %v", err)
+	}
+
+	SyncLogger(logger)
+	w.Close()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	found := false
+	for scan.Scan() {
+		var m map[string]any
+		if err := json.Unmarshal(scan.Bytes(), &m); err != nil {
+			continue
+		}
+		if m["msg"] == "Effective configuration" {
+			v, ok := m["block_size_bytes"].(float64)
+			if !ok || uint64(v) != cfg.BlockSizeBytes() {
+				t.Fatalf("expected block_size_bytes %d, got %v", cfg.BlockSizeBytes(), m["block_size_bytes"])
+			}
+			if _, ok := m["block_size"].(string); !ok {
+				t.Fatalf("missing block_size")
+			}
+			found = true
+			break
+		}
+	}
+	if err := scan.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !found {
+		t.Fatalf("Effective configuration log not found")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,6 +109,22 @@ func TestHumanBlockSize(t *testing.T) {
 	}
 }
 
+func TestBlockSizeBytes(t *testing.T) {
+	cases := []struct {
+		in   int
+		want uint64
+	}{
+		{in: 0, want: 0},
+		{in: 4096, want: 4096},
+	}
+	for _, tc := range cases {
+		c := &Config{BlockSize: tc.in}
+		if got := c.BlockSizeBytes(); got != tc.want {
+			t.Fatalf("block size bytes for %d: %d", tc.in, got)
+		}
+	}
+}
+
 //nolint:revive // complex test cases handled in subtests
 func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -138,6 +138,15 @@ func (c *Config) HumanBlockSize() string {
 	return bs
 }
 
+// BlockSizeBytes returns the configured block size in bytes.
+// A zero or negative block size yields zero.
+func (c *Config) BlockSizeBytes() uint64 {
+	if c.BlockSize <= 0 {
+		return 0
+	}
+	return uint64(c.BlockSize)
+}
+
 func DefaultConfig() (*Config, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
## Summary
- log `block_size_bytes` alongside human-readable `block_size`
- test for numeric block size field in configuration logs
- document byte-valued log fields in logging guidelines

## Testing
- `go test -coverprofile=coverage.out ./...`
- `go build ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e2f0f89908323bdbd8f68627cf6c5