### PR TITLE
fix(device): validate freeze and thaw command names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ensure apply and dump commands flush logs with deferred SyncLogger
 - h2: ensure unreachable dial test uses context timeout and expects deadline exceeded
 - manifest: default rebuild command to a no-op logger and remove conditional logging checks
+- device: reject freeze/thaw command paths with invalid characters and document allowed format
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -309,18 +309,18 @@ Reading from a live block device can corrupt data if writes occur during the tra
 - `--fs-freeze-command`/`--fs-thaw-command` – run commands that freeze and thaw the filesystem around the read.
 - Time out freeze and thaw helpers with `--freeze-timeout` and `--thaw-timeout` (default `10s`).
 
-Freeze and thaw commands are validated before execution. The path must be set, free of NUL bytes, every argument must avoid NULs, and the executable must be discoverable in `$PATH`; otherwise lvmsync returns an error.
+Freeze and thaw commands are validated before execution. The command name must match `^[a-zA-Z0-9._-]+$`, be set, free of NUL bytes, every argument must avoid NULs, and the executable must be discoverable in `$PATH`; otherwise lvmsync returns an error.
 
 Example using the provided scripts:
 
 ```sh
 lvmsync --source-type raw \
-  --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt" \
-  --fs-thaw-command "./docs/fsfreeze-thaw.sh /mnt" \
+  --fs-freeze-command "fsfreeze-freeze.sh /mnt" \
+  --fs-thaw-command "fsfreeze-thaw.sh /mnt" \
   /dev/sdb /tmp/dump
 ```
 
-`docs/fsfreeze-freeze.sh` and `docs/fsfreeze-thaw.sh` demonstrate basic freeze and thaw operations.
+`docs/fsfreeze-freeze.sh` and `docs/fsfreeze-thaw.sh` demonstrate basic freeze and thaw operations; add the scripts to your `$PATH` to use them.
 
 ### Configuration sources and precedence
 
