### PR TITLE
feat(lvm): add device fd cache constructor

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -18,7 +18,6 @@ import (
 	"lvmsync_go/device"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privilege"
-	"lvmsync_go/lvm"
 )
 
 // function variables for testing
@@ -125,8 +124,6 @@ func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPa
 
 // Run orchestrates the command execution.
 func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
-	defer lvm.Cleanup()
-
 	if len(args) > 0 {
 		switch args[0] {
 		case "manifest":

--- a/device/detect.go
+++ b/device/detect.go
@@ -45,7 +45,9 @@ func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawC
 	}
 	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
 		if _, err := lvm.GetVolumeGroupName(resolved); err == nil {
-			dev, err := OpenLVM(resolved, logger)
+			cache := lvm.NewDeviceFDCache(logger)
+			defer cache.Close()
+			dev, err := OpenLVM(resolved, cache, logger)
 			if err != nil {
 				if logger != nil {
 					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -28,7 +28,7 @@ type LVMDevice struct {
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
 // Size information is obtained through the lvm package helpers.
-func OpenLVM(path string, logger *zap.Logger) (*LVMDevice, error) {
+func OpenLVM(path string, cache *lvm.FDCache, logger *zap.Logger) (*LVMDevice, error) {
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func OpenLVM(path string, logger *zap.Logger) (*LVMDevice, error) {
 		f.Close()
 		return nil, err
 	}
-	size, err := lvm.GetVolumeSize(path, logger)
+	size, err := lvm.GetVolumeSize(path, cache, logger)
 	if err != nil {
 		f.Close()
 		return nil, err
@@ -99,7 +99,9 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 		_ = runLVM(ctx, "lvremove", "-f", snapPath)
 		return nil, err
 	}
-	snapDev, err := openLVMFunc(snapPath, d.logger)
+	cache := lvm.NewDeviceFDCache(d.logger)
+	defer cache.Close()
+	snapDev, err := openLVMFunc(snapPath, cache, d.logger)
 	if err != nil {
 		_ = runLVM(ctx, "lvremove", "-f", snapPath)
 		return nil, err

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -7,13 +7,15 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
+	"lvmsync_go/lvm"
 )
 
 // LVMDevice is unsupported on non-Linux platforms.
 type LVMDevice struct{}
 
 // OpenLVM returns an error on non-Linux systems.
-func OpenLVM(string, *zap.Logger) (*LVMDevice, error) {
+func OpenLVM(string, *lvm.FDCache, *zap.Logger) (*LVMDevice, error) {
 	return nil, fmt.Errorf("LVM devices are only supported on Linux")
 }
 

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"lvmsync_go/lvm"
 )
 
 func TestSnapshotLifecycle(t *testing.T) {
@@ -65,7 +66,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	origOpen := openLVMFunc
-	openLVMFunc = func(p string, _ *zap.Logger) (*LVMDevice, error) {
+	openLVMFunc = func(p string, _ *lvm.FDCache, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, cleanupPath: p, logger: zap.NewNop()}, nil
 	}
 	defer func() { openLVMFunc = origOpen }()

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -26,7 +26,7 @@ var (
 
 // SetParseSnapshotSizeForTest overrides the parseSnapshotSize helper for tests
 // and returns a function to restore the original behavior.
-func SetParseSnapshotSizeForTest(f func(string, string, *zap.Logger) (uint64, error)) func() {
+func SetParseSnapshotSizeForTest(f func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error)) func() {
 	orig := parseSnapshotSize
 	parseSnapshotSize = f
 	return func() { parseSnapshotSize = orig }
@@ -67,12 +67,15 @@ func SetRemoveSnapshotForTest(f func(context.Context, string, *zap.Logger) error
 // PrepareSnapshot sets up a snapshot for the given original volume. It returns the snapshot path,
 // an optional monitor error channel, a cleanup function, and any error encountered.
 func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
-	snapshotBytes, err := calculateSnapshotSize(cfg, originalVolume, logger)
+	cache := lvm.NewDeviceFDCache(logger)
+	defer cache.Close()
+
+	snapshotBytes, err := calculateSnapshotSize(cfg, originalVolume, cache, logger)
 	if err != nil {
 		return "", nil, nil, err
 	}
 
-	if err := ensureVolumeGroups(ctx, cfg, originalVolume, logger); err != nil {
+	if err := ensureVolumeGroups(ctx, cfg, originalVolume, cache, logger); err != nil {
 		return "", nil, nil, err
 	}
 
@@ -83,15 +86,15 @@ func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume str
 	return createSnapshotIfNeeded(ctx, cfg, originalVolume, snapshotBytes, logger)
 }
 
-func calculateSnapshotSize(cfg *config.Config, originalVolume string, logger *zap.Logger) (uint64, error) {
-	snapshotBytes, err := parseSnapshotSize(cfg.SnapshotSize, originalVolume, logger)
+func calculateSnapshotSize(cfg *config.Config, originalVolume string, cache *lvm.FDCache, logger *zap.Logger) (uint64, error) {
+	snapshotBytes, err := parseSnapshotSize(cfg.SnapshotSize, originalVolume, cache, logger)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse snapshot size: %w", err)
 	}
 	return snapshotBytes, nil
 }
 
-func ensureVolumeGroups(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) error {
+func ensureVolumeGroups(ctx context.Context, cfg *config.Config, originalVolume string, cache *lvm.FDCache, logger *zap.Logger) error {
 	if cfg.VolumeGroup == "" {
 		vg, err := getVolumeGroupName(originalVolume)
 		if err != nil {
@@ -102,7 +105,7 @@ func ensureVolumeGroups(ctx context.Context, cfg *config.Config, originalVolume 
 	}
 
 	if cfg.TargetVolumeGroup == "" && len(cfg.TargetVGCandidates) > 0 {
-		lvSize, err := getVolumeSize(originalVolume, logger)
+		lvSize, err := getVolumeSize(originalVolume, cache, logger)
 		if err != nil {
 			return fmt.Errorf("failed to determine volume size: %w", err)
 		}

--- a/internal/client/snapshot_helpers_test.go
+++ b/internal/client/snapshot_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"lvmsync_go/config"
+	"lvmsync_go/lvm"
 
 	"go.uber.org/zap"
 )
@@ -15,10 +16,12 @@ func TestCalculateSnapshotSize(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		cfg := &config.Config{SnapshotSize: "1024"}
 		origParse := parseSnapshotSize
-		parseSnapshotSize = func(string, string, *zap.Logger) (uint64, error) { return 1024, nil }
+		parseSnapshotSize = func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 1024, nil }
 		defer func() { parseSnapshotSize = origParse }()
 
-		size, err := calculateSnapshotSize(cfg, "/dev/vg/lv", zap.NewNop())
+		cache := lvm.NewDeviceFDCache(zap.NewNop())
+		defer cache.Close()
+		size, err := calculateSnapshotSize(cfg, "/dev/vg/lv", cache, zap.NewNop())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -30,10 +33,12 @@ func TestCalculateSnapshotSize(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		cfg := &config.Config{SnapshotSize: "bad"}
 		origParse := parseSnapshotSize
-		parseSnapshotSize = func(string, string, *zap.Logger) (uint64, error) { return 0, errors.New("bad") }
+		parseSnapshotSize = func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 0, errors.New("bad") }
 		defer func() { parseSnapshotSize = origParse }()
 
-		if _, err := calculateSnapshotSize(cfg, "/dev/vg/lv", zap.NewNop()); err == nil {
+		cache := lvm.NewDeviceFDCache(zap.NewNop())
+		defer cache.Close()
+		if _, err := calculateSnapshotSize(cfg, "/dev/vg/lv", cache, zap.NewNop()); err == nil {
 			t.Fatalf("expected error for invalid size")
 		}
 	})
@@ -41,10 +46,12 @@ func TestCalculateSnapshotSize(t *testing.T) {
 
 func TestEnsureVolumeGroups(t *testing.T) {
 	logger := zap.NewNop()
+	cache := lvm.NewDeviceFDCache(logger)
+	defer cache.Close()
 
 	t.Run("sets missing volume group", func(t *testing.T) {
 		cfg := &config.Config{}
-		if err := ensureVolumeGroups(context.Background(), cfg, "/dev/sourcevg/lv1", logger); err != nil {
+		if err := ensureVolumeGroups(context.Background(), cfg, "/dev/sourcevg/lv1", cache, logger); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.VolumeGroup != "sourcevg" {
@@ -54,7 +61,7 @@ func TestEnsureVolumeGroups(t *testing.T) {
 
 	t.Run("preserves existing volume group", func(t *testing.T) {
 		cfg := &config.Config{VolumeGroup: "existing"}
-		if err := ensureVolumeGroups(context.Background(), cfg, "/dev/othervg/lv", logger); err != nil {
+		if err := ensureVolumeGroups(context.Background(), cfg, "/dev/othervg/lv", cache, logger); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.VolumeGroup != "existing" {

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -9,6 +9,7 @@ import (
 
 	"lvmsync_go/config"
 	"lvmsync_go/internal/client"
+	"lvmsync_go/lvm"
 
 	"go.uber.org/zap"
 )
@@ -23,7 +24,7 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
 
-	restore := client.SetParseSnapshotSizeForTest(func(string, string, *zap.Logger) (uint64, error) { return 1, nil })
+	restore := client.SetParseSnapshotSizeForTest(func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 1, nil })
 	defer restore()
 
 	logger := zap.NewNop()
@@ -51,7 +52,7 @@ func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {
 	cfg.SnapshotSize = "25%"
 
 	var parseArg string
-	restoreParse := client.SetParseSnapshotSizeForTest(func(s, _ string, _ *zap.Logger) (uint64, error) {
+	restoreParse := client.SetParseSnapshotSizeForTest(func(s, _ string, _ *lvm.FDCache, _ *zap.Logger) (uint64, error) {
 		parseArg = s
 		return 1024, nil
 	})
@@ -117,7 +118,7 @@ func TestCreateSnapshotCleanupNoPanic(t *testing.T) {
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
 
-	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string, *zap.Logger) (uint64, error) { return 1024, nil })
+	restoreParse := client.SetParseSnapshotSizeForTest(func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 1024, nil })
 	defer restoreParse()
 
 	restoreCreate := client.SetCreateSnapshotForTest(func(context.Context, string, string, string, *zap.Logger) error { return nil })

--- a/lvm/fd_cache.go
+++ b/lvm/fd_cache.go
@@ -42,6 +42,11 @@ func NewFDCache(size int, logger *zap.Logger) *FDCache {
 	}
 }
 
+// NewDeviceFDCache returns an FDCache preconfigured for device descriptor caching.
+func NewDeviceFDCache(logger *zap.Logger) *FDCache {
+	return NewFDCache(fdCacheSize, logger)
+}
+
 // SetLogger updates the logger used by the cache.
 func (c *FDCache) SetLogger(logger *zap.Logger) {
 	if logger == nil {
@@ -66,7 +71,7 @@ func (c *FDCache) getFD(devicePath string) (int, error) {
 		return entry.fd, nil
 	}
 
-	fd, err := unix.Open(devicePath, unix.O_RDONLY|unix.O_NONBLOCK, 0)
+	fd, err := unix.Open(devicePath, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return -1, fmt.Errorf("failed to open device %s: %w", devicePath, err)
 	}
@@ -105,6 +110,3 @@ func (c *FDCache) Close() {
 	c.fds = make(map[string]*list.Element, c.size)
 	c.order.Init()
 }
-
-// deviceFDCache is the global cache used by volume operations.
-var deviceFDCache = NewFDCache(fdCacheSize, zap.NewNop())

--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -80,14 +80,15 @@ func TestFDCacheCloseClosesAll(t *testing.T) {
 }
 
 func TestGetVolumeSizeCachesFD(t *testing.T) {
-	deviceFDCache.Close()
+	cache := NewDeviceFDCache(zap.NewNop())
+	defer cache.Close()
 
 	tmpFile := filepath.Join(t.TempDir(), "vol")
 	if err := os.WriteFile(tmpFile, make([]byte, 1024), 0644); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
 
-	size, err := GetVolumeSize(tmpFile, zap.NewNop())
+	size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetVolumeSize failed: %v", err)
 	}
@@ -95,7 +96,7 @@ func TestGetVolumeSizeCachesFD(t *testing.T) {
 		t.Fatalf("size = %d, want 1024", size)
 	}
 
-	elem, ok := deviceFDCache.fds[tmpFile]
+	elem, ok := cache.fds[tmpFile]
 	if !ok {
 		t.Fatalf("file descriptor not cached")
 	}
@@ -105,7 +106,7 @@ func TestGetVolumeSizeCachesFD(t *testing.T) {
 	}
 	fd := entry.fd
 
-	size, err = GetVolumeSize(tmpFile, zap.NewNop())
+	size, err = GetVolumeSize(tmpFile, cache, zap.NewNop())
 	if err != nil {
 		t.Fatalf("second GetVolumeSize failed: %v", err)
 	}
@@ -113,7 +114,7 @@ func TestGetVolumeSizeCachesFD(t *testing.T) {
 		t.Fatalf("size = %d, want 1024", size)
 	}
 
-	elem2, ok := deviceFDCache.fds[tmpFile]
+	elem2, ok := cache.fds[tmpFile]
 	if !ok {
 		t.Fatalf("file descriptor not reused")
 	}
@@ -121,6 +122,26 @@ func TestGetVolumeSizeCachesFD(t *testing.T) {
 	if !ok || entry2.fd != fd {
 		t.Fatalf("file descriptor not reused")
 	}
+}
 
-	Cleanup()
+func TestFDCLOEXEC(t *testing.T) {
+	cache := NewDeviceFDCache(zap.NewNop())
+	defer cache.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(tmpFile, nil, 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	fd, err := cache.getFD(tmpFile)
+	if err != nil {
+		t.Fatalf("getFD: %v", err)
+	}
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("fcntl: %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatalf("FD_CLOEXEC not set")
+	}
 }

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -179,9 +179,12 @@ func ioctlGetUint64(fd int, req uint) (uint64, error) {
 	return value, nil
 }
 
-func GetVolumeSize(volumePath string, logger *zap.Logger) (uint64, error) {
-	deviceFDCache.SetLogger(logger)
-	fd, err := deviceFDCache.getFD(volumePath)
+func GetVolumeSize(volumePath string, cache *FDCache, logger *zap.Logger) (uint64, error) {
+	if cache == nil {
+		return 0, fmt.Errorf("fd cache is nil")
+	}
+	cache.SetLogger(logger)
+	fd, err := cache.getFD(volumePath)
 	if err != nil {
 		return 0, err
 	}
@@ -315,7 +318,7 @@ func GetVolumeAttributes(volumePath string, logger *zap.Logger) (*VolumeAttribut
 	return attrs, nil
 }
 
-func ParseSnapshotSize(sizeStr, volumePath string, logger *zap.Logger) (uint64, error) {
+func ParseSnapshotSize(sizeStr, volumePath string, cache *FDCache, logger *zap.Logger) (uint64, error) {
 	sizeStr = strings.TrimSpace(sizeStr)
 
 	val, isPercent, err := sizeparse.Parse(sizeStr)
@@ -328,7 +331,7 @@ func ParseSnapshotSize(sizeStr, volumePath string, logger *zap.Logger) (uint64, 
 			return 0, fmt.Errorf("percentage must be between 0 and 100, got %v", val)
 		}
 
-		volSize, err := GetVolumeSize(volumePath, logger)
+		volSize, err := GetVolumeSize(volumePath, cache, logger)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get volume size for %q: %w", volumePath, err)
 		}
@@ -479,8 +482,4 @@ func SelectVolumeGroupForSize(ctx context.Context, candidates []string, required
 		selector = ByFreeSpaceFit(required)
 	}
 	return SelectVolumeGroup(ctx, candidates, selector)
-}
-
-func Cleanup() {
-	deviceFDCache.Close()
 }

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -33,6 +33,8 @@ func TestParseSnapshotSize(t *testing.T) {
 	if err := os.WriteFile(tmpFile, make([]byte, 1024*1024), 0644); err != nil {
 		t.Fatalf("failed to create temp volume: %v", err)
 	}
+	cache := NewDeviceFDCache(zap.NewNop())
+	defer cache.Close()
 
 	tests := []struct {
 		name    string
@@ -49,7 +51,7 @@ func TestParseSnapshotSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseSnapshotSize(tt.input, tmpFile, zap.NewNop())
+			got, err := ParseSnapshotSize(tt.input, tmpFile, cache, zap.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ParseSnapshotSize error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -58,8 +60,6 @@ func TestParseSnapshotSize(t *testing.T) {
 			}
 		})
 	}
-
-	Cleanup()
 }
 
 func TestGetVolumeSize(t *testing.T) {
@@ -69,7 +69,9 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("failed to create temp volume: %v", err)
 		}
 
-		size, err := GetVolumeSize(tmpFile, zap.NewNop())
+		cache := NewDeviceFDCache(zap.NewNop())
+		defer cache.Close()
+		size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
 		if err != nil {
 			t.Fatalf("GetVolumeSize failed: %v", err)
 		}
@@ -89,7 +91,9 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("truncate failed: %v", err)
 		}
 
-		size, err := GetVolumeSize(tmpFile, zap.NewNop())
+		cache := NewDeviceFDCache(zap.NewNop())
+		defer cache.Close()
+		size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
 		if err != nil {
 			t.Fatalf("GetVolumeSize failed: %v", err)
 		}
@@ -98,8 +102,6 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("size = %d, want %d", size, want)
 		}
 	})
-
-	Cleanup()
 }
 
 func TestGetVolumeSizeIoctlLarge(t *testing.T) {
@@ -115,15 +117,15 @@ func TestGetVolumeSizeIoctlLarge(t *testing.T) {
 	}
 	defer func() { ioctlGetUint64Func = orig }()
 
-	size, err := GetVolumeSize(tmpFile, zap.NewNop())
+	cache := NewDeviceFDCache(zap.NewNop())
+	defer cache.Close()
+	size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetVolumeSize failed: %v", err)
 	}
 	if size != fiveGiB {
 		t.Fatalf("size = %d, want %d", size, fiveGiB)
 	}
-
-	Cleanup()
 }
 
 func TestGetVolumeAttributes(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `NewDeviceFDCache` constructor and remove global cache
- require callers to pass an `FDCache` and add CLOEXEC flag to device opens
- add tests for descriptor reuse, eviction, and CLOEXEC handling

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out $(go list ./... | grep -v 'transport/quic')`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_689f29a26e94832382b79189ab00fb78