### PR TITLE
fix(cmd): sync logs in apply and dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmd/dump: detect destination type locally without mutating configuration
 - manifest: propagate close errors when rebuilding indexes
 - log sync errors in manifest and verify commands
+- ensure apply and dump commands flush logs with deferred SyncLogger
 - h2: ensure unreachable dial test uses context timeout and expects deadline exceeded
 
 ## [v0.1.0] - 2025-02-27

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/config"
 	"lvmsync_go/device"
 	"lvmsync_go/transfer"
@@ -18,9 +19,14 @@ var applyFunc = func(cfg *config.Config, applyFile, destDevice string, logger *z
 	return t.RunApply(cfg, applyFile, destDevice)
 }
 
+func init() {
+	rootcmd.RunApply = Run
+}
+
 // Run executes apply mode using the provided configuration and arguments.
 // args should contain the destination device as the first element.
 func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error {
+	defer rootcmd.SyncLogger(logger)
 	if len(args) < 1 {
 		return fmt.Errorf("no destination device specified for apply mode")
 	}

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"lvmsync_go/config"
 )
@@ -35,5 +36,35 @@ func TestRun(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("applyFunc was not called")
+	}
+}
+
+type countingSyncCore struct {
+	zapcore.Core
+	count int
+}
+
+func (c *countingSyncCore) Sync() error {
+	c.count++
+	return nil
+}
+
+func TestRunSyncsLogger(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	core := &countingSyncCore{Core: zapcore.NewNopCore()}
+	logger := zap.New(core)
+	applyFile := "dumpfile"
+	dest := "/dev/null"
+	original := applyFunc
+	applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
+	defer func() { applyFunc = original }()
+	if err := Run(cfg, applyFile, []string{dest}, logger); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if core.count != 1 {
+		t.Fatalf("expected Sync to be called once, got %d", core.count)
 	}
 }

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/config"
 	"lvmsync_go/device"
@@ -105,6 +106,11 @@ func CopyPipeAsync(ctx context.Context, dst io.Writer, src io.Reader) <-chan err
 	return errCh
 }
 
+func init() {
+	rootcmd.RunDump = Run
+	rootcmd.SelectTransport = SelectTransport
+}
+
 // ExecuteDump selects the appropriate dump implementation based on configuration.
 func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io.Writer, logger *zap.Logger) error {
 	t := transfer.NewTransfer(logger, &sync.WaitGroup{})
@@ -125,6 +131,7 @@ func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io
 
 // Run executes client mode transferring data to dest and returns the destination type.
 func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, logger *zap.Logger) (string, error) {
+	defer rootcmd.SyncLogger(logger)
 	originDevice := snapshotDevice
 	if cfg.StdoutMode {
 		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)

--- a/cmd/dump/client_test.go
+++ b/cmd/dump/client_test.go
@@ -7,6 +7,15 @@ import (
 	"io"
 	"testing"
 	"time"
+
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"lvmsync_go/config"
+	"lvmsync_go/transfer"
 )
 
 // readerBlockingOnContext waits for ctx cancellation before returning.
@@ -57,5 +66,34 @@ func TestCopyPipeAsyncCanceledDuringWrite(t *testing.T) {
 	}
 	if dst.Len() != 0 {
 		t.Fatalf("expected no bytes written, got %d", dst.Len())
+	}
+}
+
+type countingSyncCore struct {
+	zapcore.Core
+	count int
+}
+
+func (c *countingSyncCore) Sync() error {
+	c.count++
+	return nil
+}
+
+func TestRunSyncsLogger(t *testing.T) {
+	cfg := &config.Config{StdoutMode: true, Parallel: 1, BlockSize: 4096, DedupStrategy: "none"}
+	core := &countingSyncCore{Core: zapcore.NewNopCore()}
+	logger := zap.New(core)
+	origSeq := dumpChangesSequential
+	dumpChangesSequential = func(*transfer.Transfer, *config.Config, string, string, io.Writer) error { return nil }
+	defer func() { dumpChangesSequential = origSeq }()
+	snap := filepath.Join(t.TempDir(), "snap")
+	if err := os.WriteFile(snap, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write snap: %v", err)
+	}
+	if _, err := Run(context.Background(), cfg, snap, "", logger); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if core.count != 1 {
+		t.Fatalf("expected Sync to be called once, got %d", core.count)
 	}
 }

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -183,7 +183,7 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	}
 }
 