@@ -365,8 +365,8 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--source-type` | `LVMSYNC_SOURCE_TYPE` | `source-type` | Source device type: `auto`, `file`, `raw`, or `lvm` |
 | `--dest-type` | `LVMSYNC_DEST_TYPE` | `dest-type` | Destination device type: `auto`, `file`, `raw`, or `lvm` |
 | `--offline` | `LVMSYNC_OFFLINE` | `offline` | Assume source raw device is offline |
-| `--fs-freeze-command` | `LVMSYNC_FS_FREEZE_COMMAND` | `fs-freeze-command` | Command to freeze filesystem before reading raw source |
-| `--fs-thaw-command` | `LVMSYNC_FS_THAW_COMMAND` | `fs-thaw-command` | Command to thaw filesystem after reading raw source |
+| `--fs-freeze-command` | `LVMSYNC_FS_FREEZE_COMMAND` | `fs-freeze-command` | Command to freeze filesystem before reading raw source; executable name must match `^[a-zA-Z0-9._-]+$` |
+| `--fs-thaw-command` | `LVMSYNC_FS_THAW_COMMAND` | `fs-thaw-command` | Command to thaw filesystem after reading raw source; executable name must match `^[a-zA-Z0-9._-]+$` |
 | `--freeze-timeout` | `LVMSYNC_FREEZE_TIMEOUT` | `freeze_timeout` | Timeout for filesystem freeze command |
 | `--thaw-timeout` | `LVMSYNC_THAW_TIMEOUT` | `thaw_timeout` | Timeout for filesystem thaw command |
 | `--mode` | `LVMSYNC_MODE` | `mode` | Configuration preset: `default` or `throughput`; unknown modes fail validation |

--- a/device/raw.go
+++ b/device/raw.go
@@ -13,6 +13,8 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
+
+	"lvmsync_go/remote"
 )
 
 // RawDevice represents a generic block device opened from /dev.
@@ -169,6 +171,9 @@ func validateCmd(path string, args []string) error {
 	}
 	if strings.ContainsRune(path, '\x00') {
 		return fmt.Errorf("command path contains NUL byte")
+	}
+	if !remote.RemoteCmdRe.MatchString(path) {
+		return fmt.Errorf("command path %s contains invalid characters", path)
 	}
 	for _, a := range args {
 		if strings.ContainsRune(a, '\x00') {

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -14,6 +14,17 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+func helperCommand(t *testing.T) string {
+	dir := t.TempDir()
+	name := "cmdhelper"
+	link := filepath.Join(dir, name)
+	if err := os.Symlink(os.Args[0], link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return name
+}
+
 func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root")
@@ -187,7 +198,8 @@ func TestOpenRawFreezeThawLogs(t *testing.T) {
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
 	t.Cleanup(func() { execCommand = oldExec })
-	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-success"}, os.Args[0], []string{"thaw-success"}, time.Second, time.Second, logger)
+	helper := helperCommand(t)
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-success"}, time.Second, time.Second, logger)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -205,7 +217,8 @@ func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
 	t.Cleanup(func() { execCommand = oldExec })
-	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-timeout"}, os.Args[0], []string{"thaw-success"}, 50*time.Millisecond, time.Second, logger)
+	helper := helperCommand(t)
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, logger)
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze timeout, got %v", err)
 	}
@@ -226,7 +239,8 @@ func TestOpenRawThawFailure(t *testing.T) {
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
 	t.Cleanup(func() { execCommand = oldExec })
-	_, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-success"}, os.Args[0], []string{"thaw-fail"}, time.Second, time.Second, logger)
+	helper := helperCommand(t)
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-fail"}, time.Second, time.Second, logger)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -250,7 +264,8 @@ func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
 	t.Cleanup(func() { execCommand = oldExec })
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, os.Args[0], []string{"freeze-fail-output"}, "true", nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
+	helper := helperCommand(t)
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, "true", nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
 		t.Fatalf("expected freeze output in error, got %v", err)
 	}
 	entries := logs.FilterMessage("fs freeze failed").All()
@@ -268,9 +283,10 @@ func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
 	t.Cleanup(func() { execCommand = oldExec })
+	helper := helperCommand(t)
 	d := &RawDevice{
 		freezeIssued: true,
-		thawCmdPath:  os.Args[0],
+		thawCmdPath:  helper,
 		thawCmdArgs:  []string{"thaw-fail-output"},
 		thawTimeout:  time.Second,
 		logger:       logger,
@@ -293,9 +309,10 @@ func TestRawDeviceCleanupThawErrorLogs(t *testing.T) {
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
 	defer func() { execCommand = oldExec }()
+	helper := helperCommand(t)
 	d := &RawDevice{
 		freezeIssued: true,
-		thawCmdPath:  os.Args[0],
+		thawCmdPath:  helper,
 		thawCmdArgs:  []string{"thaw-fail"},
 		thawTimeout:  time.Second,
 		logger:       logger,
@@ -314,9 +331,10 @@ func TestRawDeviceCleanupThawTimeoutLogs(t *testing.T) {
 	oldExec := execCommand
 	execCommand = fakeExecCommandContext
 	defer func() { execCommand = oldExec }()
+	helper := helperCommand(t)
 	d := &RawDevice{
 		freezeIssued: true,
-		thawCmdPath:  os.Args[0],
+		thawCmdPath:  helper,
 		thawCmdArgs:  []string{"thaw-timeout"},
 		thawTimeout:  100 * time.Millisecond,
 		logger:       logger,

--- a/device/raw_validate_cmd_test.go
+++ b/device/raw_validate_cmd_test.go
@@ -28,6 +28,11 @@ func TestValidateCmd(t *testing.T) {
 			wantErr: "command argument contains NUL byte",
 		},
 		{
+			name:    "invalid characters",
+			path:    "tr ue",
+			wantErr: "command path tr ue contains invalid characters",
+		},
+		{
 			name:    "nonexistent command",
 			path:    "does-not-exist",
 			wantErr: "does-not-exist: exec: \"does-not-exist\": executable file not found in $PATH",

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -19,7 +19,8 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
-var remoteCmdRe = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
+// RemoteCmdRe matches allowable command names for remote execution.
+var RemoteCmdRe = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
 
 // SSHClient wraps an ssh.Client and provides structured logging.
 //
@@ -169,7 +170,7 @@ func (c *SSHClient) ValidateRemoteCommand(ctx context.Context, remoteCmd string)
 		return fmt.Errorf("remote command is empty")
 	}
 	cmd := filepath.Base(tokens[0])
-	if !remoteCmdRe.MatchString(cmd) {
+	if !RemoteCmdRe.MatchString(cmd) {
 		return fmt.Errorf("remote command %s contains invalid characters", cmd)
 	}
 	session, err := c.NewSession()


### PR DESCRIPTION
## Summary
- export `RemoteCmdRe` for shared command validation
- reject freeze/thaw command names with invalid characters and test edge cases
- document allowed command format for `--fs-freeze-command`/`--fs-thaw-command`

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTransportNegotiationMatrix, TestH2DialUnreachable, TestTCPTLSDialUnreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa03d85c48323a333096625382bba