### PR TITLE
feat(grpc): add keepalive and request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,9 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--grpc_setup_timeout` | `LVMSYNC_GRPC_SETUP_TIMEOUT` | `grpc_setup_timeout` | gRPC setup timeout |
 | `--grpc_heartbeat_interval` | `LVMSYNC_GRPC_HEARTBEAT_INTERVAL` | `grpc_heartbeat_interval` | gRPC heartbeat interval |
 | `--grpc_heartbeat_send_timeout` | `LVMSYNC_GRPC_HEARTBEAT_SEND_TIMEOUT` | `grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout |
+| `--keepalive_time` | `LVMSYNC_GRPC_KEEPALIVE_TIME` | `keepalive_time` | Interval between server pings |
+| `--keepalive_timeout` | `LVMSYNC_GRPC_KEEPALIVE_TIMEOUT` | `keepalive_timeout` | Wait for ping ack before closing |
+| `--request_timeout` | `LVMSYNC_GRPC_REQUEST_TIMEOUT` | `request_timeout` | Deadline for unary RPC handlers |
 | `--tls_cert` | `LVMSYNC_TLS_CERT` | `tls_cert` | TLS certificate file |
 | `--tls_key` | `LVMSYNC_TLS_KEY` | `tls_key` | TLS key file |
 | `--ca_cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
@@ -433,6 +436,11 @@ If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_
 The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel. Plaintext connections are rejected unless `--allow-insecure` is explicitly set.
 
 TLS mode requires explicit certificates. Provide `--tls-cert`, `--tls-key`, and `--ca-cert`; the daemon fails to start if any are missing and does not generate self-signed certificates.
+
+To detect stalled clients, the daemon sends periodic keepalive pings governed by
+`--keepalive-time` (default `2m`). If an acknowledgement is not received within
+`--keepalive-timeout` (default `20s`), the connection is closed. Unary RPCs are
+wrapped with a deadline controlled by `--request-timeout` (default `15s`).
 
 `StartGRPCServer` accepts a `context.Context` and runs the server in a goroutine, returning a buffered error channel. Cancel the context or invoke the cleanup function to stop the server and wait on the channel during shutdown to surface any serve errors.
 
@@ -911,6 +919,9 @@ The client aborts dialing if a connection cannot be established within
 | `--grpc_setup_timeout` | gRPC setup timeout        | `10s`           |
 | `--grpc_heartbeat_interval` | gRPC heartbeat interval | `30s`          |
 | `--grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout | `5s` |
+| `--keepalive_time` | Interval between server pings | `2m` |
+| `--keepalive_timeout` | Timeout waiting for keepalive ack | `20s` |
+| `--request_timeout` | Deadline for unary RPCs | `15s` |
 | `--tls_cert`       | TLS certificate file         | `""`            |
 | `--tls_key`        | TLS key file                 | `""`            |
 | `--ca_cert`        | CA certificate file          | `""`            |

--- a/cmd/grpcd/cobra.go
+++ b/cmd/grpcd/cobra.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -16,11 +17,14 @@ import (
 
 // Options holds configuration for the gRPC daemon.
 type Options struct {
-	GRPCPort      int
-	TLSCert       string
-	TLSKey        string
-	CACert        string
-	AllowInsecure bool
+	GRPCPort         int
+	TLSCert          string
+	TLSKey           string
+	CACert           string
+	AllowInsecure    bool
+	KeepaliveTime    time.Duration
+	KeepaliveTimeout time.Duration
+	RequestTimeout   time.Duration
 }
 
 // startFunc allows tests to stub server startup.
@@ -31,10 +35,13 @@ var startFunc = func(ctx context.Context, opts Options, logger *zap.Logger) erro
 		return err
 	}
 	cfg := grpcserver.Config{
-		TLSCert:       opts.TLSCert,
-		TLSKey:        opts.TLSKey,
-		CACert:        opts.CACert,
-		AllowInsecure: opts.AllowInsecure,
+		TLSCert:          opts.TLSCert,
+		TLSKey:           opts.TLSKey,
+		CACert:           opts.CACert,
+		AllowInsecure:    opts.AllowInsecure,
+		KeepaliveTime:    opts.KeepaliveTime,
+		KeepaliveTimeout: opts.KeepaliveTimeout,
+		RequestTimeout:   opts.RequestTimeout,
 	}
 	srv, cleanup, err := grpcserver.New(cfg, nil, logger)
 	if err != nil {
@@ -63,6 +70,9 @@ func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
 	grpc.String("tls-key", "", "TLS key file")
 	grpc.String("ca-cert", "", "CA certificate file")
 	grpc.Bool("allow-insecure", false, "allow plaintext gRPC")
+	grpc.Duration("keepalive-time", 2*time.Minute, "interval between server pings")
+	grpc.Duration("keepalive-timeout", 20*time.Second, "timeout waiting for keepalive ack")
+	grpc.Duration("request-timeout", 15*time.Second, "deadline for unary RPCs")
 
 	fs := cmd.Flags()
 	fs.AddFlagSet(general)
@@ -88,11 +98,14 @@ func loadConfig(v *viper.Viper) (Options, error) {
 		}
 	}
 	return Options{
-		GRPCPort:      v.GetInt("grpc-port"),
-		TLSCert:       v.GetString("tls-cert"),
-		TLSKey:        v.GetString("tls-key"),
-		CACert:        v.GetString("ca-cert"),
-		AllowInsecure: v.GetBool("allow-insecure"),
+		GRPCPort:         v.GetInt("grpc-port"),
+		TLSCert:          v.GetString("tls-cert"),
+		TLSKey:           v.GetString("tls-key"),
+		CACert:           v.GetString("ca-cert"),
+		AllowInsecure:    v.GetBool("allow-insecure"),
+		KeepaliveTime:    v.GetDuration("keepalive-time"),
+		KeepaliveTimeout: v.GetDuration("keepalive-timeout"),
+		RequestTimeout:   v.GetDuration("request-timeout"),
 	}, nil
 }
 

