### PR TITLE
fix(dedup): validate chunker size parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes
+- dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports
 - propagate seek errors during block writes to prevent silent data loss
 - Remove obsolete gap and pruning entries after rerunning static analysis.

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -183,7 +183,7 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	}
 }
 
-func TestRunSyncsLogger(t *testing.T) {
+func TestRunSyncsLoggerDryRun(t *testing.T) {
 	dir := t.TempDir()
 	devicePath := filepath.Join(dir, "dev.img")
 	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {

--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -1,6 +1,7 @@
 package dedup
 
 import (
+	"fmt"
 	"io"
 	"math"
 
@@ -36,7 +37,15 @@ type Chunker struct {
 // NewChunker returns a new chunker configured with the provided
 // minimum, average, and maximum chunk sizes. All sizes are in bytes. The mask values are
 // derived from the average size.
-func NewChunker(minSize, avgSize, maxSize int) *Chunker {
+// The sizes must be positive and ordered such that minSize ≤ avgSize ≤ maxSize.
+func NewChunker(minSize, avgSize, maxSize int) (*Chunker, error) {
+	if minSize <= 0 || avgSize <= 0 || maxSize <= 0 {
+		return nil, fmt.Errorf("chunk sizes must be positive: min=%d avg=%d max=%d", minSize, avgSize, maxSize)
+	}
+	if minSize > avgSize || avgSize > maxSize {
+		return nil, fmt.Errorf("chunk sizes must satisfy min ≤ avg ≤ max: min=%d avg=%d max=%d", minSize, avgSize, maxSize)
+	}
+
 	c := &Chunker{Min: minSize, Avg: avgSize, Max: maxSize}
 	// derive masks for different entropy levels. The mask controls the
 	// probability of finding a boundary. Higher mask -> larger chunks.
@@ -51,12 +60,12 @@ func NewChunker(minSize, avgSize, maxSize int) *Chunker {
 		c.maskHigh = 0
 	}
 	c.maskLow = (1 << (bits + 2)) - 1 // large chunks
-	return c
+	return c, nil
 }
 
 // NewChunkerFromHandshake constructs a Chunker using CDC parameters negotiated
 // via a protocol handshake.
-func NewChunkerFromHandshake(h common.Handshake) *Chunker {
+func NewChunkerFromHandshake(h common.Handshake) (*Chunker, error) {
 	return NewChunker(h.CDCMin, h.CDCAvg, h.CDCMax)
 }
 
@@ -143,7 +152,10 @@ func (c *Chunker) selectMask(e float64) uint64 {
 // FastCDC chunks the entirety of r using the FastCDC algorithm with the
 // provided size targets. It returns all detected chunks.
 func FastCDC(r io.Reader, min, avg, max int) ([]Chunk, error) {
-	ch := NewChunker(min, avg, max)
+	ch, err := NewChunker(min, avg, max)
+	if err != nil {
+		return nil, err
+	}
 	var out []Chunk
 	var offset int64
 	for {

--- a/dedup/chunker_distribution_test.go
+++ b/dedup/chunker_distribution_test.go
@@ -14,7 +14,10 @@ func TestChunkSizeDistribution(t *testing.T) {
 		t.Fatalf("rand: %v", err)
 	}
 
-	ch := NewChunker(64, 128, 256)
+	ch, err := NewChunker(64, 128, 256)
+	if err != nil {
+		t.Fatalf("new chunker: %v", err)
+	}
 	r := bytes.NewReader(data)
 
 	var lengths []int

--- a/dedup/chunker_test.go
+++ b/dedup/chunker_test.go
@@ -12,7 +12,10 @@ func TestDeterministicBoundaries(t *testing.T) {
 	for i := range data {
 		data[i] = byte(i % 256)
 	}
-	ch := NewChunker(64, 128, 256)
+	ch, err := NewChunker(64, 128, 256)
+	if err != nil {
+		t.Fatalf("new chunker: %v", err)
+	}
 	r := bytes.NewReader(data)
 
 	var offsets []int
@@ -35,5 +38,34 @@ func TestDeterministicBoundaries(t *testing.T) {
 	expected := []int{0, 119, 216, 293, 375, 472, 549, 631, 728, 805, 887, 984}
 	if !reflect.DeepEqual(offsets, expected) {
 		t.Fatalf("offsets %v != expected %v", offsets, expected)
+	}
+}
+
+func TestNewChunkerValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		min, avg, max int
+		ok            bool
+	}{
+		{"valid", 64, 128, 256, true},
+		{"zero", 0, 128, 256, false},
+		{"negative", -1, 128, 256, false},
+		{"min>avg", 128, 64, 256, false},
+		{"avg>max", 64, 256, 128, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch, err := NewChunker(tt.min, tt.avg, tt.max)
+			if tt.ok {
+				if err != nil {
+					t.Fatalf("expected success got %v", err)
+				}
+				if ch == nil {
+					t.Fatalf("expected chunker, got nil")
+				}
+			} else if err == nil {
+				t.Fatalf("expected error for %v", tt)
+			}
+		})
 	}
 }

--- a/dedup/unit_test.go
+++ b/dedup/unit_test.go
@@ -51,7 +51,10 @@ func TestBloom(t *testing.T) {
 
 func TestChunkerBounds(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), 1<<20)
-	ch := NewChunker(64, 128, 256)
+	ch, err := NewChunker(64, 128, 256)
+	if err != nil {
+		t.Fatalf("new chunker: %v", err)
+	}
 	r := bytes.NewReader(data)
 	for {
 		c, err := ch.NextChunk(r)
@@ -96,7 +99,10 @@ func TestBloomSizing(t *testing.T) {
 
 func TestChunkerBufferReuse(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), 1<<10)
-	ch := NewChunker(64, 128, 256)
+	ch, err := NewChunker(64, 128, 256)
+	if err != nil {
+		t.Fatalf("new chunker: %v", err)
+	}
 	r := bytes.NewReader(data)
 
 	c1, err := ch.NextChunk(r)

--- a/transfer/dedup_cdc.go
+++ b/transfer/dedup_cdc.go
@@ -35,10 +35,14 @@ type CDCDedup struct {
 }
 
 // NewCDCDedup constructs a CDCDedup using the tunables provided in cfg.
-func NewCDCDedup(cfg *config.Config) *CDCDedup {
+func NewCDCDedup(cfg *config.Config) (*CDCDedup, error) {
 	bf := bloom.NewWithEstimates(uint(cfg.BloomEntries), cfg.BloomFpRate)
+	ch, err := dedup.NewChunker(cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax)
+	if err != nil {
+		return nil, err
+	}
 	cd := &CDCDedup{
-		chunker:   dedup.NewChunker(cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax),
+		chunker:   ch,
 		bloom:     bf,
 		stateFile: cfg.DedupStateFile,
 		sha:       sha256.New(),
@@ -61,7 +65,7 @@ func NewCDCDedup(cfg *config.Config) *CDCDedup {
 			}
 		}
 	}
-	return cd
+	return cd, nil
 }
 
 // ChunkAndHash splits p into FastCDC chunks recording hashes. The returned

--- a/transfer/dedup_cdc_test.go
+++ b/transfer/dedup_cdc_test.go
@@ -30,7 +30,10 @@ func TestCDCDedupChunkAndHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	d := NewCDCDedup(cfg)
+	d, err := NewCDCDedup(cfg)
+	if err != nil {
+		t.Fatalf("NewCDCDedup: %v", err)
+	}
 	data := bytes.Repeat([]byte("a"), cfg.CDCMin*2)
 	chunks, final, err := d.ChunkAndHash(data)
 	if err != nil {
@@ -66,7 +69,10 @@ func TestCDCDedupChunkBoundaries(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			d := NewCDCDedup(cfg)
+			d, err := NewCDCDedup(cfg)
+			if err != nil {
+				t.Fatalf("NewCDCDedup: %v", err)
+			}
 			data := bytes.Repeat([]byte("a"), tc.size)
 			chunks, _, err := d.ChunkAndHash(data)
 			if err != nil {
@@ -94,7 +100,10 @@ func TestCDCDedupSaveStateWriteFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	d := NewCDCDedup(cfg)
+	d, err := NewCDCDedup(cfg)
+	if err != nil {
+		t.Fatalf("NewCDCDedup: %v", err)
+	}
 	fw := &cdcFailingWriter{failAfter: 0}
 	orig := createStateFile
 	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
@@ -111,7 +120,10 @@ func TestCDCDedupMmapIndex(t *testing.T) {
 	}
 	cfg.BloomMBits = 8
 	cfg.DedupStateFile = filepath.Join(t.TempDir(), "state")
-	d := NewCDCDedup(cfg)
+	d, err := NewCDCDedup(cfg)
+	if err != nil {
+		t.Fatalf("NewCDCDedup: %v", err)
+	}
 	expected := 1 << (cfg.BloomMBits - 3)
 	if len(d.index) != expected {
 		t.Fatalf("unexpected index size %d want %d", len(d.index), expected)
@@ -124,7 +136,10 @@ func TestCDCDedupSaveState(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	cfg.DedupStateFile = filepath.Join(t.TempDir(), "state")
-	d := NewCDCDedup(cfg)
+	d, err := NewCDCDedup(cfg)
+	if err != nil {
+		t.Fatalf("NewCDCDedup: %v", err)
+	}
 	if err := d.SaveState(); err != nil {
 		t.Fatalf("SaveState: %v", err)
 	}


### PR DESCRIPTION
## Summary
- enforce positive, ordered chunker sizes and return validation errors
- propagate chunker constructor errors to CDC dedup helpers
- cover valid and invalid CDC size configurations in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: expected context deadline exceeded, got dial tcp 203.0.113.1:1: connect: network is unreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_689f9b0984788323acbd628080ee5a8f