### PR TITLE
feat(transfer): unify resume checkpoints across dedup modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - device: tests for GetUUID and IsMountedRW
 - device: persist thaw command configuration for raw devices
 - transport/h2: refactor Dial into dialTLS, performH2Handshake, and logDialResult with unit tests.
+- transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.
 
 
 ### Fixed

--- a/transfer/resume_cdc.go
+++ b/transfer/resume_cdc.go
@@ -1,0 +1,24 @@
+package transfer
+
+import (
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+)
+
+func findResumeIndexCDC(cfg *config.Config, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+	next := chk.Offset + uint64(chk.Length)
+	for i := range ranges {
+		if next < ranges[i].Start {
+			return i
+		}
+		if next <= ranges[i].End {
+			ranges[i].Start = next
+			if logger != nil {
+				logger.Info("Resuming after offset", zap.Uint64("resume_offset", next))
+			}
+			return i
+		}
+	}
+	return len(ranges)
+}

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -1,7 +1,11 @@
 package transfer
 
 import (
+	"bytes"
 	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/zeebo/blake3"
@@ -27,5 +31,29 @@ func TestResumeCDCOffset(t *testing.T) {
 	}
 	if ranges[1].Start != 120 {
 		t.Fatalf("expected range start 120, got %d", ranges[1].Start)
+	}
+}
+
+func TestResumeCDCSequential(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	blockSize := int64(1024)
+	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
+
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
+
+	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
+	writeResumeState(cfg, zap.NewNop(), resume, uint64(blockSize), uint32(blockSize), digest)
+
+	var buf bytes.Buffer
+	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChangesParallel failed: %v", err)
+	}
+	finalizeResumeState(cfg, zap.NewNop())
+
+	offsets := parseOffsets(t, buf.Bytes(), blockSize)
+	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
+	expected := []int64{2 * blockSize, 3 * blockSize}
+	if !reflect.DeepEqual(offsets, expected) {
+		t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
 	}
 }

--- a/transfer/resume_fixed.go
+++ b/transfer/resume_fixed.go
@@ -1,0 +1,57 @@
+package transfer
+
+import (
+	"crypto/sha256"
+	"os"
+
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+)
+
+// findResumeIndex determines the starting range index based on the checkpoint and dedup mode.
+func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+	if cfg.ResumeState == "" {
+		return 0
+	}
+	switch cfg.DedupMode {
+	case "cdc":
+		return findResumeIndexCDC(cfg, ranges, chk, logger)
+	case "hybrid":
+		return findResumeIndexHybrid(cfg, ranges, chk, logger)
+	default:
+		return findResumeIndexFixed(cfg, srcFile, ranges, chk, logger)
+	}
+}
+
+func findResumeIndexFixed(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+	if chk.Chunk == [32]byte{} {
+		return 0
+	}
+	for i, r := range ranges {
+		offset, _, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
+		if err != nil {
+			return 0
+		}
+		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, [2]int{-1, -1}, logger)
+		if err != nil {
+			continue
+		}
+		var sum [32]byte
+		if cfg.ChecksumAlgorithm == "sha256" {
+			sumArr := sha256.Sum256(data)
+			sum = [32]byte(sumArr)
+		} else {
+			sum = blake3.Sum256(data)
+		}
+		putBlockBuffer(data)
+		if sum == chk.Chunk {
+			if logger != nil {
+				logger.Info("Resuming after index", zap.Int("resume_index", i+1))
+			}
+			return i + 1
+		}
+	}
+	return 0
+}

--- a/transfer/resume_hybrid.go
+++ b/transfer/resume_hybrid.go
@@ -1,0 +1,11 @@
+package transfer
+
+import (
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+)
+
+func findResumeIndexHybrid(cfg *config.Config, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+	return findResumeIndexCDC(cfg, ranges, chk, logger)
+}

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -1,7 +1,11 @@
 package transfer
 
 import (
+	"bytes"
 	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/zeebo/blake3"
@@ -27,5 +31,29 @@ func TestResumeHybridOffset(t *testing.T) {
 	}
 	if ranges[1].Start != 120 {
 		t.Fatalf("expected range start 120, got %d", ranges[1].Start)
+	}
+}
+
+func TestResumeHybridSequential(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	blockSize := int64(1024)
+	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
+
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
+
+	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
+	writeResumeState(cfg, zap.NewNop(), resume, uint64(blockSize), uint32(blockSize), digest)
+
+	var buf bytes.Buffer
+	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChangesParallel failed: %v", err)
+	}
+	finalizeResumeState(cfg, zap.NewNop())
+
+	offsets := parseOffsets(t, buf.Bytes(), blockSize)
+	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
+	expected := []int64{2 * blockSize, 3 * blockSize}
+	if !reflect.DeepEqual(offsets, expected) {
+		t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
 	}
 }

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -1,28 +1,18 @@
 package transfer
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"os"
 	"sync"
 	"time"
 
-	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
 )
 
