### PR TITLE
feat(h2): add TLS 1.3 HTTP/2 transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,10 +527,11 @@ lvmsync run --config config.yaml /dev/vg0/snap0 /mnt/backup
 
 Transport selection is controlled by the `--transport` flag, which accepts a comma-separated ordered list of
 transports to attempt (for example `quic,h2,tcp+tls,ssh`). The `quic` transport runs over TLS 1.3 with mutual
-authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional streams and datagrams. Provide
-certificates via `--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and
-will refuse connections when no roots are provided unless `--allow_insecure` (or the `AllowInsecure` configuration
-flag) is set. The flags below configure transport behavior.
+authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional streams and datagrams. The `h2`
+transport also requires TLS 1.3 with client certificates and negotiates the `h2` ALPN. Provide certificates via
+`--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and will refuse
+connections when no roots are provided unless `--allow_insecure` (or the `AllowInsecure` configuration flag) is
+set. The flags below configure transport behavior.
 
 ### Flags and environment variables
 
@@ -539,6 +540,7 @@ flag) is set. The flags below configure transport behavior.
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) |
 | `--concurrency` | `LVMSYNC_TRANSPORT_CONCURRENCY` | Stream concurrency (0 to autotune based on BDP) |
 | `--tcp_port` | `LVMSYNC_TRANSPORT_TCP_PORT` | TCP+TLS port |
+| `--h2-port` | `LVMSYNC_H2_PORT` | HTTP/2 port |
 | `--tcp_parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | Number of parallel TCP connections |
 | `--tcp_lowat` | `LVMSYNC_TRANSPORT_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes |
 | `--ssh_port` | `LVMSYNC_SSH_PORT` | SSH port |
@@ -571,6 +573,12 @@ LVMSYNC_TRANSPORT_TRANSPORT=quic LVMSYNC_TLS_CERT=cert.pem LVMSYNC_TLS_KEY=key.p
 lvmsync run --transport tcp+tls --tcp_port 9443
 # or
 LVMSYNC_TRANSPORT_TRANSPORT=tcp+tls LVMSYNC_TRANSPORT_TCP_PORT=9443 lvmsync run
