### PR TITLE
fix: isolate rate limiter per writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - shorten h2 dial timeout to 5s and enforce it when no deadline is provided
 - ensure verify and lvmsync commands flush logs by deferring logger.Sync()
 - remove legacy dedup manifest in favor of manifest.Index
+- transfer: give each writer an independent rate limiter
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,7 @@ lvmsync run --compress auto --zstd_level 2 --compress_threshold 0.85 /dev/vg0/sn
 #### Rate Limiting
 
 Transfers can be throttled using a token bucket accurate to ±3% of the target.
+Each writer has its own limiter, so multiple transfers with different limits run independently.
 Limit the transfer speed to 50MB/s:
 
 ```sh

--- a/transfer/utils.go
+++ b/transfer/utils.go
@@ -9,7 +9,6 @@ package transfer
 
 import (
 	"io"
-	"sync"
 
 	"lvmsync_go/internal/limiter"
 )
@@ -39,25 +38,14 @@ func (rlw *rateLimitedWriter) Write(p []byte) (int, error) {
 	return written, nil
 }
 
-var (
-	rateLimiterCache     limiter.Limiter
-	lastSpeedLimit       int
-	rateLimiterCacheLock sync.Mutex
-)
-
 // WrapRateLimitedWriter returns an io.Writer that limits throughput to
-// speedLimit bytes per second. The limiter instance is cached for reuse.
+// speedLimit bytes per second. Each invocation creates a dedicated token
+// bucket so multiple writers operate independently.
 func WrapRateLimitedWriter(w io.Writer, speedLimit int) io.Writer {
 	if speedLimit <= 0 {
 		return w
 	}
 
-	rateLimiterCacheLock.Lock()
-	if rateLimiterCache == nil || lastSpeedLimit != speedLimit {
-		rateLimiterCache = limiter.New(speedLimit, speedLimit, nil)
-		lastSpeedLimit = speedLimit
-	}
-	rlw := &rateLimitedWriter{w: w, tb: rateLimiterCache, max: speedLimit}
-	rateLimiterCacheLock.Unlock()
-	return rlw
+	tb := limiter.New(speedLimit, speedLimit, nil)
+	return &rateLimitedWriter{w: w, tb: tb, max: speedLimit}
 }

--- a/transfer/utils_test.go
+++ b/transfer/utils_test.go
@@ -8,17 +8,31 @@ package transfer
 
 import (
 	"bytes"
+	"io"
 	"math"
+	"sync"
 	"testing"
 	"time"
 
 	"lvmsync_go/internal/limiter"
 )
 
-type stubClock struct{ now time.Time }
+type stubClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
 
-func (s *stubClock) Now() time.Time        { return s.now }
-func (s *stubClock) Sleep(d time.Duration) { s.now = s.now.Add(d) }
+func (s *stubClock) Now() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.now
+}
+
+func (s *stubClock) Sleep(d time.Duration) {
+	s.mu.Lock()
+	s.now = s.now.Add(d)
+	s.mu.Unlock()
+}
 
 func TestRateLimitedWriterAccuracy(t *testing.T) {
 	clk := &stubClock{now: time.Unix(0, 0)}
@@ -37,5 +51,58 @@ func TestRateLimitedWriterAccuracy(t *testing.T) {
 	}
 	if buf.Len() != len(data) {
 		t.Fatalf("wrote %d bytes want %d", buf.Len(), len(data))
+	}
+}
+
+func TestRateLimitedWritersIndependent(t *testing.T) {
+	clk := &stubClock{now: time.Unix(0, 0)}
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+	w1 := &rateLimitedWriter{w: buf1, tb: limiter.New(1024, 1024, clk), max: 1024}
+	w2 := &rateLimitedWriter{w: buf2, tb: limiter.New(2048, 2048, clk), max: 2048}
+	data := make([]byte, 4096)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var d1, d2 time.Duration
+
+	go func() {
+		start := clk.Now()
+		if _, err := w1.Write(data); err != nil {
+			t.Errorf("w1 write: %v", err)
+		}
+		d1 = clk.Now().Sub(start)
+		wg.Done()
+	}()
+
+	go func() {
+		start := clk.Now()
+		if _, err := w2.Write(data); err != nil {
+			t.Errorf("w2 write: %v", err)
+		}
+		d2 = clk.Now().Sub(start)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	if math.Abs(float64(d1-3*time.Second)) > float64(3*time.Second)*0.03 {
+		t.Fatalf("writer1 elapsed %v outside ±3%% of %v", d1, 3*time.Second)
+	}
+	if math.Abs(float64(d2-time.Second)) > float64(time.Second)*0.03 {
+		t.Fatalf("writer2 elapsed %v outside ±3%% of %v", d2, time.Second)
+	}
+}
+
+func BenchmarkRateLimitedWritersIndependent(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		clk := &stubClock{now: time.Unix(0, 0)}
+		w1 := &rateLimitedWriter{w: io.Discard, tb: limiter.New(1024, 1024, clk), max: 1024}
+		w2 := &rateLimitedWriter{w: io.Discard, tb: limiter.New(2048, 2048, clk), max: 2048}
+		data := make([]byte, 4096)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { w1.Write(data); wg.Done() }()
+		go func() { w2.Write(data); wg.Done() }()
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
## Summary
- remove global limiter cache and create per-writer limiter
- test independence of writers with different rate limits and add benchmark
- document per-writer rate limiting in README and changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f8ca735d8832395958c92ccc656f2