### PR TITLE
feat(transport): log handshake details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- None yet.
+- Log final handshake parameters for all transports.
 
 ### Fixed
 - None yet.

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -286,6 +286,25 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			fields = append(fields, zap.Error(err))
 			t.logger.Error("negotiate_end", fields...)
 		} else {
+			fields = append(fields,
+				zap.String("dedup_mode", hs.DedupMode),
+				zap.Int("block_size_bytes", hs.BlockSize),
+				zap.String("compress", hs.Compress),
+				zap.Int("compress_level", hs.CompressLevel),
+				zap.String("digest", hs.Digest),
+				zap.String("resume_token", hs.ResumeToken),
+				zap.Bool("checksum", hs.Checksum),
+				zap.Bool("checksum_dedup", hs.ChecksumDedup),
+				zap.String("endianness", hs.Endianness),
+				zap.Bool("odirect", hs.ODirect),
+				zap.Int("max_inflight", hs.MaxInFlight),
+				zap.Int("cdc_min", hs.CDCMin),
+				zap.Int("cdc_avg", hs.CDCAvg),
+				zap.Int("cdc_max", hs.CDCMax),
+				zap.String("transport", hs.Transport),
+				zap.String("alpn", hs.ALPN),
+				zap.String("tls_version", hs.TLSVersion),
+			)
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -40,6 +40,21 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 	}
 }
 
+func checkHandshakeFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	for _, e := range entries {
+		ctx := e.ContextMap()
+		for _, k := range []string{"dedup_mode", "block_size_bytes", "compress", "digest", "resume_token", "max_inflight", "cdc_min", "cdc_avg", "cdc_max"} {
+			if _, ok := ctx[k]; !ok {
+				t.Fatalf("expected field %q in %s log", k, msg)
+			}
+		}
+	}
+}
+
 func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -81,6 +96,7 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	}
 	defer ln.Close()
 
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -88,13 +104,12 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		peerHS, err := tr.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		peerHS, err := tr.Negotiate(ctx, conn, transport.Server, hs)
 		if err != nil {
 			t.Errorf("server negotiate: %v", err)
 			return
 		}
-		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.ALPN != "h2" || peerHS.TLSVersion != "1.3" ||
-			peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+		if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.ALPN != "h2" || peerHS.TLSVersion != "1.3" || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 			t.Errorf("unexpected peer handshake: %+v", peerHS)
 		}
 		buf := make([]byte, 4)
@@ -108,12 +123,11 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peerHS, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	peerHS, err := tr.Negotiate(ctx, conn, transport.Client, hs)
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.ALPN != "h2" || peerHS.TLSVersion != "1.3" ||
-		peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+	if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.ALPN != "h2" || peerHS.TLSVersion != "1.3" || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 		t.Fatalf("unexpected peer handshake: %+v", peerHS)
 	}
 	if _, err := conn.Write([]byte("ping")); err != nil {
@@ -133,6 +147,7 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, zapcore.InfoLevel)
+	checkHandshakeFields(t, logs, "negotiate_end", 2)
 }
 
 func TestH2TransportTLSHandshakeError(t *testing.T) {

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -186,6 +186,25 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			fields = append(fields, zap.Error(err))
 			t.logger.Error("negotiate_end", fields...)
 		} else {
+			fields = append(fields,
+				zap.String("dedup_mode", hs.DedupMode),
+				zap.Int("block_size_bytes", hs.BlockSize),
+				zap.String("compress", hs.Compress),
+				zap.Int("compress_level", hs.CompressLevel),
+				zap.String("digest", hs.Digest),
+				zap.String("resume_token", hs.ResumeToken),
+				zap.Bool("checksum", hs.Checksum),
+				zap.Bool("checksum_dedup", hs.ChecksumDedup),
+				zap.String("endianness", hs.Endianness),
+				zap.Bool("odirect", hs.ODirect),
+				zap.Int("max_inflight", hs.MaxInFlight),
+				zap.Int("cdc_min", hs.CDCMin),
+				zap.Int("cdc_avg", hs.CDCAvg),
+				zap.Int("cdc_max", hs.CDCMax),
+				zap.String("transport", hs.Transport),
+				zap.String("alpn", hs.ALPN),
+				zap.String("tls_version", hs.TLSVersion),
+			)
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -44,6 +44,21 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 	}
 }
 
