### PR TITLE
refactor dedup chunker to use ring buffer

### DIFF
--- a/dedup/benchmarks_test.go
+++ b/dedup/benchmarks_test.go
@@ -10,6 +10,8 @@ import (
 	"lvmsync_go/hash"
 )
 
+var entropySink float64
+
 // BenchmarkReplicator measures end-to-end throughput of the replication
 // pipeline on random data.
 func BenchmarkReplicator(b *testing.B) {
@@ -46,4 +48,43 @@ func BenchmarkChunker(b *testing.B) {
 			}
 		}
 	}
+}
+
+// BenchmarkUpdateEntropyRing measures the cost of updating the entropy window
+// using the ring buffer implementation.
+func BenchmarkUpdateEntropyRing(b *testing.B) {
+	c := &Chunker{}
+	counts := [256]int{}
+	for i := range c.window {
+		c.window[i] = byte(i)
+		counts[c.window[i]]++
+	}
+	b.ResetTimer()
+	var res float64
+	for i := 0; i < b.N; i++ {
+		res += c.updateEntropy(byte(i), &counts)
+	}
+	entropySink = res
+}
+
+// BenchmarkUpdateEntropyCopy replicates the previous copy-based window update
+// to compare against the ring buffer implementation.
+func BenchmarkUpdateEntropyCopy(b *testing.B) {
+	var window [64]byte
+	counts := [256]int{}
+	for i := range window {
+		window[i] = byte(i)
+		counts[window[i]]++
+	}
+	b.ResetTimer()
+	var res float64
+	for i := 0; i < b.N; i++ {
+		out := window[0]
+		copy(window[:63], window[1:])
+		window[63] = byte(i)
+		counts[out]--
+		counts[byte(i)]++
+		res += entropy(counts[:])
+	}
+	entropySink = res
 }

--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -27,6 +27,7 @@ type Chunker struct {
 	maskHigh   uint64
 	maskLow    uint64
 	window     [64]byte // used for entropy estimation
+	winPos     int      // current position in the entropy window
 
 	// reusable buffer to avoid per-chunk allocations
 	buf []byte
@@ -87,6 +88,7 @@ func (c *Chunker) NextChunk(r io.Reader) (Chunk, error) {
 
 	// initialize entropy window
 	copy(c.window[:], buf[size-64:size])
+	c.winPos = 0
 	counts := [256]int{}
 	for _, b := range c.window {
 		counts[b]++
@@ -118,9 +120,9 @@ func (c *Chunker) NextChunk(r io.Reader) (Chunk, error) {
 // updateEntropy updates the rolling entropy window with the new byte and
 // returns the current entropy.
 func (c *Chunker) updateEntropy(b byte, counts *[256]int) float64 {
-	out := c.window[0]
-	copy(c.window[:63], c.window[1:])
-	c.window[63] = b
+	out := c.window[c.winPos]
+	c.window[c.winPos] = b
+	c.winPos = (c.winPos + 1) % len(c.window)
 	counts[out]--
 	counts[b]++
 	return entropy(counts[:])


### PR DESCRIPTION
## Summary
- replace entropy window copy with ring buffer index
- track window position in `Chunker`
- benchmark ring buffer vs copy implementation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f4d0b25408323bbbcb2e7d6a37d90