### PR TITLE
test(device): add freeze thaw command stub tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - device: tests for GetUUID and IsMountedRW
 - device: persist thaw command configuration for raw devices
 - transport/h2: refactor Dial into dialTLS, performH2Handshake, and logDialResult with unit tests.
+- device: add raw device freeze/thaw tests with exec command stubs
 
 
 ### Fixed

--- a/device/raw.go
+++ b/device/raw.go
@@ -67,7 +67,7 @@ func OpenRaw(
 			freezeCtx, cancel = context.WithTimeout(ctx, d.freezeTimeout)
 			defer cancel()
 		}
-		if err = exec.CommandContext(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).Run(); err != nil {
+		if err = execCommand(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).Run(); err != nil {
 			return nil, fmt.Errorf("freeze command failed: %w", err)
 		}
 		d.logger.Info("fs freeze complete")
@@ -148,7 +148,7 @@ func (d *RawDevice) Cleanup(ctx context.Context) error {
 			thawCtx, cancel = context.WithTimeout(ctx, d.thawTimeout)
 			defer cancel()
 		}
-		if err := exec.CommandContext(thawCtx, d.thawCmdPath, d.thawCmdArgs...).Run(); err != nil {
+		if err := execCommand(thawCtx, d.thawCmdPath, d.thawCmdArgs...).Run(); err != nil {
 			d.logger.Error("fs thaw failed", zap.Error(err))
 			return fmt.Errorf("thaw command failed: %w", err)
 		}

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -179,3 +179,100 @@ func TestOpenRawStoresThawConfig(t *testing.T) {
 	}
 	d.Close()
 }
+
+func TestOpenRawFreezeThawLogs(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	oldExec := execCommand
+	execCommand = fakeExecCommandContext
+	defer func() { execCommand = oldExec }()
+	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-success"}, os.Args[0], []string{"thaw-success"}, time.Second, time.Second, logger)
+	if err == nil {
+		t.Fatalf("expected error for char device")
+	}
+	if logs.FilterMessage("fs freeze start").Len() != 1 || logs.FilterMessage("fs freeze complete").Len() != 1 {
+		t.Fatalf("expected freeze start and complete logs, got %v", logs.All())
+	}
+	if logs.FilterMessage("fs thaw start").Len() != 1 || logs.FilterMessage("fs thaw complete").Len() != 1 {
+		t.Fatalf("expected thaw start and complete logs, got %v", logs.All())
+	}
+}
+
+func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	oldExec := execCommand
+	execCommand = fakeExecCommandContext
+	defer func() { execCommand = oldExec }()
+	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-timeout"}, os.Args[0], []string{"thaw-success"}, 50*time.Millisecond, time.Second, logger)
+	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("expected freeze timeout, got %v", err)
+	}
+	if logs.FilterMessage("fs freeze start").Len() != 1 {
+		t.Fatalf("expected freeze start log")
+	}
+	if logs.FilterMessage("fs freeze complete").Len() != 0 {
+		t.Fatalf("unexpected freeze complete log")
+	}
+	if logs.FilterMessage("fs thaw start").Len() != 0 || logs.FilterMessage("fs thaw complete").Len() != 0 {
+		t.Fatalf("unexpected thaw logs, got %v", logs.All())
+	}
+}
+
+func TestOpenRawThawFailure(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	oldExec := execCommand
+	execCommand = fakeExecCommandContext
+	defer func() { execCommand = oldExec }()
+	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-success"}, os.Args[0], []string{"thaw-fail"}, time.Second, time.Second, logger)
+	if err == nil {
+		t.Fatalf("expected error for char device")
+	}
+	if logs.FilterMessage("fs freeze start").Len() != 1 || logs.FilterMessage("fs freeze complete").Len() != 1 {
+		t.Fatalf("expected freeze start and complete logs, got %v", logs.All())
+	}
+	if logs.FilterMessage("fs thaw start").Len() != 1 {
+		t.Fatalf("expected thaw start log")
+	}
+	if logs.FilterMessage("fs thaw complete").Len() != 0 {
+		t.Fatalf("unexpected thaw complete log")
+	}
+	if logs.FilterMessage("fs thaw failed").Len() != 1 {
+		t.Fatalf("expected thaw failed log")
+	}
+}
+
+func fakeExecCommandContext(ctx context.Context, _ string, args ...string) *exec.Cmd {
+	cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
+	cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := os.Args
+	for i := range args {
+		if args[i] == "--" {
+			args = args[i+1:]
+			break
+		}
+	}
+	if len(args) == 0 {
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "freeze-success", "thaw-success":
+		os.Exit(0)
+	case "freeze-timeout":
+		time.Sleep(200 * time.Millisecond)
+		os.Exit(0)
+	case "thaw-fail":
+		os.Exit(1)
+	default:
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- use package-level execCommand in raw device to allow stubbing exec.CommandContext
- add tests for successful freeze/thaw, freeze timeout, and thaw failure logging

## Testing
- ❌ `go build ./...` (syntax error: transport/h2/h2.go:99:30)
- ❌ `go test -coverprofile=coverage.out ./...` (syntax error: transport/h2/h2.go:99:30)
- ✅ `go test -coverprofile=coverage.out -v ./device`
- ⚠️ `go tool cover -func=coverage.out` (48.9% coverage)
- ❌ `golangci-lint run` (build failed)
- ✅ `golangci-lint run ./device...`


------
https://chatgpt.com/codex/tasks/task_e_689f85c0e62483238d22890fad034192