### PR TITLE
feat(device): add arg support for raw device commands

### DIFF
--- a/device/detect.go
+++ b/device/detect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -30,7 +31,23 @@ func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawC
 		if _, err := lvm.GetVolumeGroupName(resolved); err == nil {
 			return OpenLVM(resolved)
 		}
-		return OpenRaw(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, logger)
+		var freezePath, thawPath string
+		var freezeArgs, thawArgs []string
+		if fsFreezeCmd != "" {
+			parts := strings.Fields(fsFreezeCmd)
+			if len(parts) > 0 {
+				freezePath = parts[0]
+				freezeArgs = parts[1:]
+			}
+		}
+		if fsThawCmd != "" {
+			parts := strings.Fields(fsThawCmd)
+			if len(parts) > 0 {
+				thawPath = parts[0]
+				thawArgs = parts[1:]
+			}
+		}
+		return OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, logger)
 	}
 	return nil, fmt.Errorf("unsupported path type: %s", resolved)
 }

--- a/device/device.go
+++ b/device/device.go
@@ -14,8 +14,10 @@ type Device interface {
 	// snapshot size (for devices that support it). The returned handle
 	// should be closed after use.
 	Snapshot(ctx context.Context, snapshotSize string) (Device, error)
-	// Cleanup releases any snapshot resources held by the device.
-	Cleanup(ctx context.Context) error
+	// Cleanup releases any snapshot resources held by the device. The
+	// provided command path and arguments are used by devices that require
+	// filesystem thaw operations.
+	Cleanup(ctx context.Context, cmdPath string, cmdArgs []string) error
 	// Close releases any resources associated with the device.
 	Close() error
 }

--- a/device/file.go
+++ b/device/file.go
@@ -56,4 +56,4 @@ func (d *FileDevice) Close() error { return d.f.Close() }
 func (d *FileDevice) Snapshot(context.Context, string) (Device, error) { return d, nil }
 
 // Cleanup is a no-op for regular files.
-func (d *FileDevice) Cleanup(context.Context) error { return nil }
+func (d *FileDevice) Cleanup(context.Context, string, []string) error { return nil }

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -106,7 +106,7 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 }
 
 // Cleanup removes the snapshot if one was created.
