### PR TITLE
refactor(device): remove logger guards

### DIFF
--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -73,7 +73,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", zap.NewNop())
+	dev, err := Detect(context.Background(), link, true, "", "", nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", zap.NewNop())
+	dev, err := Detect(context.Background(), link, true, "", "", nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(context.Background(), lvPath, true, "", "", zap.NewNop())
+	dev, err := Detect(context.Background(), lvPath, true, "", "", nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/file.go
+++ b/device/file.go
@@ -19,43 +19,34 @@ type FileDevice struct {
 
 // OpenFile opens a regular file and reports its size and filesystem block size.
 func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	info, err := os.Stat(path)
 	if err != nil {
-		if logger != nil {
-			logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
-		}
+		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
 	if !info.Mode().IsRegular() {
 		err := fmt.Errorf("%s is not a regular file", path)
-		if logger != nil {
-			logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
-		}
+		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
-		if logger != nil {
-			logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
-		}
+		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
-	if logger != nil {
-		logger.Info("file device opened", zap.String("path", path))
-	}
+	logger.Info("file device opened", zap.String("path", path))
 	var st unix.Stat_t
 	if err := unix.Fstat(int(f.Fd()), &st); err != nil {
 		f.Close()
-		if logger != nil {
-			logger.Error("file device stat failed", zap.String("path", path), zap.Error(err))
-		}
+		logger.Error("file device stat failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
 	size := uint64(info.Size())
 	block := uint64(st.Blksize)
-	if logger != nil {
-		logger.Info("file device info", zap.String("path", path), zap.Uint64("size_bytes", size), zap.Uint64("block_size", block))
-	}
+	logger.Info("file device info", zap.String("path", path), zap.Uint64("size_bytes", size), zap.Uint64("block_size", block))
 	return &FileDevice{
 		f:         f,
 		size:      size,
@@ -76,12 +67,10 @@ func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 // Close closes the underlying file descriptor.
 func (d *FileDevice) Close() error {
 	err := d.f.Close()
-	if d.logger != nil {
-		if err != nil {
-			d.logger.Error("file device close failed", zap.String("path", d.Path()), zap.Error(err))
-		} else {
-			d.logger.Info("file device closed", zap.String("path", d.Path()))
-		}
+	if err != nil {
+		d.logger.Error("file device close failed", zap.String("path", d.Path()), zap.Error(err))
+	} else {
+		d.logger.Info("file device closed", zap.String("path", d.Path()))
 	}
 	return err
 }
@@ -98,8 +87,6 @@ func (d *FileDevice) Snapshot(context.Context, string) (Device, error) {
 
 // Cleanup is a no-op for regular files.
 func (d *FileDevice) Cleanup(context.Context, string, []string) error {
-	if d.logger != nil {
-		d.logger.Info("file device cleanup", zap.String("path", d.Path()))
-	}
+	d.logger.Info("file device cleanup", zap.String("path", d.Path()))
 	return nil
 }

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -51,7 +51,7 @@ func TestOpenFile(t *testing.T) {
 
 func TestOpenFileRejectsNonRegular(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := OpenFile(dir, zap.NewNop()); err == nil {
+	if _, err := OpenFile(dir, nil); err == nil {
 		t.Fatalf("expected error for directory")
 	}
 }
@@ -73,7 +73,7 @@ func TestFileSnapshotIdentityAndFDLeak(t *testing.T) {
 	path := f.Name()
 	f.Close()
 
-	d, err := OpenFile(path, zap.NewNop())
+	d, err := OpenFile(path, nil)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestFileSnapshotClosedDevice(t *testing.T) {
 	path := f.Name()
 	f.Close()
 
-	d, err := OpenFile(path, zap.NewNop())
+	d, err := OpenFile(path, nil)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -36,6 +36,9 @@ func OpenRaw(
 	fsThawCmdArgs []string,
 	logger *zap.Logger,
 ) (_ *RawDevice, err error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	d := &RawDevice{logger: logger}
 	if !offline {
 		if fsFreezeCmdPath == "" || fsThawCmdPath == "" {
@@ -47,15 +50,11 @@ func OpenRaw(
 		if err := validateCmd(fsThawCmdPath, fsThawCmdArgs); err != nil {
 			return nil, fmt.Errorf("invalid thaw command: %w", err)
 		}
-		if d.logger != nil {
-			d.logger.Info("fs freeze start", zap.String("command", fsFreezeCmdPath), zap.Strings("args", fsFreezeCmdArgs))
-		}
+		d.logger.Info("fs freeze start", zap.String("command", fsFreezeCmdPath), zap.Strings("args", fsFreezeCmdArgs))
 		if err = exec.CommandContext(ctx, fsFreezeCmdPath, fsFreezeCmdArgs...).Run(); err != nil {
 			return nil, fmt.Errorf("freeze command failed: %w", err)
 		}
-		if d.logger != nil {
-			d.logger.Info("fs freeze complete")
-		}
+		d.logger.Info("fs freeze complete")
 		d.freezeIssued = true
 		defer func() {
 			if err != nil {
@@ -87,12 +86,10 @@ func OpenRaw(
 	d.f = f
 	d.size = size
 	d.blockSize = uint64(bs)
-	if d.logger != nil {
-		d.logger.Info("raw device info",
-			zap.String("path", path),
-			zap.Uint64("size_bytes", size),
-			zap.Uint64("block_size", uint64(bs)))
-	}
+	d.logger.Info("raw device info",
+		zap.String("path", path),
+		zap.Uint64("size_bytes", size),
+		zap.Uint64("block_size", uint64(bs)))
 	return d, nil
 }
 
@@ -108,12 +105,10 @@ func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
 // Close closes the underlying file descriptor.
 func (d *RawDevice) Close() error {
 	err := d.f.Close()
-	if d.logger != nil {
-		if err != nil {
-			d.logger.Error("raw device close failed", zap.String("path", d.Path()), zap.Error(err))
-		} else {
-			d.logger.Info("raw device closed", zap.String("path", d.Path()))
-		}
+	if err != nil {
+		d.logger.Error("raw device close failed", zap.String("path", d.Path()), zap.Error(err))
+	} else {
+		d.logger.Info("raw device closed", zap.String("path", d.Path()))
 	}
 	return err
 }
@@ -125,23 +120,15 @@ func (d *RawDevice) Snapshot(context.Context, string) (Device, error) { return d
 func (d *RawDevice) Cleanup(ctx context.Context, fsThawCmdPath string, fsThawCmdArgs []string) error {
 	if d.freezeIssued {
 		if err := validateCmd(fsThawCmdPath, fsThawCmdArgs); err != nil {
-			if d.logger != nil {
-				d.logger.Error("fs thaw failed", zap.Error(err))
-			}
+			d.logger.Error("fs thaw failed", zap.Error(err))
 			return fmt.Errorf("invalid thaw command: %w", err)
 		}
-		if d.logger != nil {
-			d.logger.Info("fs thaw start", zap.String("command", fsThawCmdPath), zap.Strings("args", fsThawCmdArgs))
-		}
+		d.logger.Info("fs thaw start", zap.String("command", fsThawCmdPath), zap.Strings("args", fsThawCmdArgs))
 		if err := exec.CommandContext(ctx, fsThawCmdPath, fsThawCmdArgs...).Run(); err != nil {
-			if d.logger != nil {
-				d.logger.Error("fs thaw failed", zap.Error(err))
-			}
+			d.logger.Error("fs thaw failed", zap.Error(err))
 			return fmt.Errorf("thaw command failed: %w", err)
 		}
-		if d.logger != nil {
-			d.logger.Info("fs thaw complete")
-		}
+		d.logger.Info("fs thaw complete")
 	}
 	return nil
 }

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -71,14 +71,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, nil); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, zap.NewNop()); err == nil {
+		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, nil); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -87,13 +87,13 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, nil); err == nil {
 		t.Fatalf("expected offline or freeze command error")
 	}
 }
 
 func TestOpenRawFreezeCommandFailure(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, nil); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -105,7 +105,7 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 	freezeArgs := []string{freezeTmp}
 	thawCmdPath := "touch"
 	thawArgs := []string{thawTmp}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, nil); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -25,7 +25,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	fd, err := OpenFile(f.Name(), zap.NewNop())
+	fd, err := OpenFile(f.Name(), nil)
 	if err != nil {
 		t.Fatalf("open file: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	}
 
 	// Raw device snapshot is also a no-op.
-	rd := &RawDevice{f: os.NewFile(uintptr(0), "/dev/sda")}
+	rd := &RawDevice{f: os.NewFile(uintptr(0), "/dev/sda"), logger: zap.NewNop()}
 	rsnap, err := rd.Snapshot(ctx, "")
 	if err != nil {
 		t.Fatalf("raw snapshot: %v", err)


### PR DESCRIPTION
## Summary
- default devices to zap.NewNop when no logger provided
- log file and raw device operations unconditionally
- adjust tests for unconditional logging

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` (fails: TestRequestTimeout unauthorized role)
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f3b69b50c832386cd0aab0486675b