### PR TITLE
refactor(transfer): add resume tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: give each writer an independent rate limiter
 - cmd/dump: handle context cancellation during pipe copies to avoid incomplete writes
 - rename dry run log field to `eta_seconds` and log durations in seconds
+- transfer: replace global checkpoint state with per-transfer resume trackers
 - cmd/dump: detect destination type locally without mutating configuration
 
 ## [v0.1.0] - 2025-02-27

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -39,7 +39,16 @@ func newDigestHasher(algo string) hash.Hash {
 	}
 }
 
-func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut *bufio.Writer, dedup DeduplicationStrategy, pipeFds [2]int, logger *zap.Logger) (int64, int, []byte, error) {
+func iterateBlocks(
+	cfg *config.Config,
+	ranges []Range,
+	srcFile *os.File,
+	bufOut *bufio.Writer,
+	dedup DeduplicationStrategy,
+	pipeFds [2]int,
+	logger *zap.Logger,
+	rt *resumeTracker,
+) (int64, int, []byte, error) {
 	var totalBytes int64
 	skippedBlocks := 0
 	var header [12]byte
@@ -94,7 +103,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 				return totalBytes, skippedBlocks, nil, fmt.Errorf("failed to write header: %w", err)
 			}
 			zh := zeroHash(int(blockSize))
-			saveResumeState(cfg, r.Start, zh, int64(blockSize), logger)
+			saveResumeState(cfg, rt, r.Start, zh, int64(blockSize), logger)
 			if idx != nil {
 				if err := idx.Set(r.Start, blockSize, xx, zh); err != nil {
 					putBlockBuffer(data)
@@ -123,7 +132,7 @@ func iterateBlocks(cfg *config.Config, ranges []Range, srcFile *os.File, bufOut 
 				return totalBytes, skippedBlocks, nil, fmt.Errorf("manifest set: %w", err)
 			}
 		}
-		saveResumeState(cfg, r.Start, sum, int64(blockSize), logger)
+		saveResumeState(cfg, rt, r.Start, sum, int64(blockSize), logger)
 
 		putBlockBuffer(data)
 
@@ -162,6 +171,7 @@ func processParallelResults(
 	totalDataSize int64,
 	startTime time.Time,
 	logger *zap.Logger,
+	rt *resumeTracker,
 ) (int64, []byte, error) {
 	headerSize := 12
 	if cfg.VerifyChecksum {
@@ -207,7 +217,7 @@ func processParallelResults(
 					return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
 				}
 			}
-			saveResumeState(cfg, res.Offset, res.ChunkID, int64(res.Size), logger)
+			saveResumeState(cfg, rt, res.Offset, res.ChunkID, int64(res.Size), logger)
 			putBlockBuffer(res.Data)
 		} else {
 			if idx != nil {
@@ -216,7 +226,7 @@ func processParallelResults(
 					return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
 				}
 			}
-			saveResumeState(cfg, res.Offset, res.ChunkID, 0, logger)
+			saveResumeState(cfg, rt, res.Offset, res.ChunkID, 0, logger)
 		}
 
 		totalBytesTransferred += int64(res.Size)

--- a/transfer/digest_verification_test.go
+++ b/transfer/digest_verification_test.go
@@ -33,7 +33,7 @@ func TestIterateBlocksFinalSHA(t *testing.T) {
 		t.Fatalf("compression writer: %v", err)
 	}
 	bufOut := bufio.NewWriter(w)
-	_, _, digest, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, logger)
+	_, _, digest, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, logger, nil)
 	if err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -263,12 +263,12 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 	if startIdx > 0 {
 		ranges = ranges[startIdx:]
 	}
-	if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, tt.Logger); err != nil {
+	if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}
 	finalizeProgress(cfg, tt.Logger)
 	cleanupOutput(bufOut, compWriter, tt.Logger)
