### PR TITLE
fix(transport): shorten tcp+tls dial timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove obsolete gap and pruning entries after rerunning static analysis.
 - Wrap README logging example in `package main` to compile with `go build`.
 - add default dial timeout and deadline propagation for h2 and tcp+tls transports
+- reduce tcp+tls default dial timeout to 5s
 - close SSH agent connections after retrieving signers and apply context-based timeouts
 
 ## [v0.1.0] - 2025-02-27

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -14,7 +14,7 @@ import (
 	"lvmsync_go/transport"
 )
 
-const defaultDialTimeout = 30 * time.Second
+const defaultDialTimeout = 5 * time.Second
 
 // Transport implements TLS over TCP.
 type Transport struct {


### PR DESCRIPTION
## Summary
- reduce tcp+tls default dial timeout to 5s

## Testing
- `go test ./transport/tcp_tls -run DialUnreachable`
- `golangci-lint run transport/tcp_tls`


------
https://chatgpt.com/codex/tasks/task_e_689f86247d28832389515be363b59846