+func checkHandshakeFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	for _, e := range entries {
+		ctx := e.ContextMap()
+		for _, k := range []string{"dedup_mode", "block_size_bytes", "compress", "digest", "resume_token", "max_inflight", "cdc_min", "cdc_avg", "cdc_max"} {
+			if _, ok := ctx[k]; !ok {
+				t.Fatalf("expected field %q in %s log", k, msg)
+			}
+		}
+	}
+}
+
 func TestQUICTransportHandshake(t *testing.T) {
 	cert, _ := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
@@ -59,6 +74,7 @@ func TestQUICTransportHandshake(t *testing.T) {
 	}
 	defer ln.Close()
 
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -67,12 +83,12 @@ func TestQUICTransportHandshake(t *testing.T) {
 			return
 		}
 		qconn := conn.(*Conn)
-		peerHS, err := tr.Negotiate(ctx, qconn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		peerHS, err := tr.Negotiate(ctx, qconn, transport.Server, hs)
 		if err != nil {
 			t.Errorf("server negotiate: %v", err)
 			return
 		}
-		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+		if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 			t.Errorf("unexpected peer handshake: %+v", peerHS)
 		}
 		buf := make([]byte, 1)
@@ -86,11 +102,11 @@ func TestQUICTransportHandshake(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	qconn := conn.(*Conn)
-	peerHS, err := tr.Negotiate(ctx, qconn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	peerHS, err := tr.Negotiate(ctx, qconn, transport.Client, hs)
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+	if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 		t.Fatalf("unexpected peer handshake: %+v", peerHS)
 	}
 	qconn.Write([]byte{1})
@@ -103,6 +119,7 @@ func TestQUICTransportHandshake(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
+	checkHandshakeFields(t, logs, "negotiate_end", 2)
 }
 
 func TestQUICTransportHandshakeError(t *testing.T) {

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -233,6 +233,25 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			fields = append(fields, zap.Error(err))
 			t.logger.Error("negotiate_end", fields...)
 		} else {
+			fields = append(fields,
+				zap.String("dedup_mode", hs.DedupMode),
+				zap.Int("block_size_bytes", hs.BlockSize),
+				zap.String("compress", hs.Compress),
+				zap.Int("compress_level", hs.CompressLevel),
+				zap.String("digest", hs.Digest),
+				zap.String("resume_token", hs.ResumeToken),
+				zap.Bool("checksum", hs.Checksum),
+				zap.Bool("checksum_dedup", hs.ChecksumDedup),
+				zap.String("endianness", hs.Endianness),
+				zap.Bool("odirect", hs.ODirect),
+				zap.Int("max_inflight", hs.MaxInFlight),
+				zap.Int("cdc_min", hs.CDCMin),
+				zap.Int("cdc_avg", hs.CDCAvg),
+				zap.Int("cdc_max", hs.CDCMax),
+				zap.String("transport", hs.Transport),
+				zap.String("alpn", hs.ALPN),
+				zap.String("tls_version", hs.TLSVersion),
+			)
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -49,6 +49,21 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 	}
 }
 
+func checkHandshakeFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	for _, e := range entries {
+		ctx := e.ContextMap()
+		for _, k := range []string{"dedup_mode", "block_size_bytes", "compress", "digest", "resume_token", "max_inflight", "cdc_min", "cdc_avg", "cdc_max"} {
+			if _, ok := ctx[k]; !ok {
+				t.Fatalf("expected field %q in %s log", k, msg)
+			}
+		}
+	}
+}
+
 func writeKnownHosts(t *testing.T, addr string, pk ssh.PublicKey) string {
 	t.Helper()
 	host, port, err := net.SplitHostPort(addr)
@@ -142,6 +157,7 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	}
 	client := clientIface.(*Transport)
 
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -149,12 +165,12 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		peerHS, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		peerHS, err := server.Negotiate(ctx, conn, transport.Server, hs)
 		if err != nil {
 			t.Errorf("server negotiate: %v", err)
 			return
 		}
