### PR TITLE
fix(grpc): add keepalive import

### DIFF
--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 


### PR DESCRIPTION
## Summary
- add missing keepalive import to gRPC server setup

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRequestTimeout, TestNewSSHClient)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_689f3761161c8323876e51416f7cb8a8