### PR TITLE
feat(common): validate ALPN and TLS version

### DIFF
--- a/common/handshake_validate.go
+++ b/common/handshake_validate.go
@@ -34,5 +34,11 @@ func ValidateHandshake(local, peer Handshake) error {
 	if peer.MaxInFlight > 0 && local.MaxInFlight > 0 && peer.MaxInFlight != local.MaxInFlight {
 		return fmt.Errorf("max in-flight mismatch: %d", peer.MaxInFlight)
 	}
+	if peer.ALPN != "" && local.ALPN != "" && peer.ALPN != local.ALPN {
+		return fmt.Errorf("alpn mismatch: %s", peer.ALPN)
+	}
+	if peer.TLSVersion != "" && local.TLSVersion != "" && peer.TLSVersion != local.TLSVersion {
+		return fmt.Errorf("tls version mismatch: %s", peer.TLSVersion)
+	}
 	return nil
 }

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -13,3 +13,21 @@ func TestValidateHandshake(t *testing.T) {
 		t.Fatal("expected dedup mismatch error")
 	}
 }
+
+func TestValidateHandshakeALPNMismatch(t *testing.T) {
+	local := Handshake{ALPN: "lvmsync"}
+	peer := local
+	peer.ALPN = "other"
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected alpn mismatch error")
+	}
+}
+
+func TestValidateHandshakeTLSVersionMismatch(t *testing.T) {
+	local := Handshake{TLSVersion: "1.3"}
+	peer := local
+	peer.TLSVersion = "1.2"
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected tls version mismatch error")
+	}
+}

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -11,6 +11,9 @@ algorithms and digests. The handshake also carries a resume token
 (`resume:<token>`) so interrupted sessions can continue and a maximum
 in‑flight hint (`inflight:<n>`) to negotiate concurrency.
 
+Handshake validation rejects mismatched ALPN protocols or TLS versions to
+ensure both peers agree on the connection parameters.
+
 TLS based transports enable mutual TLS by default and restrict cipher suites to
 `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, and
 `TLS_CHACHA20_POLY1305_SHA256`.


### PR DESCRIPTION
## Summary
- validate ALPN and TLS version during handshake
- test handshake mismatches for ALPN and TLS version
- document ALPN/TLS handshake validation in transports guide

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f4d1e5aa083238a6d02158149db73