### PR TITLE
fix: return manifest index close errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmd/dump: handle context cancellation during pipe copies to avoid incomplete writes
 - rename dry run log field to `eta_seconds` and log durations in seconds
 - cmd/dump: detect destination type locally without mutating configuration
+- manifest: propagate close errors when rebuilding indexes
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -45,7 +45,7 @@ type Index struct {
 	hdr  Header
 }
 
-var closeHook = func() {}
+var closeHook = func() error { return nil }
 
 var detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
 	return device.Detect(ctx, path, true, "", "", "", 0, 0, logger)
@@ -102,19 +102,25 @@ func (i *Index) readHeader() error {
 
 // Close flushes the mmap and closes the underlying file.
 func (i *Index) Close() error {
-	defer closeHook()
+	var err error
 	if i.data != nil {
-		if err := unix.Msync(i.data, unix.MS_SYNC); err != nil {
+		if err = unix.Msync(i.data, unix.MS_SYNC); err != nil {
 			_ = unix.Munmap(i.data)
 			_ = i.f.Close()
+			_ = closeHook()
 			return err
 		}
 		_ = unix.Munmap(i.data)
 	}
 	if i.f != nil {
-		return i.f.Close()
+		if ferr := i.f.Close(); ferr != nil {
+			err = ferr
+		}
 	}
-	return nil
+	if hookErr := closeHook(); err == nil && hookErr != nil {
+		err = hookErr
+	}
+	return err
 }
 
 // Create initializes a new manifest index at path for the given device.
@@ -278,8 +284,8 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
 // The operation respects cancellation via ctx.
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) error {
-	if err := ctx.Err(); err != nil {
+func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) (err error) {
+	if err = ctx.Err(); err != nil {
 		return err
 	}
 	mounted, err := device.IsMountedRW(devicePath)
@@ -289,43 +295,50 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	if mounted && !allowMounted {
 		return fmt.Errorf("manifest: %s is mounted read-write; use --manifest-allow-mounted to override", devicePath)
 	}
-	dev, err := detectDevice(ctx, devicePath, logger)
+	var dev device.Device
+	dev, err = detectDevice(ctx, devicePath, logger)
 	if err != nil {
 		return err
 	}
 	defer dev.Close()
 	blockSize := uint32(dev.BlockSize())
 	size := dev.SizeBytes()
-	if err := ctx.Err(); err != nil {
+	if err = ctx.Err(); err != nil {
 		return err
 	}
 	id, err := device.GetUUID(ctx, dev.Path())
 	if err != nil {
 		return err
 	}
-	if err := ctx.Err(); err != nil {
+	if err = ctx.Err(); err != nil {
 		return err
 	}
-	f, err := os.Open(dev.Path())
+	var f *os.File
+	f, err = os.Open(dev.Path())
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	idx, err := Create(output, id, size, blockSize)
+	var idx *Index
+	idx, err = Create(output, id, size, blockSize)
 	if err != nil {
 		return err
 	}
-	defer idx.Close()
+	defer func() {
+		if cerr := idx.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 	start := time.Now()
 	lastLog := start
 	buf := make([]byte, blockSize)
 	for off := uint64(0); off < size; off += uint64(blockSize) {
-		if err := ctx.Err(); err != nil {
+		if err = ctx.Err(); err != nil {
 			return err
 		}
-		n, err := f.ReadAt(buf, int64(off))
-		if err != nil && err != io.EOF {
-			return err
+		n, readErr := f.ReadAt(buf, int64(off))
+		if readErr != nil && readErr != io.EOF {
+			return readErr
 		}
 		if n == 0 {
 			break
@@ -333,11 +346,11 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 		data := buf[:n]
 		xx := xxh3.Hash(data)
 		b3 := blake3.Sum256(data)
-		if err := idx.Set(off, uint32(n), xx, b3); err != nil {
+		if err = idx.Set(off, uint32(n), xx, b3); err != nil {
 			return err
 		}
 		if logger != nil && (progressInterval == 0 || time.Since(lastLog) >= progressInterval) {
-			if err := ctx.Err(); err != nil {
+			if err = ctx.Err(); err != nil {
 				return err
 			}
 			logger.Info("rebuild progress",
@@ -346,7 +359,7 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 			)
 			lastLog = time.Now()
 		}
-		if err == io.EOF {
+		if readErr == io.EOF {
 			break
 		}
 	}
@@ -356,5 +369,5 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 		)
 	}
-	return nil
+	return err
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -282,7 +282,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 	manPath := filepath.Join(dir, "closeonce.man")
 	prevHook := closeHook
 	count := 0
-	closeHook = func() { count++ }
+	closeHook = func() error { count++; return nil }
 	defer func() { closeHook = prevHook }()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -291,6 +291,33 @@ func TestRebuildCloseOnce(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected close called once, got %d", count)
+	}
+}
+
+func TestRebuildCloseError(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	data := make([]byte, 4096)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	manPath := filepath.Join(dir, "closeerr.man")
+	prevHook := closeHook
+	closeHook = func() error { return errors.New("close fail") }
+	defer func() { closeHook = prevHook }()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false); err == nil || !strings.Contains(err.Error(), "close fail") {
+		t.Fatalf("expected close error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- propagate errors from `Index.Close` in `manifest.Rebuild`
- test `Rebuild` error propagation using a failing close hook
- document fix in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f91592c188323895cef88a939002c