### PR TITLE
feat(transport): add MustRegister with fatal logging

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -75,11 +75,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{clientConf: clientConf, serverConf: serverConf, logger: cfg.Logger}, nil
 }
 
-func init() {
-	if err := transport.Register("h2", New); err != nil {
-		panic(err)
-	}
-}
+func init() { transport.MustRegister("h2", New) }
 
 func (t *Transport) Name() string { return "h2" }
 

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -77,11 +77,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{serverTLS: serverTLS, clientTLS: clientTLS, qconf: qconf, logger: cfg.Logger}, nil
 }
 
-func init() {
-	if err := transport.Register("quic", New); err != nil {
-		panic(err)
-	}
-}
+func init() { transport.MustRegister("quic", New) }
 
 func (t *Transport) Name() string { return "quic" }
 

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -3,6 +3,8 @@ package transport
 import (
 	"fmt"
 	"sync"
+
+	"go.uber.org/zap"
 )
 
 // Factory creates a transport implementation.
@@ -22,6 +24,13 @@ func Register(name string, f Factory) error {
 	}
 	registry[name] = f
 	return nil
+}
+
+// MustRegister registers a transport factory and logs a fatal error on duplicates.
+func MustRegister(name string, f Factory) {
+	if err := Register(name, f); err != nil {
+		zap.L().Fatal("register_transport", zap.String("name", name), zap.Error(err))
+	}
 }
 
 // Get returns a transport from the registry by name.

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestConcurrentRegister(t *testing.T) {
@@ -40,4 +42,34 @@ func TestDuplicateRegister(t *testing.T) {
 	if err := Register(name, func(Config) (Interface, error) { return nil, nil }); err == nil {
 		t.Fatalf("expected duplicate registration error")
 	}
+}
+
+func TestMustRegisterDuplicate(t *testing.T) {
+	name := "must-dupe-test"
+	if err := Register(name, func(Config) (Interface, error) { return nil, nil }); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	core, logs := observer.New(zapcore.FatalLevel)
+	logger := zap.New(core, zap.WithFatalHook(zapcore.WriteThenPanic))
+	zap.ReplaceGlobals(logger)
+	defer func() {
+		zap.ReplaceGlobals(zap.NewNop())
+		logger.Sync()
+	}()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+		if logs.Len() != 1 {
+			t.Fatalf("expected 1 log entry, got %d", logs.Len())
+		}
+		entry := logs.All()[0]
+		if entry.Level != zapcore.FatalLevel {
+			t.Fatalf("expected fatal level, got %v", entry.Level)
+		}
+		if entry.Message != "register_transport" {
+			t.Fatalf("unexpected message: %s", entry.Message)
+		}
+	}()
+	MustRegister(name, func(Config) (Interface, error) { return nil, nil })
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -57,11 +57,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil
 }
 
-func init() {
-	if err := transport.Register("ssh", New); err != nil {
-		panic(err)
-	}
-}
+func init() { transport.MustRegister("ssh", New) }
 
 func (t *Transport) Name() string { return "ssh" }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -54,11 +54,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil
 }
 
-func init() {
-	if err := transport.Register("tcp+tls", New); err != nil {
-		panic(err)
-	}
-}
+func init() { transport.MustRegister("tcp+tls", New) }
 
 func (t *Transport) Name() string { return "tcp+tls" }
 


### PR DESCRIPTION
## Summary
- add MustRegister wrapper around Register with zap fatal logging on duplicates
- replace panic-based transport registrations with MustRegister
- test MustRegister duplicate registration fatal path

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: grpc/server TestRequestTimeout, remote TestSSHManagerGetClientRefresh)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f3b6741a483239dfc78a7fa14975b