### PR TITLE
feat(device): add logging for device detection and files

### DIFF
--- a/device/detect.go
+++ b/device/detect.go
@@ -18,18 +18,48 @@ import (
 func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, logger *zap.Logger) (Device, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
+		if logger != nil {
+			logger.Error("device detect failed", zap.String("path", path), zap.String("device_type", "symlink"), zap.Error(err))
+		}
 		return nil, err
 	}
 	info, err := os.Stat(resolved)
 	if err != nil {
+		if logger != nil {
+			logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
+		}
 		return nil, err
 	}
 	if info.Mode().IsRegular() {
-		return OpenFile(resolved)
+		dev, err := OpenFile(resolved, logger)
+		if err != nil {
+			if logger != nil {
+				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
+			}
+			return nil, err
+		}
+		if logger != nil {
+			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
+		}
+		return dev, nil
 	}
 	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
 		if _, err := lvm.GetVolumeGroupName(resolved); err == nil {
-			return OpenLVM(resolved)
+			dev, err := OpenLVM(resolved, logger)
+			if err != nil {
+				if logger != nil {
+					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
+				}
+				return nil, err
+			}
+			if logger != nil {
+				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
+			}
+			return dev, nil
+		} else {
+			if logger != nil {
+				logger.Debug("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
+			}
 		}
 		var freezePath, thawPath string
 		var freezeArgs, thawArgs []string
@@ -47,7 +77,21 @@ func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawC
 				thawArgs = parts[1:]
 			}
 		}
-		return OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, logger)
+		dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, logger)
+		if err != nil {
+			if logger != nil {
+				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
+			}
+			return nil, err
+		}
+		if logger != nil {
+			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
+		}
+		return dev, nil
 	}
