### PR TITLE
feat(manifest): guard rebuild on mounted devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ Rebuild a manifest index for an existing device:
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
 Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
+Rebuild refuses to run if the device is mounted read-write; pass `--manifest-allow-mounted` to override.
 
 Manifests embed a persistent device identifier in a fixed 64-byte field. The
 `manifest rebuild` command fails if the identifier exceeds this limit.

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -48,7 +48,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	if err := manifestpkg.Rebuild(ctx, device, path, logger, conf.ManifestProgressInterval); err != nil {
+	if err := manifestpkg.Rebuild(ctx, device, path, logger, conf.ManifestProgressInterval, conf.ManifestAllowMounted); err != nil {
 		if logger != nil {
 			logger.Error("rebuild failed", zap.Error(err))
 		}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -91,6 +91,7 @@ type Config struct {
 	BloomMBits               uint          `mapstructure:"bloom_mbits"`
 	ManifestPath             string        `mapstructure:"manifest_path"`
 	ManifestProgressInterval time.Duration `mapstructure:"manifest_progress_interval"`
+	ManifestAllowMounted     bool          `mapstructure:"manifest_allow_mounted"`
 	GRPCPort                 int           `mapstructure:"grpc_port"`
 	GRPCListen               string        `mapstructure:"grpc_listen"`
 	GRPCConnect              string        `mapstructure:"grpc_connect"`
@@ -218,6 +219,7 @@ func DefaultConfig() (*Config, error) {
 		BloomMBits:               0,
 		ManifestPath:             "",
 		ManifestProgressInterval: 10 * time.Second,
+		ManifestAllowMounted:     false,
 		GRPCPort:                 8443,
 		GRPCListen:               "",
 		GRPCConnect:              "",

--- a/config/flags.go
+++ b/config/flags.go
@@ -86,6 +86,7 @@ func initManifestFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Manifest Options", pflag.ExitOnError)
 	fs.String("manifest_path", cfg.ManifestPath, "Path to manifest file")
 	fs.Duration("manifest_progress_interval", cfg.ManifestProgressInterval, "Interval between progress logs during manifest rebuild")
+	fs.Bool("manifest_allow_mounted", cfg.ManifestAllowMounted, "Allow rebuilding when device is mounted read-write")
 	return fs
 }
 

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -216,6 +216,7 @@ func TestInitManifestFlags(t *testing.T) {
 	cases := []struct{ name, want string }{
 		{"manifest_path", cfg.ManifestPath},
 		{"manifest_progress_interval", cfg.ManifestProgressInterval.String()},
+		{"manifest_allow_mounted", strconv.FormatBool(cfg.ManifestAllowMounted)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -58,6 +58,9 @@ func (b *Builder) applyDefaults(conf *Config) error {
 	if conf.ManifestProgressInterval == 0 {
 		conf.ManifestProgressInterval = b.defaults.ManifestProgressInterval
 	}
+	if !b.v.IsSet("manifest_allow_mounted") {
+		conf.ManifestAllowMounted = b.defaults.ManifestAllowMounted
+	}
 
 	bs, raw, err := b.parseBlockSize()
 	if err != nil {

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -48,6 +48,7 @@ Generate a manifest for an existing device when the index is missing or stale:
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
 Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
+The command aborts if the device is mounted read-write. Override with `--manifest-allow-mounted` when rebuilding a live filesystem.
 
 ## Verification
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -266,9 +266,17 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // DeviceID is determined via device.GetUUID. The device is read sequentially using blockSize-sized chunks.
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
 // The operation respects cancellation via ctx.
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration) error {
+// When allowMounted is false, Rebuild aborts if the device is mounted read-write.
+func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	mounted, err := device.IsMountedRW(devicePath)
+	if err != nil {
+		return fmt.Errorf("manifest: check mount status: %w", err)
+	}
+	if mounted && !allowMounted {
+		return fmt.Errorf("manifest: %s is mounted read-write; use --manifest-allow-mounted to override", devicePath)
 	}
 	dev, err := detectDevice(ctx, devicePath, logger)
 	if err != nil {

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -203,7 +203,7 @@ func TestRebuild(t *testing.T) {
 	manPath := filepath.Join(dir, "rebuild.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -252,7 +252,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 	defer func() { closeHook = prevHook }()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if count != 1 {
@@ -289,7 +289,7 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	manPath := filepath.Join(dir, "rebuildbs.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -333,7 +333,7 @@ func TestRebuildLogsProgress(t *testing.T) {
 	logger := zap.New(core)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, logger, 0); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, logger, 0, false); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	entries := logs.FilterMessage("rebuild progress").All()
@@ -372,7 +372,48 @@ func TestRebuildCanceledContext(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		cancel()
 	}()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0); !errors.Is(err, context.Canceled) {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRebuildMounted(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if _, err := file.Write(make([]byte, 4096)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	cases := []struct {
+		name    string
+		mounted bool
+		allow   bool
+		wantErr bool
+	}{
+		{"mounted_disallowed", true, false, true},
+		{"mounted_allowed", true, true, false},
+		{"unmounted", false, false, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			prevMount := device.SetMountFunc(func(string) (bool, error) { return tt.mounted, nil })
+			t.Cleanup(func() { device.SetMountFunc(prevMount) })
+			manPath := filepath.Join(dir, tt.name+".man")
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, tt.allow)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -83,7 +83,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 	manifestPath := filepath.Join(t.TempDir(), "src.man")
 	ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
 	defer cancelMan()
-	if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+	if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0, false); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 
@@ -196,7 +196,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 	manifestPath := filepath.Join(dir, "src.man")
 	ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
 	defer cancelMan()
-	if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+	if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0, false); err != nil {
 		t.Fatalf("rebuild manifest: %v", err)
 	}
 
@@ -332,7 +332,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 			manifestPath := filepath.Join(t.TempDir(), "src.man")
 			ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
 			defer cancelMan()
-			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0, false); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 
@@ -453,7 +453,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 			manifestPath := filepath.Join(dir, "src.man")
 			ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
 			defer cancelMan()
-			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0, false); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 
@@ -631,7 +631,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 			manifestPath := filepath.Join(dir, "src.man")
 			ctxMan, cancelMan := context.WithTimeout(context.Background(), time.Second)
 			defer cancelMan()
-			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0); err != nil {
+			if err := manifestpkg.Rebuild(ctxMan, srcLoop, manifestPath, zap.NewNop(), 0, false); err != nil {
 				t.Fatalf("rebuild manifest: %v", err)
 			}
 

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -36,7 +36,7 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 	manPath := filepath.Join(dir, "dev.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := manifestpkg.Rebuild(ctx, dev.Name(), manPath, zap.NewNop(), 0); err != nil {
+	if err := manifestpkg.Rebuild(ctx, dev.Name(), manPath, zap.NewNop(), 0, false); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	src, err := os.Open(dev.Name())


### PR DESCRIPTION
## Summary
- abort manifest rebuild when target device is mounted read-write
- add `--manifest-allow-mounted` flag and document behavior
- cover mounted vs. unmounted rebuilds in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f4d14d4388323a03bb6e9b13faf0e