### PR TITLE
refactor(manifest): inject close hook via options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- manifest: allow custom close hook via index options, removing global hook.
 
 
 ### Fixed

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -14,6 +14,7 @@ import (
 
 	"lvmsync_go/config"
 	"lvmsync_go/device"
+	manifestpkg "lvmsync_go/manifest"
 )
 
 type syncTrackerCore struct {
@@ -149,7 +150,7 @@ func TestRunAppliesManifestTimeout(t *testing.T) {
 	cfg.ManifestTimeout = 2 * time.Second
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, _ ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}
@@ -170,7 +171,7 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, _ ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}
@@ -197,7 +198,7 @@ func TestRunContextNoDeadline(t *testing.T) {
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, _ ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -40,12 +40,19 @@ type Header struct {
 
 // Index is an mmap-backed manifest file containing chunk metadata.
 type Index struct {
-	f    *os.File
-	data []byte
-	hdr  Header
+	f         *os.File
+	data      []byte
+	hdr       Header
+	closeHook func() error
 }
 
-var closeHook = func() error { return nil }
+// IndexOption configures an Index on creation.
+type IndexOption func(*Index)
+
+// WithCloseHook sets a hook invoked when Index.Close is called.
+func WithCloseHook(h func() error) IndexOption {
+	return func(i *Index) { i.closeHook = h }
+}
 
 var detectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
 	return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
@@ -107,7 +114,9 @@ func (i *Index) Close() error {
 		if err = unix.Msync(i.data, unix.MS_SYNC); err != nil {
 			_ = unix.Munmap(i.data)
 			_ = i.f.Close()
-			_ = closeHook()
+			if i.closeHook != nil {
+				_ = i.closeHook()
+			}
 			return err
 		}
 		_ = unix.Munmap(i.data)
@@ -117,14 +126,16 @@ func (i *Index) Close() error {
 			err = ferr
 		}
 	}
-	if hookErr := closeHook(); err == nil && hookErr != nil {
-		err = hookErr
+	if i.closeHook != nil {
+		if hookErr := i.closeHook(); err == nil && hookErr != nil {
+			err = hookErr
+		}
 	}
 	return err
 }
 
 // Create initializes a new manifest index at path for the given device.
-func Create(path, deviceID string, size uint64, blockSize uint32) (*Index, error) {
+func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexOption) (*Index, error) {
 	if len(deviceID) > 64 {
 		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
 	}
@@ -143,7 +154,10 @@ func Create(path, deviceID string, size uint64, blockSize uint32) (*Index, error
 		f.Close()
 		return nil, err
 	}
-	idx := &Index{f: f, data: data}
+	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
+	for _, opt := range opts {
+		opt(idx)
+	}
 	idx.hdr = Header{
 		Version:    Version,
 		BlockSize:  blockSize,
@@ -157,7 +171,7 @@ func Create(path, deviceID string, size uint64, blockSize uint32) (*Index, error
 }
 
 // Open maps an existing manifest index file.
-func Open(path string) (*Index, error) {
+func Open(path string, opts ...IndexOption) (*Index, error) {
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -173,7 +187,10 @@ func Open(path string) (*Index, error) {
 		f.Close()
 		return nil, err
 	}
-	idx := &Index{f: f, data: data}
+	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
+	for _, opt := range opts {
+		opt(idx)
+	}
 	if err := idx.readHeader(); err != nil {
 		idx.Close()
 		return nil, err
@@ -183,7 +200,7 @@ func Open(path string) (*Index, error) {
 
 // Upgrade opens the manifest at path, upgrading older versions in-place.
 // It returns an Index mapped to the upgraded file.
-func Upgrade(path string) (*Index, error) {
+func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -199,7 +216,10 @@ func Upgrade(path string) (*Index, error) {
 		f.Close()
 		return nil, err
 	}
-	idx := &Index{f: f, data: data}
+	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
+	for _, opt := range opts {
+		opt(idx)
+	}
 	if err := idx.readHeader(); err != nil {
 		if !errors.Is(err, ErrVersionMismatch) {
 			idx.Close()
@@ -284,7 +304,7 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
 // The operation respects cancellation via ctx.
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) (err error) {
+func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
 	if err = ctx.Err(); err != nil {
 		return err
 	}
@@ -320,7 +340,7 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	}
 	defer f.Close()
 	var idx *Index
-	idx, err = Create(output, id, size, blockSize)
+	idx, err = Create(output, id, size, blockSize, opts...)
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -280,13 +280,10 @@ func TestRebuildCloseOnce(t *testing.T) {
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeonce.man")
-	prevHook := closeHook
 	count := 0
-	closeHook = func() error { count++; return nil }
-	defer func() { closeHook = prevHook }()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { count++; return nil })); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if count != 1 {
@@ -311,12 +308,10 @@ func TestRebuildCloseError(t *testing.T) {
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeerr.man")
-	prevHook := closeHook
-	closeHook = func() error { return errors.New("close fail") }
-	defer func() { closeHook = prevHook }()
+	hookErr := errors.New("close fail")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false); err == nil || !strings.Contains(err.Error(), "close fail") {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { return hookErr })); err == nil || !strings.Contains(err.Error(), "close fail") {
 		t.Fatalf("expected close error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- allow supplying custom close hook to manifest.Index through options
- wire Rebuild and tests to use index options instead of global hooks
- drop global closeHook variable

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRateLimitedWritersIndependent, TestTransportNegotiationMatrix, TestH2DialUnreachable)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fa03b7990832399c6af9357ec1394