### PR TITLE
feat(logging): warn on insecure connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- Warn when `AllowInsecure` is enabled for gRPC server, client, and transports.
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional st
 transport also requires TLS 1.3 with client certificates and negotiates the `h2` ALPN. Provide certificates via
 `--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and will refuse
 connections when no roots are provided unless `--allow_insecure` (or the `AllowInsecure` configuration flag) is
-set. Client certificates must be supplied explicitly; transports no longer generate self-signed certificates
+set. Enabling this option logs a warning. Client certificates must be supplied explicitly; transports no longer generate self-signed certificates
 automatically. The [transport documentation](docs/transports.md) covers each option in depth. The flags below
 configure transport behavior.
 

--- a/app/app.go
+++ b/app/app.go
@@ -27,8 +27,8 @@ var (
 	newServer = func(cfg grpcserver.Config, agent lvmlib.Agent, logger *zap.Logger) (grpcServer, func(), error) {
 		return grpcserver.New(cfg, agent, logger)
 	}
-	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
-		return grpcclient.Dial(ctx, addr, conf)
+	dial = func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
+		return grpcclient.Dial(ctx, addr, conf, logger)
 	}
 	handshake     = grpcclient.Handshake
 	createSession = grpcclient.CreateSession
@@ -107,7 +107,7 @@ func ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger
 		CACert:        cfg.CACert,
 		AllowInsecure: cfg.AllowInsecure,
 		DialTimeout:   cfg.GRPCDialTimeout,
-	})
+	}, logger)
 	if err != nil {
 		cancel()
 		return nil, nil, fmt.Errorf("gRPC dial: %w", err)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -141,7 +141,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 		createSession = origCreateSession
 		ackStream = origAckStream
 	}()
-	dial = func(context.Context, string, grpcclient.Config) (closeableConn, error) { return fc, nil }
+	dial = func(context.Context, string, grpcclient.Config, *zap.Logger) (closeableConn, error) { return fc, nil }
 	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
 		return &proto.HandshakeResponse{}, nil
 	}
@@ -168,7 +168,7 @@ func TestClientHandshakeDialError(t *testing.T) {
 	logger := zap.NewNop()
 	origDial := dial
 	defer func() { dial = origDial }()
-	dial = func(context.Context, string, grpcclient.Config) (closeableConn, error) {
+	dial = func(context.Context, string, grpcclient.Config, *zap.Logger) (closeableConn, error) {
 		return nil, errors.New("dial fail")
 	}
 
@@ -193,7 +193,7 @@ func TestClientHandshakeHeartbeatFailure(t *testing.T) {
 		createSession = origCreateSession
 		ackStream = origAckStream
 	}()
-	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
+	dial = func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
 		return fc, nil
 	}
 	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
@@ -236,7 +236,7 @@ func TestClientHandshakeHeartbeatTimeout(t *testing.T) {
 		createSession = origCreateSession
 		ackStream = origAckStream
 	}()
-	dial = func(ctx context.Context, addr string, conf grpcclient.Config) (closeableConn, error) {
+	dial = func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
 		return fc, nil
 	}
 	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -20,7 +20,7 @@ TLS based transports enable mutual TLS by default and restrict cipher suites to
 
 TLS transports require an explicit set of trusted CA roots. Connections are
 rejected if no roots are provided unless the transport configuration sets
-`AllowInsecure` to skip verification.
+`AllowInsecure` to skip verification. Enabling this option logs a warning.
 
 ## gRPC keepalive and timeouts
 

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -28,8 +29,12 @@ type Config struct {
 	DialTimeout   time.Duration
 }
 
-func Dial(ctx context.Context, addr string, conf Config, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func Dial(ctx context.Context, addr string, conf Config, logger *zap.Logger, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	if conf.AllowInsecure {
+		logger.Warn("allow_insecure_enabled", zap.String("component", "grpc_client"))
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		cert, err := tls.LoadX509KeyPair(conf.TLSCert, conf.TLSKey)

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
@@ -127,7 +128,7 @@ func setupClient(t *testing.T) (proto.ReplicationClient, func()) {
 	}
 	go srv.Serve(lis)
 	ctx, cancel := context.WithCancel(context.Background())
-	conn, err := Dial(ctx, "bufnet", cliCfg, grpc.WithContextDialer(bufDialer(lis)))
+	conn, err := Dial(ctx, "bufnet", cliCfg, zap.NewNop(), grpc.WithContextDialer(bufDialer(lis)))
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -205,7 +206,7 @@ func TestDial(t *testing.T) {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			conn, err := Dial(ctx, "bufnet", tc.conf, opts...)
+			conn, err := Dial(ctx, "bufnet", tc.conf, zap.NewNop(), opts...)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")
@@ -220,11 +221,39 @@ func TestDial(t *testing.T) {
 	}
 }
 
+func TestDialAllowInsecureWarn(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	srv, srvCleanup, err := servers.New(servers.Config{AllowInsecure: true}, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	go srv.Serve(lis)
+	defer func() {
+		srv.Stop()
+		srvCleanup()
+	}()
+	core, obs := observer.New(zap.WarnLevel)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conn, err := Dial(ctx, "bufnet", Config{AllowInsecure: true, DialTimeout: time.Second}, zap.New(core), grpc.WithContextDialer(bufDialer(lis)))
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	conn.Close()
+	entries := obs.FilterMessage("allow_insecure_enabled").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if comp := entries[0].ContextMap()["component"]; comp != "grpc_client" {
+		t.Fatalf("unexpected component %v", comp)
+	}
+}
+
 func TestDialFailure(t *testing.T) {
 	failDialer := func(ctx context.Context, s string) (net.Conn, error) {
 		return nil, errors.New("fail")
 	}
-	_, err := Dial(context.Background(), "fail", Config{AllowInsecure: true, DialTimeout: time.Second}, grpc.WithContextDialer(failDialer))
+	_, err := Dial(context.Background(), "fail", Config{AllowInsecure: true, DialTimeout: time.Second}, zap.NewNop(), grpc.WithContextDialer(failDialer))
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -235,7 +264,7 @@ func TestDialTimeoutExceeded(t *testing.T) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	_, err := Dial(context.Background(), "slow", Config{AllowInsecure: true, DialTimeout: 10 * time.Millisecond}, grpc.WithContextDialer(slowDialer))
+	_, err := Dial(context.Background(), "slow", Config{AllowInsecure: true, DialTimeout: 10 * time.Millisecond}, zap.NewNop(), grpc.WithContextDialer(slowDialer))
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -251,7 +280,7 @@ func TestDialContextCancelled(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := Dial(ctx, "cancel", Config{AllowInsecure: true, DialTimeout: time.Second}, grpc.WithContextDialer(dialer))
+	_, err := Dial(ctx, "cancel", Config{AllowInsecure: true, DialTimeout: time.Second}, zap.NewNop(), grpc.WithContextDialer(dialer))
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -50,7 +50,12 @@ func New(conf Config, a lvmagent.Agent, logger *zap.Logger) (*grpc.Server, func(
 		opts = append(opts, grpc.KeepaliveParams(params))
 	}
 
-	if !conf.AllowInsecure {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if conf.AllowInsecure {
+		logger.Warn("allow_insecure_enabled", zap.String("component", "grpc_server"))
+	} else {
 		if conf.TLSCert == "" || conf.TLSKey == "" || conf.CACert == "" {
 			return nil, nil, fmt.Errorf("TLSCert, TLSKey, and CACert must be provided when AllowInsecure is false")
 		}
@@ -74,10 +79,6 @@ func New(conf Config, a lvmagent.Agent, logger *zap.Logger) (*grpc.Server, func(
 			MaxVersion:   tls.VersionTLS13,
 		}
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsCfg)))
-	}
-
-	if logger == nil {
-		logger = zap.NewNop()
 	}
 
 	srv := grpc.NewServer(opts...)

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -32,6 +32,22 @@ import (
 
 const bufSize = 1024 * 1024
 
+func TestNewAllowInsecureWarn(t *testing.T) {
+	core, obs := observer.New(zap.WarnLevel)
+	_, cleanup, err := New(Config{AllowInsecure: true}, nil, zap.New(core))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cleanup()
+	entries := obs.FilterMessage("allow_insecure_enabled").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if comp, ok := entries[0].ContextMap()["component"]; !ok || comp != "grpc_server" {
+		t.Fatalf("unexpected component %v", comp)
+	}
+}
+
 // mockAgent implements lvmagent.Agent for testing.
 type mockAgent struct {
 	lock      func(ctx context.Context, volume, requester string) error

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -55,6 +55,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "quic"))
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverTLS := &tls.Config{

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -295,6 +295,20 @@ func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
 	checkLogFields(t, logs, "negotiate_end", 2, true, zapcore.ErrorLevel)
 }
 
+func TestQUICTransportAllowInsecureWarn(t *testing.T) {
+	core, obs := observer.New(zap.WarnLevel)
+	if _, err := New(transport.Config{Logger: zap.New(core), AllowInsecure: true}); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	entries := obs.FilterMessage("allow_insecure_enabled").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if tr := entries[0].ContextMap()["transport"]; tr != "quic" {
+		t.Fatalf("unexpected transport %v", tr)
+	}
+}
+
 func TestQUICTransportRequiresLogger(t *testing.T) {
 	if _, err := New(transport.Config{}); err == nil {
 		t.Fatalf("expected error when logger is nil")

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -90,6 +90,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		}
 		hkc = ssh.FixedHostKey(pk)
 	case cfg.AllowInsecure:
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "ssh"))
 		hkc = ssh.InsecureIgnoreHostKey()
 	default:
 		return nil, fmt.Errorf("known hosts or host key required")

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -172,10 +172,17 @@ func TestNewWithHostKey(t *testing.T) {
 }
 
 func TestNewAllowInsecure(t *testing.T) {
-	core, _ := observer.New(zap.InfoLevel)
+	core, obs := observer.New(zap.WarnLevel)
 	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", AllowInsecure: true}
 	if _, err := New(cfg); err != nil {
 		t.Fatalf("New: %v", err)
+	}
+	entries := obs.FilterMessage("allow_insecure_enabled").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if tr := entries[0].ContextMap()["transport"]; tr != "ssh" {
+		t.Fatalf("unexpected transport %v", tr)
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -40,6 +40,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "tcp+tls"))
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverConf := &tls.Config{

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -444,6 +444,20 @@ func TestTCPTLSNegotiateContextCancel(t *testing.T) {
 	}
 }
 
+func TestTCPTLSTransportAllowInsecureWarn(t *testing.T) {
+	core, obs := observer.New(zap.WarnLevel)
+	if _, err := New(transport.Config{Logger: zap.New(core), AllowInsecure: true}); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	entries := obs.FilterMessage("allow_insecure_enabled").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if tr := entries[0].ContextMap()["transport"]; tr != "tcp+tls" {
+		t.Fatalf("unexpected transport %v", tr)
+	}
+}
+
 func TestTCPTLSTransportRequiresLogger(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
 	if _, err := New(transport.Config{Roots: root, ClientCert: cert}); err == nil {


### PR DESCRIPTION
## Summary
- log a warning when AllowInsecure is enabled for gRPC and transports
- cover AllowInsecure warnings with unit tests
- document that enabling AllowInsecure emits a warning

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTransportNegotiationMatrix/tcp+tls, TestH2DialUnreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_689fa03c30a483238f9b753b741c2465