### PR TITLE
feat(device): add freeze and thaw timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Reading from a live block device can corrupt data if writes occur during the tra
 
 - `--offline` – assert that no process will write to the source device.
 - `--fs-freeze-command`/`--fs-thaw-command` – run commands that freeze and thaw the filesystem around the read.
+- Time out freeze and thaw helpers with `--freeze-timeout` and `--thaw-timeout` (default `10s`).
 
 Freeze and thaw commands are validated before execution. The path must be set, free of NUL bytes, every argument must avoid NULs, and the executable must be discoverable in `$PATH`; otherwise lvmsync returns an error.
 
@@ -336,6 +337,11 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--stdout` | `LVMSYNC_STDOUT` | `stdout` | Write change dump to STDOUT |
 | `--source-type` | `LVMSYNC_SOURCE_TYPE` | `source-type` | Source device type: `auto`, `file`, `raw`, or `lvm` |
 | `--dest-type` | `LVMSYNC_DEST_TYPE` | `dest-type` | Destination device type: `auto`, `file`, `raw`, or `lvm` |
+| `--offline` | `LVMSYNC_OFFLINE` | `offline` | Assume source raw device is offline |
+| `--fs-freeze-command` | `LVMSYNC_FS_FREEZE_COMMAND` | `fs-freeze-command` | Command to freeze filesystem before reading raw source |
+| `--fs-thaw-command` | `LVMSYNC_FS_THAW_COMMAND` | `fs-thaw-command` | Command to thaw filesystem after reading raw source |
+| `--freeze-timeout` | `LVMSYNC_FREEZE_TIMEOUT` | `freeze_timeout` | Timeout for filesystem freeze command |
+| `--thaw-timeout` | `LVMSYNC_THAW_TIMEOUT` | `thaw_timeout` | Timeout for filesystem thaw command |
 | `--mode` | `LVMSYNC_MODE` | `mode` | Configuration preset: `default` or `throughput`; unknown modes fail validation |
 | `--parallel` | `LVMSYNC_PARALLEL` | `parallel` | Number of concurrent workers |
 | `--concurrency` | `LVMSYNC_TRANSPORT_CONCURRENCY` | `concurrency` | Stream concurrency (0 to autotune based on BDP) |
@@ -835,6 +841,11 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--progress`        | Show progress percentage during the transfer                                                            | `true`    |
 | `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
 | `--dry-run`         | Print actions without executing | `false`   |
+| `--offline`         | Assume source raw device is offline | `false`   |
+| `--fs-freeze-command` | Command to freeze filesystem before reading raw source | `""` |
+| `--fs-thaw-command`  | Command to thaw filesystem after reading raw source | `""` |
+| `--freeze-timeout`   | Timeout for filesystem freeze command | `10s` |
+| `--thaw-timeout`     | Timeout for filesystem thaw command | `10s` |
 | `--transport`       | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) | `""`      |
 
 #### SSH Options

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -26,7 +26,7 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	}
 	destDevice := args[0]
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(context.Background(), destDevice, true, "", "", logger); err == nil {
+		if dev, err := device.Detect(context.Background(), destDevice, true, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -109,7 +109,7 @@ func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, l
 // RunLocalDump dumps changes to a local destination device.
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(context.Background(), dest, true, "", "", logger); err == nil {
+		if dev, err := device.Detect(context.Background(), dest, true, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -186,7 +186,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	)
 
 	if cfg.SourceType == "" || cfg.SourceType == "auto" {
-		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.FSFreezeCommand, cfg.FSThawCommand, logger)
+		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
 		if err != nil {
 			return err
 		}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -36,6 +36,8 @@ type Config struct {
 	Offline                  bool          `mapstructure:"offline"`
 	FSFreezeCommand          string        `mapstructure:"fs-freeze-command"`
 	FSThawCommand            string        `mapstructure:"fs-thaw-command"`
+	FreezeTimeout            time.Duration `mapstructure:"freeze_timeout"`
+	ThawTimeout              time.Duration `mapstructure:"thaw_timeout"`
 	Mode                     string        `mapstructure:"mode"`
 	Parallel                 int           `mapstructure:"parallel"`
 	Concurrency              int           `mapstructure:"concurrency"`
@@ -164,6 +166,8 @@ func DefaultConfig() (*Config, error) {
 		Offline:                  false,
 		FSFreezeCommand:          "",
 		FSThawCommand:            "",
+		FreezeTimeout:            10 * time.Second,
+		ThawTimeout:              10 * time.Second,
 		Parallel:                 4,
 		Concurrency:              0,
 		ZeroCopy:                 false,

--- a/config/flags.go
+++ b/config/flags.go
@@ -61,6 +61,8 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")
 	fs.String("fs-freeze-command", cfg.FSFreezeCommand, "Command to freeze filesystem before reading raw source")
 	fs.String("fs-thaw-command", cfg.FSThawCommand, "Command to thaw filesystem after reading raw source")
+	fs.Duration("freeze_timeout", cfg.FreezeTimeout, "Timeout for filesystem freeze command")
+	fs.Duration("thaw_timeout", cfg.ThawTimeout, "Timeout for filesystem thaw command")
 	fs.String("source-type", cfg.SourceType, "Source device type (auto,file,raw,lvm)")
 	fs.String("dest-type", cfg.DestType, "Destination device type (auto,file,raw,lvm)")
 	fs.String("mode", cfg.Mode, "Preset mode: default or throughput")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -21,6 +21,8 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"offline", strconv.FormatBool(cfg.Offline)},
 		{"fs-freeze-command", cfg.FSFreezeCommand},
 		{"fs-thaw-command", cfg.FSThawCommand},
+		{"freeze_timeout", cfg.FreezeTimeout.String()},
+		{"thaw_timeout", cfg.ThawTimeout.String()},
 		{"mode", cfg.Mode},
 		{"parallel", strconv.Itoa(cfg.Parallel)},
 		{"zerocopy", strconv.FormatBool(cfg.ZeroCopy)},

--- a/device/detect.go
+++ b/device/detect.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -15,7 +16,7 @@ import (
 // Detect inspects the path and returns the appropriate Device implementation.
 // Regular files return FileDevice, block devices are classified as either LVM
 // logical volumes or raw devices based on LVM metadata.
-func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, logger *zap.Logger) (Device, error) {
+func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		if logger != nil {
@@ -79,7 +80,7 @@ func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawC
 				thawArgs = parts[1:]
 			}
 		}
-		dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, logger)
+		dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
 		if err != nil {
 			if logger != nil {
 				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -42,7 +42,7 @@ func TestDetectFile(t *testing.T) {
 	f.Close()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), f.Name(), true, "", "", logger)
+	dev, err := Detect(context.Background(), f.Name(), true, "", "", 0, 0, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", nil)
+	dev, err := Detect(context.Background(), link, true, "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestDetectRaw(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), loop, true, "", "", logger)
+	dev, err := Detect(context.Background(), loop, true, "", "", 0, 0, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", nil)
+	dev, err := Detect(context.Background(), link, true, "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(context.Background(), lvPath, true, "", "", nil)
+	dev, err := Detect(context.Background(), lvPath, true, "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -16,11 +17,13 @@ import (
 
 // RawDevice represents a generic block device opened from /dev.
 type RawDevice struct {
-	f            *os.File
-	size         uint64
-	blockSize    uint64
-	freezeIssued bool
-	logger       *zap.Logger
+	f             *os.File
+	size          uint64
+	blockSize     uint64
+	freezeIssued  bool
+	logger        *zap.Logger
+	freezeTimeout time.Duration
+	thawTimeout   time.Duration
 }
 
 // OpenRaw opens a block device at the given path and queries its size and block
@@ -34,12 +37,14 @@ func OpenRaw(
 	fsFreezeCmdArgs []string,
 	fsThawCmdPath string,
 	fsThawCmdArgs []string,
+	freezeTimeout time.Duration,
+	thawTimeout time.Duration,
 	logger *zap.Logger,
 ) (_ *RawDevice, err error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	d := &RawDevice{logger: logger}
+	d := &RawDevice{logger: logger, freezeTimeout: freezeTimeout, thawTimeout: thawTimeout}
 	if !offline {
 		if fsFreezeCmdPath == "" || fsThawCmdPath == "" {
 			return nil, fmt.Errorf("raw sources require --offline or --fs-freeze-command/--fs-thaw-command")
@@ -51,7 +56,13 @@ func OpenRaw(
 			return nil, fmt.Errorf("invalid thaw command: %w", err)
 		}
 		d.logger.Info("fs freeze start", zap.String("command", fsFreezeCmdPath), zap.Strings("args", fsFreezeCmdArgs))
-		if err = exec.CommandContext(ctx, fsFreezeCmdPath, fsFreezeCmdArgs...).Run(); err != nil {
+		freezeCtx := ctx
+		if _, ok := ctx.Deadline(); !ok && d.freezeTimeout > 0 {
+			var cancel context.CancelFunc
+			freezeCtx, cancel = context.WithTimeout(ctx, d.freezeTimeout)
+			defer cancel()
+		}
+		if err = exec.CommandContext(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).Run(); err != nil {
 			return nil, fmt.Errorf("freeze command failed: %w", err)
 		}
 		d.logger.Info("fs freeze complete")
@@ -126,7 +137,13 @@ func (d *RawDevice) Cleanup(ctx context.Context, fsThawCmdPath string, fsThawCmd
 			return fmt.Errorf("invalid thaw command: %w", err)
 		}
 		d.logger.Info("fs thaw start", zap.String("command", fsThawCmdPath), zap.Strings("args", fsThawCmdArgs))
-		if err := exec.CommandContext(ctx, fsThawCmdPath, fsThawCmdArgs...).Run(); err != nil {
+		thawCtx := ctx
+		if _, ok := ctx.Deadline(); !ok && d.thawTimeout > 0 {
+			var cancel context.CancelFunc
+			thawCtx, cancel = context.WithTimeout(ctx, d.thawTimeout)
+			defer cancel()
+		}
+		if err := exec.CommandContext(thawCtx, fsThawCmdPath, fsThawCmdArgs...).Run(); err != nil {
 			d.logger.Error("fs thaw failed", zap.Error(err))
 			return fmt.Errorf("thaw command failed: %w", err)
 		}

--- a/device/raw_nonlinux.go
+++ b/device/raw_nonlinux.go
@@ -5,6 +5,7 @@ package device
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -13,7 +14,7 @@ import (
 type RawDevice struct{}
 
 // OpenRaw returns an error on non-Linux systems.
-func OpenRaw(context.Context, string, bool, string, string, *zap.Logger) (*RawDevice, error) {
+func OpenRaw(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, *zap.Logger) (*RawDevice, error) {
 	return nil, fmt.Errorf("raw devices are only supported on Linux")
 }
 
@@ -23,5 +24,5 @@ func (d *RawDevice) BlockSize() uint64 { return 0 }
 func (d *RawDevice) Snapshot(context.Context, string) (Device, error) {
 	return nil, fmt.Errorf("raw device snapshots are only supported on Linux")
 }
-func (d *RawDevice) Cleanup(context.Context) error { return nil }
-func (d *RawDevice) Close() error                  { return nil }
+func (d *RawDevice) Cleanup(context.Context, string, []string) error { return nil }
+func (d *RawDevice) Close() error                                    { return nil }

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -3,8 +3,11 @@ package device
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -18,7 +21,7 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, logger)
+	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -50,7 +53,7 @@ func TestRawDeviceCloseErrorLogging(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, logger)
+	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -71,14 +74,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, 0, 0, nil); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, nil); err == nil {
+		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, nil); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -87,13 +90,13 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, nil); err == nil {
 		t.Fatalf("expected offline or freeze command error")
 	}
 }
 
 func TestOpenRawFreezeCommandFailure(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, time.Second, time.Second, nil); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -105,7 +108,7 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 	freezeArgs := []string{freezeTmp}
 	thawCmdPath := "touch"
 	thawArgs := []string{thawTmp}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, time.Second, time.Second, nil); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {
@@ -131,5 +134,25 @@ func TestCleanupThawCommandFailure(t *testing.T) {
 	d := &RawDevice{freezeIssued: true, logger: zap.NewNop()}
 	if err := d.Cleanup(context.Background(), "false", nil); err == nil {
 		t.Fatalf("expected thaw command failure")
+	}
+}
+
+func TestOpenRawFreezeTimeout(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep command not found")
+	}
+	_, err := OpenRaw(context.Background(), "/dev/null", false, "sleep", []string{"2"}, "true", nil, 100*time.Millisecond, time.Second, nil)
+	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("expected freeze command to be killed, got %v", err)
+	}
+}
+
+func TestCleanupThawTimeout(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep command not found")
+	}
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawTimeout: 100 * time.Millisecond}
+	if err := d.Cleanup(context.Background(), "sleep", []string{"2"}); err == nil || !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("expected thaw command to be killed, got %v", err)
 	}
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -48,7 +48,7 @@ type Index struct {
 var closeHook = func() {}
 
 var detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-	return device.Detect(ctx, path, true, "", "", logger)
+	return device.Detect(ctx, path, true, "", "", 0, 0, logger)
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.


### PR DESCRIPTION
## Summary
- add configurable timeouts for filesystem freeze/thaw helpers
- expose `--freeze-timeout` and `--thaw-timeout` flags and env vars
- test that long-running freeze/thaw commands are killed

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f4d1a0d14832392b869013aac05c8