### PR TITLE
test(common): add handshake token tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- None yet.
+- Add handshake parsing tests for unknown and malformed tokens.
 
 ### Fixed
 - None yet.

--- a/common/handshake_test.go
+++ b/common/handshake_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 
 	"lvmsync_go/common"
@@ -65,5 +66,37 @@ func TestSelectBest(t *testing.T) {
 	}
 	if best := common.SelectBest([]string{}, remote); best != "" {
 		t.Fatalf("expected empty, got %s", best)
+	}
+}
+
+func TestHandshakeIgnoresUnknownTokens(t *testing.T) {
+	line := "lvmsync PROTO[3] transport:ssh foo bar baz:qux compress:none digest:sha256\n"
+	h, err := common.ReadHandshake(bufio.NewReader(strings.NewReader(line)))
+	if err != nil {
+		t.Fatalf("read handshake: %v", err)
+	}
+	expected := common.Handshake{Version: common.ProtocolVersion, Transport: "ssh", Compress: "none", Digest: "sha256"}
+	if !reflect.DeepEqual(h, expected) {
+		t.Fatalf("handshake mismatch: %+v != %+v", h, expected)
+	}
+}
+
+func TestHandshakeMalformedTokens(t *testing.T) {
+	cases := []struct {
+		token     string
+		errSubstr string
+	}{
+		{"block:not-a-number", "invalid block size"},
+		{"level:abc", "invalid compression level"},
+		{"inflight:xyz", "invalid max in-flight"},
+		{"cdcmin:foo", "invalid cdc min"},
+		{"cdcavg:bar", "invalid cdc avg"},
+		{"cdcmax:baz", "invalid cdc max"},
+	}
+	for _, tt := range cases {
+		line := "lvmsync PROTO[3] " + tt.token + "\n"
+		if _, err := common.ReadHandshake(bufio.NewReader(strings.NewReader(line))); err == nil || !strings.Contains(err.Error(), tt.errSubstr) {
+			t.Fatalf("expected error containing %q for token %q, got %v", tt.errSubstr, tt.token, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add tests ensuring unknown handshake tokens are ignored
- add tests for malformed handshake tokens returning parse errors
- record tests in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f68dc4b4c83238c49daa268202c40