### PR TITLE
fix(transport): log errors only when non-nil

### DIFF
--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -71,7 +71,6 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	d := &net.Dialer{}
@@ -81,7 +80,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
+			zap.Error(err),
 		)
 		return nil, err
 	}
@@ -92,7 +91,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
+			zap.Error(err),
 		)
 		return nil, err
 	}
@@ -104,7 +103,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
+			zap.Error(err),
 		)
 		return nil, err
 	}
@@ -113,7 +112,6 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", ""),
 	)
 	return &sshConn{netConn: raw, channel: ch, client: client}, nil
 }
@@ -124,7 +122,6 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	lc := net.ListenConfig{}
@@ -134,7 +131,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
+			zap.Error(err),
 		)
 		return nil, err
 	}
@@ -147,7 +144,6 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", ""),
 	)
 	return ln, nil
 }
@@ -159,16 +155,18 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		zap.String("address", address),
 		zap.String("role", roleStr),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	defer func() {
-		t.logger.Info("negotiate_end",
+		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", roleStr),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.String("error", errString(err)),
-		)
+		}
+		if err != nil {
+			fields = append(fields, zap.Error(err))
+		}
+		t.logger.Info("negotiate_end", fields...)
 	}()
 
 	hs.Version = common.ProtocolVersion
@@ -271,13 +269,6 @@ func (s *serverConn) RemoteAddr() net.Addr               { return s.netConn.Remo
 func (s *serverConn) SetDeadline(t time.Time) error      { return s.netConn.SetDeadline(t) }
 func (s *serverConn) SetReadDeadline(t time.Time) error  { return s.netConn.SetReadDeadline(t) }
 func (s *serverConn) SetWriteDeadline(t time.Time) error { return s.netConn.SetWriteDeadline(t) }
-
-func errString(err error) string {
-	if err == nil {
-		return ""
-	}
-	return err.Error()
-}
 
 func roleString(r transport.Role) string {
 	switch r {

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -12,7 +12,7 @@ import (
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
@@ -21,10 +21,15 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 		return
 	}
 	ctx := entries[0].ContextMap()
-	for _, k := range []string{"address", "role", "duration_ms", "error"} {
+	for _, k := range []string{"address", "role", "duration_ms"} {
 		if _, ok := ctx[k]; !ok {
 			t.Fatalf("expected field %q in %s log", k, msg)
 		}
+	}
+	if _, ok := ctx["error"]; wantErr && !ok {
+		t.Fatalf("expected error field in %s log", msg)
+	} else if !wantErr && ok {
+		t.Fatalf("unexpected error field in %s log", msg)
 	}
 }
 
@@ -92,12 +97,12 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 2)
-	checkLogFields(t, logs, "negotiate_end", 2)
+	checkLogFields(t, logs, "dial_start", 1, false)
+	checkLogFields(t, logs, "dial_end", 1, false)
+	checkLogFields(t, logs, "listen_start", 1, false)
+	checkLogFields(t, logs, "listen_end", 1, false)
+	checkLogFields(t, logs, "negotiate_start", 2, false)
+	checkLogFields(t, logs, "negotiate_end", 2, false)
 }
 
 func TestSSHTransportAuthFailure(t *testing.T) {
@@ -134,12 +139,12 @@ func TestSSHTransportAuthFailure(t *testing.T) {
 	}
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 0)
-	checkLogFields(t, logs, "negotiate_end", 0)
+	checkLogFields(t, logs, "dial_start", 1, false)
+	checkLogFields(t, logs, "dial_end", 1, true)
+	checkLogFields(t, logs, "listen_start", 1, false)
+	checkLogFields(t, logs, "listen_end", 1, false)
+	checkLogFields(t, logs, "negotiate_start", 0, false)
+	checkLogFields(t, logs, "negotiate_end", 0, false)
 }
 
 func TestSSHTransportRequiresLogger(t *testing.T) {

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -25,6 +25,9 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
 	}
+	if expected == 0 {
+		return
+	}
 	ctx := entries[0].ContextMap()
 	for _, k := range []string{"address", "role", "duration_ms"} {
 		if _, ok := ctx[k]; !ok {


### PR DESCRIPTION
## Summary
- log SSH transport errors only when present
- drop unused `errString` helper
- tighten transport tests to assert `error` field only on failures

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f1c34fa588323a4befde47c0ac9fa