### PR TITLE
feat(transport): add error fields to lifecycle logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- None yet.
+- Log dial and listen lifecycle events with duration_ms and error fields across transports, with tests covering handshake and teardown logs.
 
 ### Fixed
 - None yet.

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -91,6 +91,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	d := net.Dialer{}
@@ -102,62 +103,108 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.Error(err),
 	}
 	if err != nil {
-		fields = append(fields, zap.Error(err))
 		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
 	if dl, ok := ctx.Deadline(); ok {
 		if err := conn.SetDeadline(dl); err != nil {
 			conn.Close()
-			fields = append(fields, zap.Error(err))
+			fields := []zap.Field{
+				zap.String("address", address),
+				zap.String("role", role),
+				zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+				zap.Error(err),
+			}
 			t.logger.Error("dial_end", fields...)
 			return nil, err
 		}
 	}
 	fr := http2.NewFramer(conn, conn)
 	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
-		fields = append(fields, zap.Error(err))
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
 		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if err := fr.WriteSettings(); err != nil {
-		fields = append(fields, zap.Error(err))
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
 		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if f, err := fr.ReadFrame(); err != nil {
-		fields = append(fields, zap.Error(err))
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
 		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	} else if _, ok := f.(*http2.SettingsFrame); !ok {
 		err = fmt.Errorf("expected settings frame")
-		fields = append(fields, zap.Error(err))
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
 		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if err := fr.WriteSettingsAck(); err != nil {
-		fields = append(fields, zap.Error(err))
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
 		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	}
 	if f, err := fr.ReadFrame(); err != nil {
-		fields = append(fields, zap.Error(err))
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
 		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
 	} else if sf, ok := f.(*http2.SettingsFrame); !ok || !sf.IsAck() {
 		err = fmt.Errorf("expected settings ack")
-		fields = append(fields, zap.Error(err))
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
 		t.logger.Error("dial_end", fields...)
 		conn.Close()
 		return nil, err
+	}
+	fields = []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", ""),
 	}
 	t.logger.Info("dial_end", fields...)
 	if err := conn.SetDeadline(time.Time{}); err != nil {
@@ -179,6 +226,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	ln, err := net.Listen("tcp", address)
@@ -189,11 +237,17 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.Error(err),
 	}
 	if err != nil {
-		fields = append(fields, zap.Error(err))
 		t.logger.Error("listen_end", fields...)
 		return nil, err
+	}
+	fields = []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", ""),
 	}
 	t.logger.Info("listen_end", fields...)
 	return &listener{ln: ln, ctx: ctx}, nil

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -21,7 +21,7 @@ import (
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, level zapcore.Level) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool, level zapcore.Level) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
@@ -34,6 +34,11 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 		if _, ok := ctx[k]; !ok {
 			t.Fatalf("expected field %q in %s log", k, msg)
 		}
+	}
+	if _, ok := ctx["error"]; wantErr && !ok {
+		t.Fatalf("expected error field in %s log", msg)
+	} else if !wantErr && ok {
+		t.Fatalf("unexpected error field in %s log", msg)
 	}
 	if entries[0].Level != level {
 		t.Fatalf("expected level %v for %s log, got %v", level, msg, entries[0].Level)
@@ -127,12 +132,12 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel)
-	checkLogFields(t, logs, "negotiate_end", 2, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
 
 func TestH2TransportTLSHandshakeError(t *testing.T) {
@@ -162,10 +167,10 @@ func TestH2TransportTLSHandshakeError(t *testing.T) {
 		t.Fatalf("expected dial error")
 	}
 
-	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, zapcore.ErrorLevel)
-	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 }
 
 func TestH2TransportTLSCDCMismatch(t *testing.T) {
@@ -208,12 +213,12 @@ func TestH2TransportTLSCDCMismatch(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel)
-	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel)
-	checkLogFields(t, logs, "negotiate_end", 2, zapcore.ErrorLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 
 	entries := logs.FilterMessage("negotiate_end").All()
 	for _, e := range entries {

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -92,6 +92,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	qconn, err := quic.DialAddr(ctx, address, t.clientTLS, t.qconf)
@@ -100,8 +101,8 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 			zap.String("address", address),
 			zap.String("role", role),
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
 		}
-		fields = append(fields, zap.Error(err))
 		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
@@ -110,12 +111,18 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.Error(err),
 	}
 	if err != nil {
-		fields = append(fields, zap.Error(err))
 		t.logger.Error("dial_end", fields...)
 		qconn.CloseWithError(0, err.Error())
 		return nil, err
+	}
+	fields = []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", ""),
 	}
 	t.logger.Info("dial_end", fields...)
 	return &Conn{qconn: qconn, stream: stream}, nil
