### PR TITLE
fix(cli): validate config in run and rebuild commands

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -52,6 +52,9 @@ func NewRootCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := cfg.Validate(); err != nil {
+				return err
+			}
 			if len(remaining) != 2 {
 				fs.Usage()
 				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
@@ -90,6 +93,9 @@ func NewRootCmd() *cobra.Command {
 			flagSets := config.NewFlagSets(defaults)
 			cfg, remaining, err := config.LoadConfig(flagSets, defaults, fs, args)
 			if err != nil {
+				return err
+			}
+			if err := cfg.Validate(); err != nil {
 				return err
 			}
 			if len(remaining) != 1 {

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -79,6 +79,22 @@ func TestRunCommandDryRunEnv(t *testing.T) {
 	}
 }
 
+func TestRunCommandInvalidConfig(t *testing.T) {
+	called := false
+	runCommand = func(src, dst string, opts RunOptions) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
+
+	if err := Execute([]string{"run", "--ssh_keepalive=0s", "src", "dst"}); err == nil {
+		t.Fatalf("expected error for invalid config")
+	}
+	if called {
+		t.Fatalf("runCommand should not be called on invalid config")
+	}
+}
+
 func TestManifestRebuildRoutes(t *testing.T) {
 	var gotDevice string
 	var dry bool
@@ -96,6 +112,22 @@ func TestManifestRebuildRoutes(t *testing.T) {
 	}
 	if !dry {
 		t.Fatalf("expected dry-run true")
+	}
+}
+
+func TestManifestRebuildInvalidConfig(t *testing.T) {
+	called := false
+	manifestRebuild = func(device string, dryRun bool) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool) error { return nil } })
+
+	if err := Execute([]string{"manifest", "rebuild", "--ssh_keepalive=0s", "/dev/vg0"}); err == nil {
+		t.Fatalf("expected error for invalid config")
+	}
+	if called {
+		t.Fatalf("manifestRebuild should not be called on invalid config")
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate configuration after loading flags in `run` and `manifest rebuild`
- add tests ensuring invalid config prevents command execution

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: device/file_test.go: not enough arguments in call to OpenFile; manifest tests)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689f2146713883238008f76319cfeaf8