-func (d *LVMDevice) Cleanup(ctx context.Context) error {
+func (d *LVMDevice) Cleanup(ctx context.Context, _ string, _ []string) error {
 	if d.cleanupPath == "" {
 		return nil
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -16,25 +17,38 @@ type RawDevice struct {
 	f            *os.File
 	size         uint64
 	blockSize    uint64
-	fsFreezeCmd  string
-	fsThawCmd    string
 	freezeIssued bool
 	logger       *zap.Logger
 }
 
-// OpenRaw opens a block device at the given path and queries its size and block size.
-// If offline is false, fsFreezeCmd and fsThawCmd must be commands that successfully
-// freeze and thaw the filesystem around the device access.
-func OpenRaw(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, logger *zap.Logger) (_ *RawDevice, err error) {
-	d := &RawDevice{fsFreezeCmd: fsFreezeCmd, fsThawCmd: fsThawCmd, logger: logger}
+// OpenRaw opens a block device at the given path and queries its size and block
+// size. If offline is false, fsFreezeCmdPath and fsThawCmdPath must be commands
+// that successfully freeze and thaw the filesystem around the device access.
+func OpenRaw(
+	ctx context.Context,
+	path string,
+	offline bool,
+	fsFreezeCmdPath string,
+	fsFreezeCmdArgs []string,
+	fsThawCmdPath string,
+	fsThawCmdArgs []string,
+	logger *zap.Logger,
+) (_ *RawDevice, err error) {
+	d := &RawDevice{logger: logger}
 	if !offline {
-		if fsFreezeCmd == "" || fsThawCmd == "" {
+		if fsFreezeCmdPath == "" || fsThawCmdPath == "" {
 			return nil, fmt.Errorf("raw sources require --offline or --fs-freeze-command/--fs-thaw-command")
 		}
-		if d.logger != nil {
-			d.logger.Info("fs freeze start", zap.String("command", fsFreezeCmd))
+		if err := validateCmd(fsFreezeCmdPath, fsFreezeCmdArgs); err != nil {
+			return nil, fmt.Errorf("invalid freeze command: %w", err)
 		}
-		if err = exec.CommandContext(ctx, "sh", "-c", fsFreezeCmd).Run(); err != nil {
+		if err := validateCmd(fsThawCmdPath, fsThawCmdArgs); err != nil {
+			return nil, fmt.Errorf("invalid thaw command: %w", err)
+		}
+		if d.logger != nil {
+			d.logger.Info("fs freeze start", zap.String("command", fsFreezeCmdPath), zap.Strings("args", fsFreezeCmdArgs))
+		}
+		if err = exec.CommandContext(ctx, fsFreezeCmdPath, fsFreezeCmdArgs...).Run(); err != nil {
 			return nil, fmt.Errorf("freeze command failed: %w", err)
 		}
 		if d.logger != nil {
@@ -43,7 +57,7 @@ func OpenRaw(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThaw
 		d.freezeIssued = true
 		defer func() {
 			if err != nil {
-				_ = d.Cleanup(ctx)
+				_ = d.Cleanup(ctx, fsThawCmdPath, fsThawCmdArgs)
 			}
 		}()
 	}
@@ -90,12 +104,18 @@ func (d *RawDevice) Close() error { return d.f.Close() }
 func (d *RawDevice) Snapshot(context.Context, string) (Device, error) { return d, nil }
 
 // Cleanup thaws the filesystem if a freeze command was issued.
-func (d *RawDevice) Cleanup(ctx context.Context) error {
-	if d.freezeIssued && d.fsThawCmd != "" {
-		if d.logger != nil {
-			d.logger.Info("fs thaw start", zap.String("command", d.fsThawCmd))
+func (d *RawDevice) Cleanup(ctx context.Context, fsThawCmdPath string, fsThawCmdArgs []string) error {
+	if d.freezeIssued {
+		if err := validateCmd(fsThawCmdPath, fsThawCmdArgs); err != nil {
+			if d.logger != nil {
+				d.logger.Error("fs thaw failed", zap.Error(err))
+			}
+			return fmt.Errorf("invalid thaw command: %w", err)
 		}
-		if err := exec.CommandContext(ctx, "sh", "-c", d.fsThawCmd).Run(); err != nil {
+		if d.logger != nil {
+			d.logger.Info("fs thaw start", zap.String("command", fsThawCmdPath), zap.Strings("args", fsThawCmdArgs))
+		}
+		if err := exec.CommandContext(ctx, fsThawCmdPath, fsThawCmdArgs...).Run(); err != nil {
 			if d.logger != nil {
 				d.logger.Error("fs thaw failed", zap.Error(err))
 			}
@@ -104,6 +124,25 @@ func (d *RawDevice) Cleanup(ctx context.Context) error {
 		if d.logger != nil {
 			d.logger.Info("fs thaw complete")
 		}
+	}
+	return nil
+}
+
+// validateCmd ensures the command path and arguments are suitable for execution.
+func validateCmd(path string, args []string) error {
+	if path == "" {
+		return fmt.Errorf("command path is empty")
+	}
+	if strings.ContainsRune(path, '\x00') {
+		return fmt.Errorf("command path contains NUL byte")
+	}
+	for _, a := range args {
+		if strings.ContainsRune(a, '\x00') {
+			return fmt.Errorf("command argument contains NUL byte")
+		}
+	}
+	if _, err := exec.LookPath(path); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
 	}
 	return nil
 }

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -2,7 +2,6 @@ package device
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,14 +15,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(context.Background(), f.Name(), true, "", "", zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", "", zap.NewNop()); err == nil {
+		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, zap.NewNop()); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -32,13 +31,13 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", "", zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, zap.NewNop()); err == nil {
 		t.Fatalf("expected offline or freeze command error")
 	}
 }
 
 func TestOpenRawFreezeCommandFailure(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", "true", zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, zap.NewNop()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -46,9 +45,11 @@ func TestOpenRawFreezeCommandFailure(t *testing.T) {
 func TestOpenRawThawsOnFailure(t *testing.T) {
 	freezeTmp := filepath.Join(t.TempDir(), "freeze")
 	thawTmp := filepath.Join(t.TempDir(), "thaw")
-	freezeCmd := fmt.Sprintf("touch %s", freezeTmp)
-	thawCmd := fmt.Sprintf("touch %s", thawTmp)
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmd, thawCmd, zap.NewNop()); err == nil {
+	freezeCmdPath := "touch"
+	freezeArgs := []string{freezeTmp}
+	thawCmdPath := "touch"
+	thawArgs := []string{thawTmp}
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {
@@ -61,8 +62,8 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 
 func TestCleanupRunsThawCommand(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "thaw")
-	d := &RawDevice{fsThawCmd: fmt.Sprintf("touch %s", tmp), freezeIssued: true, logger: zap.NewNop()}
-	if err := d.Cleanup(context.Background()); err != nil {
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop()}
+	if err := d.Cleanup(context.Background(), "touch", []string{tmp}); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
 	if _, err := os.Stat(tmp); err != nil {
@@ -71,8 +72,8 @@ func TestCleanupRunsThawCommand(t *testing.T) {
 }
 
 func TestCleanupThawCommandFailure(t *testing.T) {
-	d := &RawDevice{fsThawCmd: "false", freezeIssued: true, logger: zap.NewNop()}
-	if err := d.Cleanup(context.Background()); err == nil {
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop()}
+	if err := d.Cleanup(context.Background(), "false", nil); err == nil {
 		t.Fatalf("expected thaw command failure")
 	}
 }

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -32,7 +32,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	if fsnap.Path() != fd.Path() {
 		t.Fatalf("file snapshot path mismatch")
 	}
-	if err := fsnap.Cleanup(ctx); err != nil {
+	if err := fsnap.Cleanup(ctx, "", nil); err != nil {
 		t.Fatalf("file cleanup: %v", err)
 	}
 
@@ -45,7 +45,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	if rsnap.Path() != rd.Path() {
 		t.Fatalf("raw snapshot path mismatch")
 	}
-	if err := rsnap.Cleanup(ctx); err != nil {
+	if err := rsnap.Cleanup(ctx, "", nil); err != nil {
 		t.Fatalf("raw cleanup: %v", err)
 	}
 
@@ -80,7 +80,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	if snap.Path() != "/dev/vg0/snap" {
 		t.Fatalf("lvm snapshot path = %s", snap.Path())
 	}
-	if err := snap.Cleanup(ctx); err != nil {
+	if err := snap.Cleanup(ctx, "", nil); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -28,7 +28,7 @@ func (m *mockDevice) SizeBytes() uint64                                       { 
 func (m *mockDevice) BlockSize() uint64                                       { return m.blockSize }
 func (m *mockDevice) Close() error                                            { return nil }
 func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
-func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
+func (m *mockDevice) Cleanup(context.Context, string, []string) error         { return nil }
 
 func TestIndexCRUD(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- pass command paths and argument slices to OpenRaw and Cleanup
- validate freeze/thaw commands before execution
- update device tests for argument-based API

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e41fab8088323be82dd8b1acf376a