### PR TITLE
feat(transport): add ssh key and agent auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,8 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |
 | `--ssh_host` | `LVMSYNC_SSH_HOST` | `ssh_host` | SSH host |
 | `--ssh_user` | `LVMSYNC_SSH_USER` | `ssh_user` | SSH username |
-| `--ssh_key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key or use agent |
+| `--ssh_key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key |
+| `--ssh_agent` | `LVMSYNC_SSH_AGENT` | `ssh_agent` | Use SSH agent for authentication |
 | `--ssh_port` | `LVMSYNC_SSH_PORT` | `ssh_port` | SSH port |
 | `--ssh_timeout` | `LVMSYNC_SSH_TIMEOUT` | `ssh_timeout` | SSH connection timeout |
 | `--ssh_keepalive` | `LVMSYNC_SSH_KEEPALIVE` | `ssh_keepalive` | SSH keepalive interval |
@@ -413,7 +414,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--ca_cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
 | `--allow_insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
 
-If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh_timeout` as its deadline.
+When `--ssh_agent` is set and `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh_timeout` as its deadline.
 
 ### Common deployment scenarios
 
@@ -855,13 +856,14 @@ Flags are parsed via Viper, so the same settings can be provided through
 | ------------------------- | --------------------------------------------------------------- | ------------------------ |
 | `--ssh_host`              | SSH host                                                        | `"localhost"`            |
 | `--ssh_user`              | SSH username                                                    | `"root"`                 |
-| `--ssh_key`               | Path to SSH private key or use the SSH agent                    | `""`                     |
+| `--ssh_key`               | Path to SSH private key                                          | `""`                     |
+| `--ssh_agent`             | Use the SSH agent for authentication                            | `false`                  |
 | `--ssh_port`              | SSH port number                                                 | `22`                     |
 | `--known_hosts`           | Path to known_hosts file (defaults to `$HOME/.ssh/known_hosts`) | `$HOME/.ssh/known_hosts` |
 | `--strict_host_key_checking` | Require host keys to be present in `known_hosts`; when `false`, host key verification is disabled | `true`                   |
 
 Programmatic use of the SSH transport requires a configuration populated with
-fields like `SSHUser`, `SSHKeyPath`, `SSHPort`, `KnownHosts`,
+fields like `SSHUser`, `SSHKeyPath`, `SSHUseAgent`, `SSHPort`, `KnownHosts`,
 `StrictHostKeyCheck`, `SSHTimeout`, `SSHKeepAliveInterval`, and `MaxRetries`.
 The constructor also requires a `*zap.Logger`:
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -59,6 +59,8 @@ lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 
 - Establishes sessions using `golang.org/x/crypto/ssh`
 - Supports `sudo -n` escalation hooks
+- Key authentication via `--ssh_key`/`LVMSYNC_SSH_KEY`
+- Optional agent auth with `--ssh_agent`/`LVMSYNC_SSH_AGENT` using `SSH_AUTH_SOCK`
 
 Example selecting transports and custom port:
 

