### PR TITLE
refactor(cmd/lvmsync): inject logger into run command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ command-line use, environment variables, and `config.yaml` files.
 - Zap is the sole logging backend; avoid `log` or `fmt.Print*` for progress output.
 - Always call `Sync()` (e.g., `defer logger.Sync()`) before program exit to flush buffers.
 - Transport constructors must accept a `*zap.Logger`; avoid package-level loggers.
+- Pass loggers explicitly to commands and helpers; do not use `zap.L()` or other globals.
 - Log connection lifecycle events and errors with `snake_case` fields including units (e.g., `bytes_transferred`, `duration_ms`).
 - Callers using transports should `defer logger.Sync()` to ensure logs are flushed.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ tooling to track transfer completion.
 ### Expectations
 
 - Use `zap` for all logging and avoid `fmt.Print*` or `log.*` calls.
+- Pass loggers explicitly to commands and helpers; `cmd/lvmsync.Execute` requires a
+  `*zap.Logger` argument instead of relying on `zap.L()`.
 - Log field keys in `snake_case` and include units where relevant (for example, `duration_ms`).
 - Provide raw byte values alongside human-readable sizes (for example, `block_size` and `block_size_bytes`).
 - Always defer `syncLogger(logger)` to flush buffers and log if the sync fails.

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -25,13 +25,13 @@ type RunOptions struct {
 
 var (
 	// These function variables allow tests to stub command behavior.
-	runCommand      = func(src, dst string, opts RunOptions) error { return nil }
-	manifestRebuild = func(device string, dryRun bool) error { return nil }
-	verifyRun       = func(args []string) error { return verifycmd.Run(args, nil) }
+	runCommand      = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil }
+	manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error { return nil }
+	verifyRun       = func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) }
 )
 
 // NewRootCmd creates the root cobra command with all subcommands wired.
-func NewRootCmd() *cobra.Command {
+func NewRootCmd(logger *zap.Logger) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "lvmsync",
 		Short: "LVMSync command line tool",
@@ -60,15 +60,6 @@ func NewRootCmd() *cobra.Command {
 				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
 			}
 			if cfg.DryRun {
-				logger := zap.L()
-				if logger == nil {
-					var err error
-					logger, err = zap.NewProduction()
-					if err != nil {
-						return err
-					}
-				}
-				defer logger.Sync()
 				if err := estimateTransfer(remaining[0], cfg, logger); err != nil {
 					return err
 				}
@@ -78,7 +69,7 @@ func NewRootCmd() *cobra.Command {
 				DryRun:    cfg.DryRun,
 				Transport: cfg.Transport,
 			}
-			return runCommand(remaining[0], remaining[1], opts)
+			return runCommand(remaining[0], remaining[1], opts, logger)
 		},
 	}
 
@@ -109,7 +100,7 @@ func NewRootCmd() *cobra.Command {
 				fs.Usage()
 				return fmt.Errorf("usage: lvmsync manifest rebuild [flags] <device>")
 			}
-			return manifestRebuild(remaining[0], cfg.DryRun)
+			return manifestRebuild(remaining[0], cfg.DryRun, logger)
 		},
 	}
 	manifestCmd.AddCommand(rebuildCmd)
@@ -119,7 +110,7 @@ func NewRootCmd() *cobra.Command {
 		Short:              "Verify that source and destination match",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return verifyRun(args)
+			return verifyRun(args, logger)
 		},
 	}
 
