### PR TITLE
test(device): add stubbed tests for info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- None yet.
+- device: tests for GetUUID and IsMountedRW
 
 ### Fixed
 - None yet.

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -13,3 +13,43 @@ func TestGetUUIDCanceledContext(t *testing.T) {
 		t.Fatalf("expected context canceled error, got %v", err)
 	}
 }
+
+func TestGetUUIDStub(t *testing.T) {
+	prev := SetUUIDFunc(func(ctx context.Context, path string) (string, error) {
+		return "stub-uuid", nil
+	})
+	defer SetUUIDFunc(prev)
+
+	got, err := GetUUID(context.Background(), "/dev/sda")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "stub-uuid" {
+		t.Fatalf("expected stub-uuid, got %q", got)
+	}
+}
+
+func TestIsMountedRW(t *testing.T) {
+	tests := []struct {
+		name string
+		val  bool
+	}{
+		{"mounted", true},
+		{"unmounted", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := SetMountFunc(func(path string) (bool, error) { return tt.val, nil })
+			defer SetMountFunc(prev)
+
+			got, err := IsMountedRW("/dev/sda")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.val {
+				t.Fatalf("expected %v, got %v", tt.val, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- stub UUID lookup and mount checker in tests
- verify GetUUID and IsMountedRW behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: server tests hang)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f68a35644832390e0c160d62784d4