### PR TITLE
fix(config): validate CDC chunk ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.
+- config: enforce CDC chunk size ordering during validation.
 - validate block size mismatch in handshakes
 - dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -523,6 +523,43 @@ func TestValidateMode(t *testing.T) {
 	}
 }
 
+func TestValidateCDCOrdering(t *testing.T) {
+	geteuid := func() int { return 0 }
+	base := Config{
+		Mode:                 "default",
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+	}
+
+	cases := []struct {
+		name    string
+		min     int
+		avg     int
+		max     int
+		wantErr bool
+	}{
+		{name: "ascending", min: 64, avg: 128, max: 256, wantErr: false},
+		{name: "avgEqualsMin", min: 64, avg: 64, max: 128, wantErr: false},
+		{name: "avgEqualsMax", min: 64, avg: 128, max: 128, wantErr: false},
+		{name: "avgLessThanMin", min: 128, avg: 64, max: 256, wantErr: true},
+		{name: "avgGreaterThanMax", min: 64, avg: 256, max: 128, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax = tc.min, tc.avg, tc.max
+			if err := cfg.ValidateWith(geteuid); (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateWith min=%d avg=%d max=%d error = %v, wantErr %v", tc.min, tc.avg, tc.max, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestBuildBlockSize(t *testing.T) {
 	t.Run(Auto, func(t *testing.T) {
 		v := viper.New()

--- a/config/validation.go
+++ b/config/validation.go
@@ -42,6 +42,11 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.TCPNotSentLowAt < 0 {
 		return fmt.Errorf("tcp_lowat must be >= 0")
 	}
+	if c.CDCMin > 0 && c.CDCAvg > 0 && c.CDCMax > 0 {
+		if !(c.CDCMin <= c.CDCAvg && c.CDCAvg <= c.CDCMax) {
+			return fmt.Errorf("invalid cdc ordering: min %d avg %d max %d", c.CDCMin, c.CDCAvg, c.CDCMax)
+		}
+	}
 	if c.VolumeGroup != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), c.LVMTimeout)
 		defer cancel()


### PR DESCRIPTION
## Summary
- enforce CDC chunk ordering in config validation
- test CDC min/avg/max boundaries and invalid cases
- document CDC validation in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` (fails: TestTransportNegotiationMatrix/tcp+tls unexpected peer handshake, TestH2DialUnreachable expected context deadline exceeded)
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689fa69eba988323b028a2b9e5bfd449