### PR TITLE
feat(verify): add checksum digest helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- cmd/verify: support SHA-256 verification with configurable digest helper.
 
 
 ### Fixed

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -1,9 +1,11 @@
 package verify
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -69,9 +71,16 @@ func Run(args []string, logger *zap.Logger) error {
 
 func verifyDevices(cfg *config.Config, src, dst, manifest string, logger *zap.Logger) error {
 	if manifest != "" {
-		return verifyWithManifest(src, manifest, logger)
+		return verifyWithManifest(cfg, src, manifest, logger)
 	}
 	return verifyFull(cfg, src, dst, logger)
+}
+
+func digestFunc(cfg *config.Config) func([]byte) [32]byte {
+	if strings.ToLower(cfg.ChecksumAlgorithm) == "sha256" {
+		return sha256.Sum256
+	}
+	return blake3.Sum256
 }
 
 func verifyFull(cfg *config.Config, src, dst string, logger *zap.Logger) error {
@@ -107,6 +116,7 @@ func verifyFull(cfg *config.Config, src, dst string, logger *zap.Logger) error {
 	mismatches := 0
 	bufSrc := make([]byte, blockSize)
 	bufDst := make([]byte, blockSize)
+	digest := digestFunc(cfg)
 	for off := int64(0); off < total; off += int64(blockSize) {
 		size := blockSize
 		if remaining := int(total - off); remaining < size {
@@ -118,7 +128,7 @@ func verifyFull(cfg *config.Config, src, dst string, logger *zap.Logger) error {
 		if err := transfer.ReadBlockInto(fDst, off, bufDst[:size]); err != nil && err != io.EOF {
 			return fmt.Errorf("read dest: %w", err)
 		}
-		if blake3.Sum256(bufSrc[:size]) != blake3.Sum256(bufDst[:size]) {
+		if digest(bufSrc[:size]) != digest(bufDst[:size]) {
 			mismatches++
 			logger.Error("mismatched_block", zap.Int64("offset_bytes", off))
 		}
@@ -130,7 +140,7 @@ func verifyFull(cfg *config.Config, src, dst string, logger *zap.Logger) error {
 	return nil
 }
 
-func verifyWithManifest(src, manifestPath string, logger *zap.Logger) error {
+func verifyWithManifest(cfg *config.Config, src, manifestPath string, logger *zap.Logger) error {
 	idx, err := manifest.Open(manifestPath)
 	if err != nil {
 		return fmt.Errorf("open manifest: %w", err)
@@ -144,6 +154,7 @@ func verifyWithManifest(src, manifestPath string, logger *zap.Logger) error {
 
 	mismatches := 0
 	buf := make([]byte, 0)
+	hash := digestFunc(cfg)
 	for i := uint64(0); i < idx.ChunkCount(); i++ {
 		off, length, _, digest, err := idx.Entry(i)
 		if err != nil {
@@ -159,7 +170,7 @@ func verifyWithManifest(src, manifestPath string, logger *zap.Logger) error {
 		if _, err := fSrc.ReadAt(buf, int64(off)); err != nil {
 			return fmt.Errorf("read source: %w", err)
 		}
-		actual := blake3.Sum256(buf)
+		actual := hash(buf)
 		if actual != digest {
 			mismatches++
 			logger.Error("digest_mismatch",

--- a/cmd/verify/verify_mismatch_test.go
+++ b/cmd/verify/verify_mismatch_test.go
@@ -29,3 +29,24 @@ func TestRunLogsMismatchBlock(t *testing.T) {
 		t.Fatalf("expected mismatched_block log, got %v", logs.All())
 	}
 }
+
+func TestRunLogsMismatchBlockSHA256(t *testing.T) {
+	dir := t.TempDir()
+	src := dir + "/src"
+	dst := dir + "/dst"
+	if err := os.WriteFile(src, []byte("foo"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("bar"), 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	err := Run([]string{"--checksum_algorithm", "sha256", src, dst}, logger)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if logs.FilterMessage("mismatched_block").Len() == 0 {
+		t.Fatalf("expected mismatched_block log, got %v", logs.All())
+	}
+}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -78,6 +78,17 @@ func TestVerifyFullAllocations(t *testing.T) {
 	}
 }
 
+func TestVerifyFullSHA256(t *testing.T) {
+	blockSize := 1024
+	size := blockSize * 2
+	src := createTestFile(t, size)
+	dst := createTestFile(t, size)
+	cfg := &config.Config{BlockSize: blockSize, ChecksumAlgorithm: "sha256"}
+	if err := verifyFull(cfg, src, dst, zap.NewNop()); err != nil {
+		t.Fatalf("verifyFull: %v", err)
+	}
+}
+
 func TestVerifyWithManifestAllocations(t *testing.T) {
 	blockSize := 512
 	size := blockSize * 3
@@ -104,8 +115,9 @@ func TestVerifyWithManifestAllocations(t *testing.T) {
 	}
 	idx.Close()
 	fSrc.Close()
+	cfg := &config.Config{}
 	allocs := testing.AllocsPerRun(10, func() {
-		if err := verifyWithManifest(src, manifestPath, zap.NewNop()); err != nil {
+		if err := verifyWithManifest(cfg, src, manifestPath, zap.NewNop()); err != nil {
 			t.Fatalf("verifyWithManifest: %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary
- allow verify to select SHA-256 or BLAKE3 via `digestFunc`
- use digest helper in block and manifest verification
- test SHA-256 verification paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: writer elapsed outside range, transport negotiation, h2 unreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa69c5f148323b9cc1c26cc811e3c