### PR TITLE
fix: add default dial timeouts to h2 and tcp+tls transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes
+- add default dial timeout and deadline propagation for h2 and tcp+tls transports
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -18,7 +18,10 @@ import (
 	"lvmsync_go/transport"
 )
 
-const maxFrameSize = 1 << 14
+const (
+	maxFrameSize       = 1 << 14
+	defaultDialTimeout = 30 * time.Second
+)
 
 // Transport implements HTTP/2 over TLS1.3 with mutual authentication.
 type Transport struct {
@@ -94,10 +97,14 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("error", ""),
 	)
 	start := time.Now()
-	d := net.Dialer{}
-	if dl, ok := ctx.Deadline(); ok {
-		d.Deadline = dl
+	dl, ok := ctx.Deadline()
+	if !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultDialTimeout)
+		defer cancel()
+		dl, _ = ctx.Deadline()
 	}
+	d := net.Dialer{Deadline: dl}
 	conn, err := tls.DialWithDialer(&d, "tcp", address, t.clientConf)
 	fields := []zap.Field{
 		zap.String("address", address),
@@ -109,18 +116,16 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
-	if dl, ok := ctx.Deadline(); ok {
-		if err := conn.SetDeadline(dl); err != nil {
-			conn.Close()
-			fields := []zap.Field{
-				zap.String("address", address),
-				zap.String("role", role),
-				zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-				zap.Error(err),
-			}
-			t.logger.Error("dial_end", fields...)
-			return nil, err
+	if err := conn.SetDeadline(dl); err != nil {
+		conn.Close()
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
 		}
+		t.logger.Error("dial_end", fields...)
+		return nil, err
 	}
 	fr := http2.NewFramer(conn, conn)
 	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -243,6 +243,22 @@ func TestH2TransportTLSCDCMismatch(t *testing.T) {
 	}
 }
 
+func TestH2DialUnreachable(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ClientCert: cert, ServerCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	start := time.Now()
+	if _, err := tr.Dial(ctx, "203.0.113.1:1"); err == nil {
+		t.Fatalf("expected dial error")
+	} else if time.Since(start) > 5*time.Second {
+		t.Fatalf("dial took too long: %v", time.Since(start))
+	}
+}
+
 func TestH2TransportRequiresLogger(t *testing.T) {
 	if _, err := New(transport.Config{}); err == nil {
 		t.Fatalf("expected error when logger is nil")

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -14,6 +14,8 @@ import (
 	"lvmsync_go/transport"
 )
 
+const defaultDialTimeout = 30 * time.Second
+
 // Transport implements TLS over TCP.
 type Transport struct {
 	serverConf *tls.Config
@@ -71,7 +73,14 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("error", ""),
 	)
 	start := time.Now()
-	d := &net.Dialer{}
+	dl, ok := ctx.Deadline()
+	if !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultDialTimeout)
+		defer cancel()
+		dl, _ = ctx.Deadline()
+	}
+	d := &net.Dialer{Deadline: dl}
 	tcpConn, err := d.DialContext(ctx, "tcp", address)
 	if err != nil {
 		fields := []zap.Field{
@@ -88,9 +97,31 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		host, _, _ := net.SplitHostPort(address)
 		tlsConf.ServerName = host
 	}
+	if err := tcpConn.SetDeadline(dl); err != nil {
+		tcpConn.Close()
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		t.logger.Error("dial_end", fields...)
+		return nil, err
+	}
 	conn := tls.Client(tcpConn, tlsConf)
 	if err := conn.HandshakeContext(ctx); err != nil {
 		tcpConn.Close()
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		t.logger.Error("dial_end", fields...)
+		return nil, err
+	}
+	if err := conn.SetDeadline(dl); err != nil {
+		conn.Close()
 		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", role),
@@ -107,6 +138,10 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("error", ""),
 	}
 	t.logger.Info("dial_end", fields...)
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		conn.Close()
+		return nil, err
+	}
 	return conn, nil
 }
 

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -221,6 +221,22 @@ func TestTCPTLSTransportCDCMismatch(t *testing.T) {
 	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }
 
+func TestTCPTLSDialUnreachable(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	start := time.Now()
+	if _, err := tr.Dial(ctx, "203.0.113.1:1"); err == nil {
+		t.Fatalf("expected dial error")
+	} else if time.Since(start) > 5*time.Second {
+		t.Fatalf("dial took too long: %v", time.Since(start))
+	}
+}
+
 func TestTCPTLSDialErrorLogging(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)


### PR DESCRIPTION
## Summary
- set 30s default dial timeout when context lacks deadline
- propagate deadlines to dialers and connections
- add unreachable dial tests for h2 and tcp+tls

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f6d5a22fc832383e0d57348971f6f