### PR TITLE
feat: allow explicit device type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - device: tests for GetUUID and IsMountedRW
 - device: persist thaw command configuration for raw devices
 - transport/h2: refactor Dial into dialTLS, performH2Handshake, and logDialResult with unit tests.
+- cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 | Raw block device |   ✅   |      ✅      | requires `--offline` or `--fs-freeze-command`/`--fs-thaw-command` when used as a source |
 | Regular file     |   ✅   |      ✅      | includes loopback images |
 
+Override automatic detection with `--source-type` and `--dest-type` when a device's type is known in advance.
+
 ## Supported Platforms
 
 LVMSync targets Linux systems only. Builds are tested on the `amd64` and `arm64` architectures.

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -26,7 +26,7 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	}
 	destDevice := args[0]
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(context.Background(), destDevice, true, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
+		if dev, err := device.Detect(context.Background(), destDevice, true, cfg.DestType, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -109,7 +109,7 @@ func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, l
 // RunLocalDump dumps changes to a local destination device.
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(context.Background(), dest, true, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
+		if dev, err := device.Detect(context.Background(), dest, true, cfg.DestType, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {
@@ -234,7 +234,11 @@ func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remot
 		return err
 	}
 
-	remoteCmd := fmt.Sprintf("%s --apply - %s", cfg.LVMSyncPath, destDevice)
+	baseCmd := cfg.LVMSyncPath
+	if cfg.DestType != "" && cfg.DestType != "auto" {
+		baseCmd = fmt.Sprintf("%s --dest-type %s", baseCmd, cfg.DestType)
+	}
+	remoteCmd := fmt.Sprintf("%s --apply - %s", baseCmd, destDevice)
 	logger.Info("Starting remote apply command", zap.String("command", remoteCmd))
 
 	if err = session.Start(remoteCmd); err != nil {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -186,7 +186,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	)
 
 	if cfg.SourceType == "" || cfg.SourceType == "auto" {
-		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
+		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
 		if err != nil {
 			return err
 		}

--- a/device/detect.go
+++ b/device/detect.go
@@ -15,8 +15,10 @@ import (
 
 // Detect inspects the path and returns the appropriate Device implementation.
 // Regular files return FileDevice, block devices are classified as either LVM
-// logical volumes or raw devices based on LVM metadata.
-func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
+// logical volumes or raw devices based on LVM metadata. When typeHint is not
+// empty or "auto", Detect will attempt to open the device using the explicit
+// type and will not perform auto detection.
+func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		if logger != nil {
@@ -30,6 +32,75 @@ func Detect(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawC
 			logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
 		}
 		return nil, err
+	}
+	if typeHint != "" && typeHint != "auto" {
+		switch typeHint {
+		case "file":
+			if !info.Mode().IsRegular() {
+				return nil, fmt.Errorf("expected regular file for type file: %s", resolved)
+			}
+			dev, err := OpenFile(resolved, logger)
+			if err != nil {
+				if logger != nil {
+					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
+				}
+				return nil, err
+			}
+			if logger != nil {
+				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
+			}
+			return dev, nil
+		case "lvm":
+			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
+				return nil, fmt.Errorf("expected block device for type lvm: %s", resolved)
+			}
+			cache := lvm.NewDeviceFDCache(logger)
+			defer cache.Close()
+			dev, err := OpenLVM(resolved, cache, logger)
+			if err != nil {
+				if logger != nil {
+					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
+				}
+				return nil, err
+			}
+			if logger != nil {
+				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
+			}
+			return dev, nil
+		case "raw":
+			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
+				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
+			}
+			var freezePath, thawPath string
+			var freezeArgs, thawArgs []string
+			if fsFreezeCmd != "" {
+				parts := strings.Fields(fsFreezeCmd)
+				if len(parts) > 0 {
+					freezePath = parts[0]
+					freezeArgs = parts[1:]
+				}
+			}
+			if fsThawCmd != "" {
+				parts := strings.Fields(fsThawCmd)
+				if len(parts) > 0 {
+					thawPath = parts[0]
+					thawArgs = parts[1:]
+				}
+			}
+			dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
+			if err != nil {
+				if logger != nil {
+					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
+				}
+				return nil, err
+			}
+			if logger != nil {
+				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
+			}
+			return dev, nil
+		default:
+			return nil, fmt.Errorf("unknown device type %q", typeHint)
+		}
 	}
 	if info.Mode().IsRegular() {
 		dev, err := OpenFile(resolved, logger)

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -42,7 +42,7 @@ func TestDetectFile(t *testing.T) {
 	f.Close()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), f.Name(), true, "", "", 0, 0, logger)
+	dev, err := Detect(context.Background(), f.Name(), true, "", "", "", 0, 0, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), link, true, "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestDetectRaw(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), loop, true, "", "", 0, 0, logger)
+	dev, err := Detect(context.Background(), loop, true, "", "", "", 0, 0, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), link, true, "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(context.Background(), lvPath, true, "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), lvPath, true, "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -48,7 +48,7 @@ type Index struct {
 var closeHook = func() {}
 
 var detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-	return device.Detect(ctx, path, true, "", "", 0, 0, logger)
+	return device.Detect(ctx, path, true, "", "", "", 0, 0, logger)
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.


### PR DESCRIPTION
## Summary
- allow `device.Detect` to open a specific device type when `--source-type` or `--dest-type` is provided
- pass explicit device types through dump/apply commands and remote apply invocation
- document source/dest type overrides in the device support matrix

## Testing
- `go build ./...` *(fails: transport/h2/h2.go:99:30: syntax error: unexpected name context in argument list; possibly missing comma or ))*
- `go test -coverprofile=coverage.out ./...` *(fails: transport/h2/h2.go:99:30: syntax error: unexpected name context in argument list; possibly missing comma or ))*
- `golangci-lint run` *(fails: lvmsync_go [build failed])* 
- `go tool cover -func=coverage.out | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689f85bb9300832382dc2d9d0fcc7b58