### PR TITLE
fix(grpc): block on dial and handle context cancellation

### DIFF
--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -59,21 +58,15 @@ func Dial(ctx context.Context, addr string, conf Config, opts ...grpc.DialOption
 	}
 	ctx, cancel := context.WithTimeout(ctx, conf.DialTimeout)
 	defer cancel()
-	conn, err := grpc.NewClient(target, opts...)
+	opts = append(opts, grpc.WithBlock())
+	conn, err := grpc.DialContext(ctx, target, opts...)
 	if err != nil {
-		return nil, err
-	}
-	conn.Connect()
-	for {
-		state := conn.GetState()
-		if state == connectivity.Ready {
-			return conn, nil
-		}
-		if !conn.WaitForStateChange(ctx, state) {
-			conn.Close()
+		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
+		return nil, err
 	}
+	return conn, nil
 }
 
 func Handshake(ctx context.Context, c proto.ReplicationClient, hs *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -220,10 +220,20 @@ func TestDial(t *testing.T) {
 	}
 }
 
+func TestDialFailure(t *testing.T) {
+	failDialer := func(ctx context.Context, s string) (net.Conn, error) {
+		return nil, errors.New("fail")
+	}
+	_, err := Dial(context.Background(), "fail", Config{AllowInsecure: true, DialTimeout: time.Second}, grpc.WithContextDialer(failDialer))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
 func TestDialTimeoutExceeded(t *testing.T) {
 	slowDialer := func(ctx context.Context, s string) (net.Conn, error) {
-		time.Sleep(50 * time.Millisecond)
-		return nil, errors.New("no connection")
+		<-ctx.Done()
+		return nil, ctx.Err()
 	}
 	_, err := Dial(context.Background(), "slow", Config{AllowInsecure: true, DialTimeout: 10 * time.Millisecond}, grpc.WithContextDialer(slowDialer))
 	if err == nil {
@@ -231,6 +241,22 @@ func TestDialTimeoutExceeded(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestDialContextCancelled(t *testing.T) {
+	dialer := func(ctx context.Context, s string) (net.Conn, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Dial(ctx, "cancel", Config{AllowInsecure: true, DialTimeout: time.Second}, grpc.WithContextDialer(dialer))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace manual client connect loop with `grpc.DialContext` and `grpc.WithBlock`
- surface context cancellation errors to callers
- add client dial failure, timeout, and cancelled context tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f4d21be4c832385539f1d56e2d15a