### PR TITLE
feat(device): add filesystem thaw command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 | Device type      | Source | Destination | Notes |
 |------------------|:------:|:-----------:|-------|
 | LVM snapshot     |   ✅   |      ❌      | snapshots are auto-created |
-| Raw block device |   ✅   |      ✅      | requires `--offline` or `--fs-freeze-command` when used as a source |
+| Raw block device |   ✅   |      ✅      | requires `--offline` or `--fs-freeze-command`/`--fs-thaw-command` when used as a source |
 | Regular file     |   ✅   |      ✅      | includes loopback images |
 
 ## Supported Platforms
@@ -249,7 +249,7 @@ examines the path to select the correct handling:
 | Type | Detection | Notes |
 |------|-----------|-------|
 | `lvm` | `/dev/<vg>/<lv>` or `/dev/mapper/<vg>-<lv>` | A snapshot is created and removed automatically |
-| `raw` | Other block devices | Require `--skip_snapshot_creation` and either `--offline` or `--fs-freeze-command` |
+| `raw` | Other block devices | Require `--skip_snapshot_creation` and either `--offline` or `--fs-freeze-command`/`--fs-thaw-command` |
 | `file` | Regular files | Used as-is with no snapshot |
 
 Override detection with `--source-type` and `--dest-type` when necessary.
@@ -258,7 +258,7 @@ Snapshots provide a crash-consistent view of a device. LVM volumes are
 snapshotted automatically and removed after transfer. Raw block devices and
 regular files do not have a snapshot mechanism; to avoid inconsistent reads you
 must either take them offline with `--offline` or freeze the filesystem with
-`--fs-freeze-command`. Snapshot creation requires root privileges, so non-root
+`--fs-freeze-command` and `--fs-thaw-command`. Snapshot creation requires root privileges, so non-root
 invocations must permit escalation via `sudo -n`.
 
 Examples:
@@ -267,7 +267,7 @@ Examples:
 lvmsync --source-type lvm /dev/vg0/origin /tmp/dump
 lvmsync --dest-type raw dumpfile /dev/sdb
 lvmsync --source-type raw --offline /dev/sdb /tmp/dump
-lvmsync --source-type raw --fs-freeze-command "fsfreeze -f /mnt && fsfreeze -u /mnt" /dev/sdb /tmp/dump
+lvmsync --source-type raw --fs-freeze-command "fsfreeze -f /mnt" --fs-thaw-command "fsfreeze -u /mnt" /dev/sdb /tmp/dump
 ```
 
 ### Raw device safety
@@ -275,13 +275,14 @@ lvmsync --source-type raw --fs-freeze-command "fsfreeze -f /mnt && fsfreeze -u /
 Reading from a live block device can corrupt data if writes occur during the transfer. Ensure a consistent view with one of the following options:
 
 - `--offline` – assert that no process will write to the source device.
-- `--fs-freeze-command` – run a command that freezes the filesystem and thaws it after the read.
+- `--fs-freeze-command`/`--fs-thaw-command` – run commands that freeze and thaw the filesystem around the read.
 
 Example using the provided scripts:
 
 ```sh
 lvmsync --source-type raw \