-	finalizeResumeState(cfg, tt.Logger)
+	finalizeResumeState(cfg, tt.Tracker, tt.Logger)
 	srcFile.Close()
 	conn.Close()
 	if err := <-done; err != nil {
@@ -534,13 +534,13 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 				ranges = ranges[startIdx:]
 			}
 			dedup, cleanup := tt.setupDedup(cfg)
-			if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger); err != nil {
+			if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
 				t.Fatalf("iterateBlocks: %v", err)
 			}
 			cleanup()
 			finalizeProgress(cfg, tt.Logger)
 			cleanupOutput(bufOut, compWriter, tt.Logger)
-			finalizeResumeState(cfg, tt.Logger)
+			finalizeResumeState(cfg, tt.Tracker, tt.Logger)
 			srcFile.Close()
 			conn.Close()
 			if err := <-done; err != nil {
@@ -708,13 +708,13 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 				ranges = ranges[startIdx:]
 			}
 			dedup, cleanup := tt.setupDedup(cfg)
-			if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger); err != nil {
+			if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
 				t.Fatalf("iterateBlocks: %v", err)
 			}
 			cleanup()
 			finalizeProgress(cfg, tt.Logger)
 			cleanupOutput(bufOut, compWriter, tt.Logger)
-			finalizeResumeState(cfg, tt.Logger)
+			finalizeResumeState(cfg, tt.Tracker, tt.Logger)
 			srcFile.Close()
 			conn.Close()
 			if err := <-done; err != nil {

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -54,7 +54,7 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 	cfg := &config.Config{BlockSize: 4096, ChecksumAlgorithm: "sha256", ManifestPath: manPath, MaxRetries: 1}
 	ranges := []Range{{Start: 0, End: 4096}, {Start: 4096, End: 8192}}
 	buf := bufio.NewWriter(bytes.NewBuffer(nil))
-	total, skipped, _, err := iterateBlocks(cfg, ranges, src, buf, nil, [2]int{-1, -1}, zap.NewNop())
+	total, skipped, _, err := iterateBlocks(cfg, ranges, src, buf, nil, [2]int{-1, -1}, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -36,6 +36,7 @@ func TestResumeCDCOffset(t *testing.T) {
 
 func TestResumeCDCSequential(t *testing.T) {
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	tr.Tracker = &resumeTracker{}
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
 
@@ -48,7 +49,7 @@ func TestResumeCDCSequential(t *testing.T) {
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
-	finalizeResumeState(cfg, zap.NewNop())
+	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
 
 	offsets := parseOffsets(t, buf.Bytes(), blockSize)
 	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })

--- a/transfer/resume_checksum_test.go
+++ b/transfer/resume_checksum_test.go
@@ -30,7 +30,7 @@ func TestResumeFinalChecksum(t *testing.T) {
 	checkpoint := readResumeState(cfg, logger)
 	start := findResumeIndex(cfg, srcFile, ranges, checkpoint, logger)
 	w := bufio.NewWriter(io.Discard)
-	_, _, digest, err := iterateBlocks(cfg, ranges[start:], srcFile, w, nil, [2]int{-1, -1}, logger)
+	_, _, digest, err := iterateBlocks(cfg, ranges[start:], srcFile, w, nil, [2]int{-1, -1}, logger, nil)
 	if err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -36,6 +36,7 @@ func TestResumeHybridOffset(t *testing.T) {
 
 func TestResumeHybridSequential(t *testing.T) {
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	tr.Tracker = &resumeTracker{}
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
 
@@ -48,7 +49,7 @@ func TestResumeHybridSequential(t *testing.T) {
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
-	finalizeResumeState(cfg, zap.NewNop())
+	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
 
 	offsets := parseOffsets(t, buf.Bytes(), blockSize)
 	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -30,17 +29,14 @@ type resumeCheckpoint struct {
 	Length uint32
 }
 
-// stateManager encapsulates checkpoint tracking independent of dedup mode.
-type stateManager struct {
-	mu     sync.Mutex
+// resumeTracker tracks checkpoint progress for an ongoing transfer.
+type resumeTracker struct {
 	bytes  int64
 	last   time.Time
 	chunk  [32]byte
 	offset uint64
 	length uint32
 }
-
-var checkpointState stateManager
 
 func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offset uint64, length uint32, chunk [32]byte) {
 	rs := resumeState{
@@ -66,34 +62,30 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offse
 	}
 }
 
-func saveResumeState(cfg *config.Config, offset uint64, chunk [32]byte, size int64, logger *zap.Logger) {
-	if cfg.ResumeState == "" {
+func saveResumeState(cfg *config.Config, rt *resumeTracker, offset uint64, chunk [32]byte, size int64, logger *zap.Logger) {
+	if cfg.ResumeState == "" || rt == nil {
 		return
 	}
-	checkpointState.mu.Lock()
-	defer checkpointState.mu.Unlock()
-	if checkpointState.last.IsZero() {
-		checkpointState.last = time.Now()
+	if rt.last.IsZero() {
+		rt.last = time.Now()
 	}
-	checkpointState.bytes += size
-	checkpointState.chunk = chunk
-	checkpointState.offset = offset
-	checkpointState.length = uint32(size)
-	if (cfg.CheckpointBytes > 0 && checkpointState.bytes >= int64(cfg.CheckpointBytes)) ||
-		(cfg.CheckpointInterval > 0 && time.Since(checkpointState.last) >= cfg.CheckpointInterval) {
-		writeResumeState(cfg, logger, cfg.ResumeState, checkpointState.offset, checkpointState.length, checkpointState.chunk)
-		checkpointState.bytes = 0
-		checkpointState.last = time.Now()
+	rt.bytes += size
+	rt.chunk = chunk
+	rt.offset = offset
+	rt.length = uint32(size)
+	if (cfg.CheckpointBytes > 0 && rt.bytes >= int64(cfg.CheckpointBytes)) ||
+		(cfg.CheckpointInterval > 0 && time.Since(rt.last) >= cfg.CheckpointInterval) {
+		writeResumeState(cfg, logger, cfg.ResumeState, rt.offset, rt.length, rt.chunk)
+		rt.bytes = 0
+		rt.last = time.Now()
 	}
 }
 
-func finalizeResumeState(cfg *config.Config, logger *zap.Logger) {
-	if cfg.ResumeState == "" {
+func finalizeResumeState(cfg *config.Config, rt *resumeTracker, logger *zap.Logger) {
+	if cfg.ResumeState == "" || rt == nil {
 		return
 	}
-	checkpointState.mu.Lock()
-	defer checkpointState.mu.Unlock()
-	if checkpointState.last.IsZero() {
+	if rt.last.IsZero() {
 		return
 	}
 	if err := os.Remove(cfg.ResumeState); err != nil && !os.IsNotExist(err) {
@@ -101,8 +93,8 @@ func finalizeResumeState(cfg *config.Config, logger *zap.Logger) {
 			logger.Warn("Failed to remove resume state", zap.Error(err))
 		}
 	}
-	checkpointState.bytes = 0
-	checkpointState.last = time.Time{}
+	rt.bytes = 0
+	rt.last = time.Time{}
 }
 
 func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -74,6 +74,7 @@ func parseOffsets(t *testing.T, data []byte, blockSize int64) []int64 {
 
 func TestResumeSequential(t *testing.T) {
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	tr.Tracker = &resumeTracker{}
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
 
@@ -83,7 +84,7 @@ func TestResumeSequential(t *testing.T) {
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
-	finalizeResumeState(cfg, zap.NewNop())
+	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
 
 	offsets := parseOffsets(t, buf.Bytes(), blockSize)
 	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
@@ -98,6 +99,7 @@ func TestResumeSequential(t *testing.T) {
 
 func TestResumeParallel(t *testing.T) {
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	tr.Tracker = &resumeTracker{}
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
 
@@ -107,7 +109,7 @@ func TestResumeParallel(t *testing.T) {
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
-	finalizeResumeState(cfg, zap.NewNop())
+	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
 
 	offsets := parseOffsets(t, buf.Bytes(), blockSize)
 	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -18,6 +18,7 @@ import (
 type Transfer struct {
 	Logger   *zap.Logger
 	workerWG *sync.WaitGroup
+	Tracker  *resumeTracker
 }
 
 // NewTransfer creates a Transfer with the provided logger and wait group.
@@ -26,7 +27,7 @@ func NewTransfer(logger *zap.Logger, wg *sync.WaitGroup) *Transfer {
 	if wg == nil {
 		wg = &sync.WaitGroup{}
 	}
-	return &Transfer{Logger: logger, workerWG: wg}
+	return &Transfer{Logger: logger, workerWG: wg, Tracker: &resumeTracker{}}
 }
 
 // ChecksumState stores block checksums and the algorithm used for deduplication.
@@ -120,14 +121,14 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	var totalBytesTransferred int64
 	var skippedBlocks int
 	var finalDigest []byte
-	totalBytesTransferred, skippedBlocks, finalDigest, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds, t.Logger)
+	totalBytesTransferred, skippedBlocks, finalDigest, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds, t.Logger, t.Tracker)
 	if err != nil {
 		return err
 	}
 	finalizeProgress(cfg, t.Logger)
 
 	logSequentialSummary(t.Logger, totalBytesTransferred, skippedBlocks, startTime)
-	finalizeResumeState(cfg, t.Logger)
+	finalizeResumeState(cfg, t.Tracker, t.Logger)
 	if len(finalDigest) > 0 && t.Logger != nil {
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -22,7 +22,7 @@ func TestIterateBlocksOffsetOverflow(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: 4096}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop())
+	_, _, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop(), nil)
 	if err == nil || !strings.Contains(err.Error(), "offset") {
 		t.Fatalf("expected offset error, got %v", err)
 	}
@@ -34,7 +34,7 @@ func TestIterateBlocksOversizedBlockSize(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(math.MaxUint32) + 1}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop())
+	_, _, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop(), nil)
 	if err == nil || !strings.Contains(err.Error(), "block size") {
 		t.Fatalf("expected block size error, got %v", err)
 	}
@@ -43,7 +43,8 @@ func TestIterateBlocksOversizedBlockSize(t *testing.T) {
 func TestSaveResumeStatePermissions(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{ResumeState: filepath.Join(dir, "resume"), CheckpointBytes: 1}
-	saveResumeState(cfg, 0, [32]byte{}, 1, zap.NewNop())
+	rt := &resumeTracker{}
+	saveResumeState(cfg, rt, 0, [32]byte{}, 1, zap.NewNop())
 
 	info, err := os.Stat(cfg.ResumeState)
 	if err != nil {

--- a/transfer/worker.go
+++ b/transfer/worker.go
@@ -171,13 +171,13 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	var totalBytesTransferred int64
 	var finalDigest []byte
-	totalBytesTransferred, finalDigest, err = processParallelResults(cfg, results, bufOut, checksum, totalDataSize, startTime, t.Logger)
+	totalBytesTransferred, finalDigest, err = processParallelResults(cfg, results, bufOut, checksum, totalDataSize, startTime, t.Logger, t.Tracker)
 	if err != nil {
 		return err
 	}
 	finalizeProgress(cfg, t.Logger)
 	logParallelSummary(t.Logger, totalBytesTransferred, startTime)
-	finalizeResumeState(cfg, t.Logger)
+	finalizeResumeState(cfg, t.Tracker, t.Logger)
 	if len(finalDigest) > 0 && t.Logger != nil {
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}


### PR DESCRIPTION
## Summary
- track resume checkpoints with a per-transfer tracker
- remove global state and wire tracker through transfer pipeline
- update resume tests to construct trackers explicitly

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f913f906883239471d1f21425f705