### PR TITLE
test(h2): cover tls and role string helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tests: verify ALPN and TLS version round-trip in handshake and transport negotiation.
 - manifest: test zero `manifest_timeout` uses background context.
 - cmd/verify: add test ensuring mismatched blocks log `mismatched_block`.
+- transport/h2: add tests for tlsVersionString and roleString helpers.
 
 
 ### Fixed

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -520,3 +520,37 @@ func TestH2NegotiateContextCancel(t *testing.T) {
 		t.Fatalf("negotiation did not fail promptly")
 	}
 }
+
+func TestTLSVersionString(t *testing.T) {
+	tests := []struct {
+		version uint16
+		want    string
+	}{
+		{tls.VersionTLS10, "1.0"},
+		{tls.VersionTLS11, "1.1"},
+		{tls.VersionTLS12, "1.2"},
+		{tls.VersionTLS13, "1.3"},
+		{0xffff, ""},
+	}
+	for _, tt := range tests {
+		if got := tlsVersionString(tt.version); got != tt.want {
+			t.Errorf("tlsVersionString(%#x) = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestRoleString(t *testing.T) {
+	tests := []struct {
+		role transport.Role
+		want string
+	}{
+		{transport.Client, "client"},
+		{transport.Server, "server"},
+		{transport.Role(99), ""},
+	}
+	for _, tt := range tests {
+		if got := roleString(tt.role); got != tt.want {
+			t.Errorf("roleString(%v) = %q, want %q", tt.role, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for `tlsVersionString`
- add table-driven tests for `roleString`
- document new tests in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: network is unreachable/i/o timeout in existing tests)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f9b0d374883239f367e3b6ff19a90