### PR TITLE
test(tcp_tls): enforce dial timeout via context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -296,12 +296,23 @@ func TestTCPTLSDialUnreachable(t *testing.T) {
 		t.Fatalf("new transport: %v", err)
 	}
 	tr := trIface.(*Transport)
-	ctx := context.Background()
-	start := time.Now()
-	if _, err := tr.Dial(ctx, "203.0.113.1:1"); err == nil {
-		t.Fatalf("expected dial error")
-	} else if time.Since(start) > 5*time.Second {
-		t.Fatalf("dial took too long: %v", time.Since(start))
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		time.Sleep(2 * time.Second)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := tr.Dial(ctx, ln.Addr().String()); err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure unreachable dial times out via context deadline
- document tcp+tls unreachable dial test

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/manifest/rebuild_test.go:167:6: expected '(' found TestRunSyncsLogger)*
- `go test ./transport/tcp_tls -run TestTCPTLSDialUnreachable -count=1`
- `golangci-lint run`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689f97669bac8323b3e21c32e052b277