-func TestRunSyncsLogger(t *testing.T) {
+func TestRunContextNoDeadline(t *testing.T) {
 	dir := t.TempDir()
 	devicePath := filepath.Join(dir, "dev.img")
 	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -10,12 +10,11 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/app"
-	applycmd "lvmsync_go/cmd/apply"
-	dumpcmd "lvmsync_go/cmd/dump"
 	"lvmsync_go/config"
 	"lvmsync_go/device"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privilege"
+	"lvmsync_go/transport"
 )
 
 // function variables for testing
@@ -25,10 +24,14 @@ var (
 	setupSignalHandle = app.SetupSignalHandling
 	prepareSnapshotFn = app.PrepareSnapshot
 	executeClientFn   = clientpkg.ExecuteClient
-	selectTransport   = dumpcmd.SelectTransport
-	runDump           = func(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) error {
-		_, err := dumpcmd.Run(ctx, cfg, snapshot, dest, logger)
-		return err
+	RunApply          = func(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error {
+		return fmt.Errorf("apply command not registered")
+	}
+	SelectTransport = func(cfg *config.Config, logger *zap.Logger) (transport.Interface, error) {
+		return nil, fmt.Errorf("transport not registered")
+	}
+	RunDump = func(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) (string, error) {
+		return "", fmt.Errorf("dump command not registered")
 	}
 	RunManifest = func(cfg *config.Config, args []string, logger *zap.Logger) error {
 		return fmt.Errorf("manifest command not registered")
@@ -37,6 +40,11 @@ var (
 		return fmt.Errorf("verify command not registered")
 	}
 )
+
+func runDump(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) error {
+	_, err := RunDump(ctx, cfg, snapshot, dest, logger)
+	return err
+}
 
 // SyncLogger flushes buffered log entries and logs if syncing fails.
 func SyncLogger(logger *zap.Logger) {
@@ -141,13 +149,13 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	}
 
 	if cfg.ApplyMode != "" {
-		if err := applycmd.Run(cfg, cfg.ApplyMode, args, logger); err != nil {
+		if err := RunApply(cfg, cfg.ApplyMode, args, logger); err != nil {
 			return fmt.Errorf("apply operation failed: %w", err)
 		}
 		return nil
 	}
 
-	if _, err := selectTransport(cfg, logger); err != nil {
+	if _, err := SelectTransport(cfg, logger); err != nil {
 		return fmt.Errorf("select transport: %w", err)
 	}
 

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -246,10 +246,10 @@ func TestExecuteClient(t *testing.T) {
 	logger := zap.NewNop()
 	called := false
 	origExec := executeClientFn
-	origRunDump := runDump
+	origRunDump := RunDump
 	defer func() {
 		executeClientFn = origExec
-		runDump = origRunDump
+		RunDump = origRunDump
 	}()
 	executeClientFn = func(ctx context.Context, f func(context.Context, string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
 		called = true
@@ -258,11 +258,11 @@ func TestExecuteClient(t *testing.T) {
 		}
 		return f(ctx, snap, dest)
 	}
-	runDump = func(_ context.Context, _ *config.Config, snap, dest string, _ *zap.Logger) error {
+	RunDump = func(_ context.Context, _ *config.Config, snap, dest string, _ *zap.Logger) (string, error) {
 		if snap != "s" || dest != "d" {
 			t.Fatalf("unexpected dump args")
 		}
-		return nil
+		return "", nil
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -283,14 +283,14 @@ func TestRunHeartbeatError(t *testing.T) {
 	origSetup := setupSignalHandle
 	origPrepare := prepareSnapshotFn
 	origExec := executeClientFn
-	origSelect := selectTransport
+	origSelect := SelectTransport
 	defer func() {
 		startGRPCServer = origStart
 		clientHandshake = origClient
 		setupSignalHandle = origSetup
 		prepareSnapshotFn = origPrepare
 		executeClientFn = origExec
-		selectTransport = origSelect
+		SelectTransport = origSelect
 	}()
 
 	hbErrCh := make(chan error, 1)
@@ -304,7 +304,7 @@ func TestRunHeartbeatError(t *testing.T) {
 	clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
 	}
-	selectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
+	SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
 
 	sigErrCh := make(chan error, 1)
 	setupSignalHandle = func(_ context.Context, _ *config.Config, _ *string, _ *zap.Logger) (chan os.Signal, chan error) {
@@ -345,14 +345,14 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 			origSetup := setupSignalHandle
 			origPrepare := prepareSnapshotFn
 			origExec := executeClientFn
-			origSelect := selectTransport
+			origSelect := SelectTransport
 			defer func() {
 				startGRPCServer = origStart
 				clientHandshake = origClient
 				setupSignalHandle = origSetup
 				prepareSnapshotFn = origPrepare
 				executeClientFn = origExec
-				selectTransport = origSelect
+				SelectTransport = origSelect
 			}()
 
 			startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
@@ -376,7 +376,7 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 				return nil, make(chan error, 1)
 			}
 
-			selectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
+			SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
 
 			prepareSnapshotFn = func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
 				return "snap", nil, func() {}, nil

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 
 	"go.uber.org/zap"
 
+	_ "lvmsync_go/cmd/apply"
+	_ "lvmsync_go/cmd/dump"
 	rootcmd "lvmsync_go/cmd/root"
 )
 


### PR DESCRIPTION
## Summary
- defer root.SyncLogger in `apply.Run` and `dump.Run`
- register apply and dump Run functions via init to avoid import cycles
- add tests ensuring logger Sync is invoked

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f9b97770c8323a7be20a700dabc9d