### PR TITLE
fix(transport): log errors at error level

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -104,49 +104,49 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	}
 	if err != nil {
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
 	fr := http2.NewFramer(conn, conn)
 	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if err := fr.WriteSettings(); err != nil {
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if f, err := fr.ReadFrame(); err != nil {
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	} else if _, ok := f.(*http2.SettingsFrame); !ok {
 		err = fmt.Errorf("expected settings frame")
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if err := fr.WriteSettingsAck(); err != nil {
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if f, err := fr.ReadFrame(); err != nil {
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	} else if sf, ok := f.(*http2.SettingsFrame); !ok || !sf.IsAck() {
 		err = fmt.Errorf("expected settings ack")
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
@@ -179,11 +179,10 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 	}
 	if err != nil {
 		fields = append(fields, zap.Error(err))
-	}
-	t.logger.Info("listen_end", fields...)
-	if err != nil {
+		t.logger.Error("listen_end", fields...)
 		return nil, err
 	}
+	t.logger.Info("listen_end", fields...)
 	return &listener{ln: ln}, nil
 }
 
@@ -262,8 +261,10 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		if err != nil {
 			fields = append(fields, zap.Error(err))
+			t.logger.Error("negotiate_end", fields...)
+		} else {
+			t.logger.Info("negotiate_end", fields...)
 		}
-		t.logger.Info("negotiate_end", fields...)
 	}()
 
 	if h2c, ok := conn.(*Conn); ok {

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -13,22 +13,29 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, level zapcore.Level) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	if expected == 0 {
+		return
 	}
 	ctx := entries[0].ContextMap()
 	for _, k := range []string{"address", "role", "duration_ms"} {
 		if _, ok := ctx[k]; !ok {
 			t.Fatalf("expected field %q in %s log", k, msg)
 		}
+	}
+	if entries[0].Level != level {
+		t.Fatalf("expected level %v for %s log, got %v", level, msg, entries[0].Level)
 	}
 }
 
@@ -119,12 +126,12 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 2)
-	checkLogFields(t, logs, "negotiate_end", 2)
+	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, zapcore.InfoLevel)
 }
 
 func TestH2TransportTLSHandshakeError(t *testing.T) {
@@ -154,10 +161,10 @@ func TestH2TransportTLSHandshakeError(t *testing.T) {
 		t.Fatalf("expected dial error")
 	}
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
+	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, zapcore.ErrorLevel)
+	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel)
 }
 
 func TestH2TransportTLSCDCMismatch(t *testing.T) {
@@ -200,12 +207,12 @@ func TestH2TransportTLSCDCMismatch(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1)
-	checkLogFields(t, logs, "dial_end", 1)
-	checkLogFields(t, logs, "listen_start", 1)
-	checkLogFields(t, logs, "listen_end", 1)
-	checkLogFields(t, logs, "negotiate_start", 2)
-	checkLogFields(t, logs, "negotiate_end", 2)
+	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, zapcore.ErrorLevel)
 
 	entries := logs.FilterMessage("negotiate_end").All()
 	for _, e := range entries {

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -102,7 +102,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 		}
 		fields = append(fields, zap.Error(err))
-		t.logger.Info("dial_end", fields...)
+		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
 	stream, err := qconn.OpenStreamSync(ctx)
@@ -113,12 +113,11 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	}
 	if err != nil {
 		fields = append(fields, zap.Error(err))
-	}
-	t.logger.Info("dial_end", fields...)
-	if err != nil {
+		t.logger.Error("dial_end", fields...)
 		qconn.CloseWithError(0, err.Error())
 		return nil, err
 	}
+	t.logger.Info("dial_end", fields...)
 	return &Conn{qconn: qconn, stream: stream}, nil
 }
 
@@ -139,11 +138,10 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 	}
 	if err != nil {
 		fields = append(fields, zap.Error(err))
-	}
-	t.logger.Info("listen_end", fields...)
-	if err != nil {
+		t.logger.Error("listen_end", fields...)
 		return nil, err
 	}
+	t.logger.Info("listen_end", fields...)
 	return &listener{ql: ql, ctx: ctx}, nil
 }
 
@@ -186,8 +184,10 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		if err != nil {
 			fields = append(fields, zap.Error(err))
+			t.logger.Error("negotiate_end", fields...)
+		} else {
+			t.logger.Info("negotiate_end", fields...)
 		}
