### PR TITLE
docs: document cdc ordering and logger defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tests: verify ALPN and TLS version round-trip in handshake and transport negotiation.
 - manifest: test zero `manifest_timeout` uses background context.
 - cmd/verify: add test ensuring mismatched blocks log `mismatched_block`.
+- README: document CDC parameter ordering and the error when violated.
+- README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ tooling to track transfer completion.
 - Use `zap` for all logging and avoid `fmt.Print*` or `log.*` calls.
 - Pass loggers explicitly to commands and helpers; `cmd/lvmsync.Execute` requires a
   `*zap.Logger` argument instead of relying on `zap.L()`.
+- All commands receive an explicit `*zap.Logger` and default to `zap.NewNop()` when no logger is supplied.
 - Log field keys in `snake_case` and include units where relevant (for example, `duration_ms`).
 - Provide raw byte values alongside human-readable sizes (for example, `block_size` and `block_size_bytes`).
 - Always defer `syncLogger(logger)` to flush buffers and log if the sync fails.
@@ -651,6 +652,9 @@ Hybrid dedup combines fixed-size and content-defined chunking. Enable it with `-
 | `--cdc-min`      | `LVMSYNC_CDC_MIN`    | `cdc_min`  | Minimum chunk size |
 | `--cdc-avg`      | `LVMSYNC_CDC_AVG`    | `cdc_avg`  | Target average chunk size |
 | `--cdc-max`      | `LVMSYNC_CDC_MAX`    | `cdc_max`  | Maximum chunk size |
+
+The three values must satisfy `--cdc-min ≤ --cdc-avg ≤ --cdc-max`. LVMSync aborts with
+`invalid local cdc ordering: min %d avg %d max %d` when the ordering is invalid.
 
 The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom_entries` and desired false positive rate via `--bloom_fp_rate`. For an mmap-backed index, `--bloom_mbits` controls the bitmap size in megabits.
 


### PR DESCRIPTION
## Summary
- document that `--cdc-min ≤ --cdc-avg ≤ --cdc-max` and note the error when violated
- state that commands take an explicit `*zap.Logger` defaulting to `zap.NewNop`

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRunSyncsLogger redeclared in cmd/manifest/rebuild_test.go)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_689f9b0f289c8323ba1d4b9ae3eda9e7