### PR TITLE
test(common,transport): verify ALPN/TLS round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: add manifest index persistence test covering read/write, rebuild, and verify paths.
 - cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 - transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.
+- tests: verify ALPN and TLS version round-trip in handshake and transport negotiation.
 
 
 ### Fixed

--- a/common/handshake_test.go
+++ b/common/handshake_test.go
@@ -11,39 +11,60 @@ import (
 )
 
 func TestHandshakeRoundTrip(t *testing.T) {
-	original := common.Handshake{
-		Version:       common.ProtocolVersion,
-		Compress:      "gzip",
-		CompressLevel: 2,
-		Checksum:      true,
-		Endianness:    common.NativeEndianness(),
-		BlockSize:     4096,
-		DedupMode:     "fixed",
-		ResumeToken:   "token",
-		ODirect:       true,
-		MaxInFlight:   8,
-		CDCMin:        1024,
-		CDCAvg:        2048,
-		CDCMax:        4096,
-		ALPN:          "h2",
-		TLSVersion:    "1.3",
-		Transports:    []string{"ssh", "tcp+tls"},
-		Compressors:   []string{"lz4", "zstd"},
-		Digests:       []string{"sha256", "blake3"},
-		Transport:     "ssh",
-		Digest:        "blake3",
+	cases := []struct {
+		name     string
+		original common.Handshake
+	}{
+		{
+			name: "minimal with alpn and tls",
+			original: common.Handshake{
+				Version:    common.ProtocolVersion,
+				Compress:   "none",
+				ALPN:       "h2",  // expect ALPN "h2" to round-trip
+				TLSVersion: "1.3", // expect TLS version "1.3" to round-trip
+			},
+		},
+		{
+			name: "full handshake",
+			original: common.Handshake{
+				Version:       common.ProtocolVersion,
+				Compress:      "gzip",
+				CompressLevel: 2,
+				Checksum:      true,
+				Endianness:    common.NativeEndianness(),
+				BlockSize:     4096,
+				DedupMode:     "fixed",
+				ResumeToken:   "token",
+				ODirect:       true,
+				MaxInFlight:   8,
+				CDCMin:        1024,
+				CDCAvg:        2048,
+				CDCMax:        4096,
+				ALPN:          "h2",  // expect ALPN "h2" to round-trip
+				TLSVersion:    "1.3", // expect TLS version "1.3" to round-trip
+				Transports:    []string{"ssh", "tcp+tls"},
+				Compressors:   []string{"lz4", "zstd"},
+				Digests:       []string{"sha256", "blake3"},
+				Transport:     "ssh",
+				Digest:        "blake3",
+			},
+		},
 	}
 
-	var buf bytes.Buffer
-	if err := common.WriteHandshake(&buf, original); err != nil {
-		t.Fatalf("write handshake: %v", err)
-	}
-	parsed, err := common.ReadHandshake(bufio.NewReader(&buf))
-	if err != nil {
-		t.Fatalf("read handshake: %v", err)
-	}
-	if !reflect.DeepEqual(original, parsed) {
-		t.Fatalf("handshake mismatch: %+v != %+v", original, parsed)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := common.WriteHandshake(&buf, tt.original); err != nil {
+				t.Fatalf("write handshake: %v", err)
+			}
+			parsed, err := common.ReadHandshake(bufio.NewReader(&buf))
+			if err != nil {
+				t.Fatalf("read handshake: %v", err)
+			}
+			if !reflect.DeepEqual(tt.original, parsed) {
+				t.Fatalf("handshake mismatch: %+v != %+v", tt.original, parsed)
+			}
+		})
 	}
 }
 

--- a/transport/negotiation_integration_test.go
+++ b/transport/negotiation_integration_test.go
@@ -44,7 +44,13 @@ func handshakeRoundTrip(t transport.Interface, tname string) error {
 			done <- err
 			return
 		}
-		resp := common.Handshake{Version: common.ProtocolVersion}
+		if req.ALPN != "h2" || req.TLSVersion != "1.3" {
+			// Expect ALPN "h2" and TLS version "1.3" from the client handshake
+			conn.Close()
+			done <- fmt.Errorf("unexpected request: %+v", req)
+			return
+		}
+		resp := common.Handshake{Version: common.ProtocolVersion, ALPN: req.ALPN, TLSVersion: req.TLSVersion}
 		resp.Transport = common.SelectBest([]string{tname}, req.Transports)
 		resp.Compress = common.SelectBest([]string{"zstd", "lz4"}, req.Compressors)
 		resp.Digest = common.SelectBest([]string{"blake3", "sha256"}, req.Digests)
@@ -63,6 +69,8 @@ func handshakeRoundTrip(t transport.Interface, tname string) error {
 	}
 	req := common.Handshake{
 		Version:     common.ProtocolVersion,
+		ALPN:        "h2",  // expect server to echo ALPN "h2"
+		TLSVersion:  "1.3", // expect server to echo TLS version "1.3"
 		Transports:  []string{"h2", "quic", "tcp+tls", "ssh"},
 		Compressors: []string{"lz4", "zstd"},
 		Digests:     []string{"sha256", "blake3"},
@@ -74,7 +82,7 @@ func handshakeRoundTrip(t transport.Interface, tname string) error {
 	if err != nil {
 		return err
 	}
-	if resp.Transport != tname || resp.Compress != "zstd" || resp.Digest != "blake3" {
+	if resp.Transport != tname || resp.Compress != "zstd" || resp.Digest != "blake3" || resp.ALPN != "h2" || resp.TLSVersion != "1.3" {
 		return fmt.Errorf("unexpected response: %+v", resp)
 	}
 	conn.Close()


### PR DESCRIPTION
## Summary
- add ALPN and TLSVersion to handshake round-trip tests
- assert ALPN and TLSVersion are preserved across transport negotiation
- document expected ALPN/TLS values in test comments

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f91560ae883238bebf854deb3bed0