### PR TITLE
test(device): cover thaw errors and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: refactor Dial into dialTLS, performH2Handshake, and logDialResult with unit tests.
 - transport: tests covering SelectBest handshake negotiation with custom CDC settings, resume tokens, and O_DIRECT for ssh, tcp+tls, h2, and quic transports.
 - device: add raw device freeze/thaw tests with exec command stubs
+- device: add cleanup tests for thaw errors and timeouts
 - transfer: add manifest index persistence test covering read/write, rebuild, and verify paths.
 - cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 - transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -287,6 +287,48 @@ func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
 	}
 }
 
+func TestRawDeviceCleanupThawErrorLogs(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	oldExec := execCommand
+	execCommand = fakeExecCommandContext
+	defer func() { execCommand = oldExec }()
+	d := &RawDevice{
+		freezeIssued: true,
+		thawCmdPath:  os.Args[0],
+		thawCmdArgs:  []string{"thaw-fail"},
+		thawTimeout:  time.Second,
+		logger:       logger,
+	}
+	if err := d.Cleanup(context.Background()); err == nil {
+		t.Fatalf("expected thaw command failure")
+	}
+	if logs.FilterMessage("fs thaw failed").Len() != 1 {
+		t.Fatalf("expected thaw failed log")
+	}
+}
+
+func TestRawDeviceCleanupThawTimeoutLogs(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	oldExec := execCommand
+	execCommand = fakeExecCommandContext
+	defer func() { execCommand = oldExec }()
+	d := &RawDevice{
+		freezeIssued: true,
+		thawCmdPath:  os.Args[0],
+		thawCmdArgs:  []string{"thaw-timeout"},
+		thawTimeout:  100 * time.Millisecond,
+		logger:       logger,
+	}
+	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "killed") {
+		t.Fatalf("expected thaw command to be killed, got %v", err)
+	}
+	if logs.FilterMessage("fs thaw failed").Len() != 1 {
+		t.Fatalf("expected thaw failed log")
+	}
+}
+
 func fakeExecCommandContext(ctx context.Context, _ string, args ...string) *exec.Cmd {
 	cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
 	cmd := exec.CommandContext(ctx, os.Args[0], cs...)
@@ -311,7 +353,7 @@ func TestHelperProcess(t *testing.T) {
 	switch args[0] {
 	case "freeze-success", "thaw-success":
 		os.Exit(0)
-	case "freeze-timeout":
+	case "freeze-timeout", "thaw-timeout":
 		time.Sleep(200 * time.Millisecond)
 		os.Exit(0)
 	case "thaw-fail":


### PR DESCRIPTION
## Summary
- add failing execCommand tests for raw device cleanup
- exercise thaw timeout handling and error logging

## Testing
- `go build ./...`
- `go test -short -coverprofile=coverage.out ./...` *(fails: TestRunSyncsLogger redeclared)*
- `go test ./device -run CleanupThaw -count=1`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f9b9264388323a706443c294492aa