### PR TITLE
fix(manifest): default to no-op logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manifest: propagate close errors when rebuilding indexes
 - log sync errors in manifest and verify commands
 - h2: ensure unreachable dial test uses context timeout and expects deadline exceeded
+- manifest: default rebuild command to a no-op logger and remove conditional logging checks
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -20,9 +20,10 @@ func init() {
 
 // Run executes manifest subcommands. Currently only "rebuild" is supported.
 func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
-	if logger != nil {
-		defer rootcmd.SyncLogger(logger)
+	if logger == nil {
+		logger = zap.NewNop()
 	}
+	defer rootcmd.SyncLogger(logger)
 	if len(args) == 0 || args[0] != "rebuild" {
 		fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)
 		fs.Usage()
@@ -43,13 +44,9 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if path == "" {
 		path = device + ".manifest"
 	}
-	if logger != nil {
-		logger.Info("rebuilding manifest", zap.String("device", device), zap.String("output", path))
-	}
+	logger.Info("rebuilding manifest", zap.String("device", device), zap.String("output", path))
 	if conf.DryRun {
-		if logger != nil {
-			logger.Info("dry run - skipping rebuild")
-		}
+		logger.Info("dry run - skipping rebuild")
 		return nil
 	}
 	ctx := context.Background()
@@ -59,13 +56,9 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 		defer cancel()
 	}
 	if err := rebuildFn(ctx, device, path, logger, conf.ManifestProgressInterval, conf.ManifestAllowMounted); err != nil {
-		if logger != nil {
-			logger.Error("rebuild failed", zap.Error(err))
-		}
+		logger.Error("rebuild failed", zap.Error(err))
 		return err
 	}
-	if logger != nil {
-		logger.Info("rebuild complete")
-	}
+	logger.Info("rebuild complete")
 	return nil
 }

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -133,7 +133,7 @@ func TestRunMissingArgs(t *testing.T) {
 					t.Fatalf("expected failure for args %v", tc.args)
 				}
 			}()
-			runErr = Run(cfg, tc.args, zap.NewNop())
+			runErr = Run(cfg, tc.args, nil)
 			if runErr == nil {
 				t.Fatalf("expected failure for args %v", tc.args)
 			}
@@ -154,7 +154,7 @@ func TestRunAppliesManifestTimeout(t *testing.T) {
 		return nil
 	}
 	defer func() { rebuildFn = orig }()
-	if err := Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
+	if err := Run(cfg, []string{"rebuild", "/dev/test"}, nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if _, ok := captured.Deadline(); !ok {
@@ -175,40 +175,12 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 		return nil
 	}
 	defer func() { rebuildFn = orig }()
-	if err := Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
+	if err := Run(cfg, []string{"rebuild", "/dev/test"}, nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if _, ok := captured.Deadline(); ok {
 		t.Fatalf("unexpected deadline on context")
 	}
-}
-
-func TestRunSyncsLogger(t *testing.T) {
-	dir := t.TempDir()
-	devicePath := filepath.Join(dir, "dev.img")
-	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write device: %v", err)
-	}
-
-	cfg, err := config.DefaultConfig()
-	if err != nil {
-		t.Fatalf("DefaultConfig: %v", err)
-	}
-	cfg.ManifestTimeout = 0
-	var captured context.Context
-	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool) error {
-		captured = ctx
-		return nil
-	}
-	defer func() { rebuildFn = orig }()
-	if err := Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-	if _, ok := captured.Deadline(); ok {
-		t.Fatalf("unexpected deadline on context")
-	}
-
 }
 
 func TestRunSyncsLogger(t *testing.T) {


### PR DESCRIPTION
## Summary
- default manifest rebuild logger to zap.NewNop when nil
- drop conditional logger checks and update tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f9b0afafc8323a687250f56577cd6