### PR TITLE
build(device): add linux build tags with stubs

### DIFF
--- a/device/lvm.go
+++ b/device/lvm.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package device
 
 import (

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -1,0 +1,25 @@
+//go:build !linux
+
+package device
+
+import (
+	"context"
+	"fmt"
+)
+
+// LVMDevice is unsupported on non-Linux platforms.
+type LVMDevice struct{}
+
+// OpenLVM returns an error on non-Linux systems.
+func OpenLVM(string) (*LVMDevice, error) {
+	return nil, fmt.Errorf("LVM devices are only supported on Linux")
+}
+
+func (d *LVMDevice) Path() string      { return "" }
+func (d *LVMDevice) SizeBytes() uint64 { return 0 }
+func (d *LVMDevice) BlockSize() uint64 { return 0 }
+func (d *LVMDevice) Close() error      { return nil }
+func (d *LVMDevice) Snapshot(context.Context, string) (Device, error) {
+	return nil, fmt.Errorf("LVM snapshots are only supported on Linux")
+}
+func (d *LVMDevice) Cleanup(context.Context) error { return nil }

--- a/device/raw.go
+++ b/device/raw.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package device
 
 import (

--- a/device/raw_nonlinux.go
+++ b/device/raw_nonlinux.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+package device
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+)
+
+// RawDevice is unsupported on non-Linux platforms.
+type RawDevice struct{}
+
+// OpenRaw returns an error on non-Linux systems.
+func OpenRaw(context.Context, string, bool, string, string, *zap.Logger) (*RawDevice, error) {
+	return nil, fmt.Errorf("raw devices are only supported on Linux")
+}
+
+func (d *RawDevice) Path() string      { return "" }
+func (d *RawDevice) SizeBytes() uint64 { return 0 }
+func (d *RawDevice) BlockSize() uint64 { return 0 }
+func (d *RawDevice) Snapshot(context.Context, string) (Device, error) {
+	return nil, fmt.Errorf("raw device snapshots are only supported on Linux")
+}
+func (d *RawDevice) Cleanup(context.Context) error { return nil }
+func (d *RawDevice) Close() error                  { return nil }


### PR DESCRIPTION
## Summary
- restrict LVM and raw device code to Linux with `//go:build linux`
- provide stub implementations for non-Linux targets

## Testing
- `go build ./...`
- `GOOS=darwin go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689e42f6f1c48323963187b844e7f74f