### PR TITLE
feat(ssh): enforce handshake deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--allow_insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
 
 If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh_timeout` as its deadline.
+SSH transport negotiation also derives read and write deadlines from the caller's context; when the context expires, the handshake fails quickly and deadlines are cleared afterward.
 
 ### Common deployment scenarios
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -59,6 +59,7 @@ lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 
 - Establishes sessions using `golang.org/x/crypto/ssh`
 - Supports `sudo -n` escalation hooks
+- Uses context deadlines for handshake I/O, failing fast when the caller's context times out
 
 Example selecting transports and custom port:
 

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -170,6 +170,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()
+	defer conn.SetDeadline(time.Time{})
 
 	hs.Version = common.ProtocolVersion
 	if hs.Endianness == "" {
@@ -177,7 +178,13 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	}
 	switch role {
 	case transport.Client:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
+			return peer, err
+		}
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
@@ -189,11 +196,17 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		return peer, nil
 	case transport.Server:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
 			return peer, err
 		}
 		if err := common.ValidateHandshake(hs, peer); err != nil {
+			return peer, err
+		}
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
@@ -281,4 +294,11 @@ func roleString(r transport.Role) string {
 	default:
 		return ""
 	}
+}
+
+func setDeadline(ctx context.Context, conn net.Conn) error {
+	if d, ok := ctx.Deadline(); ok {
+		return conn.SetDeadline(d)
+	}
+	return conn.SetDeadline(time.Time{})
 }

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -202,6 +203,104 @@ func TestSSHTransportCDCMismatch(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
+}
+
+func TestSSHTransportNegotiateTimeoutClient(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	serverIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new server transport: %v", err)
+	}
+	clientIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new client transport: %v", err)
+	}
+	server := serverIface.(*Transport)
+	client := clientIface.(*Transport)
+	ctx := context.Background()
+	ln, err := server.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		<-done
+		conn.Close()
+	}()
+
+	conn, err := client.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	time.Sleep(60 * time.Millisecond)
+	start := time.Now()
+	if _, err := client.Negotiate(timeoutCtx, conn, transport.Client, common.Handshake{}); err == nil {
+		t.Fatalf("expected client negotiate error")
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Fatalf("negotiation did not fail promptly")
+	}
+	conn.Close()
+	close(done)
+	cancel()
+}
+
+func TestSSHTransportNegotiateTimeoutServer(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	serverIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new server transport: %v", err)
+	}
+	clientIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new client transport: %v", err)
+	}
+	server := serverIface.(*Transport)
+	client := clientIface.(*Transport)
+	ctx := context.Background()
+	ln, err := server.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		timeoutCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		time.Sleep(60 * time.Millisecond)
+		_, err = server.Negotiate(timeoutCtx, conn, transport.Server, common.Handshake{})
+		conn.Close()
+		errCh <- err
+		cancel()
+	}()
+
+	conn, err := client.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	start := time.Now()
+	err = <-errCh
+	if err == nil {
+		t.Fatalf("expected server negotiate error")
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Fatalf("negotiation did not fail promptly")
+	}
+	conn.Close()
 }
 
 func TestSSHTransportRequiresLogger(t *testing.T) {


### PR DESCRIPTION
## Summary
- add context-based deadlines to SSH transport handshake and clear after negotiation
- test SSH handshake with timed-out contexts
- document SSH handshake timeout behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f5af73ee08323af46c04c65a5c167