### PR TITLE
fix: rename device and progress log fields with byte units

### DIFF
--- a/device/file.go
+++ b/device/file.go
@@ -54,7 +54,7 @@ func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
 	size := uint64(info.Size())
 	block := uint64(st.Blksize)
 	if logger != nil {
-		logger.Info("file device info", zap.String("path", path), zap.Uint64("size_bytes", size), zap.Uint64("block_size", block))
+		logger.Info("file device info", zap.String("path", path), zap.Uint64("size_bytes", size), zap.Uint64("block_size_bytes", block))
 	}
 	return &FileDevice{
 		f:         f,

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -41,8 +41,17 @@ func TestOpenFile(t *testing.T) {
 	if logs.FilterMessage("file device opened").Len() == 0 {
 		t.Fatalf("expected file device opened log")
 	}
-	if logs.FilterMessage("file device info").Len() == 0 {
-		t.Fatalf("expected file device info log")
+	entries := logs.FilterMessage("file device info").All()
+	found := false
+	for _, e := range entries {
+		if e.ContextMap()["path"] == path &&
+			e.ContextMap()["size_bytes"].(uint64) == d.SizeBytes() &&
+			e.ContextMap()["block_size_bytes"].(uint64) == d.BlockSize() {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected file device info log with fields, got %v", logs.All())
 	}
 	if logs.FilterMessage("file device closed").Len() == 0 {
 		t.Fatalf("expected file device closed log")

--- a/device/raw.go
+++ b/device/raw.go
@@ -91,7 +91,7 @@ func OpenRaw(
 		d.logger.Info("raw device info",
 			zap.String("path", path),
 			zap.Uint64("size_bytes", size),
-			zap.Uint64("block_size", uint64(bs)))
+			zap.Uint64("block_size_bytes", uint64(bs)))
 	}
 	return d, nil
 }

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -29,8 +29,8 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	found := false
 	for _, e := range entries {
 		if e.ContextMap()["path"] == loop &&
-			uint64(e.ContextMap()["size_bytes"].(float64)) == d.SizeBytes() &&
-			uint64(e.ContextMap()["block_size"].(float64)) == d.BlockSize() {
+			e.ContextMap()["size_bytes"].(uint64) == d.SizeBytes() &&
+			e.ContextMap()["block_size_bytes"].(uint64) == d.BlockSize() {
 			found = true
 		}
 	}

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -437,8 +437,8 @@ func (s *replicationServer) ProgressStream(req *proto.ProgressRequest, stream pr
 			}
 			s.logger.Debug("progress_update",
 				zap.String("session_id", p.GetSessionId()),
-				zap.Uint64("completed", p.GetCompleted()),
-				zap.Uint64("total", p.GetTotal()),
+				zap.Uint64("completed_bytes", p.GetCompleted()),
+				zap.Uint64("total_bytes", p.GetTotal()),
 			)
 			if err := stream.Send(p); err != nil {
 				return err

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -990,7 +990,8 @@ func TestNewTLSFailures(t *testing.T) {
 }
 
 func TestRequestTimeout(t *testing.T) {
-	cfg := Config{AllowInsecure: true, RequestTimeout: 50 * time.Millisecond}
+	cfg, good, _, _ := generateTLS(t)
+	cfg.RequestTimeout = 50 * time.Millisecond
 	agent := &mockAgent{probe: func(ctx context.Context, _ string) error {
 		select {
 		case <-ctx.Done():
@@ -999,23 +1000,10 @@ func TestRequestTimeout(t *testing.T) {
 			return nil
 		}
 	}}
-	lis := bufconn.Listen(bufSize)
-	srv, cleanup, err := New(cfg, agent, zap.NewNop())
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	go srv.Serve(lis)
-	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
-	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-	client := proto.NewReplicationClient(conn)
-	_, err = client.Probe(ctxWithRole("replicator"), &proto.ProbeRequest{VolumeName: "vol"})
+	client, cleanup := newClient(t, cfg, agent, credentials.NewTLS(good))
+	defer cleanup()
+	_, err := client.Probe(context.Background(), &proto.ProbeRequest{VolumeName: "vol"})
 	if status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
-	conn.Close()
-	srv.Stop()
-	cleanup()
 }


### PR DESCRIPTION
## Summary
- rename device block_size log field to block_size_bytes
- log progress as completed_bytes/total_bytes
- update tests for new log field names and ensure request timeout test uses TLS

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f3b63836c832396f1a78dbf0ff555