### PR TITLE
fix(device): resolve paths and add thaw command

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -35,6 +35,7 @@ type Config struct {
 	Force                    bool          `mapstructure:"force"`
 	Offline                  bool          `mapstructure:"offline"`
 	FSFreezeCommand          string        `mapstructure:"fs-freeze-command"`
+	FSThawCommand            string        `mapstructure:"fs-thaw-command"`
 	Mode                     string        `mapstructure:"mode"`
 	Parallel                 int           `mapstructure:"parallel"`
 	Concurrency              int           `mapstructure:"concurrency"`
@@ -161,6 +162,7 @@ func DefaultConfig() (*Config, error) {
 		Force:                    false,
 		Offline:                  false,
 		FSFreezeCommand:          "",
+		FSThawCommand:            "",
 		Parallel:                 4,
 		Concurrency:              0,
 		ZeroCopy:                 false,

--- a/device/detect.go
+++ b/device/detect.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"lvmsync_go/lvm"
 )
@@ -11,7 +12,13 @@ import (
 // Regular files return FileDevice, block devices are classified as either LVM
 // logical volumes or raw devices based on LVM metadata.
 func Detect(path string, offline bool, fsFreezeCmd, fsThawCmd string) (Device, error) {
-	info, err := os.Stat(path)
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", path, err)
+	}
+	resolved = filepath.Clean(resolved)
+
+	info, err := os.Stat(resolved)
 	if err != nil {
 		return nil, err
 	}
@@ -22,7 +29,7 @@ func Detect(path string, offline bool, fsFreezeCmd, fsThawCmd string) (Device, e
 		if _, err := lvm.GetVolumeGroupName(resolved); err == nil {
 			return OpenLVM(resolved)
 		}
-		return OpenRaw(path, offline, fsFreezeCmd, fsThawCmd)
+		return OpenRaw(resolved, offline, fsFreezeCmd, fsThawCmd)
 	}
 	return nil, fmt.Errorf("unsupported path type: %s", resolved)
 }

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -56,7 +56,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(link, true, "")
+	dev, err := Detect(link, true, "", "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(link, true, "")
+	dev, err := Detect(link, true, "", "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}


### PR DESCRIPTION
## Summary
- pass thaw command argument in Detect tests
- resolve symlinks in Detect and plumb thaw command to raw devices
- add FSThawCommand option to configuration defaults

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e33b1009083239f315ca801300665