### PR TITLE
feat(manifest): log rebuild completion metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- None yet.
+- Log manifest rebuild completion with size and duration metrics.
 
 ### Fixed
 - None yet.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -350,5 +350,11 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 			break
 		}
 	}
+	if logger != nil {
+		logger.Info("rebuild_complete",
+			zap.Uint64("size_bytes", size),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		)
+	}
 	return nil
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -388,6 +388,42 @@ func TestRebuildLogsProgress(t *testing.T) {
 	}
 }
 
+func TestRebuildLogsCompletion(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	data := make([]byte, 8192)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	manPath := filepath.Join(dir, "complete.man")
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Rebuild(ctx, file.Name(), manPath, logger, 0, false); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	entries := logs.FilterMessage("rebuild_complete").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 completion log, got %d", len(entries))
+	}
+	if sz, ok := entries[0].ContextMap()["size_bytes"].(uint64); !ok || sz != uint64(len(data)) {
+		t.Fatalf("unexpected size_bytes %v", entries[0].ContextMap()["size_bytes"])
+	}
+	if _, ok := entries[0].ContextMap()["duration_ms"]; !ok {
+		t.Fatalf("missing duration_ms field")
+	}
+}
+
 func TestRebuildCanceledContext(t *testing.T) {
 	dir := t.TempDir()
 	file, err := os.CreateTemp(dir, "dev-*.img")


### PR DESCRIPTION
## Summary
- log manifest rebuild completion with size and duration metrics
- test manifest rebuild completion log fields

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f68d353a88323bc12d8237cd3a83d