### PR TITLE
fix(device): surface FileDevice snapshot errors

### DIFF
--- a/device/file.go
+++ b/device/file.go
@@ -52,8 +52,15 @@ func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 // Close closes the underlying file descriptor.
 func (d *FileDevice) Close() error { return d.f.Close() }
 
-// Snapshot returns the device itself for regular files.
-func (d *FileDevice) Snapshot(context.Context, string) (Device, error) { return d, nil }
+// Snapshot returns the device itself for regular files. It verifies the
+// underlying file descriptor is still open to surface errors when called on a
+// closed device.
+func (d *FileDevice) Snapshot(context.Context, string) (Device, error) {
+	if _, err := d.f.Stat(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
 
 // Cleanup is a no-op for regular files.
 func (d *FileDevice) Cleanup(context.Context, string, []string) error { return nil }

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -1,6 +1,7 @@
 package device
 
 import (
+	"context"
 	"os"
 	"testing"
 )
@@ -34,5 +35,63 @@ func TestOpenFileRejectsNonRegular(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := OpenFile(dir); err == nil {
 		t.Fatalf("expected error for directory")
+	}
+}
+
+func fdCount(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	return len(entries)
+}
+
+func TestFileSnapshotIdentityAndFDLeak(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "filedev")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	path := f.Name()
+	f.Close()
+
+	d, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	before := fdCount(t)
+	snap, err := d.Snapshot(context.Background(), "")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snap != d {
+		t.Fatalf("snapshot returned different device")
+	}
+	after := fdCount(t)
+	if before != after {
+		t.Fatalf("fd leak: before %d after %d", before, after)
+	}
+}
+
+func TestFileSnapshotClosedDevice(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "filedev")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	path := f.Name()
+	f.Close()
+
+	d, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := d.Snapshot(context.Background(), ""); err == nil {
+		t.Fatalf("expected error for closed device")
 	}
 }


### PR DESCRIPTION
## Summary
- verify FileDevice snapshots fail if the underlying file is closed
- test FileDevice snapshot identity and descriptor hygiene

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_689f1c3779548323821e3b42f1e1c763