### PR TITLE
fix(quic): respect context cancellation

### DIFF
--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -37,7 +37,8 @@ type Conn struct {
 // listener adapts a quic.Listener to net.Listener by accepting a stream for
 // each connection.
 type listener struct {
-	ql *quic.Listener
+	ql  *quic.Listener
+	ctx context.Context
 }
 
 // New constructs a Transport using the provided TLS roots and client cert.
@@ -143,16 +144,19 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 	if err != nil {
 		return nil, err
 	}
-	return &listener{ql: ql}, nil
+	return &listener{ql: ql, ctx: ctx}, nil
 }
 
 // Accept waits for the next connection and returns its first stream.
+//
+// It uses the context passed to Listen, allowing callers to cancel the
+// pending accept via context cancellation.
 func (l *listener) Accept() (net.Conn, error) {
-	qconn, err := l.ql.Accept(context.Background())
+	qconn, err := l.ql.Accept(l.ctx)
 	if err != nil {
 		return nil, err
 	}
-	stream, err := qconn.AcceptStream(context.Background())
+	stream, err := qconn.AcceptStream(l.ctx)
 	if err != nil {
 		qconn.CloseWithError(0, err.Error())
 		return nil, err

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"math/big"
 	"net"
 	"testing"
@@ -13,6 +14,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+
+	quic "github.com/quic-go/quic-go"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
@@ -142,6 +145,47 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, false)
 	checkLogFields(t, logs, "negotiate_start", 1, false)
 	checkLogFields(t, logs, "negotiate_end", 1, true)
+}
+
+func TestQUICListenerAcceptContextCancel(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), ClientCert: cert, AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx, cancel := context.WithCancel(context.Background())
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		_, err := ln.Accept()
+		acceptErr <- err
+	}()
+
+	qconn, err := quic.DialAddr(context.Background(), ln.Addr().String(), tr.clientTLS, tr.qconf)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	// Allow Accept to block on AcceptStream.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-acceptErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("accept did not return after cancel")
+	}
+
+	qconn.CloseWithError(0, "")
 }
 
 func TestQUICTransportRequiresLogger(t *testing.T) {


### PR DESCRIPTION
## Summary
- wire listener context into `Accept` and `AcceptStream`
- test that canceling the context makes `Accept` return

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f253c03a08323b0d47af281857cb5