+```
+
+**HTTP/2**
+
+```sh
+lvmsync run --transport h2 --h2-port 9443 --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 ```
 
 **SSH**

--- a/common/handshake.go
+++ b/common/handshake.go
@@ -35,6 +35,9 @@ type Handshake struct {
 	CDCMin int
 	CDCAvg int
 	CDCMax int
+
+	ALPN       string
+	TLSVersion string
 }
 
 // NativeEndianness reports the platform byte order as "little" or "big".
@@ -88,6 +91,12 @@ func WriteHandshake(w io.Writer, h Handshake) error {
 	}
 	if h.CDCMax > 0 {
 		tokens = append(tokens, fmt.Sprintf("cdcmax:%d", h.CDCMax))
+	}
+	if h.ALPN != "" {
+		tokens = append(tokens, "alpn:"+h.ALPN)
+	}
+	if h.TLSVersion != "" {
+		tokens = append(tokens, "tls:"+h.TLSVersion)
 	}
 
 	if len(h.Transports) > 0 {
@@ -198,6 +207,10 @@ func ReadHandshake(r *bufio.Reader) (Handshake, error) {
 				return Handshake{}, fmt.Errorf("invalid cdc max: %w", err)
 			}
 			h.CDCMax = v
+		case strings.HasPrefix(t, "alpn:"):
+			h.ALPN = strings.TrimPrefix(t, "alpn:")
+		case strings.HasPrefix(t, "tls:"):
+			h.TLSVersion = strings.TrimPrefix(t, "tls:")
 		case t == "checksum":
 			h.Checksum = true
 		case t == "checksum-dedup":

--- a/common/handshake_test.go
+++ b/common/handshake_test.go
@@ -24,6 +24,8 @@ func TestHandshakeRoundTrip(t *testing.T) {
 		CDCMin:        1024,
 		CDCAvg:        2048,
 		CDCMax:        4096,
+		ALPN:          "h2",
+		TLSVersion:    "1.3",
 		Transports:    []string{"ssh", "tcp+tls"},
 		Compressors:   []string{"lz4", "zstd"},
 		Digests:       []string{"sha256", "blake3"},

--- a/transport/config.go
+++ b/transport/config.go
@@ -13,6 +13,7 @@ import (
 type Config struct {
 	Roots         *x509.CertPool
 	ClientCert    tls.Certificate
+	ServerCert    tls.Certificate
 	Logger        *zap.Logger
 	AllowInsecure bool
 }

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -3,6 +3,7 @@ package h2
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"time"
@@ -13,10 +14,11 @@ import (
 	"lvmsync_go/transport"
 )
 
-// Transport is a placeholder HTTP/2 transport using plain TCP.
+// Transport implements HTTP/2 over TLS1.3 with mutual authentication.
 type Transport struct {
-	cfg    transport.Config
-	logger *zap.Logger
+	clientConf *tls.Config
+	serverConf *tls.Config
+	logger     *zap.Logger
 }
 
 // New returns a new Transport.
@@ -24,7 +26,30 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
 		return nil, fmt.Errorf("logger is required")
 	}
-	return &Transport{cfg: cfg, logger: cfg.Logger}, nil
+	if cfg.Roots == nil {
+		return nil, fmt.Errorf("tls roots are required")
+	}
+	if len(cfg.ServerCert.Certificate) == 0 {
+		return nil, fmt.Errorf("server certificate is required")
+	}
+	clientConf := &tls.Config{
+		RootCAs:    cfg.Roots,
+		NextProtos: []string{"h2"},
+		MinVersion: tls.VersionTLS13,
+		MaxVersion: tls.VersionTLS13,
+	}
+	if len(cfg.ClientCert.Certificate) != 0 {
+		clientConf.Certificates = []tls.Certificate{cfg.ClientCert}
+	}
+	serverConf := &tls.Config{
+		Certificates: []tls.Certificate{cfg.ServerCert},
+		ClientCAs:    cfg.Roots,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+		MaxVersion:   tls.VersionTLS13,
+		NextProtos:   []string{"h2"},
+	}
+	return &Transport{clientConf: clientConf, serverConf: serverConf, logger: cfg.Logger}, nil
 }
 
 func init() {
@@ -41,17 +66,22 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	d := net.Dialer{}
-	conn, err := d.DialContext(ctx, "tcp", address)
-	t.logger.Info("dial_end",
+	if dl, ok := ctx.Deadline(); ok {
+		d.Deadline = dl
+	}
+	conn, err := tls.DialWithDialer(&d, "tcp", address, t.clientConf)
+	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", errString(err)),
-	)
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	t.logger.Info("dial_end", fields...)
 	return conn, err
 }
 
@@ -61,16 +91,21 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	ln, err := net.Listen("tcp", address)
-	t.logger.Info("listen_end",
+	if err == nil {
+		ln = tls.NewListener(ln, t.serverConf)
+	}
+	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", errString(err)),
-	)
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	t.logger.Info("listen_end", fields...)
 	return ln, err
 }
 
@@ -81,18 +116,28 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		zap.String("address", address),
 		zap.String("role", roleStr),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	defer func() {
-		t.logger.Info("negotiate_end",
+		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", roleStr),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
-		)
+		}
+		if err != nil {
+			fields = append(fields, zap.Error(err))
+		}
+		t.logger.Info("negotiate_end", fields...)
 	}()
 
+	if tlsConn, ok := conn.(*tls.Conn); ok {
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			return peer, err
+		}
+		state := tlsConn.ConnectionState()
+		hs.ALPN = state.NegotiatedProtocol
+		hs.TLSVersion = tlsVersionString(state.Version)
+	}
 	hs.Version = common.ProtocolVersion
 	if hs.Endianness == "" {
 		hs.Endianness = common.NativeEndianness()
@@ -127,11 +172,19 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	}
 }
 
-func errString(err error) string {
-	if err == nil {
+func tlsVersionString(v uint16) string {
+	switch v {
+	case tls.VersionTLS10:
+		return "1.0"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS13:
+		return "1.3"
+	default:
 		return ""
 	}
-	return err.Error()
 }
 
 func roleString(r transport.Role) string {

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -2,8 +2,15 @@ package h2
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
 	"io"
+	"math/big"
+	"net"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -18,16 +25,43 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
 	}
 	ctx := entries[0].ContextMap()
-	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+	for _, k := range []string{"address", "role", "duration_ms"} {
 		if _, ok := ctx[k]; !ok {
 			t.Fatalf("expected field %q in %s log", k, msg)
 		}
 	}
 }
 
-func TestH2TransportHandshake(t *testing.T) {
+func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(parsed)
+	return cert, pool
+}
+
+func TestH2TransportTLSHandshake(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: pool, ClientCert: cert, ServerCert: cert})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}
@@ -51,7 +85,7 @@ func TestH2TransportHandshake(t *testing.T) {
 			t.Errorf("server negotiate: %v", err)
 			return
 		}
-		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 {
+		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.ALPN != "h2" || peerHS.TLSVersion != "1.3" {
 			t.Errorf("unexpected peer handshake: %+v", peerHS)
 		}
 		buf := make([]byte, 4)
@@ -69,7 +103,7 @@ func TestH2TransportHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 {
+	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.ALPN != "h2" || peerHS.TLSVersion != "1.3" {
 		t.Fatalf("unexpected peer handshake: %+v", peerHS)
 	}
 	if _, err := conn.Write([]byte("ping")); err != nil {
@@ -91,48 +125,37 @@ func TestH2TransportHandshake(t *testing.T) {
 	checkLogFields(t, logs, "negotiate_end", 2)
 }
 
-func TestH2TransportHandshakeError(t *testing.T) {
+func TestH2TransportTLSHandshakeError(t *testing.T) {
+	serverCert, pool := generateSelfSignedCert(t)
+	clientCert, _ := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, err := New(transport.Config{Logger: zap.New(core)})
+	serverTrIface, err := New(transport.Config{Logger: zap.New(core), Roots: pool, ClientCert: serverCert, ServerCert: serverCert})
 	if err != nil {
-		t.Fatalf("new transport: %v", err)
+		t.Fatalf("server transport: %v", err)
 	}
-	tr := trIface.(*Transport)
+	clientTrIface, err := New(transport.Config{Logger: zap.New(core), Roots: pool, ClientCert: clientCert, ServerCert: clientCert})
+	if err != nil {
+		t.Fatalf("client transport: %v", err)
+	}
+	serverTr := serverTrIface.(*Transport)
+	clientTr := clientTrIface.(*Transport)
 	ctx := context.Background()
-	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	ln, err := serverTr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
 
-	done := make(chan struct{})
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			t.Errorf("accept: %v", err)
-			return
-		}
-		conn.Write([]byte("bad\n"))
-		conn.Close()
-		close(done)
-	}()
-
-	conn, err := tr.Dial(ctx, ln.Addr().String())
-	if err != nil {
-		t.Fatalf("dial: %v", err)
+	dctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	if _, err := clientTr.Dial(dctx, ln.Addr().String()); err == nil {
+		t.Fatalf("expected dial error")
 	}
-	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{}); err == nil {
-		t.Fatalf("expected negotiate error")
-	}
-	conn.Close()
-	<-done
 
 	checkLogFields(t, logs, "dial_start", 1)
 	checkLogFields(t, logs, "dial_end", 1)
 	checkLogFields(t, logs, "listen_start", 1)
 	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 1)
-	checkLogFields(t, logs, "negotiate_end", 1)
 }
 
 func TestH2TransportRequiresLogger(t *testing.T) {

--- a/transport/negotiation_integration_test.go
+++ b/transport/negotiation_integration_test.go
@@ -92,6 +92,7 @@ func TestNegotiationTransports(t *testing.T) {
 				root.AddCert(c)
 			}
 			cfg.ClientCert = cert
+			cfg.ServerCert = cert
 			cfg.Roots = root
 		}
 		tr, err := transport.Get(name, cfg)

--- a/transport/negotiation_params_test.go
+++ b/transport/negotiation_params_test.go
@@ -50,9 +50,10 @@ func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 func newTransport(t *testing.T, name string) transport.Interface {
 	t.Helper()
 	cfg := transport.Config{Logger: zap.NewNop()}
-	if name == "tcp+tls" || name == "quic" {
+	if name == "tcp+tls" || name == "quic" || name == "h2" {
 		cert, pool := generateSelfSignedCert(t)
 		cfg.ClientCert = cert
+		cfg.ServerCert = cert
 		cfg.Roots = pool
 	}
 	tr, err := transport.Get(name, cfg)


### PR DESCRIPTION
## Summary
- secure h2 transport with TLS 1.3, ALPN negotiation and client certs
- expose certificate and port options for HTTP/2
- document new flags and add TLS handshake tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e373077188323a15bb8b5f0e7dad9