### PR TITLE
fix(transport): omit error field from start logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - validate block size mismatch in handshakes
 - dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports
+- remove placeholder error field from dial_start and listen_start logs for quic and ssh transports
 - propagate seek errors during block writes to prevent silent data loss
 - Remove obsolete gap and pruning entries after rerunning static analysis.
 - Wrap README logging example in `package main` to compile with `go build`.

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -92,37 +92,30 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	qconn, err := quic.DialAddr(ctx, address, t.clientTLS, t.qconf)
-	if err != nil {
-		fields := []zap.Field{
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		}
-		t.logger.Error("dial_end", fields...)
-		return nil, err
-	}
-	stream, err := qconn.OpenStreamSync(ctx)
 	fields := []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.Error(err),
 	}
 	if err != nil {
+		fields = append(fields, zap.Error(err))
 		t.logger.Error("dial_end", fields...)
-		qconn.CloseWithError(0, err.Error())
 		return nil, err
 	}
+	stream, err := qconn.OpenStreamSync(ctx)
 	fields = []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", ""),
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+		t.logger.Error("dial_end", fields...)
+		qconn.CloseWithError(0, err.Error())
+		return nil, err
 	}
 	t.logger.Info("dial_end", fields...)
 	return &Conn{qconn: qconn, stream: stream}, nil
@@ -135,7 +128,6 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	ql, err := quic.ListenAddr(address, t.serverTLS, t.qconf)
@@ -143,17 +135,11 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.Error(err),
 	}
 	if err != nil {
+		fields = append(fields, zap.Error(err))
 		t.logger.Error("listen_end", fields...)
 		return nil, err
-	}
-	fields = []zap.Field{
-		zap.String("address", address),
-		zap.String("role", role),
-		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", ""),
 	}
 	t.logger.Info("listen_end", fields...)
 	return &listener{ql: ql, ctx: ctx}, nil

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -113,10 +113,10 @@ func TestQUICTransportHandshake(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 	checkHandshakeFields(t, logs, "negotiate_end", 2)
@@ -237,10 +237,10 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 1, true, zapcore.ErrorLevel)
 }
@@ -287,10 +287,10 @@ func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
 	qconn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -149,50 +149,47 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	d := &net.Dialer{}
 	raw, err := d.DialContext(ctx, "tcp", address)
+	fields := []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
 	if err != nil {
-		t.logger.Error("dial_end",
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		)
+		fields = append(fields, zap.Error(err))
+		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
 	cc, chans, reqs, err := ssh.NewClientConn(raw, address, t.clientConf)
+	fields = []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
 	if err != nil {
 		raw.Close()
-		t.logger.Error("dial_end",
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		)
+		fields = append(fields, zap.Error(err))
+		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
 	client := ssh.NewClient(cc, chans, reqs)
 	ch, chReqs, err := client.OpenChannel("session", nil)
-	if err != nil {
-		client.Close()
-		t.logger.Error("dial_end",
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		)
-		return nil, err
-	}
-	go ssh.DiscardRequests(chReqs)
-	t.logger.Info("dial_end",
+	fields = []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", ""),
-	)
+	}
+	if err != nil {
+		client.Close()
+		fields = append(fields, zap.Error(err))
+		t.logger.Error("dial_end", fields...)
+		return nil, err
+	}
+	go ssh.DiscardRequests(chReqs)
+	t.logger.Info("dial_end", fields...)
 	return &sshConn{netConn: raw, channel: ch, client: client}, nil
 }
 
@@ -202,18 +199,18 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.String("address", address),
 		zap.String("role", role),
 		zap.Int64("duration_ms", 0),
-		zap.String("error", ""),
 	)
 	start := time.Now()
 	lc := net.ListenConfig{}
 	tcpLn, err := lc.Listen(ctx, "tcp", address)
+	fields := []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
 	if err != nil {
-		t.logger.Error("listen_end",
-			zap.String("address", address),
-			zap.String("role", role),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-			zap.Error(err),
-		)
+		fields = append(fields, zap.Error(err))
+		t.logger.Error("listen_end", fields...)
 		return nil, err
 	}
 	ln := &sshListener{Listener: tcpLn, config: t.serverConf, logger: t.logger}
@@ -221,12 +218,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		<-ctx.Done()
 		ln.Close()
 	}()
-	t.logger.Info("listen_end",
-		zap.String("address", address),
-		zap.String("role", role),
-		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		zap.String("error", ""),
-	)
+	t.logger.Info("listen_end", fields...)
 	return ln, nil
 }
 

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -245,10 +245,10 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 	checkHandshakeFields(t, logs, "negotiate_end", 2)
@@ -330,10 +330,10 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
@@ -476,10 +476,10 @@ func TestSSHTransportAgentFallback(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
 }
@@ -518,10 +518,10 @@ func TestSSHTransportAuthFailure(t *testing.T) {
 	}
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 0, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 0, false, zapcore.InfoLevel)
 }
@@ -572,10 +572,10 @@ func TestSSHTransportCDCMismatch(t *testing.T) {
 	conn.Close()
 	<-done
 
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "dial_end", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_start", 1, true, zapcore.InfoLevel)
-	checkLogFields(t, logs, "listen_end", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }
@@ -716,6 +716,6 @@ func TestSSHTransportRejectsUnknownHost(t *testing.T) {
 		t.Fatalf("expected dial error")
 	}
 	<-done
-	checkLogFields(t, logs, "dial_start", 1, true, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
 }


### PR DESCRIPTION
## Summary
- remove placeholder error field from dial_start and listen_start logs for quic and ssh transports
- log successful dial and listen operations without error fields
- test that successful dial_end logs emit no error field

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTransportNegotiationMatrix/tcp+tls unexpected peer handshake; TestH2DialUnreachable got network is unreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa03777648323a6fd5ad934578ca4