-		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+		if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 			t.Errorf("unexpected peer handshake: %+v", peerHS)
 		}
 		buf := make([]byte, 4)
@@ -168,11 +184,11 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peerHS, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	peerHS, err := client.Negotiate(ctx, conn, transport.Client, hs)
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+	if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 		t.Fatalf("unexpected peer handshake: %+v", peerHS)
 	}
 	if _, err := conn.Write([]byte("ping")); err != nil {
@@ -192,6 +208,7 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
+	checkHandshakeFields(t, logs, "negotiate_end", 2)
 }
 
 func TestSSHTransportKeyAuth(t *testing.T) {

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -158,6 +158,25 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			fields = append(fields, zap.Error(err))
 			t.logger.Error("negotiate_end", fields...)
 		} else {
+			fields = append(fields,
+				zap.String("dedup_mode", hs.DedupMode),
+				zap.Int("block_size_bytes", hs.BlockSize),
+				zap.String("compress", hs.Compress),
+				zap.Int("compress_level", hs.CompressLevel),
+				zap.String("digest", hs.Digest),
+				zap.String("resume_token", hs.ResumeToken),
+				zap.Bool("checksum", hs.Checksum),
+				zap.Bool("checksum_dedup", hs.ChecksumDedup),
+				zap.String("endianness", hs.Endianness),
+				zap.Bool("odirect", hs.ODirect),
+				zap.Int("max_inflight", hs.MaxInFlight),
+				zap.Int("cdc_min", hs.CDCMin),
+				zap.Int("cdc_avg", hs.CDCAvg),
+				zap.Int("cdc_max", hs.CDCMax),
+				zap.String("transport", hs.Transport),
+				zap.String("alpn", hs.ALPN),
+				zap.String("tls_version", hs.TLSVersion),
+			)
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -44,6 +44,21 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 	}
 }
 
+func checkHandshakeFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	for _, e := range entries {
+		ctx := e.ContextMap()
+		for _, k := range []string{"dedup_mode", "block_size_bytes", "compress", "digest", "resume_token", "max_inflight", "cdc_min", "cdc_avg", "cdc_max"} {
+			if _, ok := ctx[k]; !ok {
+				t.Fatalf("expected field %q in %s log", k, msg)
+			}
+		}
+	}
+}
+
 func TestTCPTLSTransportHandshake(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)
@@ -59,6 +74,7 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	}
 	defer ln.Close()
 
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -66,12 +82,12 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		peerHS, err := tr.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		peerHS, err := tr.Negotiate(ctx, conn, transport.Server, hs)
 		if err != nil {
 			t.Errorf("server negotiate: %v", err)
 			return
 		}
-		if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+		if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 			t.Errorf("unexpected peer handshake: %+v", peerHS)
 		}
 		buf := make([]byte, 4)
@@ -85,11 +101,11 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peerHS, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	peerHS, err := tr.Negotiate(ctx, conn, transport.Client, hs)
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+	if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 		t.Fatalf("unexpected peer handshake: %+v", peerHS)
 	}
 	if _, err := conn.Write([]byte("ping")); err != nil {
@@ -109,6 +125,7 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel, false)
 	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel, false)
 	checkLogFields(t, logs, "negotiate_end", 2, zapcore.InfoLevel, false)
+	checkHandshakeFields(t, logs, "negotiate_end", 2)
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {


### PR DESCRIPTION
## Summary
- log final handshake parameters (dedup mode, block size, compression, digest, resume token, etc.) in all transports
- test that each transport's negotiate logs include handshake fields
- document handshake logging in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f68d0d5408323b0f6a38d76d35ad0