### PR TITLE
refactor(transport): drop global fatal logging

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -75,7 +75,11 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{clientConf: clientConf, serverConf: serverConf, logger: cfg.Logger}, nil
 }
 
-func init() { transport.MustRegister("h2", New) }
+func init() {
+	if err := transport.Register("h2", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "h2" }
 

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -77,7 +77,11 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{serverTLS: serverTLS, clientTLS: clientTLS, qconf: qconf, logger: cfg.Logger}, nil
 }
 
-func init() { transport.MustRegister("quic", New) }
+func init() {
+	if err := transport.Register("quic", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "quic" }
 

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -3,8 +3,6 @@ package transport
 import (
 	"fmt"
 	"sync"
-
-	"go.uber.org/zap"
 )
 
 // Factory creates a transport implementation.
@@ -26,10 +24,11 @@ func Register(name string, f Factory) error {
 	return nil
 }
 
-// MustRegister registers a transport factory and logs a fatal error on duplicates.
+// MustRegister registers a transport factory and panics on duplicate names.
+// Deprecated: callers should prefer Register and handle the error.
 func MustRegister(name string, f Factory) {
 	if err := Register(name, f); err != nil {
-		zap.L().Fatal("register_transport", zap.String("name", name), zap.Error(err))
+		panic(fmt.Sprintf("register_transport %q: %v", name, err))
 	}
 }
 

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestConcurrentRegister(t *testing.T) {
@@ -49,26 +47,9 @@ func TestMustRegisterDuplicate(t *testing.T) {
 	if err := Register(name, func(Config) (Interface, error) { return nil, nil }); err != nil {
 		t.Fatalf("first register: %v", err)
 	}
-	core, logs := observer.New(zapcore.FatalLevel)
-	logger := zap.New(core, zap.WithFatalHook(zapcore.WriteThenPanic))
-	zap.ReplaceGlobals(logger)
-	defer func() {
-		zap.ReplaceGlobals(zap.NewNop())
-		logger.Sync()
-	}()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatalf("expected panic")
-		}
-		if logs.Len() != 1 {
-			t.Fatalf("expected 1 log entry, got %d", logs.Len())
-		}
-		entry := logs.All()[0]
-		if entry.Level != zapcore.FatalLevel {
-			t.Fatalf("expected fatal level, got %v", entry.Level)
-		}
-		if entry.Message != "register_transport" {
-			t.Fatalf("unexpected message: %s", entry.Message)
 		}
 	}()
 	MustRegister(name, func(Config) (Interface, error) { return nil, nil })

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -57,7 +57,11 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil
 }
 
-func init() { transport.MustRegister("ssh", New) }
+func init() {
+	if err := transport.Register("ssh", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "ssh" }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -54,7 +54,11 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil
 }
 
-func init() { transport.MustRegister("tcp+tls", New) }
+func init() {
+	if err := transport.Register("tcp+tls", New); err != nil {
+		panic(err)
+	}
+}
 
 func (t *Transport) Name() string { return "tcp+tls" }
 


### PR DESCRIPTION
## Summary
- replace global fatal logging in transport registry with panic
- register transports explicitly and panic on registration errors
- test duplicate registrations without global logger

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689f4d0973988323859bee856575deba