### PR TITLE
test(manifest): ensure zero timeout uses background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manifest: add `manifest_timeout` option to control rebuild timeout.
 - device: allow configurable LVM privilege escalation command.
 - tests: verify ALPN and TLS version round-trip in handshake and transport negotiation.
+- manifest: test zero `manifest_timeout` uses background context.
 - cmd/verify: add test ensuring mismatched blocks log `mismatched_block`.
 
 

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -163,20 +163,10 @@ func TestRunAppliesManifestTimeout(t *testing.T) {
 }
 
 func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
-
-func TestRunSyncsLogger(t *testing.T) {
-	dir := t.TempDir()
-	devicePath := filepath.Join(dir, "dev.img")
-	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write device: %v", err)
-	}
-
-
 	cfg, err := config.DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	orig := rebuildFn
@@ -190,6 +180,21 @@ func TestRunSyncsLogger(t *testing.T) {
 	}
 	if _, ok := captured.Deadline(); ok {
 		t.Fatalf("unexpected deadline on context")
+	}
+}
+
+func TestRunSyncsLogger(t *testing.T) {
+	dir := t.TempDir()
+	devicePath := filepath.Join(dir, "dev.img")
+	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+
 	cfg.DryRun = true
 
 	var syncs int


### PR DESCRIPTION
## Summary
- add test verifying Run uses context without deadline when manifest timeout is zero
- document test in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f976221f0832399acec2baca01e92