### PR TITLE
fix(ssh): add timeout for agent signers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes
+- close SSH agent connections after retrieving signers and apply context-based timeouts
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -101,9 +101,8 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	}
 	if cfg.SSHUseAgent {
 		if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
-			if conn, err := net.Dial("unix", sock); err == nil {
-				ag := agent.NewClient(conn)
-				auths = append(auths, ssh.PublicKeysCallback(ag.Signers))
+			if signers, err := agentSigners(context.Background(), sock); err == nil && len(signers) > 0 {
+				auths = append(auths, ssh.PublicKeys(signers...))
 			}
 		}
 	}
@@ -121,6 +120,19 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	}
 
 	return &Transport{serverConf: serverConf, clientConf: clientConf, hostSigner: hostSigner, logger: cfg.Logger}, nil
+}
+
+func agentSigners(ctx context.Context, sock string) ([]ssh.Signer, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "unix", sock)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	ag := agent.NewClient(conn)
+	return ag.Signers()
 }
 
 func init() {

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -19,6 +20,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
 
 	"lvmsync_go/common"
@@ -92,6 +94,47 @@ func emptyKnownHosts(t *testing.T) string {
 	}
 	f.Close()
 	return f.Name()
+}
+
+func TestAgentSignersCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sock := filepath.Join(t.TempDir(), "agent.sock")
+	if _, err := agentSigners(ctx, sock); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func TestAgentSignersClosesConnection(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "agent.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			close(done)
+			return
+		}
+		agent.ServeAgent(agent.NewKeyring(), conn)
+		close(done)
+	}()
+	ctx := context.Background()
+	signers, err := agentSigners(ctx, sock)
+	if err != nil {
+		t.Fatalf("agentSigners: %v", err)
+	}
+	if len(signers) != 0 {
+		t.Fatalf("expected no signers, got %d", len(signers))
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("agent server did not exit")
+	}
 }
 
 func TestNewWithKnownHosts(t *testing.T) {


### PR DESCRIPTION
## Summary
- limit SSH agent connections with context-based timeout
- close agent sockets after retrieving signers
- test agent signer timeout and cleanup behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f6d597e34832386c5f31d3f342da7