### PR TITLE
feat(device): make snapshot size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to the device's NUMA node.
 - **LVM Snapshot Management**:
   - Automatic snapshot creation and removal.
-  - Configurable snapshot size (absolute or percentage-based).
+  - Configurable snapshot size (absolute or percentage-based) via `--snapshot_size`,
+    `LVMSYNC_SNAPSHOT_SIZE`, or the `snapshot_size` config key.
   - Configurable volume group for constructing the snapshot device path.
   - Auto-selection of target volume groups with sufficient free space.
   - Automatic privilege escalation (defaulting to `sudo -n`).

--- a/device/device.go
+++ b/device/device.go
@@ -10,9 +10,10 @@ type Device interface {
 	SizeBytes() uint64
 	// BlockSize returns the logical block size of the device in bytes.
 	BlockSize() uint64
-	// Snapshot prepares the device for a consistent read, returning a
-	// handle that should be closed after use.
-	Snapshot(ctx context.Context) (Device, error)
+	// Snapshot prepares the device for a consistent read using the provided
+	// snapshot size (for devices that support it). The returned handle
+	// should be closed after use.
+	Snapshot(ctx context.Context, snapshotSize string) (Device, error)
 	// Cleanup releases any snapshot resources held by the device.
 	Cleanup(ctx context.Context) error
 	// Close releases any resources associated with the device.

--- a/device/file.go
+++ b/device/file.go
@@ -53,7 +53,7 @@ func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 func (d *FileDevice) Close() error { return d.f.Close() }
 
 // Snapshot returns the device itself for regular files.
-func (d *FileDevice) Snapshot(context.Context) (Device, error) { return d, nil }
+func (d *FileDevice) Snapshot(context.Context, string) (Device, error) { return d, nil }
 
 // Cleanup is a no-op for regular files.
 func (d *FileDevice) Cleanup(context.Context) error { return nil }

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -80,14 +80,15 @@ func runLVM(ctx context.Context, name string, args ...string) error {
 	return nil
 }
 
-// Snapshot creates, activates, and opens an LVM snapshot of the device.
-func (d *LVMDevice) Snapshot(ctx context.Context) (Device, error) {
+// Snapshot creates, activates, and opens an LVM snapshot of the device using
+// the provided snapshotSize (e.g., "1G" or "20%").
+func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, error) {
 	vg, err := lvm.GetVolumeGroupName(d.path)
 	if err != nil {
 		return nil, err
 	}
 	snapName := generateSnapshot()
-	if err := runLVM(ctx, "lvcreate", "-s", "-n", snapName, "-L", "1G", d.path); err != nil {
+	if err := runLVM(ctx, "lvcreate", "-s", "-n", snapName, "-L", snapshotSize, d.path); err != nil {
 		return nil, err
 	}
 	snapPath := lvm.GetSnapshotDevicePath(snapName, vg, zap.NewNop())

--- a/device/raw.go
+++ b/device/raw.go
@@ -74,7 +74,7 @@ func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
 func (d *RawDevice) Close() error { return d.f.Close() }
 
 // Snapshot returns the device itself for raw block devices.
-func (d *RawDevice) Snapshot(context.Context) (Device, error) { return d, nil }
+func (d *RawDevice) Snapshot(context.Context, string) (Device, error) { return d, nil }
 
 // Cleanup thaws the filesystem if a freeze command was issued.
 func (d *RawDevice) Cleanup(ctx context.Context) error {

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -25,7 +25,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open file: %v", err)
 	}
-	fsnap, err := fd.Snapshot(ctx)
+	fsnap, err := fd.Snapshot(ctx, "")
 	if err != nil {
 		t.Fatalf("file snapshot: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 
 	// Raw device snapshot is also a no-op.
 	rd := &RawDevice{f: os.NewFile(uintptr(0), "/dev/sda")}
-	rsnap, err := rd.Snapshot(ctx)
+	rsnap, err := rd.Snapshot(ctx, "")
 	if err != nil {
 		t.Fatalf("raw snapshot: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	defer func() { geteuid = origEuid }()
 
 	lvd := &LVMDevice{path: "/dev/vg0/origin"}
-	snap, err := lvd.Snapshot(ctx)
+	snap, err := lvd.Snapshot(ctx, "2G")
 	if err != nil {
 		t.Fatalf("lvm snapshot: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	}
 
 	want := []string{
-		"sudo -n lvcreate -s -n snap -L 1G /dev/vg0/origin",
+		"sudo -n lvcreate -s -n snap -L 2G /dev/vg0/origin",
 		"sudo -n lvchange -ay /dev/vg0/snap",
 		"sudo -n lvremove -f /dev/vg0/snap",
 	}

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -48,8 +48,13 @@ func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
 	cfg.SkipDiskCheck = true
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
+	cfg.SnapshotSize = "25%"
 
-	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string, *zap.Logger) (uint64, error) { return 1024, nil })
+	var parseArg string
+	restoreParse := client.SetParseSnapshotSizeForTest(func(s, _ string, _ *zap.Logger) (uint64, error) {
+		parseArg = s
+		return 1024, nil
+	})
 	defer restoreParse()
 
 	var created bool
@@ -83,6 +88,9 @@ func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
 	snap, monitorCh, cleanup, err := client.PrepareSnapshot(context.Background(), cfg, "/dev/vg/orig", logger)
 	if err != nil {
 		t.Fatalf("PrepareSnapshot error: %v", err)
+	}
+	if parseArg != cfg.SnapshotSize {
+		t.Fatalf("unexpected snapshot size arg %q", parseArg)
 	}
 	if !strings.HasPrefix(snap, "/dev/vg/snap-") {
 		t.Fatalf("unexpected snapshot path: %s", snap)

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -23,12 +23,12 @@ type mockDevice struct {
 	blockSize uint64
 }
 
-func (m *mockDevice) Path() string                                    { return m.path }
-func (m *mockDevice) SizeBytes() uint64                               { return m.size }
-func (m *mockDevice) BlockSize() uint64                               { return m.blockSize }
-func (m *mockDevice) Close() error                                    { return nil }
-func (m *mockDevice) Snapshot(context.Context) (device.Device, error) { return m, nil }
-func (m *mockDevice) Cleanup(context.Context) error                   { return nil }
+func (m *mockDevice) Path() string                                            { return m.path }
+func (m *mockDevice) SizeBytes() uint64                                       { return m.size }
+func (m *mockDevice) BlockSize() uint64                                       { return m.blockSize }
+func (m *mockDevice) Close() error                                            { return nil }
+func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
+func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
 
 func TestIndexCRUD(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- allow LVMDevice.Snapshot to take an explicit size and generate lvcreate with that size
- verify snapshot size is wired from config and reflected in lvcreate
- document `--snapshot_size`/`LVMSYNC_SNAPSHOT_SIZE`

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_689e371c2f348323bff4e59e9c663af4