### PR TITLE
refactor(device): centralize exec command helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: refactor Dial into dialTLS, performH2Handshake, and logDialResult with unit tests.
 - transport: tests covering SelectBest handshake negotiation with custom CDC settings, resume tokens, and O_DIRECT for ssh, tcp+tls, h2, and quic transports.
 - device: add raw device freeze/thaw tests with exec command stubs
+- device: centralize exec command helper for LVM and raw devices
 - transfer: add manifest index persistence test covering read/write, rebuild, and verify paths.
 - cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 - transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.

--- a/device/exec.go
+++ b/device/exec.go
@@ -1,0 +1,8 @@
+//go:build linux
+
+package device
+
+import "os/exec"
+
+// execCommand is a helper for running external commands. It can be stubbed in tests.
+var execCommand = exec.CommandContext

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -65,7 +64,6 @@ func (d *LVMDevice) Close() error {
 }
 
 var (
-	execCommand      = exec.CommandContext
 	generateSnapshot = func() string { return fmt.Sprintf("lvmsync_%d", time.Now().UnixNano()) }
 	geteuid          = os.Geteuid
 	openLVMFunc      = OpenLVM

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -186,7 +186,7 @@ func TestOpenRawFreezeThawLogs(t *testing.T) {
 	logger := zap.New(core)
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
-	defer func() { execCommand = oldExec }()
+	t.Cleanup(func() { execCommand = oldExec })
 	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-success"}, os.Args[0], []string{"thaw-success"}, time.Second, time.Second, logger)
 	if err == nil {
 		t.Fatalf("expected error for char device")
@@ -204,7 +204,7 @@ func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 	logger := zap.New(core)
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
-	defer func() { execCommand = oldExec }()
+	t.Cleanup(func() { execCommand = oldExec })
 	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-timeout"}, os.Args[0], []string{"thaw-success"}, 50*time.Millisecond, time.Second, logger)
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze timeout, got %v", err)
@@ -225,7 +225,7 @@ func TestOpenRawThawFailure(t *testing.T) {
 	logger := zap.New(core)
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
-	defer func() { execCommand = oldExec }()
+	t.Cleanup(func() { execCommand = oldExec })
 	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-success"}, os.Args[0], []string{"thaw-fail"}, time.Second, time.Second, logger)
 	if err == nil {
 		t.Fatalf("expected error for char device")
@@ -249,7 +249,7 @@ func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 	logger := zap.New(core)
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
-	defer func() { execCommand = oldExec }()
+	t.Cleanup(func() { execCommand = oldExec })
 	if _, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-fail-output"}, "true", nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
 		t.Fatalf("expected freeze output in error, got %v", err)
 	}
@@ -267,7 +267,7 @@ func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
 	logger := zap.New(core)
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
-	defer func() { execCommand = oldExec }()
+	t.Cleanup(func() { execCommand = oldExec })
 	d := &RawDevice{
 		freezeIssued: true,
 		thawCmdPath:  os.Args[0],

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -60,7 +60,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 		cmds = append(cmds, name+" "+strings.Join(args, " "))
 		return exec.CommandContext(ctx, "true")
 	}
-	defer func() { execCommand = origCmd }()
+	t.Cleanup(func() { execCommand = origCmd })
 
 	origName := generateSnapshot
 	generateSnapshot = func() string { return "snap" }


### PR DESCRIPTION
## Summary
- share execCommand helper for LVM and raw device operations
- stub execCommand in raw and snapshot tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: context deadline exceeded and network unreachable in transport tests)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689f9b8a941c83239ae3c13021c6183f