### PR TITLE
test(remote): ensure deterministic SSH connection counts

### DIFF
--- a/remote/ssh_manager_test.go
+++ b/remote/ssh_manager_test.go
@@ -82,9 +82,20 @@ func TestSSHManagerGetClientRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetClient first: %v", err)
 	}
-	if server.ConnectionCount() != 1 {
-		t.Fatalf("expected 1 connection, got %d", server.ConnectionCount())
+	waitConn := func(want int) {
+		t.Helper()
+		deadline := time.Now().Add(time.Second)
+		for {
+			if server.ConnectionCount() == want {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("expected %d connections, got %d", want, server.ConnectionCount())
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
+	waitConn(1)
 
 	c1.Close()
 	time.Sleep(50 * time.Millisecond)
@@ -96,9 +107,7 @@ func TestSSHManagerGetClientRefresh(t *testing.T) {
 	if c1 == c2 {
 		t.Fatal("expected new connection after close")
 	}
-	if server.ConnectionCount() != 2 {
-		t.Fatalf("expected 2 connections, got %d", server.ConnectionCount())
-	}
+	waitConn(2)
 	if err := mgr.CloseAll(); err != nil {
 		t.Fatalf("CloseAll: %v", err)
 	}

--- a/remote/testutil/ssh_mock.go
+++ b/remote/testutil/ssh_mock.go
@@ -62,14 +62,15 @@ func (s *MockSSHServer) serve(config *ssh.ServerConfig) {
 		if err != nil {
 			return
 		}
+		s.mu.Lock()
+		s.connCount++
+		s.mu.Unlock()
+
 		go func(nConn net.Conn) {
 			serverConn, chans, reqs, err := ssh.NewServerConn(nConn, config)
 			if err != nil {
 				return
 			}
-			s.mu.Lock()
-			s.connCount++
-			s.mu.Unlock()
 			go s.handleRequests(reqs)
 			for newCh := range chans {
 				if newCh.ChannelType() != "session" {


### PR DESCRIPTION
## Summary
- ensure mock SSH server increments connection count immediately after accepting a connection
- wait for the expected connection count in TestSSHManagerGetClientRefresh

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f49e6c728832396f1ce9d2775fde9