### PR TITLE
feat(h2): enforce handshake deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Hashing**: Hardware-accelerated XXH3 provides fast deduplication hints while BLAKE3 digests are stored in manifests for integrity.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers.
+- **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
 - **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it.
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to the device's NUMA node.
 - **LVM Snapshot Management**:

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -49,6 +49,7 @@ lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 
 - Runs over TLS 1.3 with mutual authentication
 - Provides stream-level back-pressure
+- Enforces context deadlines during connection and HTTP/2 handshakes
 
 ## TCP+TLS
 

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -41,7 +41,8 @@ type Conn struct {
 
 // listener adapts a TLS listener and performs HTTP/2 handshakes.
 type listener struct {
-	ln net.Listener
+	ln  net.Listener
+	ctx context.Context
 }
 
 // New returns a new Transport.
@@ -107,6 +108,14 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
+	if dl, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(dl); err != nil {
+			conn.Close()
+			fields = append(fields, zap.Error(err))
+			t.logger.Error("dial_end", fields...)
+			return nil, err
+		}
+	}
 	fr := http2.NewFramer(conn, conn)
 	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
 		fields = append(fields, zap.Error(err))
@@ -151,6 +160,10 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		return nil, err
 	}
 	t.logger.Info("dial_end", fields...)
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		conn.Close()
+		return nil, err
+	}
 	return &Conn{
 		Conn:     conn,
 		fr:       fr,
@@ -183,13 +196,19 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		return nil, err
 	}
 	t.logger.Info("listen_end", fields...)
-	return &listener{ln: ln}, nil
+	return &listener{ln: ln, ctx: ctx}, nil
 }
 
 func (l *listener) Accept() (net.Conn, error) {
 	conn, err := l.ln.Accept()
 	if err != nil {
 		return nil, err
+	}
+	if dl, ok := l.ctx.Deadline(); ok {
+		if err := conn.SetDeadline(dl); err != nil {
+			conn.Close()
+			return nil, err
+		}
 	}
 	tlsConn, ok := conn.(*tls.Conn)
 	if !ok {
@@ -231,6 +250,10 @@ func (l *listener) Accept() (net.Conn, error) {
 	} else if sf, ok := f.(*http2.SettingsFrame); !ok || !sf.IsAck() {
 		conn.Close()
 		return nil, fmt.Errorf("expected settings ack")
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		conn.Close()
+		return nil, err
 	}
 	return &Conn{
 		Conn:     tlsConn,

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -227,3 +227,77 @@ func TestH2TransportRequiresLogger(t *testing.T) {
 		t.Fatalf("expected error when logger is nil")
 	}
 }
+
+func TestH2DialTimeout(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ClientCert: cert, ServerCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	tlsLn := tls.NewListener(ln, tr.serverConf)
+	go func() {
+		conn, err := tlsLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		time.Sleep(time.Second)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := tr.Dial(ctx, tlsLn.Addr().String()); err == nil {
+		t.Fatalf("expected dial timeout")
+	} else if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestH2AcceptTimeout(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ClientCert: cert, ServerCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := ln.Accept()
+		errCh <- err
+	}()
+
+	clientConf := &tls.Config{
+		RootCAs:      pool,
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2"},
+		MinVersion:   tls.VersionTLS13,
+		MaxVersion:   tls.VersionTLS13,
+	}
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientConf)
+	if err != nil {
+		t.Fatalf("tls dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := <-errCh; err == nil {
+		t.Fatalf("expected accept timeout")
+	} else if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce context deadlines during h2 dial and accept handshakes
- test client and server handshake timeouts
- document handshake timeout behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f5b028b2c83239e10ff98504d54d7