### PR TITLE
fix(dump): honor context cancellation during copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - shorten h2 dial timeout to 5s and enforce it when no deadline is provided
 - ensure verify and lvmsync commands flush logs by deferring logger.Sync()
 - remove legacy dedup manifest in favor of manifest.Index
+- cmd/dump: handle context cancellation during pipe copies to avoid incomplete writes
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -68,9 +68,39 @@ func CopyPipeAsync(ctx context.Context, dst io.Writer, src io.Reader) <-chan err
 		bufAny := copyBufferPool.Get()
 		buf := *(bufAny.(*[]byte))
 		defer copyBufferPool.Put(&buf)
-
-		_, err := io.CopyBuffer(dst, &contextReader{ctx: ctx, r: src}, buf)
-		errCh <- err
+		cr := &contextReader{ctx: ctx, r: src}
+		for {
+			if err := ctx.Err(); err != nil {
+				errCh <- err
+				return
+			}
+			n, err := cr.Read(buf)
+			if n > 0 {
+				written := 0
+				for written < n {
+					if err := ctx.Err(); err != nil {
+						errCh <- err
+						return
+					}
+					w, werr := dst.Write(buf[written:n])
+					if w > 0 {
+						written += w
+					}
+					if werr != nil {
+						errCh <- werr
+						return
+					}
+				}
+			}
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					errCh <- nil
+				} else {
+					errCh <- err
+				}
+				return
+			}
+		}
 	}()
 	return errCh
 }

--- a/cmd/dump/client_test.go
+++ b/cmd/dump/client_test.go
@@ -1,0 +1,61 @@
+package dump
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+// readerBlockingOnContext waits for ctx cancellation before returning.
+type readerBlockingOnContext struct {
+	ctx context.Context
+}
+
+func (r *readerBlockingOnContext) Read(p []byte) (int, error) {
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}
+
+// readerWithRelease returns data only after release is closed.
+type readerWithRelease struct {
+	data    []byte
+	release chan struct{}
+}
+
+func (r *readerWithRelease) Read(p []byte) (int, error) {
+	n := copy(p, r.data)
+	<-r.release
+	return n, io.EOF
+}
+
+func TestCopyPipeAsyncCanceledDuringRead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &readerBlockingOnContext{ctx: ctx}
+	var dst bytes.Buffer
+	errCh := CopyPipeAsync(ctx, &dst, r)
+	time.AfterFunc(10*time.Millisecond, cancel)
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if dst.Len() != 0 {
+		t.Fatalf("expected no bytes written, got %d", dst.Len())
+	}
+}
+
+func TestCopyPipeAsyncCanceledDuringWrite(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &readerWithRelease{data: []byte("hello"), release: make(chan struct{})}
+	var dst bytes.Buffer
+	errCh := CopyPipeAsync(ctx, &dst, r)
+	cancel()
+	close(r.release)
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if dst.Len() != 0 {
+		t.Fatalf("expected no bytes written, got %d", dst.Len())
+	}
+}


### PR DESCRIPTION
## Summary
- add bounded copy loop that checks context before each write
- cover CopyPipeAsync cancellation during read and write phases
- document cancellation fix in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f8ca4d4a48323912eb30d349e3757