### PR TITLE
fix(device): validate command basename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - h2: ensure unreachable dial test uses context timeout and expects deadline exceeded
 - manifest: default rebuild command to a no-op logger and remove conditional logging checks
 - device: reject freeze/thaw command paths with invalid characters and document allowed format
+- device: allow freeze/thaw command paths containing directories by validating basename only
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/device/raw.go
+++ b/device/raw.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 	"unsafe"
@@ -172,7 +173,7 @@ func validateCmd(path string, args []string) error {
 	if strings.ContainsRune(path, '\x00') {
 		return fmt.Errorf("command path contains NUL byte")
 	}
-	if !remote.RemoteCmdRe.MatchString(path) {
+	if !remote.RemoteCmdRe.MatchString(filepath.Base(path)) {
 		return fmt.Errorf("command path %s contains invalid characters", path)
 	}
 	for _, a := range args {

--- a/device/raw_validate_cmd_test.go
+++ b/device/raw_validate_cmd_test.go
@@ -1,10 +1,17 @@
 package device
 
 import (
+	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
 func TestValidateCmd(t *testing.T) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	invalidBase := filepath.Join(filepath.Dir(truePath), "tr ue")
 	tests := []struct {
 		name    string
 		path    string
@@ -33,6 +40,11 @@ func TestValidateCmd(t *testing.T) {
 			wantErr: "command path tr ue contains invalid characters",
 		},
 		{
+			name:    "invalid characters in basename",
+			path:    invalidBase,
+			wantErr: "command path " + invalidBase + " contains invalid characters",
+		},
+		{
 			name:    "nonexistent command",
 			path:    "does-not-exist",
 			wantErr: "does-not-exist: exec: \"does-not-exist\": executable file not found in $PATH",
@@ -40,6 +52,10 @@ func TestValidateCmd(t *testing.T) {
 		{
 			name: "valid command",
 			path: "true",
+		},
+		{
+			name: "valid absolute path",
+			path: truePath,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- allow freeze/thaw command paths containing directories by validating basename
- test validation with absolute paths and malformed basenames
- document the new behavior in the changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTransportNegotiationMatrix/tcp+tls and TestH2DialUnreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa6a2fe448323981885d8f526a4a9