--- a/transport/config.go
+++ b/transport/config.go
@@ -18,4 +18,6 @@ type Config struct {
 	AllowInsecure bool
 	SSHUser       string
 	SSHPassword   string
+	SSHKeyPath    string
+	SSHUseAgent   bool
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -2,16 +2,19 @@ package ssh
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
@@ -32,11 +35,22 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.SSHUser == "" {
 		return nil, fmt.Errorf("ssh user is required")
 	}
+	var keySigner ssh.Signer
+	if cfg.SSHKeyPath != "" {
+		keyBytes, err := os.ReadFile(cfg.SSHKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		keySigner, err = ssh.ParsePrivateKey(keyBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
 	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
 	}
-	signer, err := ssh.NewSignerFromKey(hostKey)
+	hostSigner, err := ssh.NewSignerFromKey(hostKey)
 	if err != nil {
 		return nil, err
 	}
@@ -48,10 +62,36 @@ func New(cfg transport.Config) (transport.Interface, error) {
 			return nil, fmt.Errorf("authentication failed")
 		},
 	}
-	serverConf.AddHostKey(signer)
+	serverConf.AddHostKey(hostSigner)
+	if keySigner != nil {
+		serverConf.PublicKeyCallback = func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if c.User() == cfg.SSHUser && bytes.Equal(key.Marshal(), keySigner.PublicKey().Marshal()) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("public key rejected")
+		}
+	}
+	var auths []ssh.AuthMethod
+	if keySigner != nil {
+		auths = append(auths, ssh.PublicKeys(keySigner))
+	}
+	if cfg.SSHUseAgent {
+		if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
+			if conn, err := net.Dial("unix", sock); err == nil {
+				ag := agent.NewClient(conn)
+				auths = append(auths, ssh.PublicKeysCallback(ag.Signers))
+			}
+		}
+	}
+	if cfg.SSHPassword != "" {
+		auths = append(auths, ssh.Password(cfg.SSHPassword))
+	}
+	if len(auths) == 0 {
+		return nil, fmt.Errorf("no authentication methods configured")
+	}
 	clientConf := &ssh.ClientConfig{
 		User:            cfg.SSHUser,
-		Auth:            []ssh.AuthMethod{ssh.Password(cfg.SSHPassword)},
+		Auth:            auths,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	return &Transport{serverConf: serverConf, clientConf: clientConf, logger: cfg.Logger}, nil

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -2,7 +2,13 @@ package ssh
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"go.uber.org/zap"
@@ -40,6 +46,162 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 func TestSSHTransportAuthSuccess(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	serverIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new server transport: %v", err)
+	}
+	clientIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new client transport: %v", err)
+	}
+	server := serverIface.(*Transport)
+	client := clientIface.(*Transport)
+	ctx := context.Background()
+	ln, err := server.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		peerHS, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		if err != nil {
+			t.Errorf("server negotiate: %v", err)
+			return
+		}
+		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+			t.Errorf("unexpected peer handshake: %+v", peerHS)
+		}
+		buf := make([]byte, 4)
+		io.ReadFull(conn, buf)
+		conn.Write([]byte("pong"))
+		conn.Close()
+		close(done)
+	}()
+
+	conn, err := client.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	peerHS, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	if err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+		t.Fatalf("unexpected peer handshake: %+v", peerHS)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 4)
+	io.ReadFull(conn, buf)
+	if string(buf) != "pong" {
+		t.Fatalf("unexpected response %q", buf)
+	}
+	conn.Close()
+	<-done
+
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
+}
+
+func TestSSHTransportKeyAuth(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_rsa")
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	privBytes := x509.MarshalPKCS1PrivateKey(priv)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes})
+	if err := os.WriteFile(keyPath, pemBytes, 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHKeyPath: keyPath}
+	serverIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new server transport: %v", err)
+	}
+	clientIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new client transport: %v", err)
+	}
+	server := serverIface.(*Transport)
+	client := clientIface.(*Transport)
+	ctx := context.Background()
+	ln, err := server.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		peerHS, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		if err != nil {
+			t.Errorf("server negotiate: %v", err)
+			return
+		}
+		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+			t.Errorf("unexpected peer handshake: %+v", peerHS)
+		}
+		buf := make([]byte, 4)
+		io.ReadFull(conn, buf)
+		conn.Write([]byte("pong"))
+		conn.Close()
+		close(done)
+	}()
+
+	conn, err := client.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	peerHS, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	if err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+		t.Fatalf("unexpected peer handshake: %+v", peerHS)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 4)
+	io.ReadFull(conn, buf)
+	if string(buf) != "pong" {
+		t.Fatalf("unexpected response %q", buf)
+	}
+	conn.Close()
+	<-done
+
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
+}
+
+func TestSSHTransportAgentFallback(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	t.Setenv("SSH_AUTH_SOCK", filepath.Join(os.TempDir(), "nonexistent"))
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", SSHUseAgent: true}
 	serverIface, err := New(cfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)


### PR DESCRIPTION
## Summary
- allow transports to specify an SSH private key path and agent usage
- enable SSH client auth via key files and SSH agent, falling back to password
- document SSH key and agent options for transports

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f5add71548323950869bb158b06c1