--- a/cmd/grpcd/cobra_test.go
+++ b/cmd/grpcd/cobra_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -24,11 +25,14 @@ func TestFlagParsing(t *testing.T) {
 		"--tls-key", "key",
 		"--ca-cert", "ca",
 		"--allow-insecure",
+		"--keepalive-time", "30s",
+		"--keepalive-timeout", "5s",
+		"--request-timeout", "1m",
 	}
 	if err := Execute(args, logger); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	want := Options{GRPCPort: 1234, TLSCert: "cert", TLSKey: "key", CACert: "ca", AllowInsecure: true}
+	want := Options{GRPCPort: 1234, TLSCert: "cert", TLSKey: "key", CACert: "ca", AllowInsecure: true, KeepaliveTime: 30 * time.Second, KeepaliveTimeout: 5 * time.Second, RequestTimeout: time.Minute}
 	if got != want {
 		t.Fatalf("got %+v want %+v", got, want)
 	}

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -19,6 +19,15 @@ TLS transports require an explicit set of trusted CA roots. Connections are
 rejected if no roots are provided unless the transport configuration sets
 `AllowInsecure` to skip verification.
 
+## gRPC keepalive and timeouts
+
+The gRPC control plane uses keepalive pings and deadlines to detect stalled
+clients. Defaults:
+
+- `--keepalive-time` (2m): interval between server pings.
+- `--keepalive-timeout` (20s): wait for a ping acknowledgement before closing.
+- `--request-timeout` (15s): deadline enforced on unary RPC handlers.
+
 ## QUIC
 
 - Uses [quic-go](https://github.com/quic-go/quic-go)

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -22,18 +24,30 @@ import (
 )
 
 type Config struct {
-	TLSCert       string
-	TLSKey        string
-	CACert        string
-	AllowInsecure bool
+	TLSCert          string
+	TLSKey           string
+	CACert           string
+	AllowInsecure    bool
+	KeepaliveTime    time.Duration
+	KeepaliveTimeout time.Duration
+	RequestTimeout   time.Duration
 }
 
 // New constructs a gRPC server and returns it along with a cleanup function
 // that flushes logger buffers on shutdown.
 func New(conf Config, a lvmagent.Agent, logger *zap.Logger) (*grpc.Server, func(), error) {
+	unary := []grpc.UnaryServerInterceptor{authorizeInterceptor}
+	if conf.RequestTimeout > 0 {
+		unary = append([]grpc.UnaryServerInterceptor{timeoutInterceptor(conf.RequestTimeout)}, unary...)
+	}
 	opts := []grpc.ServerOption{
-		grpc.UnaryInterceptor(authorizeInterceptor),
+		grpc.ChainUnaryInterceptor(unary...),
 		grpc.StreamInterceptor(authorizeStreamInterceptor),
+	}
+
+	if conf.KeepaliveTime > 0 || conf.KeepaliveTimeout > 0 {
+		params := keepalive.ServerParameters{Time: conf.KeepaliveTime, Timeout: conf.KeepaliveTimeout}
+		opts = append(opts, grpc.KeepaliveParams(params))
 	}
 
 	if !conf.AllowInsecure {
@@ -72,6 +86,27 @@ func New(conf Config, a lvmagent.Agent, logger *zap.Logger) (*grpc.Server, func(
 		_ = logger.Sync()
 	}
 	return srv, cleanup, nil
+}
+
+func timeoutInterceptor(d time.Duration) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		c := ctx
+		var cancel context.CancelFunc
+		if d > 0 {
+			c, cancel = context.WithTimeout(ctx, d)
+		}
+		if cancel != nil {
+			defer cancel()
+		}
+		resp, err := handler(c, req)
+		if err != nil {
+			return resp, err
+		}
+		if e := c.Err(); e != nil {
+			return nil, e
+		}
+		return resp, nil
+	}
 }
 
 func authorizeInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -940,3 +940,34 @@ func TestNewTLSFailures(t *testing.T) {
 		}
 	})
 }
+
+func TestRequestTimeout(t *testing.T) {
+	cfg := Config{AllowInsecure: true, RequestTimeout: 50 * time.Millisecond}
+	agent := &mockAgent{probe: func(ctx context.Context, _ string) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+			return nil
+		}
+	}}
+	lis := bufconn.Listen(bufSize)
+	srv, cleanup, err := New(cfg, agent, zap.NewNop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	go srv.Serve(lis)
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	client := proto.NewReplicationClient(conn)
+	_, err = client.Probe(ctxWithRole("replicator"), &proto.ProbeRequest{VolumeName: "vol"})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	conn.Close()
+	srv.Stop()
+	cleanup()
+}


### PR DESCRIPTION
## Summary
- add keepalive and request timeout settings to gRPC server
- expose keepalive and timeout flags in `lvmsync-grpcd`
- document gRPC keepalive defaults

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: transport/quic/quic_test.go:199:6: expected '(' found TestQUICTransportRequiresLogger)*
- `go test ./grpc/server ./cmd/grpcd`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f29a4a0a88323aec3f7e61d00e030