### PR TITLE
feat(transport): require explicit certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,8 @@ authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional st
 transport also requires TLS 1.3 with client certificates and negotiates the `h2` ALPN. Provide certificates via
 `--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and will refuse
 connections when no roots are provided unless `--allow_insecure` (or the `AllowInsecure` configuration flag) is
-set. The flags below configure transport behavior.
+set. Client certificates must be supplied explicitly; transports no longer generate self-signed certificates
+automatically. The flags below configure transport behavior.
 
 ### Flags and environment variables
 

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -3,12 +3,8 @@ package quic
 import (
 	"bufio"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"math/big"
 	"net"
 	"time"
 
@@ -53,30 +49,28 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")
 	}
 	cert := cfg.ClientCert
-	if len(cert.Certificate) == 0 {
-		var err error
-		cert, err = generateSelfSignedCert()
-		if err != nil {
-			return nil, err
-		}
+	if len(cert.Certificate) == 0 && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("client certificate is required unless AllowInsecure is set")
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverTLS := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		ClientCAs:    cfg.Roots,
-		ClientAuth:   clientAuth,
-		MinVersion:   tls.VersionTLS13,
-		NextProtos:   []string{alpn},
+		ClientCAs:  cfg.Roots,
+		ClientAuth: clientAuth,
+		MinVersion: tls.VersionTLS13,
+		NextProtos: []string{alpn},
 	}
 	clientTLS := &tls.Config{
-		Certificates:       []tls.Certificate{cert},
 		RootCAs:            cfg.Roots,
 		InsecureSkipVerify: cfg.AllowInsecure,
 		MinVersion:         tls.VersionTLS13,
 		NextProtos:         []string{alpn},
+	}
+	if len(cert.Certificate) > 0 {
+		serverTLS.Certificates = []tls.Certificate{cert}
+		clientTLS.Certificates = []tls.Certificate{cert}
 	}
 	qconf := &quic.Config{EnableDatagrams: true}
 	return &Transport{serverTLS: serverTLS, clientTLS: clientTLS, qconf: qconf, logger: cfg.Logger}, nil
@@ -265,24 +259,4 @@ func roleString(r transport.Role) string {
 	default:
 		return ""
 	}
-}
-
-// generateSelfSignedCert creates a short-lived self-signed certificate.
-func generateSelfSignedCert() (tls.Certificate, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-	tmpl := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(time.Hour),
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
-	}
-	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
-	return cert, nil
 }

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -2,7 +2,14 @@ package quic
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"math/big"
+	"net"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -30,8 +37,9 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 }
 
 func TestQUICTransportHandshake(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, err := New(transport.Config{Logger: zap.New(core), AllowInsecure: true})
+	trIface, err := New(transport.Config{Logger: zap.New(core), ClientCert: cert, AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}
@@ -90,8 +98,9 @@ func TestQUICTransportHandshake(t *testing.T) {
 }
 
 func TestQUICTransportHandshakeError(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
-	trIface, err := New(transport.Config{Logger: zap.New(core), AllowInsecure: true})
+	trIface, err := New(transport.Config{Logger: zap.New(core), ClientCert: cert, AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}
@@ -148,4 +157,40 @@ func TestQUICTransportRequiresRootsOrAllowInsecure(t *testing.T) {
 	if _, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true}); err != nil {
 		t.Fatalf("allow insecure should permit missing roots: %v", err)
 	}
+}
+
+func TestQUICTransportRequiresClientCert(t *testing.T) {
+	root := x509.NewCertPool()
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: root}); err == nil {
+		t.Fatalf("expected error when client cert is nil")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing client cert: %v", err)
+	}
+}
+
+func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(parsed)
+	return cert, pool
 }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -3,12 +3,8 @@ package tcp_tls
 import (
 	"bufio"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"math/big"
 	"net"
 	"time"
 
@@ -34,28 +30,26 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")
 	}
 	cert := cfg.ClientCert
-	if len(cert.Certificate) == 0 {
-		var err error
-		cert, err = generateSelfSignedCert()
-		if err != nil {
-			return nil, err
-		}
+	if len(cert.Certificate) == 0 && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("client certificate is required unless AllowInsecure is set")
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverConf := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		ClientCAs:    cfg.Roots,
-		ClientAuth:   clientAuth,
-		MinVersion:   tls.VersionTLS13,
+		ClientCAs:  cfg.Roots,
+		ClientAuth: clientAuth,
+		MinVersion: tls.VersionTLS13,
 	}
 	clientConf := &tls.Config{
-		Certificates:       []tls.Certificate{cert},
 		RootCAs:            cfg.Roots,
 		InsecureSkipVerify: cfg.AllowInsecure,
 		MinVersion:         tls.VersionTLS13,
+	}
+	if len(cert.Certificate) > 0 {
+		serverConf.Certificates = []tls.Certificate{cert}
+		clientConf.Certificates = []tls.Certificate{cert}
 	}
 	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil
 }
@@ -207,23 +201,4 @@ func roleString(r transport.Role) string {
 	default:
 		return ""
 	}
-}
-
-func generateSelfSignedCert() (tls.Certificate, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-	tmpl := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(time.Hour),
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
-	}
-	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
-	return cert, nil
 }

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -2,9 +2,13 @@ package tcp_tls
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"io"
+	"math/big"
 	"net"
 	"testing"
 	"time"
@@ -35,13 +39,7 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 }
 
 func TestTCPTLSTransportHandshake(t *testing.T) {
-	cert, _ := generateSelfSignedCert()
-	root := x509.NewCertPool()
-	if len(cert.Certificate) > 0 {
-		if c, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
-			root.AddCert(c)
-		}
-	}
+	cert, root := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
 	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: root, ClientCert: cert})
 	if err != nil {
@@ -108,11 +106,7 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {
-	cert, _ := generateSelfSignedCert()
-	root := x509.NewCertPool()
-	if c, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
-		root.AddCert(c)
-	}
+	cert, root := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
 	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: root, ClientCert: cert})
 	if err != nil {
@@ -158,7 +152,7 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 
 func TestTCPTLSCertValidation(t *testing.T) {
 	root := x509.NewCertPool()
-	cert, _ := generateSelfSignedCert()
+	cert, _ := generateSelfSignedCert(t)
 	trIface, _ := New(transport.Config{Roots: root, ClientCert: cert, Logger: zap.NewNop()})
 	tr := trIface.(*Transport)
 	ctx := context.Background()
@@ -182,11 +176,7 @@ func TestTCPTLSCertValidation(t *testing.T) {
 }
 
 func TestTCPTLSDialContextCancel(t *testing.T) {
-	cert, _ := generateSelfSignedCert()
-	root := x509.NewCertPool()
-	if c, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
-		root.AddCert(c)
-	}
+	cert, root := generateSelfSignedCert(t)
 	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
@@ -218,8 +208,7 @@ func TestTCPTLSDialContextCancel(t *testing.T) {
 }
 
 func TestTCPTLSTransportRequiresLogger(t *testing.T) {
-	cert, _ := generateSelfSignedCert()
-	root := x509.NewCertPool()
+	cert, root := generateSelfSignedCert(t)
 	if _, err := New(transport.Config{Roots: root, ClientCert: cert}); err == nil {
 		t.Fatalf("expected error when logger is nil")
 	}
@@ -232,4 +221,40 @@ func TestTCPTLSTransportRequiresRootsOrAllowInsecure(t *testing.T) {
 	if _, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true}); err != nil {
 		t.Fatalf("allow insecure should permit missing roots: %v", err)
 	}
+}
+
+func TestTCPTLSTransportRequiresClientCert(t *testing.T) {
+	root := x509.NewCertPool()
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: root}); err == nil {
+		t.Fatalf("expected error when client cert is nil")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing client cert: %v", err)
+	}
+}
+
+func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(parsed)
+	return cert, pool
 }


### PR DESCRIPTION
## Summary
- drop automatic self-signed certificate generation for tcp+tls and quic transports
- require ClientCert unless `AllowInsecure` is set and document this in README
- adjust transport unit tests to generate and supply certificates explicitly

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e4205275c8323be4432263a996f55