-		t.logger.Info("negotiate_end", fields...)
 	}()
 
 	hs.Version = common.ProtocolVersion

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -12,16 +12,20 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool, level zapcore.Level) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	if expected == 0 {
+		return
 	}
 	ctx := entries[0].ContextMap()
 	for _, k := range []string{"address", "role", "duration_ms"} {
@@ -33,6 +37,9 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 		t.Fatalf("expected error field in %s log", msg)
 	} else if !wantErr && ok {
 		t.Fatalf("unexpected error field in %s log", msg)
+	}
+	if entries[0].Level != level {
+		t.Fatalf("expected level %v for %s log, got %v", level, msg, entries[0].Level)
 	}
 }
 
@@ -89,12 +96,12 @@ func TestQUICTransportHandshake(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, false)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 2, false)
-	checkLogFields(t, logs, "negotiate_end", 2, false)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
 
 func TestQUICTransportHandshakeError(t *testing.T) {
@@ -136,12 +143,12 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, false)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 1, false)
-	checkLogFields(t, logs, "negotiate_end", 1, true)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 1, true, zapcore.ErrorLevel)
 }
 
 func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
@@ -186,12 +193,12 @@ func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, false)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 2, false)
-	checkLogFields(t, logs, "negotiate_end", 2, true)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }
 
 func TestQUICTransportRequiresLogger(t *testing.T) {

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -76,7 +76,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	d := &net.Dialer{}
 	raw, err := d.DialContext(ctx, "tcp", address)
 	if err != nil {
-		t.logger.Info("dial_end",
+		t.logger.Error("dial_end",
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
@@ -87,7 +87,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	cc, chans, reqs, err := ssh.NewClientConn(raw, address, t.clientConf)
 	if err != nil {
 		raw.Close()
-		t.logger.Info("dial_end",
+		t.logger.Error("dial_end",
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
@@ -99,7 +99,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	ch, chReqs, err := client.OpenChannel("session", nil)
 	if err != nil {
 		client.Close()
-		t.logger.Info("dial_end",
+		t.logger.Error("dial_end",
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
@@ -127,7 +127,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 	lc := net.ListenConfig{}
 	tcpLn, err := lc.Listen(ctx, "tcp", address)
 	if err != nil {
-		t.logger.Info("listen_end",
+		t.logger.Error("listen_end",
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
@@ -165,8 +165,10 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		if err != nil {
 			fields = append(fields, zap.Error(err))
+			t.logger.Error("negotiate_end", fields...)
+		} else {
+			t.logger.Info("negotiate_end", fields...)
 		}
-		t.logger.Info("negotiate_end", fields...)
 	}()
 
 	hs.Version = common.ProtocolVersion

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool, level zapcore.Level) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
@@ -30,6 +31,9 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 		t.Fatalf("expected error field in %s log", msg)
 	} else if !wantErr && ok {
 		t.Fatalf("unexpected error field in %s log", msg)
+	}
+	if entries[0].Level != level {
+		t.Fatalf("expected level %v for %s log, got %v", level, msg, entries[0].Level)
 	}
 }
 
@@ -97,12 +101,12 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, false)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 2, false)
-	checkLogFields(t, logs, "negotiate_end", 2, false)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
 
 func TestSSHTransportAuthFailure(t *testing.T) {
@@ -139,12 +143,12 @@ func TestSSHTransportAuthFailure(t *testing.T) {
 	}
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, true)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 0, false)
-	checkLogFields(t, logs, "negotiate_end", 0, false)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 0, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 0, false, zapcore.InfoLevel)
 }
 
 func TestSSHTransportCDCMismatch(t *testing.T) {
@@ -192,12 +196,12 @@ func TestSSHTransportCDCMismatch(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false)
-	checkLogFields(t, logs, "dial_end", 1, false)
-	checkLogFields(t, logs, "listen_start", 1, false)
-	checkLogFields(t, logs, "listen_end", 1, false)
-	checkLogFields(t, logs, "negotiate_start", 2, false)
-	checkLogFields(t, logs, "negotiate_end", 2, true)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }
 
 func TestSSHTransportRequiresLogger(t *testing.T) {


### PR DESCRIPTION
## Summary
- log transport errors at error level instead of info
- assert error log levels in transport tests

## Testing
- `go build ./...`
- `go test ./transport/h2 ./transport/quic ./transport/ssh`
- `go test -coverprofile=coverage.out ./...` *(fails: rpc error: code = PermissionDenied desc = unauthorized role)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f3b5ed44883239cd7f6e05c432692