### PR TITLE
feat(device): add context-aware filesystem freeze and thaw

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -1,6 +1,7 @@
 package apply
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -25,7 +26,7 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	}
 	destDevice := args[0]
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(destDevice, true, "", ""); err == nil {
+		if dev, err := device.Detect(context.Background(), destDevice, true, "", "", logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -109,7 +109,7 @@ func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, l
 // RunLocalDump dumps changes to a local destination device.
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(dest, true, "", ""); err == nil {
+		if dev, err := device.Detect(context.Background(), dest, true, "", "", logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -189,7 +189,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	)
 
 	if cfg.SourceType == "" || cfg.SourceType == "auto" {
-		dev, err := device.Detect(originalVolume, cfg.Offline, cfg.FSFreezeCommand, cfg.FSThawCommand)
+		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.FSFreezeCommand, cfg.FSThawCommand, logger)
 		if err != nil {
 			return err
 		}

--- a/device/detect.go
+++ b/device/detect.go
@@ -1,9 +1,12 @@
 package device
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"go.uber.org/zap"
 
 	"lvmsync_go/lvm"
 )
@@ -11,7 +14,7 @@ import (
 // Detect inspects the path and returns the appropriate Device implementation.
 // Regular files return FileDevice, block devices are classified as either LVM
 // logical volumes or raw devices based on LVM metadata.
-func Detect(path string, offline bool, fsFreezeCmd, fsThawCmd string) (Device, error) {
+func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, logger *zap.Logger) (Device, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		return nil, err
@@ -27,7 +30,7 @@ func Detect(path string, offline bool, fsFreezeCmd, fsThawCmd string) (Device, e
 		if _, err := lvm.GetVolumeGroupName(resolved); err == nil {
 			return OpenLVM(resolved)
 		}
-		return OpenRaw(resolved, offline, fsFreezeCmd, fsThawCmd)
+		return OpenRaw(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, logger)
 	}
 	return nil, fmt.Errorf("unsupported path type: %s", resolved)
 }

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -1,11 +1,14 @@
 package device
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func setupLoop(t *testing.T, size int64) (string, func()) {
@@ -36,7 +39,7 @@ func TestDetectFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	dev, err := Detect(f.Name(), true, "", "")
+	dev, err := Detect(context.Background(), f.Name(), true, "", "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -56,7 +59,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(link, true, "", "")
+	dev, err := Detect(context.Background(), link, true, "", "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -72,7 +75,7 @@ func TestDetectRaw(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	dev, err := Detect(loop, true, "", "")
+	dev, err := Detect(context.Background(), loop, true, "", "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -92,7 +95,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(link, true, "", "")
+	dev, err := Detect(context.Background(), link, true, "", "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -115,7 +118,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(lvPath, true, "", "")
+	dev, err := Detect(context.Background(), lvPath, true, "", "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"unsafe"
 
+	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
 
@@ -18,21 +19,33 @@ type RawDevice struct {
 	fsFreezeCmd  string
 	fsThawCmd    string
 	freezeIssued bool
+	logger       *zap.Logger
 }
 
 // OpenRaw opens a block device at the given path and queries its size and block size.
 // If offline is false, fsFreezeCmd and fsThawCmd must be commands that successfully
 // freeze and thaw the filesystem around the device access.
-func OpenRaw(path string, offline bool, fsFreezeCmd, fsThawCmd string) (*RawDevice, error) {
-	d := &RawDevice{fsFreezeCmd: fsFreezeCmd, fsThawCmd: fsThawCmd}
+func OpenRaw(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, logger *zap.Logger) (_ *RawDevice, err error) {
+	d := &RawDevice{fsFreezeCmd: fsFreezeCmd, fsThawCmd: fsThawCmd, logger: logger}
 	if !offline {
 		if fsFreezeCmd == "" || fsThawCmd == "" {
 			return nil, fmt.Errorf("raw sources require --offline or --fs-freeze-command/--fs-thaw-command")
 		}
-		if err := exec.Command("sh", "-c", fsFreezeCmd).Run(); err != nil {
+		if d.logger != nil {
+			d.logger.Info("fs freeze start", zap.String("command", fsFreezeCmd))
+		}
+		if err = exec.CommandContext(ctx, "sh", "-c", fsFreezeCmd).Run(); err != nil {
 			return nil, fmt.Errorf("freeze command failed: %w", err)
 		}
+		if d.logger != nil {
+			d.logger.Info("fs freeze complete")
+		}
 		d.freezeIssued = true
+		defer func() {
+			if err != nil {
+				_ = d.Cleanup(ctx)
+			}
+		}()
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -79,8 +92,17 @@ func (d *RawDevice) Snapshot(context.Context) (Device, error) { return d, nil }
 // Cleanup thaws the filesystem if a freeze command was issued.
 func (d *RawDevice) Cleanup(ctx context.Context) error {
 	if d.freezeIssued && d.fsThawCmd != "" {
+		if d.logger != nil {
+			d.logger.Info("fs thaw start", zap.String("command", d.fsThawCmd))
+		}
 		if err := exec.CommandContext(ctx, "sh", "-c", d.fsThawCmd).Run(); err != nil {
+			if d.logger != nil {
+				d.logger.Error("fs thaw failed", zap.Error(err))
+			}
 			return fmt.Errorf("thaw command failed: %w", err)
+		}
+		if d.logger != nil {
+			d.logger.Info("fs thaw complete")
 		}
 	}
 	return nil

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestOpenRawRejectsRegularFile(t *testing.T) {
@@ -14,14 +16,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(f.Name(), true, "", ""); err == nil {
+	if _, err := OpenRaw(context.Background(), f.Name(), true, "", "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw("/dev/null", true, "", ""); err == nil {
+		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", "", zap.NewNop()); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -30,31 +32,36 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw("/dev/null", false, "", ""); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", "", zap.NewNop()); err == nil {
 		t.Fatalf("expected offline or freeze command error")
 	}
 }
 
 func TestOpenRawFreezeCommandFailure(t *testing.T) {
-	if _, err := OpenRaw("/dev/null", false, "false", "true"); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", "true", zap.NewNop()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
 
-func TestOpenRawRunsFreezeCommand(t *testing.T) {
-	tmp := filepath.Join(t.TempDir(), "freeze")
-	freezeCmd := fmt.Sprintf("touch %s", tmp)
-	if _, err := OpenRaw("/dev/null", false, freezeCmd, "true"); err == nil {
+func TestOpenRawThawsOnFailure(t *testing.T) {
+	freezeTmp := filepath.Join(t.TempDir(), "freeze")
+	thawTmp := filepath.Join(t.TempDir(), "thaw")
+	freezeCmd := fmt.Sprintf("touch %s", freezeTmp)
+	thawCmd := fmt.Sprintf("touch %s", thawTmp)
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmd, thawCmd, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for char device")
 	}
-	if _, err := os.Stat(tmp); err != nil {
+	if _, err := os.Stat(freezeTmp); err != nil {
 		t.Fatalf("freeze command did not run")
+	}
+	if _, err := os.Stat(thawTmp); err != nil {
+		t.Fatalf("thaw command did not run")
 	}
 }
 
 func TestCleanupRunsThawCommand(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "thaw")
-	d := &RawDevice{fsThawCmd: fmt.Sprintf("touch %s", tmp), freezeIssued: true}
+	d := &RawDevice{fsThawCmd: fmt.Sprintf("touch %s", tmp), freezeIssued: true, logger: zap.NewNop()}
 	if err := d.Cleanup(context.Background()); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
@@ -64,7 +71,7 @@ func TestCleanupRunsThawCommand(t *testing.T) {
 }
 
 func TestCleanupThawCommandFailure(t *testing.T) {
-	d := &RawDevice{fsThawCmd: "false", freezeIssued: true}
+	d := &RawDevice{fsThawCmd: "false", freezeIssued: true, logger: zap.NewNop()}
 	if err := d.Cleanup(context.Background()); err == nil {
 		t.Fatalf("expected thaw command failure")
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -46,8 +46,8 @@ type Index struct {
 
 var closeHook = func() {}
 
-var detectDevice = func(path string) (device.Device, error) {
-	return device.Detect(path, true, "", "")
+var detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+	return device.Detect(ctx, path, true, "", "", logger)
 }
 
 func headerMAC(h *Header) [32]byte {
@@ -219,7 +219,7 @@ func (i *Index) ChunkCount() int { return int(i.hdr.ChunkCount) }
 // DeviceID is determined via device.GetUUID. The device is read sequentially using blockSize-sized chunks.
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
 func Rebuild(devicePath, output string, logger *zap.Logger, progressInterval time.Duration) error {
-	dev, err := detectDevice(devicePath)
+	dev, err := detectDevice(context.Background(), devicePath, logger)
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -208,7 +208,7 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-bs", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	prevDetect := detectDevice
-	detectDevice = func(string) (device.Device, error) {
+	detectDevice = func(context.Context, string, *zap.Logger) (device.Device, error) {
 		return &mockDevice{path: file.Name(), size: uint64(2 * bs), blockSize: uint64(bs)}, nil
 	}
 	defer func() { detectDevice = prevDetect }()


### PR DESCRIPTION
## Summary
- run freeze/thaw commands with `exec.CommandContext`
- defer thaw on failure and log freeze/thaw lifecycle
- propagate context and logger through device detection
- test automatic thaw after freeze errors

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e3728ac1c83238f81b41392074844