### PR TITLE
refactor(h2): split Dial into helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind LVMSYNC_DEDUP_* environment variables and extend tests for dedup flag precedence.
 - Privilege escalation tests covering sudo success and failure modes.
 - device: tests for GetUUID and IsMountedRW
+- transport/h2: refactor Dial into dialTLS, performH2Handshake, and logDialResult with unit tests.
 
 
 ### Fixed

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -84,6 +84,63 @@ func init() {
 
 func (t *Transport) Name() string { return "h2" }
 
+func dialTLS(ctx context.Context, address string, conf *tls.Config, logger *zap.Logger) (*tls.Conn, error) {
+	d := net.Dialer{}
+	if dl, ok := ctx.Deadline(); ok {
+		d.Deadline = dl
+	}
+	conn, err := tls.DialWithDialer(&d, "tcp", address, conf)
+	if err != nil {
+		return nil, err
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(dl); err != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+	return conn, nil
+}
+
+func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger) (*http2.Framer, error) {
+	fr := http2.NewFramer(conn, conn)
+	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
+		return nil, err
+	}
+	if err := fr.WriteSettings(); err != nil {
+		return nil, err
+	}
+	if f, err := fr.ReadFrame(); err != nil {
+		return nil, err
+	} else if _, ok := f.(*http2.SettingsFrame); !ok {
+		return nil, fmt.Errorf("expected settings frame")
+	}
+	if err := fr.WriteSettingsAck(); err != nil {
+		return nil, err
+	}
+	if f, err := fr.ReadFrame(); err != nil {
+		return nil, err
+	} else if sf, ok := f.(*http2.SettingsFrame); !ok || !sf.IsAck() {
+		return nil, fmt.Errorf("expected settings ack")
+	}
+	return fr, nil
+}
+
+func logDialResult(ctx context.Context, logger *zap.Logger, address, role string, start time.Time, err error) {
+	fields := []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+		logger.Error("dial_end", fields...)
+		return
+	}
+	fields = append(fields, zap.String("error", ""))
+	logger.Info("dial_end", fields...)
+}
+
 // Dial establishes a TLS1.3 connection and performs an HTTP/2 handshake.
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
 	role := "client"
@@ -94,119 +151,18 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("error", ""),
 	)
 	start := time.Now()
-	d := net.Dialer{}
-	if dl, ok := ctx.Deadline(); ok {
-		d.Deadline = dl
-	}
-	conn, err := tls.DialWithDialer(&d, "tcp", address, t.clientConf)
-	fields := []zap.Field{
-		zap.String("address", address),
-		zap.String("role", role),
-		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.Error(err),
-	}
+	conn, err := dialTLS(ctx, address, t.clientConf, t.logger)
 	if err != nil {
-		t.logger.Error("dial_end", fields...)
+		logDialResult(ctx, t.logger, address, role, start, err)
 		return nil, err
 	}
-	if dl, ok := ctx.Deadline(); ok {
-		if err := conn.SetDeadline(dl); err != nil {
-			conn.Close()
-			fields := []zap.Field{
-				zap.String("address", address),
-				zap.String("role", role),
-				zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-				zap.Error(err),
-			}
-			t.logger.Error("dial_end", fields...)
-			return nil, err
-		}
-	}
-	fr := http2.NewFramer(conn, conn)
-	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
+	fr, err := performH2Handshake(ctx, conn, t.logger)
+	if err != nil {
 		conn.Close()
+		logDialResult(ctx, t.logger, address, role, start, err)
 		return nil, err
 	}
-	if err := fr.WriteSettings(); err != nil {
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
-		conn.Close()
-		return nil, err
-	}
-	if f, err := fr.ReadFrame(); err != nil {
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
-		conn.Close()
-		return nil, err
-	} else if _, ok := f.(*http2.SettingsFrame); !ok {
-		err = fmt.Errorf("expected settings frame")
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
-		conn.Close()
-		return nil, err
-	}
-	if err := fr.WriteSettingsAck(); err != nil {
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
-		conn.Close()
-		return nil, err
-	}
-	if f, err := fr.ReadFrame(); err != nil {
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
-		conn.Close()
-		return nil, err
-	} else if sf, ok := f.(*http2.SettingsFrame); !ok || !sf.IsAck() {
-		err = fmt.Errorf("expected settings ack")
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
-		conn.Close()
-		return nil, err
-	}
-	fields = []zap.Field{
-		zap.String("address", address),
-		zap.String("role", role),
-		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", ""),
-	}
-	t.logger.Info("dial_end", fields...)
+	logDialResult(ctx, t.logger, address, role, start, nil)
 	if err := conn.SetDeadline(time.Time{}); err != nil {
 		conn.Close()
 		return nil, err

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/net/http2"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
@@ -84,6 +85,102 @@ func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 	pool := x509.NewCertPool()
 	pool.AddCert(parsed)
 	return cert, pool
+}
+
+func TestDialTLS(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	serverConf := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverConf)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		io.ReadAll(conn)
+	}()
+	clientConf := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	if conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, zap.NewNop()); err != nil {
+		t.Fatalf("dialTLS: %v", err)
+	} else {
+		conn.Close()
+	}
+	badConf := &tls.Config{RootCAs: x509.NewCertPool(), MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	if _, err := dialTLS(context.Background(), ln.Addr().String(), badConf, zap.NewNop()); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestPerformH2Handshake(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	serverConf := &tls.Config{Certificates: []tls.Certificate{cert}, NextProtos: []string{"h2"}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverConf)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	// successful handshake
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := conn.(*tls.Conn)
+		fr := http2.NewFramer(tlsConn, tlsConn)
+		preface := make([]byte, len(http2.ClientPreface))
+		io.ReadFull(tlsConn, preface)
+		fr.ReadFrame()
+		fr.WriteSettings()
+		fr.WriteSettingsAck()
+		fr.ReadFrame()
+		<-done
+		conn.Close()
+	}()
+	clientConf := &tls.Config{RootCAs: pool, NextProtos: []string{"h2"}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, zap.NewNop())
+	if err != nil {
+		t.Fatalf("dialTLS: %v", err)
+	}
+	if _, err := performH2Handshake(context.Background(), conn, zap.NewNop()); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	close(done)
+	conn.Close()
+
+	// failing handshake
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		conn.Close()
+	}()
+	conn2, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, zap.NewNop())
+	if err != nil {
+		t.Fatalf("dialTLS: %v", err)
+	}
+	if _, err := performH2Handshake(context.Background(), conn2, zap.NewNop()); err == nil {
+		t.Fatalf("expected handshake error")
+	}
+	conn2.Close()
+}
+
+func TestLogDialResult(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	logDialResult(context.Background(), logger, "addr", "client", time.Now(), nil)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+
+	core2, logs2 := observer.New(zap.InfoLevel)
+	logger2 := zap.New(core2)
+	logDialResult(context.Background(), logger2, "addr", "client", time.Now(), errors.New("boom"))
+	checkLogFields(t, logs2, "dial_end", 1, true, zapcore.ErrorLevel)
 }
 
 func TestH2TransportTLSHandshake(t *testing.T) {


### PR DESCRIPTION
## Summary
- split h2.Dial into dialTLS, performH2Handshake, and logDialResult
- inject logger and context into helpers for better testability
- add unit tests for helper success and failure paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f76166c28832393197055859cca6e