### PR TITLE
fix(tcp_tls): error on invalid role

### DIFF
--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -188,7 +188,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		return peer, nil
 	default:
-		return peer, nil
+		return peer, fmt.Errorf("invalid role %v", role)
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -153,6 +153,22 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 	checkLogFields(t, logs, "negotiate_end", 1, true)
 }
 
+func TestTCPTLSNegotiateInvalidRole(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	if _, err := tr.Negotiate(ctx, c1, transport.Role(99), common.Handshake{}); err == nil {
+		t.Fatalf("expected error for invalid role")
+	}
+}
+
 func TestTCPTLSCertValidation(t *testing.T) {
 	root := x509.NewCertPool()
 	cert, _ := generateSelfSignedCert(t)


### PR DESCRIPTION
## Summary
- return descriptive error when tcp+tls Negotiate receives an invalid role
- add unit test verifying invalid role causes negotiation failure

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: device and cmd/manifest tests)*
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f20ad66a0832386a66986927b085b