### PR TITLE
test(grpc): verify BuildManifest and Verify logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- grpc: tests cover ProgressStream, BuildManifest, and Verify logging and forwarding.
 
 
 ### Fixed

--- a/docs/privilege_escalation.md
+++ b/docs/privilege_escalation.md
@@ -28,5 +28,6 @@ lvmsync --check-escalation
 
 The gRPC control plane derives authorization roles from client TLS certificates.
 Roles are read from the certificate's `OrganizationalUnit` field and must
-include `replicator` to invoke replication RPCs. Any user-supplied metadata is
+include `replicator` to invoke replication RPCs such as `StartSync`, `Cancel`,
+`ProgressStream`, `BuildManifest`, and `Verify`. Any user-supplied metadata is
 ignored, and requests without a verified role are rejected.

--- a/grpc/server/server_test.go
+++ b/grpc/server/server_test.go
@@ -604,6 +604,74 @@ func TestProgressStream(t *testing.T) {
 	})
 }
 
+func TestBuildManifestLogs(t *testing.T) {
+	ctx := ctxWithRole("replicator")
+	called := false
+	agent := &mockAgent{buildManifest: func(_ context.Context, id string) error {
+		if id != "s" {
+			t.Fatalf("unexpected id %s", id)
+		}
+		called = true
+		return nil
+	}}
+	cfg, good, _, _ := generateTLS(t)
+	core, obs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	client, cleanup := newClientWithLogger(t, cfg, agent, credentials.NewTLS(good), logger)
+	defer cleanup()
+	if _, err := client.BuildManifest(ctx, &proto.BuildManifestRequest{SessionId: "s"}); err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	if !called {
+		t.Fatalf("agent not called")
+	}
+	logs := obs.All()
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logs))
+	}
+	if logs[0].Message != "build_manifest" {
+		t.Fatalf("unexpected message %q", logs[0].Message)
+	}
+	fields := logs[0].ContextMap()
+	if fields["session_id"] != "s" {
+		t.Fatalf("unexpected log fields: %v", fields)
+	}
+}
+
+func TestVerifyLogs(t *testing.T) {
+	ctx := ctxWithRole("replicator")
+	called := false
+	agent := &mockAgent{verify: func(_ context.Context, id string) error {
+		if id != "s" {
+			t.Fatalf("unexpected id %s", id)
+		}
+		called = true
+		return nil
+	}}
+	cfg, good, _, _ := generateTLS(t)
+	core, obs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	client, cleanup := newClientWithLogger(t, cfg, agent, credentials.NewTLS(good), logger)
+	defer cleanup()
+	if _, err := client.Verify(ctx, &proto.VerifyRequest{SessionId: "s"}); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !called {
+		t.Fatalf("agent not called")
+	}
+	logs := obs.All()
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logs))
+	}
+	if logs[0].Message != "verify_request" {
+		t.Fatalf("unexpected message %q", logs[0].Message)
+	}
+	fields := logs[0].ContextMap()
+	if fields["session_id"] != "s" {
+		t.Fatalf("unexpected log fields: %v", fields)
+	}
+}
+
 func generateTLS(t *testing.T) (Config, *tls.Config, *tls.Config, *tls.Config) {
 	ca := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),


### PR DESCRIPTION
## Summary
- test that BuildManifest and Verify RPCs forward calls and log session IDs
- document which RPCs require the `replicator` role
- record test coverage for ProgressStream, BuildManifest and Verify in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` (fails: TestTransportNegotiationMatrix/tcp+tls; TestH2DialUnreachable; TestTCPTLSDialUnreachable)
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa6ccf180832397e0b28af7abe8e4