@@ -128,6 +135,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	ql, err := quic.ListenAddr(address, t.serverTLS, t.qconf)
@@ -135,11 +143,17 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.Error(err),
 	}
 	if err != nil {
-		fields = append(fields, zap.Error(err))
 		t.logger.Error("listen_end", fields...)
 		return nil, err
+	}
+	fields = []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", ""),
 	}
 	t.logger.Info("listen_end", fields...)
 	return &listener{ql: ql, ctx: ctx}, nil

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -97,10 +97,10 @@ func TestQUICTransportHandshake(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
@@ -144,10 +144,10 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 1, true, zapcore.ErrorLevel)
 }
@@ -194,10 +194,10 @@ func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -137,6 +137,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	d := &net.Dialer{}
@@ -178,6 +179,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", ""),
 	)
 	return &sshConn{netConn: raw, channel: ch, client: client}, nil
 }
@@ -188,6 +190,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	lc := net.ListenConfig{}
@@ -210,6 +213,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", ""),
 	)
 	return ln, nil
 }

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -186,10 +186,10 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
@@ -270,10 +270,10 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
@@ -343,10 +343,10 @@ func TestSSHTransportAgentFallback(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
@@ -385,10 +385,10 @@ func TestSSHTransportAuthFailure(t *testing.T) {
 	}
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 0, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 0, false, zapcore.InfoLevel)
 }
@@ -439,10 +439,10 @@ func TestSSHTransportCDCMismatch(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }
@@ -583,6 +583,6 @@ func TestSSHTransportRejectsUnknownHost(t *testing.T) {
 		t.Fatalf("expected dial error")
 	}
 	<-done
-	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
 	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
 }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -68,6 +68,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	d := &net.Dialer{}
@@ -103,6 +104,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.String("error", ""),
 	}
 	t.logger.Info("dial_end", fields...)
 	return conn, nil
@@ -114,6 +116,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
+		zap.String("error", ""),
 	)
 	start := time.Now()
 	lc := net.ListenConfig{}
@@ -129,11 +132,17 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.Error(err),
 	}
 	if err != nil {
-		fields = append(fields, zap.Error(err))
 		t.logger.Error("listen_end", fields...)
 	} else {
+		fields = []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.String("error", ""),
+		}
 		t.logger.Info("listen_end", fields...)
 	}
 	return ln, err

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -21,7 +21,7 @@ import (
 	"lvmsync_go/transport"
 )
 
-func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, level zapcore.Level, wantErr bool) {
+func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, wantErr bool, level zapcore.Level) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
 		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
@@ -103,12 +103,12 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "negotiate_end", 2, zapcore.InfoLevel, false)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {
@@ -148,12 +148,12 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "negotiate_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "negotiate_end", 1, zapcore.ErrorLevel, true)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 1, true, zapcore.ErrorLevel)
 }
 
 func TestTCPTLSTransportCDCMismatch(t *testing.T) {
@@ -196,12 +196,12 @@ func TestTCPTLSTransportCDCMismatch(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "dial_end", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "listen_end", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "negotiate_start", 2, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "negotiate_end", 2, zapcore.ErrorLevel, true)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }
 
 func TestTCPTLSDialErrorLogging(t *testing.T) {
@@ -216,8 +216,8 @@ func TestTCPTLSDialErrorLogging(t *testing.T) {
 	if _, err := tr.Dial(ctx, "127.0.0.1:65000"); err == nil {
 		t.Fatalf("expected dial error")
 	}
-	checkLogFields(t, logs, "dial_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "dial_end", 1, zapcore.ErrorLevel, true)
+	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
 }
 
 func TestTCPTLSListenErrorLogging(t *testing.T) {
@@ -232,8 +232,8 @@ func TestTCPTLSListenErrorLogging(t *testing.T) {
 	if _, err := tr.Listen(ctx, "bad_address"); err == nil {
 		t.Fatalf("expected listen error")
 	}
-	checkLogFields(t, logs, "listen_start", 1, zapcore.InfoLevel, false)
-	checkLogFields(t, logs, "listen_end", 1, zapcore.ErrorLevel, true)
+	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, true, zapcore.ErrorLevel)
 }
 
 func TestTCPTLSNegotiateInvalidRole(t *testing.T) {


### PR DESCRIPTION
## Summary
- include error fields in dial and listen lifecycle logs for ssh, h2, quic, and tcp+tls transports
- require tests to assert handshake and teardown logging across all transports
- document new lifecycle logging in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f68a64a50832389d044e583fd96b4