### PR TITLE
feat(manifest): log rebuild progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--checksum_algorithm` | `LVMSYNC_CHECKSUM_ALGORITHM` | `checksum_algorithm` | Checksum algorithm: `auto`, `sha256`, `blake3`, or `blake3-512` |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
 | `--manifest_path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
+| `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |
 | `--ssh_host` | `LVMSYNC_SSH_HOST` | `ssh_host` | SSH host |
 | `--ssh_user` | `LVMSYNC_SSH_USER` | `ssh_user` | SSH username |
 | `--ssh_key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key or use agent |
@@ -774,6 +775,7 @@ Rebuild a manifest index for an existing device:
 ```sh
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
+Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
 
 Verify that a source and destination match:
 
@@ -982,6 +984,7 @@ Rebuild a manifest for an existing device when the index is missing or stale:
 ```sh
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
+Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
 
 Compare source and destination devices against a manifest:
 

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -41,7 +41,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		}
 		return nil
 	}
-	if err := manifestpkg.Rebuild(device, path); err != nil {
+	if err := manifestpkg.Rebuild(device, path, logger, conf.ManifestProgressInterval); err != nil {
 		if logger != nil {
 			logger.Error("rebuild failed", zap.Error(err))
 		}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -80,7 +80,7 @@ func TestVerifyManifestMismatch(t *testing.T) {
 	manPath := filepath.Join(t.TempDir(), "dst.man")
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
-	if err := manifest.Rebuild(dst, manPath); err != nil {
+	if err := manifest.Rebuild(dst, manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 	core, observed := observer.New(zap.ErrorLevel)
@@ -118,7 +118,7 @@ func TestVerifyManifestSuccess(t *testing.T) {
 	manPath := filepath.Join(t.TempDir(), "src.man")
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
-	if err := manifest.Rebuild(src, manPath); err != nil {
+	if err := manifest.Rebuild(src, manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 	if err := Run([]string{"--manifest_path", manPath, src, src}, zap.NewNop()); err != nil {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -26,88 +26,89 @@ var (
 )
 
 type Config struct {
-	SourceType           string        `mapstructure:"source-type"`
-	DestType             string        `mapstructure:"dest-type"`
-	ConfigFile           string        `mapstructure:"config"`
-	ApplyMode            string        `mapstructure:"apply"`
-	StdoutMode           bool          `mapstructure:"stdout"`
-	DryRun               bool          `mapstructure:"dry-run"`
-	Force                bool          `mapstructure:"force"`
-	Offline              bool          `mapstructure:"offline"`
-	FSFreezeCommand      string        `mapstructure:"fs-freeze-command"`
-	Mode                 string        `mapstructure:"mode"`
-	Parallel             int           `mapstructure:"parallel"`
-	Concurrency          int           `mapstructure:"concurrency"`
-	ZeroCopy             bool          `mapstructure:"zerocopy"`
-	ODirect              bool          `mapstructure:"odirect"`
-	NumaPin              bool          `mapstructure:"numa_pin"`
-	MaxRetries           int           `mapstructure:"max_retries"`
-	ResumeState          string        `mapstructure:"resume"`
-	ResumeToken          string        `mapstructure:"resume_token"`
-	DeviceUUID           string        `mapstructure:"device_uuid"`
-	SSHHost              string        `mapstructure:"ssh_host"`
-	SSHUser              string        `mapstructure:"ssh_user"`
-	SSHKeyPath           string        `mapstructure:"ssh_key"`
-	SSHPort              int           `mapstructure:"ssh_port"`
-	SSHTimeout           time.Duration `mapstructure:"ssh_timeout"`
-	SSHKeepAliveInterval time.Duration `mapstructure:"ssh_keepalive"`
-	KnownHosts           string        `mapstructure:"known_hosts"`
-	StrictHostKeyCheck   bool          `mapstructure:"strict_host_key_checking"`
-	LVMSyncPath          string        `mapstructure:"lvmsync_path"`
-	RemotePreScript      string        `mapstructure:"remote_pre_script"`
-	RemotePostScript     string        `mapstructure:"remote_post_script"`
-	Compress             string        `mapstructure:"compress"`
-	ZstdLevel            int           `mapstructure:"zstd_level"`
-	LZ4Level             string        `mapstructure:"lz4_level"`
-	CompressLevel        int           `mapstructure:"-"`
-	CompressConcurrency  int           `mapstructure:"compress_concurrency"`
-	CompressThreshold    float64       `mapstructure:"compress_threshold"`
-	Speed                string        `mapstructure:"speed"`
-	SpeedLimit           int           `mapstructure:"-"`
-	VerifyChecksum       bool          `mapstructure:"verify_checksum"`
-	ChecksumAlgorithm    string        `mapstructure:"checksum_algorithm"`
-	Verbose              int           `mapstructure:"verbose"`
-	SkipSnapshotCreation bool          `mapstructure:"skip_snapshot_creation"`
-	SkipDiskCheck        bool          `mapstructure:"skip_disk_check"`
-	SnapshotSize         string        `mapstructure:"snapshot_size"`
-	VolumeGroup          string        `mapstructure:"volume_group"`
-	TargetVolumeGroup    string        `mapstructure:"target_volume_group"`
-	TargetVGCandidates   []string      `mapstructure:"target_vgs"`
-	LVMEscalation        string        `mapstructure:"lvm_escalation"`
-	LVMTimeout           time.Duration `mapstructure:"lvm_timeout"`
-	Progress             bool          `mapstructure:"progress"`
-	BlockSize            int           `mapstructure:"-"`
-	BlockSizeRaw         string        `mapstructure:"-"`
-	DedupMode            string        `mapstructure:"dedup"`
-	CDCMin               int           `mapstructure:"cdc_min"`
-	CDCAvg               int           `mapstructure:"cdc_avg"`
-	CDCMax               int           `mapstructure:"cdc_max"`
-	DedupStrategy        string        `mapstructure:"dedup_strategy"`
-	DedupStateFile       string        `mapstructure:"dedup_state_file"`
-	BloomEntries         int           `mapstructure:"bloom_entries"`
-	BloomFpRate          float64       `mapstructure:"bloom_fp_rate"`
-	BloomMBits           uint          `mapstructure:"bloom_mbits"`
-	ManifestPath         string        `mapstructure:"manifest_path"`
-	GRPCPort             int           `mapstructure:"grpc_port"`
-	GRPCListen           string        `mapstructure:"grpc_listen"`
-	GRPCConnect          string        `mapstructure:"grpc_connect"`
-	GRPCDialTimeout      time.Duration `mapstructure:"grpc_dial_timeout"`
-	GRPCSetupTimeout     time.Duration `mapstructure:"grpc_setup_timeout"`
-	HeartbeatInterval    time.Duration `mapstructure:"grpc_heartbeat_interval"`
-	HeartbeatSendTimeout time.Duration `mapstructure:"grpc_heartbeat_send_timeout"`
-	TLSCert              string        `mapstructure:"tls_cert"`
-	TLSKey               string        `mapstructure:"tls_key"`
-	CACert               string        `mapstructure:"ca_cert"`
-	AllowInsecure        bool          `mapstructure:"allow_insecure"`
-	Transport            string        `mapstructure:"transport"`
-	TCPPort              int           `mapstructure:"tcp_port"`
-	TCPParallel          int           `mapstructure:"tcp_parallel"`
-	TCPNotSentLowAt      int           `mapstructure:"tcp_lowat"`
-	SyncInterval         string        `mapstructure:"sync_interval"`
-	CheckpointInterval   time.Duration `mapstructure:"checkpoint_interval"`
-	CheckpointBytesRaw   string        `mapstructure:"checkpoint_bytes"`
-	SyncIntervalBytes    int           `mapstructure:"-"`
-	CheckpointBytes      int           `mapstructure:"-"`
+	SourceType               string        `mapstructure:"source-type"`
+	DestType                 string        `mapstructure:"dest-type"`
+	ConfigFile               string        `mapstructure:"config"`
+	ApplyMode                string        `mapstructure:"apply"`
+	StdoutMode               bool          `mapstructure:"stdout"`
+	DryRun                   bool          `mapstructure:"dry-run"`
+	Force                    bool          `mapstructure:"force"`
+	Offline                  bool          `mapstructure:"offline"`
+	FSFreezeCommand          string        `mapstructure:"fs-freeze-command"`
+	Mode                     string        `mapstructure:"mode"`
+	Parallel                 int           `mapstructure:"parallel"`
+	Concurrency              int           `mapstructure:"concurrency"`
+	ZeroCopy                 bool          `mapstructure:"zerocopy"`
+	ODirect                  bool          `mapstructure:"odirect"`
+	NumaPin                  bool          `mapstructure:"numa_pin"`
+	MaxRetries               int           `mapstructure:"max_retries"`
+	ResumeState              string        `mapstructure:"resume"`
+	ResumeToken              string        `mapstructure:"resume_token"`
+	DeviceUUID               string        `mapstructure:"device_uuid"`
+	SSHHost                  string        `mapstructure:"ssh_host"`
+	SSHUser                  string        `mapstructure:"ssh_user"`
+	SSHKeyPath               string        `mapstructure:"ssh_key"`
+	SSHPort                  int           `mapstructure:"ssh_port"`
+	SSHTimeout               time.Duration `mapstructure:"ssh_timeout"`
+	SSHKeepAliveInterval     time.Duration `mapstructure:"ssh_keepalive"`
+	KnownHosts               string        `mapstructure:"known_hosts"`
+	StrictHostKeyCheck       bool          `mapstructure:"strict_host_key_checking"`
+	LVMSyncPath              string        `mapstructure:"lvmsync_path"`
+	RemotePreScript          string        `mapstructure:"remote_pre_script"`
+	RemotePostScript         string        `mapstructure:"remote_post_script"`
+	Compress                 string        `mapstructure:"compress"`
+	ZstdLevel                int           `mapstructure:"zstd_level"`
+	LZ4Level                 string        `mapstructure:"lz4_level"`
+	CompressLevel            int           `mapstructure:"-"`
+	CompressConcurrency      int           `mapstructure:"compress_concurrency"`
+	CompressThreshold        float64       `mapstructure:"compress_threshold"`
+	Speed                    string        `mapstructure:"speed"`
+	SpeedLimit               int           `mapstructure:"-"`
+	VerifyChecksum           bool          `mapstructure:"verify_checksum"`
+	ChecksumAlgorithm        string        `mapstructure:"checksum_algorithm"`
+	Verbose                  int           `mapstructure:"verbose"`
+	SkipSnapshotCreation     bool          `mapstructure:"skip_snapshot_creation"`
+	SkipDiskCheck            bool          `mapstructure:"skip_disk_check"`
+	SnapshotSize             string        `mapstructure:"snapshot_size"`
+	VolumeGroup              string        `mapstructure:"volume_group"`
+	TargetVolumeGroup        string        `mapstructure:"target_volume_group"`
+	TargetVGCandidates       []string      `mapstructure:"target_vgs"`
+	LVMEscalation            string        `mapstructure:"lvm_escalation"`
+	LVMTimeout               time.Duration `mapstructure:"lvm_timeout"`
+	Progress                 bool          `mapstructure:"progress"`
+	BlockSize                int           `mapstructure:"-"`
+	BlockSizeRaw             string        `mapstructure:"-"`
+	DedupMode                string        `mapstructure:"dedup"`
+	CDCMin                   int           `mapstructure:"cdc_min"`
+	CDCAvg                   int           `mapstructure:"cdc_avg"`
+	CDCMax                   int           `mapstructure:"cdc_max"`
+	DedupStrategy            string        `mapstructure:"dedup_strategy"`
+	DedupStateFile           string        `mapstructure:"dedup_state_file"`
+	BloomEntries             int           `mapstructure:"bloom_entries"`
+	BloomFpRate              float64       `mapstructure:"bloom_fp_rate"`
+	BloomMBits               uint          `mapstructure:"bloom_mbits"`
+	ManifestPath             string        `mapstructure:"manifest_path"`
+	ManifestProgressInterval time.Duration `mapstructure:"manifest_progress_interval"`
+	GRPCPort                 int           `mapstructure:"grpc_port"`
+	GRPCListen               string        `mapstructure:"grpc_listen"`
+	GRPCConnect              string        `mapstructure:"grpc_connect"`
+	GRPCDialTimeout          time.Duration `mapstructure:"grpc_dial_timeout"`
+	GRPCSetupTimeout         time.Duration `mapstructure:"grpc_setup_timeout"`
+	HeartbeatInterval        time.Duration `mapstructure:"grpc_heartbeat_interval"`
+	HeartbeatSendTimeout     time.Duration `mapstructure:"grpc_heartbeat_send_timeout"`
+	TLSCert                  string        `mapstructure:"tls_cert"`
+	TLSKey                   string        `mapstructure:"tls_key"`
+	CACert                   string        `mapstructure:"ca_cert"`
+	AllowInsecure            bool          `mapstructure:"allow_insecure"`
+	Transport                string        `mapstructure:"transport"`
+	TCPPort                  int           `mapstructure:"tcp_port"`
+	TCPParallel              int           `mapstructure:"tcp_parallel"`
+	TCPNotSentLowAt          int           `mapstructure:"tcp_lowat"`
+	SyncInterval             string        `mapstructure:"sync_interval"`
+	CheckpointInterval       time.Duration `mapstructure:"checkpoint_interval"`
+	CheckpointBytesRaw       string        `mapstructure:"checkpoint_bytes"`
+	SyncIntervalBytes        int           `mapstructure:"-"`
+	CheckpointBytes          int           `mapstructure:"-"`
 }
 
 func FormatBlockSize(blockSize int) (string, error) {
@@ -144,83 +145,85 @@ func DefaultConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to get user home directory: %w", err)
 	}
 	return &Config{
-		Mode:                 "default",
-		ApplyMode:            "",
-		StdoutMode:           false,
-		DryRun:               false,
-		Force:                false,
-		Offline:              false,
-		FSFreezeCommand:      "",
-		Parallel:             4,
-		Concurrency:          0,
-		ZeroCopy:             false,
-		ODirect:              false,
-		NumaPin:              false,
-		MaxRetries:           3,
-		ResumeState:          "",
-		ResumeToken:          "",
-		DeviceUUID:           "",
-		SSHHost:              "localhost",
-		SSHUser:              "root",
-		SSHKeyPath:           "",
-		SSHPort:              22,
-		SSHTimeout:           10 * time.Second,
-		SSHKeepAliveInterval: 30 * time.Second,
-		KnownHosts:           filepath.Join(homeDir, ".ssh", "known_hosts"),
-		StrictHostKeyCheck:   true,
-		LVMSyncPath:          "lvmsync",
-		RemotePreScript:      "",
-		RemotePostScript:     "",
-		Compress:             Auto,
-		ZstdLevel:            1,
-		LZ4Level:             "fast",
-		CompressConcurrency:  runtime.GOMAXPROCS(0),
-		CompressThreshold:    0.9,
-		Speed:                "100MB",
-		VerifyChecksum:       false,
-		ChecksumAlgorithm:    Auto,
-		Verbose:              0,
-		SkipSnapshotCreation: false,
-		SkipDiskCheck:        false,
-		SnapshotSize:         "20%",
-		SourceType:           "auto",
-		DestType:             "auto",
-		VolumeGroup:          "",
-		TargetVolumeGroup:    "",
-		TargetVGCandidates:   []string{},
-		LVMEscalation:        "sudo -n",
-		LVMTimeout:           10 * time.Second,
-		Progress:             true,
-		BlockSize:            0,
-		BlockSizeRaw:         Auto,
-		DedupMode:            "fixed",
-		CDCMin:               4 * 1024,
-		CDCAvg:               64 * 1024,
-		CDCMax:               1 * 1024 * 1024,
-		DedupStrategy:        "none",
-		DedupStateFile:       filepath.Join(homeDir, ".lvmsync_dedup"),
-		BloomEntries:         1000000,
-		BloomFpRate:          0.01,
-		BloomMBits:           0,
-		GRPCPort:             8443,
-		GRPCListen:           "",
-		GRPCConnect:          "",
-		GRPCDialTimeout:      5 * time.Second,
-		GRPCSetupTimeout:     10 * time.Second,
-		HeartbeatInterval:    30 * time.Second,
-		HeartbeatSendTimeout: 5 * time.Second,
-		TLSCert:              "",
-		TLSKey:               "",
-		CACert:               "",
-		AllowInsecure:        false,
-		Transport:            "quic,h2,tcp+tls,ssh",
-		TCPPort:              0,
-		TCPParallel:          1,
-		TCPNotSentLowAt:      0,
-		SyncInterval:         "1GB",
-		CheckpointInterval:   0,
-		CheckpointBytesRaw:   "1GB",
-		SyncIntervalBytes:    1000000000,
-		CheckpointBytes:      1000000000,
+		Mode:                     "default",
+		ApplyMode:                "",
+		StdoutMode:               false,
+		DryRun:                   false,
+		Force:                    false,
+		Offline:                  false,
+		FSFreezeCommand:          "",
+		Parallel:                 4,
+		Concurrency:              0,
+		ZeroCopy:                 false,
+		ODirect:                  false,
+		NumaPin:                  false,
+		MaxRetries:               3,
+		ResumeState:              "",
+		ResumeToken:              "",
+		DeviceUUID:               "",
+		SSHHost:                  "localhost",
+		SSHUser:                  "root",
+		SSHKeyPath:               "",
+		SSHPort:                  22,
+		SSHTimeout:               10 * time.Second,
+		SSHKeepAliveInterval:     30 * time.Second,
+		KnownHosts:               filepath.Join(homeDir, ".ssh", "known_hosts"),
+		StrictHostKeyCheck:       true,
+		LVMSyncPath:              "lvmsync",
+		RemotePreScript:          "",
+		RemotePostScript:         "",
+		Compress:                 Auto,
+		ZstdLevel:                1,
+		LZ4Level:                 "fast",
+		CompressConcurrency:      runtime.GOMAXPROCS(0),
+		CompressThreshold:        0.9,
+		Speed:                    "100MB",
+		VerifyChecksum:           false,
+		ChecksumAlgorithm:        Auto,
+		Verbose:                  0,
+		SkipSnapshotCreation:     false,
+		SkipDiskCheck:            false,
+		SnapshotSize:             "20%",
+		SourceType:               "auto",
+		DestType:                 "auto",
+		VolumeGroup:              "",
+		TargetVolumeGroup:        "",
+		TargetVGCandidates:       []string{},
+		LVMEscalation:            "sudo -n",
+		LVMTimeout:               10 * time.Second,
+		Progress:                 true,
+		BlockSize:                0,
+		BlockSizeRaw:             Auto,
+		DedupMode:                "fixed",
+		CDCMin:                   4 * 1024,
+		CDCAvg:                   64 * 1024,
+		CDCMax:                   1 * 1024 * 1024,
+		DedupStrategy:            "none",
+		DedupStateFile:           filepath.Join(homeDir, ".lvmsync_dedup"),
+		BloomEntries:             1000000,
+		BloomFpRate:              0.01,
+		BloomMBits:               0,
+		ManifestPath:             "",
+		ManifestProgressInterval: 10 * time.Second,
+		GRPCPort:                 8443,
+		GRPCListen:               "",
+		GRPCConnect:              "",
+		GRPCDialTimeout:          5 * time.Second,
+		GRPCSetupTimeout:         10 * time.Second,
+		HeartbeatInterval:        30 * time.Second,
+		HeartbeatSendTimeout:     5 * time.Second,
+		TLSCert:                  "",
+		TLSKey:                   "",
+		CACert:                   "",
+		AllowInsecure:            false,
+		Transport:                "quic,h2,tcp+tls,ssh",
+		TCPPort:                  0,
+		TCPParallel:              1,
+		TCPNotSentLowAt:          0,
+		SyncInterval:             "1GB",
+		CheckpointInterval:       0,
+		CheckpointBytesRaw:       "1GB",
+		SyncIntervalBytes:        1000000000,
+		CheckpointBytes:          1000000000,
 	}, nil
 }

--- a/config/flags.go
+++ b/config/flags.go
@@ -84,6 +84,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 func initManifestFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Manifest Options", pflag.ExitOnError)
 	fs.String("manifest_path", cfg.ManifestPath, "Path to manifest file")
+	fs.Duration("manifest_progress_interval", cfg.ManifestProgressInterval, "Interval between progress logs during manifest rebuild")
 	return fs
 }
 

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -212,12 +212,18 @@ func TestInitManifestFlags(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	fs := initManifestFlags(cfg)
-	f := fs.Lookup("manifest_path")
-	if f == nil {
-		t.Fatalf("missing manifest_path flag")
+	cases := []struct{ name, want string }{
+		{"manifest_path", cfg.ManifestPath},
+		{"manifest_progress_interval", cfg.ManifestProgressInterval.String()},
 	}
-	if f.DefValue != cfg.ManifestPath {
-		t.Fatalf("manifest_path default %s want %s", f.DefValue, cfg.ManifestPath)
+	for _, tt := range cases {
+		f := fs.Lookup(tt.name)
+		if f == nil {
+			t.Fatalf("missing %s flag", tt.name)
+		}
+		if f.DefValue != tt.want {
+			t.Fatalf("%s default %s want %s", tt.name, f.DefValue, tt.want)
+		}
 	}
 }
 

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -526,3 +526,61 @@ func TestManifestPathEnvOverridesConfig(t *testing.T) {
 		t.Fatalf("expected manifest_path env.manifest, got %s", conf.ManifestPath)
 	}
 }
+
+func TestManifestProgressIntervalCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "manifest_progress_interval: 1s\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest_progress_interval", "3s"})
+	t.Setenv("LVMSYNC_MANIFEST_PROGRESS_INTERVAL", "2s")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.ManifestProgressInterval != 3*time.Second {
+		t.Fatalf("expected manifest_progress_interval 3s, got %v", conf.ManifestProgressInterval)
+	}
+}
+
+func TestManifestProgressIntervalEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "manifest_progress_interval: 1s\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_MANIFEST_PROGRESS_INTERVAL", "2s")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.ManifestProgressInterval != 2*time.Second {
+		t.Fatalf("expected manifest_progress_interval 2s, got %v", conf.ManifestProgressInterval)
+	}
+}

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -55,6 +55,9 @@ func (b *Builder) applyDefaults(conf *Config) error {
 	if conf.Transport == "" {
 		conf.Transport = b.defaults.Transport
 	}
+	if conf.ManifestProgressInterval == 0 {
+		conf.ManifestProgressInterval = b.defaults.ManifestProgressInterval
+	}
 
 	bs, raw, err := b.parseBlockSize()
 	if err != nil {

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -44,6 +44,7 @@ Generate a manifest for an existing device when the index is missing or stale:
 ```sh
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
+Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
 
 ## Verification
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
 	"lvmsync_go/device"
@@ -212,7 +214,8 @@ func (i *Index) ChunkCount() int { return int(i.hdr.ChunkCount) }
 
 // Rebuild creates a manifest index for device at output path.
 // DeviceID is determined via device.GetUUID. The device is read sequentially using blockSize-sized chunks.
-func Rebuild(devicePath, output string) error {
+// Progress is logged at the provided interval; set interval to 0 to log every chunk.
+func Rebuild(devicePath, output string, logger *zap.Logger, progressInterval time.Duration) error {
 	dev, err := detectDevice(devicePath)
 	if err != nil {
 		return err
@@ -234,6 +237,8 @@ func Rebuild(devicePath, output string) error {
 		return err
 	}
 	defer idx.Close()
+	start := time.Now()
+	lastLog := start
 	buf := make([]byte, blockSize)
 	for off := uint64(0); off < size; off += uint64(blockSize) {
 		n, err := f.ReadAt(buf, int64(off))
@@ -247,6 +252,13 @@ func Rebuild(devicePath, output string) error {
 		xx := xxh3.Hash(data)
 		b3 := blake3.Sum256(data)
 		idx.Set(off, uint32(n), xx, b3)
+		if logger != nil && (progressInterval == 0 || time.Since(lastLog) >= progressInterval) {
+			logger.Info("rebuild progress",
+				zap.Uint64("offset_bytes", off+uint64(n)),
+				zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			)
+			lastLog = time.Now()
+		}
 		if err == io.EOF {
 			break
 		}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/device"
 )
@@ -114,7 +116,7 @@ func TestRebuild(t *testing.T) {
 	prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "rebuild.man")
-	if err := Rebuild(file.Name(), manPath); err != nil {
+	if err := Rebuild(file.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -161,7 +163,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 	count := 0
 	closeHook = func() { count++ }
 	defer func() { closeHook = prevHook }()
-	if err := Rebuild(file.Name(), manPath); err != nil {
+	if err := Rebuild(file.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if count != 1 {
@@ -196,7 +198,7 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	}
 	defer func() { detectDevice = prevDetect }()
 	manPath := filepath.Join(dir, "rebuildbs.man")
-	if err := Rebuild(file.Name(), manPath); err != nil {
+	if err := Rebuild(file.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -216,5 +218,39 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	}
 	if err := idx.Close(); err != nil {
 		t.Fatalf("close manifest: %v", err)
+	}
+}
+
+func TestRebuildLogsProgress(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	data := make([]byte, 8192)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	manPath := filepath.Join(dir, "progress.man")
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	if err := Rebuild(file.Name(), manPath, logger, 0); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	entries := logs.FilterMessage("rebuild progress").All()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 progress logs, got %d", len(entries))
+	}
+	if off, ok := entries[0].ContextMap()["offset_bytes"].(uint64); !ok || off != 4096 {
+		t.Fatalf("unexpected first offset %v", entries[0].ContextMap()["offset_bytes"])
+	}
+	if _, ok := entries[0].ContextMap()["duration_ms"]; !ok {
+		t.Fatalf("missing duration_ms field")
 	}
 }

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -80,7 +80,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 	destLoop := setupLoop(t, destPath)
 
 	manifestPath := filepath.Join(t.TempDir(), "src.man")
-	if err := manifestpkg.Rebuild(srcLoop, manifestPath); err != nil {
+	if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 
@@ -191,7 +191,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 	dstLoop := setupLoop(t, dstPath)
 
 	manifestPath := filepath.Join(dir, "src.man")
-	if err := manifestpkg.Rebuild(srcLoop, manifestPath); err != nil {
+	if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 
@@ -325,7 +325,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 			destLoop := setupLoop(t, destPath)
 
 			manifestPath := filepath.Join(t.TempDir(), "src.man")
-			if err := manifestpkg.Rebuild(srcLoop, manifestPath); err != nil {
+			if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 
@@ -444,7 +444,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 			dstLoop := setupLoop(t, dstPath)
 
 			manifestPath := filepath.Join(dir, "src.man")
-			if err := manifestpkg.Rebuild(srcLoop, manifestPath); err != nil {
+			if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 
@@ -620,7 +620,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 			dstLoop := setupLoop(t, dstPath)
 
 			manifestPath := filepath.Join(dir, "src.man")
-			if err := manifestpkg.Rebuild(srcLoop, manifestPath); err != nil {
+			if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -33,7 +33,7 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 	prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
 	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "dev.man")
-	if err := manifestpkg.Rebuild(dev.Name(), manPath); err != nil {
+	if err := manifestpkg.Rebuild(dev.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	src, err := os.Open(dev.Name())


### PR DESCRIPTION
## Summary
- log `rebuild progress` with offset and elapsed time
- add `--manifest-progress-interval` flag for rebuild command
- document configurable progress interval and test logging

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_689e2ef537bc8323a1330cdecf1f9750