### PR TITLE
chore: enable lint result sorting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4180,6 +4180,9 @@ output:
   # Default: ""
   path-mode: "abs"
 
+  # Sort lint results before applying sort-order.
+  sort-results: true
+
   # Order to use when sorting results.
   # Possible values: `file`, `linter`, and `severity`.
   #


### PR DESCRIPTION
## Summary
- enable lint result sorting so `sort-order` is honored

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e441818d48323b8bdfcde5816fe5e