### PR TITLE
perf(dedup): reuse chunker buffers

### DIFF
--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -27,6 +27,9 @@ type Chunker struct {
 	maskHigh   uint64
 	maskLow    uint64
 	window     [64]byte // used for entropy estimation
+
+	// reusable buffer to avoid per-chunk allocations
+	buf []byte
 }
 
 // NewChunker returns a new chunker configured with the provided
@@ -63,7 +66,10 @@ func NewChunkerFromHandshake(h common.Handshake) *Chunker {
 //
 //nolint:revive // algorithmic complexity required for chunking
 func (c *Chunker) NextChunk(r io.Reader) (Chunk, error) {
-	buf := make([]byte, c.Max)
+	if cap(c.buf) < c.Max {
+		c.buf = make([]byte, c.Max)
+	}
+	buf := c.buf[:c.Max]
 	n, err := io.ReadFull(r, buf[:c.Min])
 	if err != nil {
 		if err == io.ErrUnexpectedEOF || err == io.EOF {

--- a/dedup/hybrid.go
+++ b/dedup/hybrid.go
@@ -14,6 +14,8 @@ type HybridChunker struct {
 	cdcAvg  int
 	cdcMax  int
 	pending []Chunk
+	// reusable buffer for fixed-size block reads
+	buf []byte
 }
 
 // NewHybridChunker returns a HybridChunker configured with the given block
@@ -34,7 +36,10 @@ func (h *HybridChunker) NextChunk(r io.Reader) (Chunk, error) {
 		return c, nil
 	}
 
-	buf := make([]byte, h.fixed)
+	if cap(h.buf) < h.fixed {
+		h.buf = make([]byte, h.fixed)
+	}
+	buf := h.buf[:h.fixed]
 	n, err := io.ReadFull(r, buf)
 	if err != nil {
 		if err == io.ErrUnexpectedEOF || err == io.EOF {

--- a/dedup/hybrid_test.go
+++ b/dedup/hybrid_test.go
@@ -28,3 +28,48 @@ func TestHybridChunkerProducesChunks(t *testing.T) {
 		t.Fatalf("expected chunks")
 	}
 }
+
+func TestHybridChunkerBufferReuse(t *testing.T) {
+	fixed := 1 << 16
+	data := bytes.Repeat([]byte("a"), fixed*2)
+	h := NewHybridChunker(fixed, 64, 128, 256)
+	r := bytes.NewReader(data)
+
+	c1, err := h.NextChunk(r)
+	if err != nil && err != io.EOF {
+		t.Fatalf("next chunk: %v", err)
+	}
+	if !bytes.Equal(c1.Data, data[:c1.Length]) {
+		t.Fatalf("unexpected chunk data")
+	}
+	chunkPtr := &c1.Data[0]
+	bufPtr := &h.buf[0]
+
+	c2, err := h.NextChunk(r)
+	if err != nil && err != io.EOF {
+		t.Fatalf("next chunk: %v", err)
+	}
+	if &c2.Data[0] != chunkPtr {
+		t.Fatalf("chunk buffer not reused")
+	}
+
+	offset := c1.Length + c2.Length
+	for len(h.pending) > 0 {
+		c, err := h.NextChunk(r)
+		if err != nil && err != io.EOF {
+			t.Fatalf("next chunk: %v", err)
+		}
+		offset += c.Length
+	}
+
+	c3, err := h.NextChunk(r)
+	if err != nil && err != io.EOF {
+		t.Fatalf("next chunk: %v", err)
+	}
+	if &h.buf[0] != bufPtr {
+		t.Fatalf("fixed buffer not reused")
+	}
+	if !bytes.Equal(c3.Data, data[offset:offset+c3.Length]) {
+		t.Fatalf("unexpected chunk data")
+	}
+}

--- a/dedup/unit_test.go
+++ b/dedup/unit_test.go
@@ -93,3 +93,32 @@ func TestBloomSizing(t *testing.T) {
 		t.Fatalf("unexpected sizing avg=%d chunks=%d", avg, chunks)
 	}
 }
+
+func TestChunkerBufferReuse(t *testing.T) {
+	data := bytes.Repeat([]byte("a"), 1<<10)
+	ch := NewChunker(64, 128, 256)
+	r := bytes.NewReader(data)
+
+	c1, err := ch.NextChunk(r)
+	if err != nil && err != io.EOF {
+		t.Fatalf("next chunk: %v", err)
+	}
+	if !bytes.Equal(c1.Data, data[:c1.Length]) {
+		t.Fatalf("unexpected chunk data")
+	}
+	ptr := &c1.Data[0]
+
+	c2, err := ch.NextChunk(r)
+	if err != nil && err != io.EOF {
+		t.Fatalf("next chunk: %v", err)
+	}
+	if c2.Length == 0 {
+		t.Fatalf("expected second chunk")
+	}
+	if &c2.Data[0] != ptr {
+		t.Fatalf("buffer not reused")
+	}
+	if !bytes.Equal(c2.Data, data[c1.Length:c1.Length+c2.Length]) {
+		t.Fatalf("unexpected chunk data")
+	}
+}


### PR DESCRIPTION
## Summary
- reuse internal buffers for Chunker and HybridChunker to avoid per-call allocations
- test buffer reuse in chunker and hybrid chunker

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e41e8ca8483238d901d127a73333d