### PR TITLE
fix(common): enforce CDC ordering in handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - None yet.
 
 ### Fixed
-- None yet.
+- Enforce CDC chunk size ordering in handshake validation.
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/common/handshake_validate.go
+++ b/common/handshake_validate.go
@@ -4,6 +4,16 @@ import "fmt"
 
 // ValidateHandshake ensures peer and local handshakes agree on critical parameters.
 func ValidateHandshake(local, peer Handshake) error {
+	if local.CDCMin > 0 && local.CDCAvg > 0 && local.CDCMax > 0 {
+		if !(local.CDCMin <= local.CDCAvg && local.CDCAvg <= local.CDCMax) {
+			return fmt.Errorf("invalid local cdc ordering: min %d avg %d max %d", local.CDCMin, local.CDCAvg, local.CDCMax)
+		}
+	}
+	if peer.CDCMin > 0 && peer.CDCAvg > 0 && peer.CDCMax > 0 {
+		if !(peer.CDCMin <= peer.CDCAvg && peer.CDCAvg <= peer.CDCMax) {
+			return fmt.Errorf("invalid peer cdc ordering: min %d avg %d max %d", peer.CDCMin, peer.CDCAvg, peer.CDCMax)
+		}
+	}
 	if peer.Endianness != "" && local.Endianness != "" && peer.Endianness != local.Endianness {
 		return fmt.Errorf("endianness mismatch: %s", peer.Endianness)
 	}

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -14,6 +14,30 @@ func TestValidateHandshake(t *testing.T) {
 	}
 }
 
+func TestValidateHandshakeCDCOrderingValid(t *testing.T) {
+	local := Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	peer := local
+	if err := ValidateHandshake(local, peer); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateHandshakeCDCOrderingInvalidLocal(t *testing.T) {
+	local := Handshake{CDCMin: 256, CDCAvg: 64, CDCMax: 128}
+	peer := Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected cdc ordering error")
+	}
+}
+
+func TestValidateHandshakeCDCOrderingInvalidPeer(t *testing.T) {
+	local := Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	peer := Handshake{CDCMin: 256, CDCAvg: 64, CDCMax: 128}
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected cdc ordering error")
+	}
+}
+
 func TestValidateHandshakeALPNMismatch(t *testing.T) {
 	local := Handshake{ALPN: "lvmsync"}
 	peer := local


### PR DESCRIPTION
## Summary
- ensure CDCMin <= CDCAvg <= CDCMax in handshake validation
- add tests for valid and invalid CDC ordering
- document CDC ordering validation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f68c487608323b26b658d4690ed1e