### PR TITLE
fix(common): validate handshake block size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - None yet.
 
 ### Fixed
-- None yet.
+- validate block size mismatch in handshakes
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/common/handshake_validate.go
+++ b/common/handshake_validate.go
@@ -7,6 +7,9 @@ func ValidateHandshake(local, peer Handshake) error {
 	if peer.Endianness != "" && local.Endianness != "" && peer.Endianness != local.Endianness {
 		return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 	}
+	if peer.BlockSize > 0 && local.BlockSize > 0 && peer.BlockSize != local.BlockSize {
+		return fmt.Errorf("block size mismatch: %d", peer.BlockSize)
+	}
 	if peer.DedupMode != "" && local.DedupMode != "" && peer.DedupMode != local.DedupMode {
 		return fmt.Errorf("dedup mode mismatch: %s", peer.DedupMode)
 	}

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -3,7 +3,7 @@ package common
 import "testing"
 
 func TestValidateHandshake(t *testing.T) {
-	local := Handshake{DedupMode: "fixed", CDCMin: 64, CDCAvg: 128, CDCMax: 256, Compress: "zstd", CompressLevel: 1, ODirect: true, ResumeToken: "tok", MaxInFlight: 8, Endianness: "little"}
+	local := Handshake{DedupMode: "fixed", CDCMin: 64, CDCAvg: 128, CDCMax: 256, Compress: "zstd", CompressLevel: 1, ODirect: true, ResumeToken: "tok", MaxInFlight: 8, Endianness: "little", BlockSize: 4096}
 	peer := local
 	if err := ValidateHandshake(local, peer); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -11,6 +11,11 @@ func TestValidateHandshake(t *testing.T) {
 	peer.DedupMode = "cdc"
 	if err := ValidateHandshake(local, peer); err == nil {
 		t.Fatal("expected dedup mismatch error")
+	}
+	peer.DedupMode = local.DedupMode
+	peer.BlockSize = 8192
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected block size mismatch error")
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure handshake validation checks for block size mismatches
- add tests covering matching and mismatched block sizes
- record fix in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f68c9f8d48323bc15657b4c581965