### PR TITLE
feat: allow custom LVM privilege escalation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: add manifest index persistence test covering read/write, rebuild, and verify paths.
 - cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 - transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.
+- device: allow configurable LVM privilege escalation command.
 
 
 ### Fixed

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -26,7 +26,7 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	}
 	destDevice := args[0]
 	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(context.Background(), destDevice, true, cfg.DestType, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
+		if dev, err := device.Detect(context.Background(), destDevice, true, cfg.DestType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -140,7 +140,7 @@ func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, l
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
 	destType := cfg.DestType
 	if destType == "auto" {
-		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
+		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -189,7 +189,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	)
 
 	if cfg.SourceType == "" || cfg.SourceType == "auto" {
-		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
+		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
 		if err != nil {
 			return err
 		}

--- a/device/detect.go
+++ b/device/detect.go
@@ -18,7 +18,7 @@ import (
 // logical volumes or raw devices based on LVM metadata. When typeHint is not
 // empty or "auto", Detect will attempt to open the device using the explicit
 // type and will not perform auto detection.
-func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
+func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCmd, fsThawCmd, lvmEscalation string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		if logger != nil {
@@ -56,7 +56,7 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			}
 			cache := lvm.NewDeviceFDCache(logger)
 			defer cache.Close()
-			dev, err := OpenLVM(resolved, cache, logger)
+			dev, err := OpenLVM(resolved, cache, lvmEscalation, logger)
 			if err != nil {
 				if logger != nil {
 					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
@@ -119,7 +119,7 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 		if _, err := lvm.GetVolumeGroupName(resolved); err == nil {
 			cache := lvm.NewDeviceFDCache(logger)
 			defer cache.Close()
-			dev, err := OpenLVM(resolved, cache, logger)
+			dev, err := OpenLVM(resolved, cache, lvmEscalation, logger)
 			if err != nil {
 				if logger != nil {
 					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -42,7 +42,7 @@ func TestDetectFile(t *testing.T) {
 	f.Close()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), f.Name(), true, "", "", "", 0, 0, logger)
+	dev, err := Detect(context.Background(), f.Name(), true, "", "", "", "", 0, 0, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestDetectRaw(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), loop, true, "", "", "", 0, 0, logger)
+	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(context.Background(), lvPath, true, "", "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), lvPath, true, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -23,12 +23,13 @@ type LVMDevice struct {
 	size        uint64
 	blockSize   uint64
 	cleanupPath string
+	escalation  string
 	logger      *zap.Logger
 }
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
 // Size information is obtained through the lvm package helpers.
-func OpenLVM(path string, cache *lvm.FDCache, logger *zap.Logger) (*LVMDevice, error) {
+func OpenLVM(path string, cache *lvm.FDCache, escalation string, logger *zap.Logger) (*LVMDevice, error) {
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -43,7 +44,7 @@ func OpenLVM(path string, cache *lvm.FDCache, logger *zap.Logger) (*LVMDevice, e
 		f.Close()
 		return nil, err
 	}
-	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs), logger: logger}, nil
+	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs), escalation: escalation, logger: logger}, nil
 }
 
 // Path returns the underlying device path.
@@ -70,12 +71,16 @@ var (
 	openLVMFunc      = OpenLVM
 )
 
-func runLVM(ctx context.Context, name string, args ...string) error {
+func runLVM(ctx context.Context, escalation, cmdName string, args ...string) error {
 	if geteuid() != 0 {
-		args = append([]string{"-n", name}, args...)
-		name = "sudo"
+		parts := strings.Fields(escalation)
+		if len(parts) > 0 {
+			lvmCmd := cmdName
+			cmdName = parts[0]
+			args = append(parts[1:], append([]string{lvmCmd}, args...)...)
+		}
 	}
-	cmd := execCommand(ctx, name, args...)
+	cmd := execCommand(ctx, cmdName, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
@@ -91,19 +96,19 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 		return nil, err
 	}
 	snapName := generateSnapshot()
-	if err := runLVM(ctx, "lvcreate", "-s", "-n", snapName, "-L", snapshotSize, d.path); err != nil {
+	if err := runLVM(ctx, d.escalation, "lvcreate", "-s", "-n", snapName, "-L", snapshotSize, d.path); err != nil {
 		return nil, err
 	}
 	snapPath := lvm.GetSnapshotDevicePath(snapName, vg, d.logger)
-	if err := runLVM(ctx, "lvchange", "-ay", snapPath); err != nil {
-		_ = runLVM(ctx, "lvremove", "-f", snapPath)
+	if err := runLVM(ctx, d.escalation, "lvchange", "-ay", snapPath); err != nil {
+		_ = runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err
 	}
 	cache := lvm.NewDeviceFDCache(d.logger)
 	defer cache.Close()
-	snapDev, err := openLVMFunc(snapPath, cache, d.logger)
+	snapDev, err := openLVMFunc(snapPath, cache, d.escalation, d.logger)
 	if err != nil {
-		_ = runLVM(ctx, "lvremove", "-f", snapPath)
+		_ = runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err
 	}
 	snapDev.cleanupPath = snapPath
@@ -115,7 +120,7 @@ func (d *LVMDevice) Cleanup(ctx context.Context) error {
 	if d.cleanupPath == "" {
 		return nil
 	}
-	if err := runLVM(ctx, "lvremove", "-f", d.cleanupPath); err != nil {
+	if err := runLVM(ctx, d.escalation, "lvremove", "-f", d.cleanupPath); err != nil {
 		return err
 	}
 	d.cleanupPath = ""

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -15,7 +15,7 @@ import (
 type LVMDevice struct{}
 
 // OpenLVM returns an error on non-Linux systems.
-func OpenLVM(string, *lvm.FDCache, *zap.Logger) (*LVMDevice, error) {
+func OpenLVM(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 	return nil, fmt.Errorf("LVM devices are only supported on Linux")
 }
 

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -53,7 +53,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("raw cleanup: %v", err)
 	}
 
-	// LVM device snapshot creates and removes snapshots via sudo when non-root.
+	// LVM device snapshot creates and removes snapshots via a custom escalation command when non-root.
 	var cmds []string
 	origCmd := execCommand
 	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
@@ -67,8 +67,8 @@ func TestSnapshotLifecycle(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	origOpen := openLVMFunc
-	openLVMFunc = func(p string, _ *lvm.FDCache, _ *zap.Logger) (*LVMDevice, error) {
-		return &LVMDevice{path: p, cleanupPath: p, logger: zap.NewNop()}, nil
+	openLVMFunc = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop()}, nil
 	}
 	defer func() { openLVMFunc = origOpen }()
 
@@ -76,7 +76,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	geteuid = func() int { return 1 }
 	defer func() { geteuid = origEuid }()
 
-	lvd := &LVMDevice{path: "/dev/vg0/origin", logger: zap.NewNop()}
+	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop()}
 	snap, err := lvd.Snapshot(ctx, "2G")
 	if err != nil {
 		t.Fatalf("lvm snapshot: %v", err)
@@ -89,9 +89,9 @@ func TestSnapshotLifecycle(t *testing.T) {
 	}
 
 	want := []string{
-		"sudo -n lvcreate -s -n snap -L 2G /dev/vg0/origin",
-		"sudo -n lvchange -ay /dev/vg0/snap",
-		"sudo -n lvremove -f /dev/vg0/snap",
+		"doas -n lvcreate -s -n snap -L 2G /dev/vg0/origin",
+		"doas -n lvchange -ay /dev/vg0/snap",
+		"doas -n lvremove -f /dev/vg0/snap",
 	}
 	if !reflect.DeepEqual(cmds, want) {
 		t.Fatalf("commands = %v, want %v", cmds, want)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -48,7 +48,7 @@ type Index struct {
 var closeHook = func() {}
 
 var detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-	return device.Detect(ctx, path, true, "", "", "", 0, 0, logger)
+	return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.


### PR DESCRIPTION
## Summary
- allow `runLVM` to use a configurable escalation helper
- plumb `config.LVMEscalation` through device detection
- test LVM snapshots with custom escalation

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_689f913ac87c8323b793d1fcbdbaf2b3