@@ -129,8 +120,8 @@ func NewRootCmd() *cobra.Command {
 
 // Execute runs the command tree with provided arguments.
 // If args is nil, the global os.Args are used by cobra.
-func Execute(args []string) error {
-	cmd := NewRootCmd()
+func Execute(args []string, logger *zap.Logger) error {
+	cmd := NewRootCmd(logger)
 	if args != nil {
 		cmd.SetArgs(args)
 	}
@@ -138,6 +129,9 @@ func Execute(args []string) error {
 }
 
 func estimateTransfer(src string, cfg *config.Config, logger *zap.Logger) error {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	info, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("stat source: %w", err)

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -18,13 +18,13 @@ func TestRunCommandExecutes(t *testing.T) {
 	t.Setenv("LVMSYNC_TRANSPORT_TRANSPORT", "ssh")
 	var gotSrc, gotDst string
 	var gotOpts RunOptions
-	runCommand = func(src, dst string, opts RunOptions) error {
+	runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error {
 		gotSrc, gotDst, gotOpts = src, dst, opts
 		return nil
 	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
+	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
 
-	if err := Execute([]string{"run", "src", "dst"}); err != nil {
+	if err := Execute([]string{"run", "src", "dst"}, zap.NewNop()); err != nil {
 		t.Fatalf("execute run: %v", err)
 	}
 	if gotSrc != "src" || gotDst != "dst" {
@@ -44,13 +44,13 @@ func TestRunCommandDryRun(t *testing.T) {
 		t.Fatalf("write src: %v", err)
 	}
 	called := false
-	runCommand = func(src, dst string, opts RunOptions) error {
+	runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error {
 		called = true
 		return nil
 	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
+	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
 
-	if err := Execute([]string{"run", "--dry-run", src, "dst"}); err != nil {
+	if err := Execute([]string{"run", "--dry-run", src, "dst"}, zap.NewNop()); err != nil {
 		t.Fatalf("execute run dry-run: %v", err)
 	}
 	if called {
@@ -65,13 +65,13 @@ func TestRunCommandDryRunEnv(t *testing.T) {
 	}
 	t.Setenv("LVMSYNC_DRY_RUN", "true")
 	called := false
-	runCommand = func(src, dst string, o RunOptions) error {
+	runCommand = func(src, dst string, o RunOptions, logger *zap.Logger) error {
 		called = true
 		return nil
 	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
+	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
 
-	if err := Execute([]string{"run", src, "dst"}); err != nil {
+	if err := Execute([]string{"run", src, "dst"}, zap.NewNop()); err != nil {
 		t.Fatalf("execute run with env: %v", err)
 	}
 	if called {
@@ -81,13 +81,13 @@ func TestRunCommandDryRunEnv(t *testing.T) {
 
 func TestRunCommandInvalidConfig(t *testing.T) {
 	called := false
-	runCommand = func(src, dst string, opts RunOptions) error {
+	runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error {
 		called = true
 		return nil
 	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions) error { return nil } })
+	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
 
-	if err := Execute([]string{"run", "--ssh_keepalive=0s", "src", "dst"}); err == nil {
+	if err := Execute([]string{"run", "--ssh_keepalive=0s", "src", "dst"}, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for invalid config")
 	}
 	if called {
@@ -98,13 +98,13 @@ func TestRunCommandInvalidConfig(t *testing.T) {
 func TestManifestRebuildRoutes(t *testing.T) {
 	var gotDevice string
 	var dry bool
-	manifestRebuild = func(device string, d bool) error {
+	manifestRebuild = func(device string, d bool, logger *zap.Logger) error {
 		gotDevice, dry = device, d
 		return nil
 	}
-	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool) error { return nil } })
+	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error { return nil } })
 
-	if err := Execute([]string{"manifest", "rebuild", "--dry-run", "/dev/vg0"}); err != nil {
+	if err := Execute([]string{"manifest", "rebuild", "--dry-run", "/dev/vg0"}, zap.NewNop()); err != nil {
 		t.Fatalf("execute rebuild: %v", err)
 	}
 	if gotDevice != "/dev/vg0" {
@@ -117,13 +117,13 @@ func TestManifestRebuildRoutes(t *testing.T) {
 
 func TestManifestRebuildInvalidConfig(t *testing.T) {
 	called := false
-	manifestRebuild = func(device string, dryRun bool) error {
+	manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error {
 		called = true
 		return nil
 	}
-	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool) error { return nil } })
+	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error { return nil } })
 
-	if err := Execute([]string{"manifest", "rebuild", "--ssh_keepalive=0s", "/dev/vg0"}); err == nil {
+	if err := Execute([]string{"manifest", "rebuild", "--ssh_keepalive=0s", "/dev/vg0"}, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for invalid config")
 	}
 	if called {
@@ -133,13 +133,15 @@ func TestManifestRebuildInvalidConfig(t *testing.T) {
 
 func TestVerifyRoutes(t *testing.T) {
 	var got []string
-	verifyRun = func(a []string) error {
+	verifyRun = func(a []string, logger *zap.Logger) error {
 		got = append([]string{}, a...)
 		return nil
 	}
-	t.Cleanup(func() { verifyRun = func(args []string) error { return verifycmd.Run(args, nil) } })
+	t.Cleanup(func() {
+		verifyRun = func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) }
+	})
 
-	if err := Execute([]string{"verify", "a", "b"}); err != nil {
+	if err := Execute([]string{"verify", "a", "b"}, zap.NewNop()); err != nil {
 		t.Fatalf("execute verify: %v", err)
 	}
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
@@ -170,6 +172,7 @@ func TestEstimateTransferWithManifest(t *testing.T) {
 	cfg := &config.Config{ManifestPath: manifestPath}
 	core, obs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
+	defer logger.Sync()
 	if err := estimateTransfer(src, cfg, logger); err != nil {
 		t.Fatalf("estimate transfer: %v", err)
 	}


### PR DESCRIPTION
## Summary
- refactor lvmsync run command to accept injected `*zap.Logger`
- update helper stubs and tests to pass loggers explicitly
- document explicit logger usage in README and AGENTS guidelines

## Testing
- `go build ./...` *(fails: grpc/server/server.go:48:13: undefined: keepalive)*
- `go test -coverprofile=coverage.out ./...` *(fails: grpc/server/server.go:48:13: undefined: keepalive)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`
- `go test -cover ./cmd/lvmsync`


------
https://chatgpt.com/codex/tasks/task_e_689f2f21437c83238f49da9f7a5325cb