### PR TITLE
fix(transfer): propagate seek errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes
+- propagate seek errors during block writes to prevent silent data loss
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -98,6 +98,8 @@ func verifyChecksum(verify bool, checksum ChecksumStrategy, data, transmitted []
 	return nil
 }
 
+// writeData seeks to offset and writes the provided data to destFile.
+// If seeking fails, no write occurs and the seek error is returned.
 func writeData(destFile *os.File, offset uint64, data []byte, logger *zap.Logger) error {
 	if offset > math.MaxInt64 {
 		return fmt.Errorf("offset %d overflows int64", offset)
@@ -106,7 +108,7 @@ func writeData(destFile *os.File, offset uint64, data []byte, logger *zap.Logger
 		if logger != nil {
 			logger.Warn("Seek error", zap.Uint64("offset", offset), zap.Error(err))
 		}
-		return nil
+		return fmt.Errorf("failed to seek to offset %d: %w", offset, err)
 	}
 	if _, err := destFile.Write(data); err != nil {
 		return fmt.Errorf("failed to write data at offset %d: %w", offset, err)
@@ -114,6 +116,9 @@ func writeData(destFile *os.File, offset uint64, data []byte, logger *zap.Logger
 	return nil
 }
 
+// processBlock validates and writes a block to destFile.
+// It returns whether data was written. Seek or write failures
+// from writeData are propagated to the caller.
 func processBlock(
 	cfg *config.Config,
 	destFile *os.File,

--- a/transfer/writer_test.go
+++ b/transfer/writer_test.go
@@ -1,0 +1,39 @@
+package transfer
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestWriteDataSeekError ensures writeData returns an error when seeking fails
+// and that no data is written to the destination file.
+func TestWriteDataSeekError(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "dest")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	path := f.Name()
+	// Close the file to force Seek to fail
+	f.Close()
+
+	err = writeData(f, 0, []byte("data"), zap.NewNop())
+	if err == nil {
+		t.Fatalf("expected seek error")
+	}
+
+	reopened, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("reopen file: %v", err)
+	}
+	defer reopened.Close()
+	info, err := reopened.Stat()
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("expected no data written, got %d bytes", info.Size())
+	}
+}


### PR DESCRIPTION
## Summary
- return seek errors from block writer
- document and propagate write failures
- add test coverage for seek failure

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f76141c1483238655b2f8dfc7b0fe