### PR TITLE
feat(manifest): add context-aware rebuild

### DIFF
--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -1,7 +1,9 @@
 package manifest
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -41,7 +43,9 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		}
 		return nil
 	}
-	if err := manifestpkg.Rebuild(device, path, logger, conf.ManifestProgressInterval); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	if err := manifestpkg.Rebuild(ctx, device, path, logger, conf.ManifestProgressInterval); err != nil {
 		if logger != nil {
 			logger.Error("rebuild failed", zap.Error(err))
 		}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -80,7 +81,9 @@ func TestVerifyManifestMismatch(t *testing.T) {
 	manPath := filepath.Join(t.TempDir(), "dst.man")
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
-	if err := manifest.Rebuild(dst, manPath, zap.NewNop(), 0); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manifest.Rebuild(ctx, dst, manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 	core, observed := observer.New(zap.ErrorLevel)
@@ -118,7 +121,9 @@ func TestVerifyManifestSuccess(t *testing.T) {
 	manPath := filepath.Join(t.TempDir(), "src.man")
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
-	if err := manifest.Rebuild(src, manPath, zap.NewNop(), 0); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manifest.Rebuild(ctx, src, manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 	if err := Run([]string{"--manifest_path", manPath, src, src}, zap.NewNop()); err != nil {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -218,16 +218,26 @@ func (i *Index) ChunkCount() int { return int(i.hdr.ChunkCount) }
 // Rebuild creates a manifest index for device at output path.
 // DeviceID is determined via device.GetUUID. The device is read sequentially using blockSize-sized chunks.
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
-func Rebuild(devicePath, output string, logger *zap.Logger, progressInterval time.Duration) error {
-	dev, err := detectDevice(context.Background(), devicePath, logger)
+// The operation respects cancellation via ctx.
+func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	dev, err := detectDevice(ctx, devicePath, logger)
 	if err != nil {
 		return err
 	}
 	defer dev.Close()
 	blockSize := uint32(dev.BlockSize())
 	size := dev.SizeBytes()
-	id, err := device.GetUUID(context.Background(), dev.Path())
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	id, err := device.GetUUID(ctx, dev.Path())
 	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	f, err := os.Open(dev.Path())
@@ -244,6 +254,9 @@ func Rebuild(devicePath, output string, logger *zap.Logger, progressInterval tim
 	lastLog := start
 	buf := make([]byte, blockSize)
 	for off := uint64(0); off < size; off += uint64(blockSize) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		n, err := f.ReadAt(buf, int64(off))
 		if err != nil && err != io.EOF {
 			return err
@@ -256,6 +269,9 @@ func Rebuild(devicePath, output string, logger *zap.Logger, progressInterval tim
 		b3 := blake3.Sum256(data)
 		idx.Set(off, uint32(n), xx, b3)
 		if logger != nil && (progressInterval == 0 || time.Since(lastLog) >= progressInterval) {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			logger.Info("rebuild progress",
 				zap.Uint64("offset_bytes", off+uint64(n)),
 				zap.Int64("duration_ms", time.Since(start).Milliseconds()),

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
@@ -131,7 +133,9 @@ func TestRebuild(t *testing.T) {
 	prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "rebuild.man")
-	if err := Rebuild(file.Name(), manPath, zap.NewNop(), 0); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -178,7 +182,9 @@ func TestRebuildCloseOnce(t *testing.T) {
 	count := 0
 	closeHook = func() { count++ }
 	defer func() { closeHook = prevHook }()
-	if err := Rebuild(file.Name(), manPath, zap.NewNop(), 0); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if count != 1 {
@@ -213,7 +219,9 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	}
 	defer func() { detectDevice = prevDetect }()
 	manPath := filepath.Join(dir, "rebuildbs.man")
-	if err := Rebuild(file.Name(), manPath, zap.NewNop(), 0); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -255,7 +263,9 @@ func TestRebuildLogsProgress(t *testing.T) {
 	manPath := filepath.Join(dir, "progress.man")
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	if err := Rebuild(file.Name(), manPath, logger, 0); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Rebuild(ctx, file.Name(), manPath, logger, 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	entries := logs.FilterMessage("rebuild progress").All()
@@ -267,5 +277,34 @@ func TestRebuildLogsProgress(t *testing.T) {
 	}
 	if _, ok := entries[0].ContextMap()["duration_ms"]; !ok {
 		t.Fatalf("missing duration_ms field")
+	}
+}
+
+func TestRebuildCanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	size := 1 << 20 // 1 MiB
+	if err := file.Truncate(int64(size)); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	file.Close()
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	prevDetect := detectDevice
+	detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &mockDevice{path: file.Name(), size: uint64(size), blockSize: 1}, nil
+	}
+	defer func() { detectDevice = prevDetect }()
+	manPath := filepath.Join(dir, "cancel.man")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
@@ -80,7 +81,9 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 	destLoop := setupLoop(t, destPath)
 
 	manifestPath := filepath.Join(t.TempDir(), "src.man")
-	if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+	ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
+	defer cancelMan()
+	if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 
@@ -191,7 +194,9 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 	dstLoop := setupLoop(t, dstPath)
 
 	manifestPath := filepath.Join(dir, "src.man")
-	if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+	ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
+	defer cancelMan()
+	if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 
@@ -325,7 +330,9 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 			destLoop := setupLoop(t, destPath)
 
 			manifestPath := filepath.Join(t.TempDir(), "src.man")
-			if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+			ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
+			defer cancelMan()
+			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 
@@ -444,7 +451,9 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 			dstLoop := setupLoop(t, dstPath)
 
 			manifestPath := filepath.Join(dir, "src.man")
-			if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+			ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
+			defer cancelMan()
+			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 
@@ -620,7 +629,9 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 			dstLoop := setupLoop(t, dstPath)
 
 			manifestPath := filepath.Join(dir, "src.man")
-			if err := manifestpkg.Rebuild(srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+			ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
+			defer cancelMan()
+			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -33,7 +34,9 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 	prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
 	defer device.SetUUIDFunc(prev)
 	manPath := filepath.Join(dir, "dev.man")
-	if err := manifestpkg.Rebuild(dev.Name(), manPath, zap.NewNop(), 0); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manifestpkg.Rebuild(ctx, dev.Name(), manPath, zap.NewNop(), 0); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	src, err := os.Open(dev.Name())


### PR DESCRIPTION
## Summary
- allow manifest rebuild to respect cancellation via context
- ensure manifest command uses a timeout-bound context
- cover rebuild cancellation with a dedicated test

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f1c3625788323afa91739ee1ef725