### PR TITLE
fix(cmd): log sync errors in manifest and verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmd/dump: handle context cancellation during pipe copies to avoid incomplete writes
 - rename dry run log field to `eta_seconds` and log durations in seconds
 - cmd/dump: detect destination type locally without mutating configuration
+- log sync errors in manifest and verify commands
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -8,14 +8,19 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/config"
 	manifestpkg "lvmsync_go/manifest"
 )
 
+func init() {
+	rootcmd.RunManifest = Run
+}
+
 // Run executes manifest subcommands. Currently only "rebuild" is supported.
 func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if logger != nil {
-		defer logger.Sync()
+		defer rootcmd.SyncLogger(logger)
 	}
 	if len(args) == 0 || args[0] != "rebuild" {
 		fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -2,16 +2,29 @@ package manifest
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/config"
 	"lvmsync_go/device"
 )
+
+type syncTrackerCore struct {
+	zapcore.Core
+	syncs *int
+}
+
+func (s syncTrackerCore) Sync() error {
+	*s.syncs++
+	_ = s.Core.Sync()
+	return fmt.Errorf("sync error")
+}
 
 func TestRunDefaultOutputPath(t *testing.T) {
 	dir := t.TempDir()
@@ -124,5 +137,32 @@ func TestRunMissingArgs(t *testing.T) {
 				t.Fatalf("expected failure for args %v", tc.args)
 			}
 		})
+	}
+}
+
+func TestRunSyncsLogger(t *testing.T) {
+	dir := t.TempDir()
+	devicePath := filepath.Join(dir, "dev.img")
+	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.DryRun = true
+
+	var syncs int
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(syncTrackerCore{Core: core, syncs: &syncs})
+	if err := Run(cfg, []string{"rebuild", devicePath}, logger); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if syncs != 1 {
+		t.Fatalf("expected logger.Sync called once, got %d", syncs)
+	}
+	if logs.FilterMessage("Logger sync error").Len() != 1 {
+		t.Fatalf("expected sync error log")
 	}
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -12,8 +12,6 @@ import (
 	"lvmsync_go/app"
 	applycmd "lvmsync_go/cmd/apply"
 	dumpcmd "lvmsync_go/cmd/dump"
-	manifestcmd "lvmsync_go/cmd/manifest"
-	verifycmd "lvmsync_go/cmd/verify"
 	"lvmsync_go/config"
 	"lvmsync_go/device"
 	clientpkg "lvmsync_go/internal/client"
@@ -31,6 +29,12 @@ var (
 	runDump           = func(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) error {
 		_, err := dumpcmd.Run(ctx, cfg, snapshot, dest, logger)
 		return err
+	}
+	RunManifest = func(cfg *config.Config, args []string, logger *zap.Logger) error {
+		return fmt.Errorf("manifest command not registered")
+	}
+	RunVerify = func(args []string, logger *zap.Logger) error {
+		return fmt.Errorf("verify command not registered")
 	}
 )
 
@@ -130,9 +134,9 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if len(args) > 0 {
 		switch args[0] {
 		case "manifest":
-			return manifestcmd.Run(cfg, args[1:], logger)
+			return RunManifest(cfg, args[1:], logger)
 		case "verify":
-			return verifycmd.Run(args[1:], logger)
+			return RunVerify(args[1:], logger)
 		}
 	}
 

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -11,10 +11,15 @@ import (
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/config"
 	"lvmsync_go/manifest"
 	"lvmsync_go/transfer"
 )
+
+func init() {
+	rootcmd.RunVerify = Run
+}
 
 // Run executes the verify command with the provided arguments and logger.
 // Args should exclude the "verify" subcommand itself.
@@ -22,7 +27,7 @@ func Run(args []string, logger *zap.Logger) error {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	defer logger.Sync()
+	defer rootcmd.SyncLogger(logger)
 	cmd := &cobra.Command{
 		Use:                "verify [flags] <source> <dest>",
 		Short:              "Verify that source and destination contain identical data",

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +23,8 @@ type syncTrackerCore struct {
 
 func (s syncTrackerCore) Sync() error {
 	*s.syncs++
-	return s.Core.Sync()
+	_ = s.Core.Sync()
+	return fmt.Errorf("sync error")
 }
 
 func createTestFile(t testing.TB, size int) string {
@@ -47,13 +49,16 @@ func TestRunSyncsLogger(t *testing.T) {
 		t.Fatalf("write src: %v", err)
 	}
 	var syncs int
-	core, _ := observer.New(zap.InfoLevel)
+	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(syncTrackerCore{Core: core, syncs: &syncs})
 	if err := Run([]string{"--dry-run", src, "dst"}, logger); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if syncs != 1 {
 		t.Fatalf("expected logger.Sync called once, got %d", syncs)
+	}
+	if logs.FilterMessage("Logger sync error").Len() != 1 {
+		t.Fatalf("expected sync error log")
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure manifest rebuild and verify commands log sync failures
- register manifest and verify subcommands with root
- test logger sync error handling

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRateLimitedWritersIndependent)*
- `go test -run TestRateLimitedWritersIndependent ./transfer`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`
- `go test ./cmd/manifest ./cmd/verify`


------
https://chatgpt.com/codex/tasks/task_e_689f9142a6a48323bc8fa516b0a3ad3d