### PR TITLE
fix(cmd): reuse logger for dry run estimate

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -57,7 +57,14 @@ func NewRootCmd() *cobra.Command {
 				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
 			}
 			if cfg.DryRun {
-				logger := zap.NewExample()
+				logger := zap.L()
+				if logger == nil {
+					var err error
+					logger, err = zap.NewProduction()
+					if err != nil {
+						return err
+					}
+				}
 				defer logger.Sync()
 				if err := estimateTransfer(remaining[0], cfg, logger); err != nil {
 					return err

--- a/cmd/lvmsync/estimate_test.go
+++ b/cmd/lvmsync/estimate_test.go
@@ -16,17 +16,17 @@ func TestEstimateTransferSuccess(t *testing.T) {
 	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write src: %v", err)
 	}
-	core, logs := observer.New(zap.InfoLevel)
+	core, obs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 	defer logger.Sync()
 	cfg := &config.Config{}
 	if err := estimateTransfer(src, cfg, logger); err != nil {
 		t.Fatalf("estimate transfer: %v", err)
 	}
-	if logs.Len() != 1 {
-		t.Fatalf("expected 1 log entry, got %d", logs.Len())
+	if obs.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", obs.Len())
 	}
-	entry := logs.All()[0]
+	entry := obs.All()[0]
 	if entry.Message != "dry run" {
 		t.Fatalf("unexpected log message %q", entry.Message)
 	}
@@ -36,9 +36,7 @@ func TestEstimateTransferSuccess(t *testing.T) {
 }
 
 func TestEstimateTransferInvalidPath(t *testing.T) {
-	core, _ := observer.New(zap.InfoLevel)
-	logger := zap.New(core)
-	defer logger.Sync()
+	logger := zap.NewNop()
 	err := estimateTransfer("/does/not/exist", &config.Config{}, logger)
 	if err == nil {
 		t.Fatalf("expected error")


### PR DESCRIPTION
## Summary
- reuse global application logger when estimating transfer size
- ensure tests inject logger explicitly

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRunDefaultOutputPath, TestRunManifestPathFlag; device package build failure; interrupted grpc/server tests)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689f2132cafc8323b08182a5c8bf81e3