### PR TITLE
fix(manifest): validate chunk index bounds

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -175,7 +175,10 @@ func estimateTransfer(src string, cfg *config.Config, logger *zap.Logger) error 
 		if idxPos >= chunks {
 			idxPos = chunks - 1
 		}
-		off, length, _, _ := idx.Entry(idxPos)
+		off, length, _, _, err := idx.Entry(idxPos)
+		if err != nil {
+			return fmt.Errorf("manifest entry: %w", err)
+		}
 		buf := make([]byte, length)
 		n, err := f.ReadAt(buf, int64(off))
 		if err != nil && err != io.EOF {

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -163,10 +163,14 @@ func TestEstimateTransferWithManifest(t *testing.T) {
 	}
 	xx0 := xxh3.Hash([]byte("aaaa"))
 	d0 := blake3.Sum256([]byte("aaaa"))
-	idx.Set(0, 4, xx0, d0)
+	if err := idx.Set(0, 4, xx0, d0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
 	xx1 := xxh3.Hash([]byte("bbbb"))
 	d1 := blake3.Sum256([]byte("bbbb"))
-	idx.Set(4, 4, xx1, d1)
+	if err := idx.Set(4, 4, xx1, d1); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
 	idx.Close()
 
 	cfg := &config.Config{ManifestPath: manifestPath}

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -139,7 +139,10 @@ func verifyWithManifest(src, manifestPath string, logger *zap.Logger) error {
 	mismatches := 0
 	buf := make([]byte, 0)
 	for i := uint64(0); i < idx.ChunkCount(); i++ {
-		off, length, _, digest := idx.Entry(i)
+		off, length, _, digest, err := idx.Entry(i)
+		if err != nil {
+			return fmt.Errorf("manifest entry: %w", err)
+		}
 		if length == 0 {
 			continue
 		}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -65,7 +65,9 @@ func TestVerifyWithManifestAllocations(t *testing.T) {
 			t.Fatalf("read: %v", err)
 		}
 		digest := blake3.Sum256(buf[:n])
-		idx.Set(uint64(off), uint32(n), 0, digest)
+		if err := idx.Set(uint64(off), uint32(n), 0, digest); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
 	}
 	idx.Close()
 	fSrc.Close()

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -52,7 +52,11 @@ var detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (d
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.
-var ErrVersionMismatch = errors.New("manifest: version mismatch")
+// ErrIndexOutOfRange is returned when a chunk index is outside the manifest range.
+var (
+	ErrVersionMismatch = errors.New("manifest: version mismatch")
+	ErrIndexOutOfRange = errors.New("manifest: chunk index out of range")
+)
 
 func headerMAC(h *Header) [32]byte {
 	var buf [headerSize - 32]byte
@@ -211,8 +215,11 @@ func Upgrade(path string) (*Index, error) {
 func entryOffset(i uint64) uint64 { return uint64(headerSize) + i*entrySize }
 
 // Set records metadata for the chunk at the given offset.
-func (i *Index) Set(offset uint64, length uint32, xxh uint64, digest [32]byte) {
+func (i *Index) Set(offset uint64, length uint32, xxh uint64, digest [32]byte) error {
 	idx := offset / uint64(i.hdr.BlockSize)
+	if idx >= i.hdr.ChunkCount {
+		return ErrIndexOutOfRange
+	}
 	off := entryOffset(idx)
 	start := int(off)
 	binary.LittleEndian.PutUint64(i.data[start:start+8], offset)
@@ -220,6 +227,7 @@ func (i *Index) Set(offset uint64, length uint32, xxh uint64, digest [32]byte) {
 	// 4 bytes padding at start+12:start+16
 	binary.LittleEndian.PutUint64(i.data[start+16:start+24], xxh)
 	copy(i.data[start+24:start+56], digest[:])
+	return nil
 }
 
 // Match reports whether the manifest already has a record for the chunk at the
@@ -249,7 +257,10 @@ func (i *Index) Match(offset uint64, length uint32, xxh uint64, digestFn func() 
 }
 
 // Entry returns metadata for the chunk at idx.
-func (i *Index) Entry(idx uint64) (offset uint64, length uint32, xxh uint64, digest [32]byte) {
+func (i *Index) Entry(idx uint64) (offset uint64, length uint32, xxh uint64, digest [32]byte, err error) {
+	if idx >= i.hdr.ChunkCount {
+		return 0, 0, 0, digest, ErrIndexOutOfRange
+	}
 	off := entryOffset(idx)
 	start := int(off)
 	offset = binary.LittleEndian.Uint64(i.data[start : start+8])
@@ -322,7 +333,9 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 		data := buf[:n]
 		xx := xxh3.Hash(data)
 		b3 := blake3.Sum256(data)
-		idx.Set(off, uint32(n), xx, b3)
+		if err := idx.Set(off, uint32(n), xx, b3); err != nil {
+			return err
+		}
 		if logger != nil && (progressInterval == 0 || time.Since(lastLog) >= progressInterval) {
 			if err := ctx.Err(); err != nil {
 				return err

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -45,7 +45,9 @@ func TestIndexCRUD(t *testing.T) {
 	}
 	xx := xxh3.Hash(data)
 	b3 := blake3.Sum256(data)
-	idx.Set(0, 4096, xx, b3)
+	if err := idx.Set(0, 4096, xx, b3); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
 	if !idx.Match(0, 4096, xx, func() [32]byte { return b3 }) {
 		t.Fatalf("Match failed")
 	}
@@ -57,7 +59,10 @@ func TestIndexCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	off, length, xx2, b32 := idx2.Entry(0)
+	off, length, xx2, b32, err := idx2.Entry(0)
+	if err != nil {
+		t.Fatalf("Entry: %v", err)
+	}
 	if off != 0 || length != 4096 || xx2 != xx || b32 != b3 {
 		t.Fatalf("entry mismatch")
 	}
@@ -131,7 +136,9 @@ func TestMatchXXHShortcut(t *testing.T) {
 	}
 	xx := xxh3.Hash(data)
 	b3 := blake3.Sum256(data)
-	idx.Set(0, 4096, xx, b3)
+	if err := idx.Set(0, 4096, xx, b3); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
 
 	other := make([]byte, 4096)
 	if _, err := rand.Read(other); err != nil {
@@ -164,11 +171,16 @@ func TestIndexLargeOffsets(t *testing.T) {
 	xx := xxh3.Hash(data)
 	b3 := blake3.Sum256(data)
 	offset := uint64(blockSize) * 2 // 4 GiB > int32
-	idx.Set(offset, uint32(len(data)), xx, b3)
+	if err := idx.Set(offset, uint32(len(data)), xx, b3); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
 	if !idx.Match(offset, uint32(len(data)), xx, func() [32]byte { return b3 }) {
 		t.Fatalf("Match failed for large offset")
 	}
-	off, length, xx2, b32 := idx.Entry(2)
+	off, length, xx2, b32, err := idx.Entry(2)
+	if err != nil {
+		t.Fatalf("Entry: %v", err)
+	}
 	if off != offset || length != uint32(len(data)) || xx2 != xx || b32 != b3 {
 		t.Fatalf("entry mismatch for large offset")
 	}
@@ -177,6 +189,22 @@ func TestIndexLargeOffsets(t *testing.T) {
 	}
 	if err := idx.Close(); err != nil {
 		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestIndexOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oor.man")
+	idx, err := Create(path, "dev", 4096, 4096)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer idx.Close()
+	if err := idx.Set(4096, 4096, 0, [32]byte{}); err == nil {
+		t.Fatalf("expected error for Set out of range")
+	}
+	if _, _, _, _, err := idx.Entry(1); err == nil {
+		t.Fatalf("expected error for Entry out of range")
 	}
 }
 
@@ -216,11 +244,17 @@ func TestRebuild(t *testing.T) {
 	if id := string(bytes.TrimRight(idx.hdr.DeviceID[:], "\x00")); id != "uuid-test" {
 		t.Fatalf("device id mismatch: %s", id)
 	}
-	_, l1, xx1, b31 := idx.Entry(0)
+	_, l1, xx1, b31, err := idx.Entry(0)
+	if err != nil {
+		t.Fatalf("Entry0: %v", err)
+	}
 	if l1 != 4096 || xx1 != xxh3.Hash(data1) || b31 != blake3.Sum256(data1) {
 		t.Fatalf("chunk1 mismatch")
 	}
-	_, l2, xx2, b32 := idx.Entry(1)
+	_, l2, xx2, b32, err := idx.Entry(1)
+	if err != nil {
+		t.Fatalf("Entry1: %v", err)
+	}
 	if l2 != 4096 || xx2 != xxh3.Hash(data2) || b32 != blake3.Sum256(data2) {
 		t.Fatalf("chunk2 mismatch")
 	}
@@ -299,11 +333,17 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	if idx.hdr.BlockSize != uint32(bs) || idx.hdr.ChunkCount != 2 || idx.hdr.SizeBytes != uint64(2*bs) {
 		t.Fatalf("header mismatch: %+v", idx.hdr)
 	}
-	_, l1, xx1, b31 := idx.Entry(0)
+	_, l1, xx1, b31, err := idx.Entry(0)
+	if err != nil {
+		t.Fatalf("Entry0: %v", err)
+	}
 	if l1 != uint32(bs) || xx1 != xxh3.Hash(data1) || b31 != blake3.Sum256(data1) {
 		t.Fatalf("chunk1 mismatch")
 	}
-	_, l2, xx2, b32 := idx.Entry(1)
+	_, l2, xx2, b32, err := idx.Entry(1)
+	if err != nil {
+		t.Fatalf("Entry1: %v", err)
+	}
 	if l2 != uint32(bs) || xx2 != xxh3.Hash(data2) || b32 != blake3.Sum256(data2) {
 		t.Fatalf("chunk2 mismatch")
 	}

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -96,7 +96,10 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 			zh := zeroHash(int(blockSize))
 			saveResumeState(cfg, r.Start, zh, int64(blockSize), logger)
 			if idx != nil {
-				idx.Set(r.Start, blockSize, xx, zh)
+				if err := idx.Set(r.Start, blockSize, xx, zh); err != nil {
+					putBlockBuffer(data)
+					return totalBytes, skippedBlocks, nil, fmt.Errorf("manifest set: %w", err)
+				}
 			}
 			putBlockBuffer(data)
 			totalBytes += int64(blockSize)
@@ -115,7 +118,10 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 
 		h.Write(data)
 		if idx != nil {
-			idx.Set(r.Start, blockSize, xx, sum)
+			if err := idx.Set(r.Start, blockSize, xx, sum); err != nil {
+				putBlockBuffer(data)
+				return totalBytes, skippedBlocks, nil, fmt.Errorf("manifest set: %w", err)
+			}
 		}
 		saveResumeState(cfg, r.Start, sum, int64(blockSize), logger)
 
@@ -196,14 +202,19 @@ func processParallelResults(
 			h.Write(res.Data)
 			if idx != nil {
 				xx := hashutil.SumXXH3(res.Data)
-				idx.Set(res.Offset, res.Size, xx, res.ChunkID)
+				if err := idx.Set(res.Offset, res.Size, xx, res.ChunkID); err != nil {
+					putBlockBuffer(res.Data)
+					return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
+				}
 			}
 			saveResumeState(cfg, res.Offset, res.ChunkID, int64(res.Size), logger)
 			putBlockBuffer(res.Data)
 		} else {
 			if idx != nil {
 				xx := hashutil.SumXXH3(nil)
-				idx.Set(res.Offset, res.Size, xx, res.ChunkID)
+				if err := idx.Set(res.Offset, res.Size, xx, res.ChunkID); err != nil {
+					return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
+				}
 			}
 			saveResumeState(cfg, res.Offset, res.ChunkID, 0, logger)
 		}


### PR DESCRIPTION
## Summary
- return an error when manifest Set or Entry are called with an out-of-range chunk index
- handle these errors in callers like block_writer and verify
- add tests for out-of-range manifest access

## Testing
- `go build ./...` *(fails: transport/ssh/ssh.go: syntax error: unexpected newline in composite literal; possibly missing comma or })*
- `go test -coverprofile=coverage.out ./...` *(fails: transport/ssh/ssh.go: syntax error: unexpected newline in composite literal; possibly missing comma or })*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f6406e3f88323acc5cf7cf03409d0