### PR TITLE
fix(tcp_tls): log errors with appropriate levels

### DIFF
--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -79,7 +79,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 			zap.Error(err),
 		}
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
 	tlsConf := t.clientConf.Clone()
@@ -96,7 +96,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 			zap.Error(err),
 		}
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
 	fields := []zap.Field{
@@ -132,8 +132,10 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 	}
 	if err != nil {
 		fields = append(fields, zap.Error(err))
+		t.logger.Error("listen_end", fields...)
+	} else {
+		t.logger.Info("listen_end", fields...)
 	}
-	t.logger.Info("listen_end", fields...)
 	return ln, err
 }
 
@@ -154,8 +156,10 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		if err != nil {
 			fields = append(fields, zap.Error(err))
+			t.logger.Error("negotiate_end", fields...)
+		} else {
+			t.logger.Info("negotiate_end", fields...)
 		}
-		t.logger.Info("negotiate_end", fields...)
 	}()
 
 	hs.Version = common.ProtocolVersion

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -14,30 +14,33 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, level zapcore.Level, wantErr bool) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
 	}
-	if expected == 0 {
-		return
-	}
-	ctx := entries[0].ContextMap()
-	for _, k := range []string{"address", "role", "duration_ms"} {
-		if _, ok := ctx[k]; !ok {
-			t.Fatalf("expected field %q in %s log", k, msg)
+	for _, e := range entries {
+		if e.Level != level {
+			t.Fatalf("expected level %s for %s log, got %s", level, msg, e.Level)
 		}
-	}
-	if _, ok := ctx["error"]; wantErr && !ok {
-		t.Fatalf("expected error field in %s log", msg)
-	} else if !wantErr && ok {
-		t.Fatalf("unexpected error field in %s log", msg)
+		ctx := e.ContextMap()
+		for _, k := range []string{"address", "role", "duration_ms"} {
+			if _, ok := ctx[k]; !ok {
+				t.Fatalf("expected field %q in %s log", k, msg)
+			}
+		}
+		if _, ok := ctx["error"]; wantErr && !ok {
+			t.Fatalf("expected error field in %s log", msg)
+		} else if !wantErr && ok {
+			t.Fatalf("unexpected error field in %s log", msg)
+		}
 	}
 }
 
@@ -100,12 +103,12 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, false)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 2, false)
-	checkLogFields(t, logs, "negotiate_end", 2, false)
+	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "negotiate_end", 2, zapcore.InfoLevel, false)
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {
@@ -145,12 +148,44 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, false)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 1, false)
-	checkLogFields(t, logs, "negotiate_end", 1, true)
+	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "negotiate_start", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "negotiate_end", 1, zapcore.ErrorLevel, true)
+}
+
+func TestTCPTLSDialErrorLogging(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	if _, err := tr.Dial(ctx, "127.0.0.1:65000"); err == nil {
+		t.Fatalf("expected dial error")
+	}
+	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "dial_end", 1, zapcore.ErrorLevel, true)
+}
+
+func TestTCPTLSListenErrorLogging(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	if _, err := tr.Listen(ctx, "bad_address"); err == nil {
+		t.Fatalf("expected listen error")
+	}
+	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "listen_end", 1, zapcore.ErrorLevel, true)
 }
 
 func TestTCPTLSCertValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
- log tcp+tls transport errors with `Error` level instead of `Info`
- use zap observer in tcp+tls tests to assert log levels
- add tests for dial and listen error logging

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: device build; cmd/manifest tests)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689f21290c988323b31bb5d4860647f0