### PR TITLE
fix(ssh): unify host key handling

### DIFF
--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -14,8 +14,8 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
@@ -48,6 +48,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 			return nil, err
 		}
 	}
+
 	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
@@ -56,6 +57,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	serverConf := &ssh.ServerConfig{
 		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
 			if c.User() == cfg.SSHUser && string(pass) == cfg.SSHPassword {
@@ -64,7 +66,16 @@ func New(cfg transport.Config) (transport.Interface, error) {
 			return nil, fmt.Errorf("authentication failed")
 		},
 	}
-	serverConf.AddHostKey(signer)
+	serverConf.AddHostKey(hostSigner)
+	if keySigner != nil {
+		serverConf.PublicKeyCallback = func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if c.User() == cfg.SSHUser && bytes.Equal(key.Marshal(), keySigner.PublicKey().Marshal()) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("public key rejected")
+		}
+	}
+
 	var hkc ssh.HostKeyCallback
 	switch {
 	case cfg.SSHKnownHosts != "":
@@ -83,20 +94,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	default:
 		return nil, fmt.Errorf("known hosts or host key required")
 	}
-	clientConf := &ssh.ClientConfig{
-		User:            cfg.SSHUser,
-		Auth:            []ssh.AuthMethod{ssh.Password(cfg.SSHPassword)},
-		HostKeyCallback: hkc,
 
-	serverConf.AddHostKey(hostSigner)
-	if keySigner != nil {
-		serverConf.PublicKeyCallback = func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-			if c.User() == cfg.SSHUser && bytes.Equal(key.Marshal(), keySigner.PublicKey().Marshal()) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("public key rejected")
-		}
-	}
 	var auths []ssh.AuthMethod
 	if keySigner != nil {
 		auths = append(auths, ssh.PublicKeys(keySigner))
@@ -115,12 +113,14 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if len(auths) == 0 {
 		return nil, fmt.Errorf("no authentication methods configured")
 	}
+
 	clientConf := &ssh.ClientConfig{
 		User:            cfg.SSHUser,
 		Auth:            auths,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hkc,
 	}
-	return &Transport{serverConf: serverConf, clientConf: clientConf, hostSigner: signer, logger: cfg.Logger}, nil
+
+	return &Transport{serverConf: serverConf, clientConf: clientConf, hostSigner: hostSigner, logger: cfg.Logger}, nil
 }
 
 func init() {

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -6,9 +6,12 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -76,9 +79,51 @@ func emptyKnownHosts(t *testing.T) string {
 	return f.Name()
 }
 
+func TestNewWithKnownHosts(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("NewSignerFromKey: %v", err)
+	}
+	kh := writeKnownHosts(t, "127.0.0.1:22", signer.PublicKey())
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", SSHKnownHosts: kh}
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+}
+
+func TestNewWithHostKey(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("NewSignerFromKey: %v", err)
+	}
+	hostKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", SSHHostKey: hostKey}
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+}
+
+func TestNewAllowInsecure(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", AllowInsecure: true}
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+}
+
 func TestSSHTransportAuthSuccess(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true}
 	serverIface, err := New(srvCfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)
@@ -162,12 +207,13 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 	if err := os.WriteFile(keyPath, pemBytes, 0600); err != nil {
 		t.Fatalf("write key: %v", err)
 	}
-	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHKeyPath: keyPath}
-	serverIface, err := New(cfg)
+	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHKeyPath: keyPath, AllowInsecure: true}
+	serverIface, err := New(srvCfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)
 	}
-	clientIface, err := New(cfg)
+	clientCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHKeyPath: keyPath, AllowInsecure: true}
+	clientIface, err := New(clientCfg)
 	if err != nil {
 		t.Fatalf("new client transport: %v", err)
 	}
@@ -235,7 +281,7 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 func TestSSHTransportAgentFallback(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	t.Setenv("SSH_AUTH_SOCK", filepath.Join(os.TempDir(), "nonexistent"))
-	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", SSHUseAgent: true}
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", SSHUseAgent: true, AllowInsecure: true}
 	serverIface, err := New(cfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)
@@ -307,7 +353,7 @@ func TestSSHTransportAgentFallback(t *testing.T) {
 
 func TestSSHTransportAuthFailure(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true}
 	serverIface, err := New(srvCfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)
@@ -349,7 +395,7 @@ func TestSSHTransportAuthFailure(t *testing.T) {
 
 func TestSSHTransportCDCMismatch(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true}
 	serverIface, err := New(srvCfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)
@@ -403,7 +449,7 @@ func TestSSHTransportCDCMismatch(t *testing.T) {
 
 func TestSSHTransportNegotiateTimeoutClient(t *testing.T) {
 	core, _ := observer.New(zap.InfoLevel)
-	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true}
 	serverIface, err := New(cfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)
@@ -451,7 +497,7 @@ func TestSSHTransportNegotiateTimeoutClient(t *testing.T) {
 
 func TestSSHTransportNegotiateTimeoutServer(t *testing.T) {
 	core, _ := observer.New(zap.InfoLevel)
-	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true}
 	serverIface, err := New(cfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)
@@ -507,7 +553,7 @@ func TestSSHTransportRequiresLogger(t *testing.T) {
 
 func TestSSHTransportRejectsUnknownHost(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
-	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass"}
+	srvCfg := transport.Config{Logger: zap.New(core), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true}
 	serverIface, err := New(srvCfg)
 	if err != nil {
 		t.Fatalf("new server transport: %v", err)


### PR DESCRIPTION
## Summary
- use hostSigner when constructing server config and return transport
- build server and client configs once and honor AllowInsecure for host key callback
- add tests covering known-hosts, fixed host key, and insecure host key modes

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f63fceff483238a6324fdb3bb9ebc