### PR TITLE
refactor(remote): precompile remote command regex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,10 @@ Run these commands locally before opening a pull request:
 - Run `go build ./...`, `go test -cover ./...`, and `golangci-lint run` before merging.
 - Document new flags, environment variables, and configuration options in `README.md`.
 
+## Regex Patterns
+
+- Remote command validation uses a precompiled regex `^[a-zA-Z0-9._-]+$` (`remoteCmdRe` in `remote/remote.go`). Maintain this pattern when checking remote commands.
+
 ## TODO
 
 - [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit (block size logs now use `size_bytes`).

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -19,6 +19,8 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
+var remoteCmdRe = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
+
 // SSHClient wraps an ssh.Client and provides structured logging.
 //
 // The embedded *zap.Logger defaults to a no-op logger when nil to avoid
@@ -167,7 +169,7 @@ func (c *SSHClient) ValidateRemoteCommand(ctx context.Context, remoteCmd string)
 		return fmt.Errorf("remote command is empty")
 	}
 	cmd := filepath.Base(tokens[0])
-	if !regexp.MustCompile(`^[a-zA-Z0-9._-]+$`).MatchString(cmd) {
+	if !remoteCmdRe.MatchString(cmd) {
 		return fmt.Errorf("remote command %s contains invalid characters", cmd)
 	}
 	session, err := c.NewSession()

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,5 +92,14 @@ func TestValidateRemoteCommandCanceled(t *testing.T) {
 	defer cancel()
 	if err := client.ValidateRemoteCommand(ctx, "echo"); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestValidateRemoteCommandInvalidChars(t *testing.T) {
+	client := &SSHClient{Logger: zap.NewNop()}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := client.ValidateRemoteCommand(ctx, "bad+cmd"); err == nil || !strings.Contains(err.Error(), "invalid characters") {
+		t.Fatalf("expected invalid characters error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- precompile regex for validating remote command names
- reject invalid remote commands with precompiled matcher
- document remote command regex pattern

## Testing
- `go build ./...` *(fails: undefined: keepalive)*
- `go test -coverprofile=coverage.out ./...` *(fails: undefined: keepalive)*
- `go test -coverprofile=coverage.out ./remote`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f2f28d2ac8323b2b72f8f902cb7b5