-var (
-	resumeMu     sync.Mutex
-	resumeBytes  int64
-	resumeLast   time.Time
-	resumeChunk  [32]byte
-	resumeOffset uint64
-	resumeLength uint32
-)
-
+// resumeState persists transfer checkpoints allowing interrupted transfers to resume.
 type resumeState struct {
 	Transport         string `json:"transport"`
 	Compress          string `json:"compress"`
@@ -33,11 +23,24 @@ type resumeState struct {
 	Chunk             string `json:"chunk"`
 }
 
+// resumeCheckpoint represents the last processed chunk on disk.
 type resumeCheckpoint struct {
 	Chunk  [32]byte
 	Offset uint64
 	Length uint32
 }
+
+// stateManager encapsulates checkpoint tracking independent of dedup mode.
+type stateManager struct {
+	mu     sync.Mutex
+	bytes  int64
+	last   time.Time
+	chunk  [32]byte
+	offset uint64
+	length uint32
+}
+
+var checkpointState stateManager
 
 func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offset uint64, length uint32, chunk [32]byte) {
 	rs := resumeState{
@@ -67,20 +70,20 @@ func saveResumeState(cfg *config.Config, offset uint64, chunk [32]byte, size int
 	if cfg.ResumeState == "" {
 		return
 	}
-	resumeMu.Lock()
-	defer resumeMu.Unlock()
-	if resumeLast.IsZero() {
-		resumeLast = time.Now()
+	checkpointState.mu.Lock()
+	defer checkpointState.mu.Unlock()
+	if checkpointState.last.IsZero() {
+		checkpointState.last = time.Now()
 	}
-	resumeBytes += size
-	resumeChunk = chunk
-	resumeOffset = offset
-	resumeLength = uint32(size)
-	if (cfg.CheckpointBytes > 0 && resumeBytes >= int64(cfg.CheckpointBytes)) ||
-		(cfg.CheckpointInterval > 0 && time.Since(resumeLast) >= cfg.CheckpointInterval) {
-		writeResumeState(cfg, logger, cfg.ResumeState, resumeOffset, resumeLength, resumeChunk)
-		resumeBytes = 0
-		resumeLast = time.Now()
+	checkpointState.bytes += size
+	checkpointState.chunk = chunk
+	checkpointState.offset = offset
+	checkpointState.length = uint32(size)
+	if (cfg.CheckpointBytes > 0 && checkpointState.bytes >= int64(cfg.CheckpointBytes)) ||
+		(cfg.CheckpointInterval > 0 && time.Since(checkpointState.last) >= cfg.CheckpointInterval) {
+		writeResumeState(cfg, logger, cfg.ResumeState, checkpointState.offset, checkpointState.length, checkpointState.chunk)
+		checkpointState.bytes = 0
+		checkpointState.last = time.Now()
 	}
 }
 
@@ -88,9 +91,9 @@ func finalizeResumeState(cfg *config.Config, logger *zap.Logger) {
 	if cfg.ResumeState == "" {
 		return
 	}
-	resumeMu.Lock()
-	defer resumeMu.Unlock()
-	if resumeLast.IsZero() {
+	checkpointState.mu.Lock()
+	defer checkpointState.mu.Unlock()
+	if checkpointState.last.IsZero() {
 		return
 	}
 	if err := os.Remove(cfg.ResumeState); err != nil && !os.IsNotExist(err) {
@@ -98,8 +101,8 @@ func finalizeResumeState(cfg *config.Config, logger *zap.Logger) {
 			logger.Warn("Failed to remove resume state", zap.Error(err))
 		}
 	}
-	resumeBytes = 0
-	resumeLast = time.Time{}
+	checkpointState.bytes = 0
+	checkpointState.last = time.Time{}
 }
 
 func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
@@ -133,54 +136,4 @@ func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
 			zap.Uint32("resume_length", out.Length))
 	}
 	return out
-}
-
-func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
-	if cfg.ResumeState == "" {
-		return 0
-	}
-	if cfg.DedupMode == "cdc" || cfg.DedupMode == "hybrid" {
-		next := chk.Offset + uint64(chk.Length)
-		for i := range ranges {
-			if next < ranges[i].Start {
-				return i
-			}
-			if next <= ranges[i].End {
-				ranges[i].Start = next
-				if logger != nil {
-					logger.Info("Resuming after offset", zap.Uint64("resume_offset", next))
-				}
-				return i
-			}
-		}
-		return len(ranges)
-	}
-	if chk.Chunk == [32]byte{} {
-		return 0
-	}
-	for i, r := range ranges {
-		offset, _, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
-		if err != nil {
-			return 0
-		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, [2]int{-1, -1}, logger)
-		if err != nil {
-			continue
-		}
-		var sum [32]byte
-		if cfg.ChecksumAlgorithm == "sha256" {
-			sumArr := sha256.Sum256(data)
-			sum = [32]byte(sumArr)
-		} else {
-			sum = blake3.Sum256(data)
-		}
-		putBlockBuffer(data)
-		if sum == chk.Chunk {
-			if logger != nil {
-				logger.Info("Resuming after index", zap.Int("resume_index", i+1))
-			}
-			return i + 1
-		}
-	}
-	return 0
 }


### PR DESCRIPTION
## Summary
- manage resume checkpoints via a shared state machine
- reuse checkpoint logic for CDC and hybrid dedup modes
- add resume tests for CDC and hybrid transfers

## Testing
- `go build ./...` *(fails: transport/h2/h2.go:99:30: syntax error: unexpected name context in argument list; possibly missing comma or ))*
- `go test -coverprofile=coverage.out ./...` *(fails: transport/h2/h2.go:99:30: syntax error: unexpected name context in argument list; possibly missing comma or ))*
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f85bec634832389eae32c93c851b5