-	return nil, fmt.Errorf("unsupported path type: %s", resolved)
+	err = fmt.Errorf("unsupported path type: %s", resolved)
+	if logger != nil {
+		logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))
+	}
+	return nil, err
 }

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func setupLoop(t *testing.T, size int64) (string, func()) {
@@ -39,7 +40,9 @@ func TestDetectFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	dev, err := Detect(context.Background(), f.Name(), true, "", "", zap.NewNop())
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	dev, err := Detect(context.Background(), f.Name(), true, "", "", logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -47,6 +50,17 @@ func TestDetectFile(t *testing.T) {
 		t.Fatalf("expected FileDevice, got %T", dev)
 	}
 	dev.Close()
+
+	entries := logs.FilterMessage("detect device success").All()
+	found := false
+	for _, e := range entries {
+		if e.ContextMap()["device_type"] == "file" && e.ContextMap()["path"] == f.Name() {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected log entry for file detection")
+	}
 }
 
 func TestDetectFileSymlink(t *testing.T) {
@@ -75,7 +89,9 @@ func TestDetectRaw(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	dev, err := Detect(context.Background(), loop, true, "", "", zap.NewNop())
+	core, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(core)
+	dev, err := Detect(context.Background(), loop, true, "", "", logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -83,6 +99,25 @@ func TestDetectRaw(t *testing.T) {
 		t.Fatalf("expected RawDevice, got %T", dev)
 	}
 	dev.Close()
+
+	// Expect LVM failure debug and Raw success info.
+	lvmFail := false
+	rawSuccess := false
+	for _, e := range logs.All() {
+		switch e.Message {
+		case "detect device failed":
+			if e.ContextMap()["device_type"] == "lvm" {
+				lvmFail = true
+			}
+		case "detect device success":
+			if e.ContextMap()["device_type"] == "raw" {
+				rawSuccess = true
+			}
+		}
+	}
+	if !lvmFail || !rawSuccess {
+		t.Fatalf("expected lvm fail and raw success logs, got %v", logs.All())
+	}
 }
 
 func TestDetectRawSymlink(t *testing.T) {

--- a/device/file.go
+++ b/device/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
 
@@ -13,30 +14,53 @@ type FileDevice struct {
 	f         *os.File
 	size      uint64
 	blockSize uint64
+	logger    *zap.Logger
 }
 
 // OpenFile opens a regular file and reports its size and filesystem block size.
-func OpenFile(path string) (*FileDevice, error) {
+func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
 	info, err := os.Stat(path)
 	if err != nil {
+		if logger != nil {
+			logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
+		}
 		return nil, err
 	}
 	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s is not a regular file", path)
+		err := fmt.Errorf("%s is not a regular file", path)
+		if logger != nil {
+			logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
+		}
+		return nil, err
 	}
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
+		if logger != nil {
+			logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
+		}
 		return nil, err
+	}
+	if logger != nil {
+		logger.Info("file device opened", zap.String("path", path))
 	}
 	var st unix.Stat_t
 	if err := unix.Fstat(int(f.Fd()), &st); err != nil {
 		f.Close()
+		if logger != nil {
+			logger.Error("file device stat failed", zap.String("path", path), zap.Error(err))
+		}
 		return nil, err
+	}
+	size := uint64(info.Size())
+	block := uint64(st.Blksize)
+	if logger != nil {
+		logger.Info("file device info", zap.String("path", path), zap.Uint64("size_bytes", size), zap.Uint64("block_size", block))
 	}
 	return &FileDevice{
 		f:         f,
-		size:      uint64(info.Size()),
-		blockSize: uint64(st.Blksize),
+		size:      size,
+		blockSize: block,
+		logger:    logger,
 	}, nil
 }
 
@@ -50,10 +74,30 @@ func (d *FileDevice) SizeBytes() uint64 { return d.size }
 func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 
 // Close closes the underlying file descriptor.
-func (d *FileDevice) Close() error { return d.f.Close() }
+func (d *FileDevice) Close() error {
+	err := d.f.Close()
+	if d.logger != nil {
+		if err != nil {
+			d.logger.Error("file device close failed", zap.String("path", d.Path()), zap.Error(err))
+		} else {
+			d.logger.Info("file device closed", zap.String("path", d.Path()))
+		}
+	}
+	return err
+}
 
 // Snapshot returns the device itself for regular files.
-func (d *FileDevice) Snapshot(context.Context, string) (Device, error) { return d, nil }
+func (d *FileDevice) Snapshot(context.Context, string) (Device, error) {
+	if d.logger != nil {
+		d.logger.Info("file device snapshot", zap.String("path", d.Path()))
+	}
+	return d, nil
+}
 
 // Cleanup is a no-op for regular files.
-func (d *FileDevice) Cleanup(context.Context, string, []string) error { return nil }
+func (d *FileDevice) Cleanup(context.Context, string, []string) error {
+	if d.logger != nil {
+		d.logger.Info("file device cleanup", zap.String("path", d.Path()))
+	}
+	return nil
+}

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -1,8 +1,12 @@
 package device
 
 import (
+	"context"
 	"os"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestOpenFile(t *testing.T) {
@@ -16,11 +20,16 @@ func TestOpenFile(t *testing.T) {
 	path := f.Name()
 	f.Close()
 
-	d, err := OpenFile(path)
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	d, err := OpenFile(path, logger)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer d.Close()
+	ctx := context.Background()
+	_, _ = d.Snapshot(ctx, "")
+	_ = d.Cleanup(ctx, "", nil)
+	d.Close()
 
 	if d.SizeBytes() != 4096 {
 		t.Fatalf("expected size 4096, got %d", d.SizeBytes())
@@ -28,11 +37,27 @@ func TestOpenFile(t *testing.T) {
 	if d.BlockSize() == 0 {
 		t.Fatalf("expected non-zero block size")
 	}
+
+	if logs.FilterMessage("file device opened").Len() == 0 {
+		t.Fatalf("expected file device opened log")
+	}
+	if logs.FilterMessage("file device info").Len() == 0 {
+		t.Fatalf("expected file device info log")
+	}
+	if logs.FilterMessage("file device snapshot").Len() == 0 {
+		t.Fatalf("expected file device snapshot log")
+	}
+	if logs.FilterMessage("file device cleanup").Len() == 0 {
+		t.Fatalf("expected file device cleanup log")
+	}
+	if logs.FilterMessage("file device closed").Len() == 0 {
+		t.Fatalf("expected file device closed log")
+	}
 }
 
 func TestOpenFileRejectsNonRegular(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := OpenFile(dir); err == nil {
+	if _, err := OpenFile(dir, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for directory")
 	}
 }

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -23,11 +23,12 @@ type LVMDevice struct {
 	size        uint64
 	blockSize   uint64
 	cleanupPath string
+	logger      *zap.Logger
 }
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
 // Size information is obtained through the lvm package helpers.
-func OpenLVM(path string) (*LVMDevice, error) {
+func OpenLVM(path string, logger *zap.Logger) (*LVMDevice, error) {
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -37,12 +38,12 @@ func OpenLVM(path string) (*LVMDevice, error) {
 		f.Close()
 		return nil, err
 	}
-	size, err := lvm.GetVolumeSize(path, zap.NewNop())
+	size, err := lvm.GetVolumeSize(path, logger)
 	if err != nil {
 		f.Close()
 		return nil, err
 	}
-	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs)}, nil
+	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs), logger: logger}, nil
 }
 
 // Path returns the underlying device path.
@@ -93,12 +94,12 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 	if err := runLVM(ctx, "lvcreate", "-s", "-n", snapName, "-L", snapshotSize, d.path); err != nil {
 		return nil, err
 	}
-	snapPath := lvm.GetSnapshotDevicePath(snapName, vg, zap.NewNop())
+	snapPath := lvm.GetSnapshotDevicePath(snapName, vg, d.logger)
 	if err := runLVM(ctx, "lvchange", "-ay", snapPath); err != nil {
 		_ = runLVM(ctx, "lvremove", "-f", snapPath)
 		return nil, err
 	}
-	snapDev, err := openLVMFunc(snapPath)
+	snapDev, err := openLVMFunc(snapPath, d.logger)
 	if err != nil {
 		_ = runLVM(ctx, "lvremove", "-f", snapPath)
 		return nil, err

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -5,13 +5,15 @@ package device
 import (
 	"context"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // LVMDevice is unsupported on non-Linux platforms.
 type LVMDevice struct{}
 
 // OpenLVM returns an error on non-Linux systems.
-func OpenLVM(string) (*LVMDevice, error) {
+func OpenLVM(string, *zap.Logger) (*LVMDevice, error) {
 	return nil, fmt.Errorf("LVM devices are only supported on Linux")
 }
 
@@ -22,4 +24,4 @@ func (d *LVMDevice) Close() error      { return nil }
 func (d *LVMDevice) Snapshot(context.Context, string) (Device, error) {
 	return nil, fmt.Errorf("LVM snapshots are only supported on Linux")
 }
-func (d *LVMDevice) Cleanup(context.Context) error { return nil }
+func (d *LVMDevice) Cleanup(context.Context, string, []string) error { return nil }

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestSnapshotLifecycle(t *testing.T) {
@@ -21,7 +23,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	fd, err := OpenFile(f.Name())
+	fd, err := OpenFile(f.Name(), zap.NewNop())
 	if err != nil {
 		t.Fatalf("open file: %v", err)
 	}
@@ -63,8 +65,8 @@ func TestSnapshotLifecycle(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	origOpen := openLVMFunc
-	openLVMFunc = func(p string) (*LVMDevice, error) {
-		return &LVMDevice{path: p, cleanupPath: p}, nil
+	openLVMFunc = func(p string, _ *zap.Logger) (*LVMDevice, error) {
+		return &LVMDevice{path: p, cleanupPath: p, logger: zap.NewNop()}, nil
 	}
 	defer func() { openLVMFunc = origOpen }()
 
@@ -72,7 +74,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	geteuid = func() int { return 1 }
 	defer func() { geteuid = origEuid }()
 
-	lvd := &LVMDevice{path: "/dev/vg0/origin"}
+	lvd := &LVMDevice{path: "/dev/vg0/origin", logger: zap.NewNop()}
 	snap, err := lvd.Snapshot(ctx, "2G")
 	if err != nil {
 		t.Fatalf("lvm snapshot: %v", err)


### PR DESCRIPTION
## Summary
- add structured logging to device detection for file, raw, and LVM branches
- extend FileDevice with zap logger and log open/info/snapshot/cleanup/close events
- verify logging with zaptest/observer in detection and file tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689f1c3370c08323bfa016f0a5571189