### PR TITLE
fix(device): log freeze/thaw command output on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - shorten h2 dial timeout to 5s and enforce it when no deadline is provided
 - ensure verify and lvmsync commands flush logs by deferring logger.Sync()
 - remove legacy dedup manifest in favor of manifest.Index
+- device: surface freeze/thaw command output when raw device operations fail
 - transfer: give each writer an independent rate limiter
 - cmd/dump: handle context cancellation during pipe copies to avoid incomplete writes
 - rename dry run log field to `eta_seconds` and log durations in seconds

--- a/device/raw.go
+++ b/device/raw.go
@@ -67,8 +67,11 @@ func OpenRaw(
 			freezeCtx, cancel = context.WithTimeout(ctx, d.freezeTimeout)
 			defer cancel()
 		}
-		if err = execCommand(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).Run(); err != nil {
-			return nil, fmt.Errorf("freeze command failed: %w", err)
+		out, cmdErr := execCommand(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).CombinedOutput()
+		if cmdErr != nil {
+			output := strings.TrimSpace(string(out))
+			d.logger.Error("fs freeze failed", zap.Error(cmdErr), zap.String("output", output))
+			return nil, fmt.Errorf("freeze command failed: %w: %s", cmdErr, output)
 		}
 		d.logger.Info("fs freeze complete")
 		d.freezeIssued = true
@@ -148,9 +151,11 @@ func (d *RawDevice) Cleanup(ctx context.Context) error {
 			thawCtx, cancel = context.WithTimeout(ctx, d.thawTimeout)
 			defer cancel()
 		}
-		if err := execCommand(thawCtx, d.thawCmdPath, d.thawCmdArgs...).Run(); err != nil {
-			d.logger.Error("fs thaw failed", zap.Error(err))
-			return fmt.Errorf("thaw command failed: %w", err)
+		out, cmdErr := execCommand(thawCtx, d.thawCmdPath, d.thawCmdArgs...).CombinedOutput()
+		if cmdErr != nil {
+			output := strings.TrimSpace(string(out))
+			d.logger.Error("fs thaw failed", zap.Error(cmdErr), zap.String("output", output))
+			return fmt.Errorf("thaw command failed: %w: %s", cmdErr, output)
 		}
 		d.logger.Info("fs thaw complete")
 	}

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -243,6 +244,49 @@ func TestOpenRawThawFailure(t *testing.T) {
 	}
 }
 
+func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	oldExec := execCommand
+	execCommand = fakeExecCommandContext
+	defer func() { execCommand = oldExec }()
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-fail-output"}, "true", nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
+		t.Fatalf("expected freeze output in error, got %v", err)
+	}
+	entries := logs.FilterMessage("fs freeze failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one freeze failed log, got %v", logs.All())
+	}
+	if v, ok := entries[0].ContextMap()["output"]; !ok || v != "freeze output" {
+		t.Fatalf("expected freeze output log, got %v", entries[0].ContextMap())
+	}
+}
+
+func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	oldExec := execCommand
+	execCommand = fakeExecCommandContext
+	defer func() { execCommand = oldExec }()
+	d := &RawDevice{
+		freezeIssued: true,
+		thawCmdPath:  os.Args[0],
+		thawCmdArgs:  []string{"thaw-fail-output"},
+		thawTimeout:  time.Second,
+		logger:       logger,
+	}
+	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "thaw output") {
+		t.Fatalf("expected thaw output in error, got %v", err)
+	}
+	entries := logs.FilterMessage("fs thaw failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one thaw failed log, got %v", logs.All())
+	}
+	if v, ok := entries[0].ContextMap()["output"]; !ok || v != "thaw output" {
+		t.Fatalf("expected thaw output log, got %v", entries[0].ContextMap())
+	}
+}
+
 func fakeExecCommandContext(ctx context.Context, _ string, args ...string) *exec.Cmd {
 	cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
 	cmd := exec.CommandContext(ctx, os.Args[0], cs...)
@@ -271,6 +315,12 @@ func TestHelperProcess(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 		os.Exit(0)
 	case "thaw-fail":
+		os.Exit(1)
+	case "freeze-fail-output":
+		fmt.Fprintln(os.Stderr, "freeze output")
+		os.Exit(1)
+	case "thaw-fail-output":
+		fmt.Fprintln(os.Stderr, "thaw output")
 		os.Exit(1)
 	default:
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- log fs-freeze and fs-thaw command output when they fail
- test that raw device freeze/thaw errors include command output

## Testing
- `go build ./... && echo build ok`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f914cc0e48323bff495a5a8b34817