### PR TITLE
test(verify): add mismatched block log test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: add manifest index persistence test covering read/write, rebuild, and verify paths.
 - cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 - transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.
+- cmd/verify: add test ensuring mismatched blocks log `mismatched_block`.
 
 
 ### Fixed

--- a/cmd/verify/verify_mismatch_test.go
+++ b/cmd/verify/verify_mismatch_test.go
@@ -1,0 +1,31 @@
+package verify
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestRunLogsMismatchBlock(t *testing.T) {
+	dir := t.TempDir()
+	src := dir + "/src"
+	dst := dir + "/dst"
+	if err := os.WriteFile(src, []byte("foo"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("bar"), 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	err := Run([]string{src, dst}, logger)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if logs.FilterMessage("mismatched_block").Len() == 0 {
+		t.Fatalf("expected mismatched_block log, got %v", logs.All())
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test verifying mismatched blocks log `mismatched_block`
- document test in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f914fec4883238a72b686383b9d12