### PR TITLE
feat(transport): add context-aware tcp+tls dialing

### DIFF
--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -76,18 +76,42 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.Int64("duration_ms", 0),
 	)
 	start := time.Now()
-	d := net.Dialer{}
-	conn, err := tls.DialWithDialer(&d, "tcp", address, t.clientConf)
+	d := &net.Dialer{}
+	tcpConn, err := d.DialContext(ctx, "tcp", address)
+	if err != nil {
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		t.logger.Info("dial_end", fields...)
+		return nil, err
+	}
+	tlsConf := t.clientConf.Clone()
+	if tlsConf.ServerName == "" && !tlsConf.InsecureSkipVerify {
+		host, _, _ := net.SplitHostPort(address)
+		tlsConf.ServerName = host
+	}
+	conn := tls.Client(tcpConn, tlsConf)
+	if err := conn.HandshakeContext(ctx); err != nil {
+		tcpConn.Close()
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		t.logger.Info("dial_end", fields...)
+		return nil, err
+	}
 	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 	}
-	if err != nil {
-		fields = append(fields, zap.Error(err))
-	}
 	t.logger.Info("dial_end", fields...)
-	return conn, err
+	return conn, nil
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
@@ -98,9 +122,14 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.Int64("duration_ms", 0),
 	)
 	start := time.Now()
-	ln, err := net.Listen("tcp", address)
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(ctx, "tcp", address)
 	if err == nil {
 		ln = tls.NewListener(ln, t.serverConf)
+		go func() {
+			<-ctx.Done()
+			ln.Close()
+		}()
 	}
 	fields := []zap.Field{
 		zap.String("address", address),

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -3,8 +3,11 @@ package tcp_tls
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"io"
+	"net"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -176,6 +179,42 @@ func TestTCPTLSCertValidation(t *testing.T) {
 		t.Fatalf("expected cert validation error")
 	}
 	<-done
+}
+
+func TestTCPTLSDialContextCancel(t *testing.T) {
+	cert, _ := generateSelfSignedCert()
+	root := x509.NewCertPool()
+	if c, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
+		root.AddCert(c)
+	}
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		io.Copy(io.Discard, conn)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := tr.Dial(ctx, ln.Addr().String()); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
 }
 
 func TestTCPTLSTransportRequiresLogger(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure tcp+tls Dial uses DialContext and TLS handshake with context
- close listeners when contexts end
- add test for cancelled dials

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e373380788323b27b438f31d80539