### PR TITLE
feat(transport): add handshake logging helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- transport: centralize handshake logging via `HandshakeFields` helper.
 
 
 ### Fixed

--- a/transport/logging.go
+++ b/transport/logging.go
@@ -1,0 +1,30 @@
+package transport
+
+import (
+	"go.uber.org/zap"
+
+	"lvmsync_go/common"
+)
+
+// HandshakeFields returns zap fields logging handshake parameters.
+func HandshakeFields(h common.Handshake) []zap.Field {
+	return []zap.Field{
+		zap.String("dedup_mode", h.DedupMode),
+		zap.Int("block_size_bytes", h.BlockSize),
+		zap.String("compress", h.Compress),
+		zap.Int("compress_level", h.CompressLevel),
+		zap.String("digest", h.Digest),
+		zap.String("resume_token", h.ResumeToken),
+		zap.Bool("checksum", h.Checksum),
+		zap.Bool("checksum_dedup", h.ChecksumDedup),
+		zap.String("endianness", h.Endianness),
+		zap.Bool("odirect", h.ODirect),
+		zap.Int("max_inflight", h.MaxInFlight),
+		zap.Int("cdc_min", h.CDCMin),
+		zap.Int("cdc_avg", h.CDCAvg),
+		zap.Int("cdc_max", h.CDCMax),
+		zap.String("transport", h.Transport),
+		zap.String("alpn", h.ALPN),
+		zap.String("tls_version", h.TLSVersion),
+	}
+}

--- a/transport/logging_test.go
+++ b/transport/logging_test.go
@@ -1,0 +1,69 @@
+package transport
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/common"
+)
+
+func TestHandshakeFields(t *testing.T) {
+	hs := common.Handshake{
+		DedupMode:     "cdc",
+		BlockSize:     4096,
+		Compress:      "zstd",
+		CompressLevel: 1,
+		Digest:        "sha256",
+		ResumeToken:   "tok",
+		Checksum:      true,
+		ChecksumDedup: true,
+		Endianness:    "little",
+		ODirect:       true,
+		MaxInFlight:   8,
+		CDCMin:        64,
+		CDCAvg:        128,
+		CDCMax:        256,
+		Transport:     "quic",
+		ALPN:          "lvmsync",
+		TLSVersion:    "1.3",
+	}
+
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	logger.Info("handshake", HandshakeFields(hs)...)
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	expected := map[string]interface{}{
+		"dedup_mode":       "cdc",
+		"block_size_bytes": int64(4096),
+		"compress":         "zstd",
+		"compress_level":   int64(1),
+		"digest":           "sha256",
+		"resume_token":     "tok",
+		"checksum":         true,
+		"checksum_dedup":   true,
+		"endianness":       "little",
+		"odirect":          true,
+		"max_inflight":     int64(8),
+		"cdc_min":          int64(64),
+		"cdc_avg":          int64(128),
+		"cdc_max":          int64(256),
+		"transport":        "quic",
+		"alpn":             "lvmsync",
+		"tls_version":      "1.3",
+	}
+	if len(ctx) != len(expected) {
+		t.Fatalf("expected %d fields, got %d", len(expected), len(ctx))
+	}
+	for k, v := range expected {
+		if val, ok := ctx[k]; !ok || val != v {
+			t.Fatalf("missing or unexpected value for %s: got %v want %v", k, val, v)
+		}
+	}
+}

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -186,25 +186,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			fields = append(fields, zap.Error(err))
 			t.logger.Error("negotiate_end", fields...)
 		} else {
-			fields = append(fields,
-				zap.String("dedup_mode", hs.DedupMode),
-				zap.Int("block_size_bytes", hs.BlockSize),
-				zap.String("compress", hs.Compress),
-				zap.Int("compress_level", hs.CompressLevel),
-				zap.String("digest", hs.Digest),
-				zap.String("resume_token", hs.ResumeToken),
-				zap.Bool("checksum", hs.Checksum),
-				zap.Bool("checksum_dedup", hs.ChecksumDedup),
-				zap.String("endianness", hs.Endianness),
-				zap.Bool("odirect", hs.ODirect),
-				zap.Int("max_inflight", hs.MaxInFlight),
-				zap.Int("cdc_min", hs.CDCMin),
-				zap.Int("cdc_avg", hs.CDCAvg),
-				zap.Int("cdc_max", hs.CDCMax),
-				zap.String("transport", hs.Transport),
-				zap.String("alpn", hs.ALPN),
-				zap.String("tls_version", hs.TLSVersion),
-			)
+			fields = append(fields, transport.HandshakeFields(hs)...)
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -241,25 +241,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			fields = append(fields, zap.Error(err))
 			t.logger.Error("negotiate_end", fields...)
 		} else {
-			fields = append(fields,
-				zap.String("dedup_mode", hs.DedupMode),
-				zap.Int("block_size_bytes", hs.BlockSize),
-				zap.String("compress", hs.Compress),
-				zap.Int("compress_level", hs.CompressLevel),
-				zap.String("digest", hs.Digest),
-				zap.String("resume_token", hs.ResumeToken),
-				zap.Bool("checksum", hs.Checksum),
-				zap.Bool("checksum_dedup", hs.ChecksumDedup),
-				zap.String("endianness", hs.Endianness),
-				zap.Bool("odirect", hs.ODirect),
-				zap.Int("max_inflight", hs.MaxInFlight),
-				zap.Int("cdc_min", hs.CDCMin),
-				zap.Int("cdc_avg", hs.CDCAvg),
-				zap.Int("cdc_max", hs.CDCMax),
-				zap.String("transport", hs.Transport),
-				zap.String("alpn", hs.ALPN),
-				zap.String("tls_version", hs.TLSVersion),
-			)
+			fields = append(fields, transport.HandshakeFields(hs)...)
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -203,25 +203,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			fields = append(fields, zap.Error(err))
 			t.logger.Error("negotiate_end", fields...)
 		} else {
-			fields = append(fields,
-				zap.String("dedup_mode", hs.DedupMode),
-				zap.Int("block_size_bytes", hs.BlockSize),
-				zap.String("compress", hs.Compress),
-				zap.Int("compress_level", hs.CompressLevel),
-				zap.String("digest", hs.Digest),
-				zap.String("resume_token", hs.ResumeToken),
-				zap.Bool("checksum", hs.Checksum),
-				zap.Bool("checksum_dedup", hs.ChecksumDedup),
-				zap.String("endianness", hs.Endianness),
-				zap.Bool("odirect", hs.ODirect),
-				zap.Int("max_inflight", hs.MaxInFlight),
-				zap.Int("cdc_min", hs.CDCMin),
-				zap.Int("cdc_avg", hs.CDCAvg),
-				zap.Int("cdc_max", hs.CDCMax),
-				zap.String("transport", hs.Transport),
-				zap.String("alpn", hs.ALPN),
-				zap.String("tls_version", hs.TLSVersion),
-			)
+			fields = append(fields, transport.HandshakeFields(hs)...)
 			t.logger.Info("negotiate_end", fields...)
 		}
 	}()


### PR DESCRIPTION
## Summary
- factor out HandshakeFields helper for reusable handshake logging
- reuse HandshakeFields across ssh, tcp+tls, and quic transports
- add unit test verifying HandshakeFields fields

## Testing
- `go build ./...`
- `go test ./transport -run TestHandshakeFields -count=1`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTransportNegotiationMatrix, TestH2DialUnreachable)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fa698cbb08323bc2b1fa9cf8def95