### PR TITLE
refactor: return dest type from RunLocalDump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - shorten h2 dial timeout to 5s and enforce it when no deadline is provided
 - ensure verify and lvmsync commands flush logs by deferring logger.Sync()
 - remove legacy dedup manifest in favor of manifest.Index
+- cmd/dump: detect destination type locally without mutating configuration
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -93,45 +93,46 @@ func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io
 	return dumpChangesParallel(t, cfg, snapshotDevice, originDevice, out)
 }
 
-// Run executes client mode transferring data to dest.
-func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, logger *zap.Logger) error {
+// Run executes client mode transferring data to dest and returns the destination type.
+func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, logger *zap.Logger) (string, error) {
 	originDevice := snapshotDevice
 	if cfg.StdoutMode {
 		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)
-		return ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
+		return cfg.DestType, ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
 	}
 	if strings.Contains(dest, ":") {
-		return RunRemoteDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
+		return cfg.DestType, RunRemoteDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
 	}
 	return RunLocalDump(cfg, snapshotDevice, originDevice, dest, logger)
 }
 
-// RunLocalDump dumps changes to a local destination device.
-func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
-	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(context.Background(), dest, true, cfg.DestType, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
+// RunLocalDump dumps changes to a local destination device and returns the detected destination type.
+func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
+	destType := cfg.DestType
+	if destType == "auto" {
+		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {
 					dev.Close()
-					return fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
+					return destType, fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
 				}
-				cfg.DestType = "raw"
+				destType = "raw"
 			case *device.LVMDevice:
-				cfg.DestType = "lvm"
+				destType = "lvm"
 			case *device.FileDevice:
-				cfg.DestType = "file"
+				destType = "file"
 			}
 			dev.Close()
 		}
 	}
 	destFile, err := openFile(dest, os.O_RDWR, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open destination device %s: %w", dest, err)
+		return destType, fmt.Errorf("failed to open destination device %s: %w", dest, err)
 	}
 	defer common.CloseWithErr(destFile, &err, "close destination device")
 	limitedOut := transfer.WrapRateLimitedWriter(destFile, cfg.SpeedLimit)
-	return ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
+	return destType, ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
 }
 
 // SetupSSHClient creates an SSH client for remote operations.

--- a/cmd/dump/local_dump_test.go
+++ b/cmd/dump/local_dump_test.go
@@ -43,8 +43,16 @@ func TestRunLocalDumpSuccess(t *testing.T) {
 	}
 	defer func() { dumpChangesSequential = originalDump }()
 
-	if err := RunLocalDump(cfg, "snap", "orig", "/fake/dest", zap.NewNop()); err != nil {
+	originalDestType := cfg.DestType
+	destType, err := RunLocalDump(cfg, "snap", "orig", "/fake/dest", zap.NewNop())
+	if err != nil {
 		t.Fatalf("runLocalDump returned error: %v", err)
+	}
+	if destType != originalDestType {
+		t.Fatalf("expected dest type %q, got %q", originalDestType, destType)
+	}
+	if cfg.DestType != originalDestType {
+		t.Fatalf("cfg.DestType was modified: expected %q, got %q", originalDestType, cfg.DestType)
 	}
 	if !openCalled {
 		t.Fatalf("openFile was not called")
@@ -73,7 +81,13 @@ func TestRunLocalDumpOpenError(t *testing.T) {
 	}
 	defer func() { dumpChangesSequential = originalDump }()
 
-	if err := RunLocalDump(cfg, "snap", "orig", "/fake/dest", zap.NewNop()); err == nil {
+	originalDestType := cfg.DestType
+	if destType, err := RunLocalDump(cfg, "snap", "orig", "/fake/dest", zap.NewNop()); err == nil {
 		t.Fatalf("expected error, got nil")
+	} else if destType != originalDestType {
+		t.Fatalf("expected dest type %q, got %q", originalDestType, destType)
+	}
+	if cfg.DestType != originalDestType {
+		t.Fatalf("cfg.DestType was modified: expected %q, got %q", originalDestType, cfg.DestType)
 	}
 }

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -52,7 +52,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
+	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "dumpChanges") {
 		t.Fatalf("expected dumpChanges error, got %v", err)
 	}
@@ -101,7 +101,7 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
+	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil {
 		t.Fatalf("expected error from pre-script")
 	}
@@ -155,7 +155,7 @@ func TestRemotePostScriptContextError(t *testing.T) {
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
+	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "remote post-script context error") {
 		t.Fatalf("expected remote post-script context error, got %v", err)
 	}

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -36,7 +36,7 @@ func TestRunLogsSaveStateError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Run(ctx, cfg, "/dev/snap", "", logger); err != nil {
+	if _, err := Run(ctx, cfg, "/dev/snap", "", logger); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -41,7 +41,7 @@ func TestRunStdout(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err = Run(ctx, cfg, "/dev/snap", "", zap.NewNop()); err != nil {
+	if _, err = Run(ctx, cfg, "/dev/snap", "", zap.NewNop()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -28,7 +28,10 @@ var (
 	prepareSnapshotFn = app.PrepareSnapshot
 	executeClientFn   = clientpkg.ExecuteClient
 	selectTransport   = dumpcmd.SelectTransport
-	runDump           = dumpcmd.Run
+	runDump           = func(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) error {
+		_, err := dumpcmd.Run(ctx, cfg, snapshot, dest, logger)
+		return err
+	}
 )
 
 // SyncLogger flushes buffered log entries and logs if syncing fails.


### PR DESCRIPTION
## Summary
- refactor RunLocalDump to detect destination type locally without mutating the config and return the detected type
- propagate the returned type through Run and wrap dump.Run in root command
- update tests to use the new return value and assert cfg.DestType remains unchanged

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f8ca19dc48323add9f9cb17b9f645