### PR TITLE
feat: enforce handshake deadlines across transports

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -304,10 +304,20 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	}
 	switch role {
 	case transport.Client:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
+			clearDeadline(conn)
+			return peer, err
+		}
+		clearDeadline(conn)
+
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
+		clearDeadline(conn)
 		if err != nil {
 			return peer, err
 		}
@@ -316,20 +326,40 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		return peer, nil
 	case transport.Server:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
+		clearDeadline(conn)
 		if err != nil {
 			return peer, err
 		}
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}
-		if err = common.WriteHandshake(conn, hs); err != nil {
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
+		if err = common.WriteHandshake(conn, hs); err != nil {
+			clearDeadline(conn)
+			return peer, err
+		}
+		clearDeadline(conn)
 		return peer, nil
 	default:
 		return peer, nil
 	}
+}
+
+func setDeadline(ctx context.Context, conn net.Conn) error {
+	if dl, ok := ctx.Deadline(); ok {
+		return conn.SetDeadline(dl)
+	}
+	return nil
+}
+
+func clearDeadline(conn net.Conn) {
+	_ = conn.SetDeadline(time.Time{})
 }
 
 // Conn implements net.Conn using HTTP/2 DATA frames.

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io"
 	"math/big"
 	"net"
@@ -299,5 +300,28 @@ func TestH2AcceptTimeout(t *testing.T) {
 		t.Fatalf("expected accept timeout")
 	} else if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
 		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestH2NegotiateContextCancel(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+		t.Fatalf("expected negotiate error")
+	} else {
+		var ne net.Error
+		if !errors.As(err, &ne) || !ne.Timeout() {
+			t.Fatalf("expected timeout error, got %v", err)
+		}
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Fatalf("negotiation did not fail promptly")
 	}
 }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -196,10 +196,20 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	}
 	switch role {
 	case transport.Client:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
+			clearDeadline(conn)
+			return peer, err
+		}
+		clearDeadline(conn)
+
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
+		clearDeadline(conn)
 		if err != nil {
 			return peer, err
 		}
@@ -208,20 +218,40 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		return peer, nil
 	case transport.Server:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
+		clearDeadline(conn)
 		if err != nil {
 			return peer, err
 		}
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}
-		if err = common.WriteHandshake(conn, hs); err != nil {
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
+		if err = common.WriteHandshake(conn, hs); err != nil {
+			clearDeadline(conn)
+			return peer, err
+		}
+		clearDeadline(conn)
 		return peer, nil
 	default:
 		return peer, nil
 	}
+}
+
+func setDeadline(ctx context.Context, conn net.Conn) error {
+	if dl, ok := ctx.Deadline(); ok {
+		return conn.SetDeadline(dl)
+	}
+	return nil
+}
+
+func clearDeadline(conn net.Conn) {
+	_ = conn.SetDeadline(time.Time{})
 }
 
 // Datagram APIs.

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"math/big"
 	"net"
 	"testing"
@@ -223,6 +224,29 @@ func TestQUICTransportRequiresClientCert(t *testing.T) {
 	}
 	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, AllowInsecure: true}); err != nil {
 		t.Fatalf("allow insecure should permit missing client cert: %v", err)
+	}
+}
+
+func TestQUICNegotiateContextCancel(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+		t.Fatalf("expected negotiate error")
+	} else {
+		var ne net.Error
+		if !errors.As(err, &ne) || !ne.Timeout() {
+			t.Fatalf("expected timeout error, got %v", err)
+		}
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Fatalf("negotiation did not fail promptly")
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -168,10 +168,20 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	}
 	switch role {
 	case transport.Client:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
+			clearDeadline(conn)
+			return peer, err
+		}
+		clearDeadline(conn)
+
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
+		clearDeadline(conn)
 		if err != nil {
 			return peer, err
 		}
@@ -180,20 +190,40 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		}
 		return peer, nil
 	case transport.Server:
+		if err = setDeadline(ctx, conn); err != nil {
+			return peer, err
+		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
+		clearDeadline(conn)
 		if err != nil {
 			return peer, err
 		}
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}
-		if err = common.WriteHandshake(conn, hs); err != nil {
+		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
+		if err = common.WriteHandshake(conn, hs); err != nil {
+			clearDeadline(conn)
+			return peer, err
+		}
+		clearDeadline(conn)
 		return peer, nil
 	default:
 		return peer, fmt.Errorf("invalid role %v", role)
 	}
+}
+
+func setDeadline(ctx context.Context, conn net.Conn) error {
+	if dl, ok := ctx.Deadline(); ok {
+		return conn.SetDeadline(dl)
+	}
+	return nil
+}
+
+func clearDeadline(conn net.Conn) {
+	_ = conn.SetDeadline(time.Time{})
 }
 
 func roleString(r transport.Role) string {

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -309,6 +309,29 @@ func TestTCPTLSDialContextCancel(t *testing.T) {
 	}
 }
 
+func TestTCPTLSNegotiateContextCancel(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+		t.Fatalf("expected negotiate error")
+	} else {
+		var ne net.Error
+		if !errors.As(err, &ne) || !ne.Timeout() {
+			t.Fatalf("expected timeout error, got %v", err)
+		}
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Fatalf("negotiation did not fail promptly")
+	}
+}
+
 func TestTCPTLSTransportRequiresLogger(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
 	if _, err := New(transport.Config{Roots: root, ClientCert: cert}); err == nil {


### PR DESCRIPTION
## Summary
- add context-driven deadlines around transport handshake I/O
- test handshake cancellation for tcp+tls, h2, and quic transports

## Testing
- `go build ./transport/tcp_tls ./transport/h2 ./transport/quic`
- `go build ./...` *(fails: transport/ssh/ssh.go:91:35: syntax error: unexpected newline in composite literal)*
- `go test -coverprofile=coverage.out ./transport/tcp_tls ./transport/h2 ./transport/quic`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run transport/tcp_tls transport/h2 transport/quic`


------
https://chatgpt.com/codex/tasks/task_e_689f64000d908323a5f973ee9f90c65a