-  --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt && ./docs/fsfreeze-thaw.sh /mnt" \
+  --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt" \
+  --fs-thaw-command "./docs/fsfreeze-thaw.sh /mnt" \
   /dev/sdb /tmp/dump
 ```
 

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -25,7 +25,7 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	}
 	destDevice := args[0]
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(destDevice, true, ""); err == nil {
+		if dev, err := device.Detect(destDevice, true, "", ""); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -109,7 +109,7 @@ func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, l
 // RunLocalDump dumps changes to a local destination device.
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(dest, true, ""); err == nil {
+		if dev, err := device.Detect(dest, true, "", ""); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -188,7 +188,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	)
 
 	if cfg.SourceType == "" || cfg.SourceType == "auto" {
-		dev, err := device.Detect(originalVolume, cfg.Offline, cfg.FSFreezeCommand)
+		dev, err := device.Detect(originalVolume, cfg.Offline, cfg.FSFreezeCommand, cfg.FSThawCommand)
 		if err != nil {
 			return err
 		}
@@ -210,7 +210,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		}
 	case "raw":
 		if !cfg.SkipSnapshotCreation {
-			return fmt.Errorf("raw sources require --skip_snapshot_creation and either --offline or --fs-freeze-command")
+			return fmt.Errorf("raw sources require --skip_snapshot_creation and either --offline or --fs-freeze-command/--fs-thaw-command")
 		}
 	case "file":
 	default:

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -35,6 +35,7 @@ type Config struct {
 	Force                bool          `mapstructure:"force"`
 	Offline              bool          `mapstructure:"offline"`
 	FSFreezeCommand      string        `mapstructure:"fs-freeze-command"`
+	FSThawCommand        string        `mapstructure:"fs-thaw-command"`
 	Mode                 string        `mapstructure:"mode"`
 	Parallel             int           `mapstructure:"parallel"`
 	Concurrency          int           `mapstructure:"concurrency"`
@@ -151,6 +152,7 @@ func DefaultConfig() (*Config, error) {
 		Force:                false,
 		Offline:              false,
 		FSFreezeCommand:      "",
+		FSThawCommand:        "",
 		Parallel:             4,
 		Concurrency:          0,
 		ZeroCopy:             false,

--- a/config/flags.go
+++ b/config/flags.go
@@ -60,6 +60,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("force", cfg.Force, "Override safety checks and proceed on mounted destination")
 	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")
 	fs.String("fs-freeze-command", cfg.FSFreezeCommand, "Command to freeze filesystem before reading raw source")
+	fs.String("fs-thaw-command", cfg.FSThawCommand, "Command to thaw filesystem after reading raw source")
 	fs.String("source-type", cfg.SourceType, "Source device type (auto,file,raw,lvm)")
 	fs.String("dest-type", cfg.DestType, "Destination device type (auto,file,raw,lvm)")
 	fs.String("mode", cfg.Mode, "Preset mode: default or throughput")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -20,6 +20,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"force", strconv.FormatBool(cfg.Force)},
 		{"offline", strconv.FormatBool(cfg.Offline)},
 		{"fs-freeze-command", cfg.FSFreezeCommand},
+		{"fs-thaw-command", cfg.FSThawCommand},
 		{"mode", cfg.Mode},
 		{"parallel", strconv.Itoa(cfg.Parallel)},
 		{"zerocopy", strconv.FormatBool(cfg.ZeroCopy)},

--- a/device/detect.go
+++ b/device/detect.go
@@ -10,7 +10,7 @@ import (
 // Detect inspects the path and returns the appropriate Device implementation.
 // Regular files return FileDevice, block devices are classified as either LVM
 // logical volumes or raw devices based on LVM metadata.
-func Detect(path string, offline bool, fsFreezeCmd string) (Device, error) {
+func Detect(path string, offline bool, fsFreezeCmd, fsThawCmd string) (Device, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func Detect(path string, offline bool, fsFreezeCmd string) (Device, error) {
 		if _, err := lvm.GetVolumeGroupName(path); err == nil {
 			return OpenLVM(path)
 		}
-		return OpenRaw(path, offline, fsFreezeCmd)
+		return OpenRaw(path, offline, fsFreezeCmd, fsThawCmd)
 	}
 	return nil, fmt.Errorf("unsupported path type: %s", path)
 }

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -36,7 +36,7 @@ func TestDetectFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	dev, err := Detect(f.Name(), true, "")
+	dev, err := Detect(f.Name(), true, "", "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestDetectRaw(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	dev, err := Detect(loop, true, "")
+	dev, err := Detect(loop, true, "", "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestDetectLVM(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(lvPath, true, "")
+	dev, err := Detect(lvPath, true, "", "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -12,22 +12,27 @@ import (
 
 // RawDevice represents a generic block device opened from /dev.
 type RawDevice struct {
-	f         *os.File
-	size      uint64
-	blockSize uint64
+	f            *os.File
+	size         uint64
+	blockSize    uint64
+	fsFreezeCmd  string
+	fsThawCmd    string
+	freezeIssued bool
 }
 
 // OpenRaw opens a block device at the given path and queries its size and block size.
-// If offline is false, fsFreezeCmd must be a command that successfully freezes the
-// filesystem before accessing the device.
-func OpenRaw(path string, offline bool, fsFreezeCmd string) (*RawDevice, error) {
+// If offline is false, fsFreezeCmd and fsThawCmd must be commands that successfully
+// freeze and thaw the filesystem around the device access.
+func OpenRaw(path string, offline bool, fsFreezeCmd, fsThawCmd string) (*RawDevice, error) {
+	d := &RawDevice{fsFreezeCmd: fsFreezeCmd, fsThawCmd: fsThawCmd}
 	if !offline {
-		if fsFreezeCmd == "" {
-			return nil, fmt.Errorf("raw sources require --offline or --fs-freeze-command")
+		if fsFreezeCmd == "" || fsThawCmd == "" {
+			return nil, fmt.Errorf("raw sources require --offline or --fs-freeze-command/--fs-thaw-command")
 		}
 		if err := exec.Command("sh", "-c", fsFreezeCmd).Run(); err != nil {
 			return nil, fmt.Errorf("freeze command failed: %w", err)
 		}
+		d.freezeIssued = true
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -50,7 +55,10 @@ func OpenRaw(path string, offline bool, fsFreezeCmd string) (*RawDevice, error) 
 		f.Close()
 		return nil, err
 	}
-	return &RawDevice{f: f, size: size, blockSize: uint64(bs)}, nil
+	d.f = f
+	d.size = size
+	d.blockSize = uint64(bs)
+	return d, nil
 }
 
 // Path returns the device path.
@@ -68,8 +76,15 @@ func (d *RawDevice) Close() error { return d.f.Close() }
 // Snapshot returns the device itself for raw block devices.
 func (d *RawDevice) Snapshot(context.Context) (Device, error) { return d, nil }
 
-// Cleanup is a no-op for raw block devices.
-func (d *RawDevice) Cleanup(context.Context) error { return nil }
+// Cleanup thaws the filesystem if a freeze command was issued.
+func (d *RawDevice) Cleanup(ctx context.Context) error {
+	if d.freezeIssued && d.fsThawCmd != "" {
+		if err := exec.CommandContext(ctx, "sh", "-c", d.fsThawCmd).Run(); err != nil {
+			return fmt.Errorf("thaw command failed: %w", err)
+		}
+	}
+	return nil
+}
 
 // ioctlGetUint64 performs an ioctl call expecting a 64-bit unsigned result.
 func ioctlGetUint64(fd int, req uint) (uint64, error) {

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -1,7 +1,10 @@
 package device
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -11,14 +14,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(f.Name(), true, ""); err == nil {
+	if _, err := OpenRaw(f.Name(), true, "", ""); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw("/dev/null", true, ""); err == nil {
+		if _, err := OpenRaw("/dev/null", true, "", ""); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -27,13 +30,42 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw("/dev/null", false, ""); err == nil {
+	if _, err := OpenRaw("/dev/null", false, "", ""); err == nil {
 		t.Fatalf("expected offline or freeze command error")
 	}
 }
 
 func TestOpenRawFreezeCommandFailure(t *testing.T) {
-	if _, err := OpenRaw("/dev/null", false, "false"); err == nil {
+	if _, err := OpenRaw("/dev/null", false, "false", "true"); err == nil {
 		t.Fatalf("expected freeze command failure")
+	}
+}
+
+func TestOpenRawRunsFreezeCommand(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "freeze")
+	freezeCmd := fmt.Sprintf("touch %s", tmp)
+	if _, err := OpenRaw("/dev/null", false, freezeCmd, "true"); err == nil {
+		t.Fatalf("expected error for char device")
+	}
+	if _, err := os.Stat(tmp); err != nil {
+		t.Fatalf("freeze command did not run")
+	}
+}
+
+func TestCleanupRunsThawCommand(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "thaw")
+	d := &RawDevice{fsThawCmd: fmt.Sprintf("touch %s", tmp), freezeIssued: true}
+	if err := d.Cleanup(context.Background()); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if _, err := os.Stat(tmp); err != nil {
+		t.Fatalf("thaw command did not run")
+	}
+}
+
+func TestCleanupThawCommandFailure(t *testing.T) {
+	d := &RawDevice{fsThawCmd: "false", freezeIssued: true}
+	if err := d.Cleanup(context.Background()); err == nil {
+		t.Fatalf("expected thaw command failure")
 	}
 }

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -66,8 +66,8 @@ Working on a live block device can lead to inconsistent manifests if writes
 occur during the scan. To ensure a stable view:
 
 - `--offline` asserts that no process will modify the device while it is read.
-- `--fs-freeze-command` runs a command that freezes the filesystem and thaws it
-  once the read completes.
+- `--fs-freeze-command`/`--fs-thaw-command` run commands that freeze the
+  filesystem and thaw it once the read completes.
 
 Example scripts in this repository:
 
@@ -77,5 +77,5 @@ Example scripts in this repository:
 Use them together:
 
 ```sh
-lvmsync manifest rebuild --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt && ./docs/fsfreeze-thaw.sh /mnt" /dev/sdb
+lvmsync manifest rebuild --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt" --fs-thaw-command "./docs/fsfreeze-thaw.sh /mnt" /dev/sdb
 ```

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -45,7 +45,7 @@ type Index struct {
 var closeHook = func() {}
 
 var detectDevice = func(path string) (device.Device, error) {
-	return device.Detect(path, true, "")
+	return device.Detect(path, true, "", "")
 }
 
 func headerMAC(h *Header) [32]byte {


### PR DESCRIPTION
## Summary
- add fs-thaw-command support to raw device handling
- thaw filesystem on cleanup when a freeze occurred
- document new fs-freeze-command/fs-thaw-command flags

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e2ef0a8d8832397868bd5d4aea4a1