### PR TITLE
docs: make logging example compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes
+- Wrap README logging example in `package main` to compile with `go build`.
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,16 +107,35 @@ tooling to track transfer completion.
 
 The example below demonstrates these conventions:
 
-```
-logger, _ := zap.NewProduction()
-defer syncLogger(logger)
-start := time.Now()
+```go
+package main
 
-logger.Info("snapshot complete",
-    zap.String("source_path", src),
-    zap.String("dest_path", dst),
-    zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+import (
+    "time"
+
+    "go.uber.org/zap"
 )
+
+func syncLogger(logger *zap.Logger) {
+    if err := logger.Sync(); err != nil {
+        logger.Error("sync failed", zap.Error(err))
+    }
+}
+
+func main() {
+    logger, _ := zap.NewProduction()
+    defer syncLogger(logger)
+    start := time.Now()
+
+    src := "/dev/vg0/source"
+    dst := "/dev/vg0/backup"
+
+    logger.Info("snapshot complete",
+        zap.String("source_path", src),
+        zap.String("dest_path", dst),
+        zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+    )
+}
 ```
 
 Errors during block operations log the byte offset and block size explicitly:


### PR DESCRIPTION
## Summary
- wrap README logging snippet in a standalone `main` package with imports
- note logging example fix in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f6d5d7db88323814d278ef3cba442