### PR TITLE
test: cover device apply UUID and mount errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- transfer: tests ensure mismatched device UUIDs and mounted devices return errors without writes.
 
 
 ### Fixed

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -37,14 +38,39 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create dest: %v", err)
 	}
+	sentinel := []byte("original")
+	if _, err := f.Write(sentinel); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
 	if err := f.Truncate(1024); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
 	f.Close()
+	before, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
 
 	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for uuid mismatch")
+	}
+	if !strings.Contains(err.Error(), "does not match expected") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) || after.Size() != before.Size() {
+		t.Fatalf("expected no writes to destination")
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.HasPrefix(data, sentinel) {
+		t.Fatalf("destination modified")
 	}
 }
 
@@ -62,20 +88,52 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create dest: %v", err)
 	}
+	sentinel := []byte("original")
+	if _, err := f.Write(sentinel); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
 	if err := f.Truncate(1024); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
 	f.Close()
+	before, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
 
 	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for mounted device")
+	}
+	if !strings.Contains(err.Error(), "mounted read-write") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) || after.Size() != before.Size() {
+		t.Fatalf("expected no writes to destination")
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.HasPrefix(data, sentinel) {
+		t.Fatalf("destination modified")
 	}
 
 	cfg.Force = true
 	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err != nil {
 		t.Fatalf("unexpected error with force: %v", err)
+	}
+	data, err = os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.HasPrefix(data, sentinel) {
+		t.Fatalf("destination modified after force")
 	}
 }
 
@@ -93,14 +151,39 @@ func TestApplyDataUUIDMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create dest: %v", err)
 	}
+	sentinel := []byte("original")
+	if _, err := f.Write(sentinel); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
 	if err := f.Truncate(1024); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
 	f.Close()
+	before, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
 
 	err = tr.applyData(cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for uuid mismatch")
+	}
+	if !strings.Contains(err.Error(), "does not match expected") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) || after.Size() != before.Size() {
+		t.Fatalf("expected no writes to destination")
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.HasPrefix(data, sentinel) {
+		t.Fatalf("destination modified")
 	}
 }
 
@@ -118,13 +201,38 @@ func TestApplyDataMountedDevice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create dest: %v", err)
 	}
+	sentinel := []byte("original")
+	if _, err := f.Write(sentinel); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
 	if err := f.Truncate(1024); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
 	f.Close()
+	before, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
 
 	err = tr.applyData(cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for mounted device")
+	}
+	if !strings.Contains(err.Error(), "mounted read-write") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) || after.Size() != before.Size() {
+		t.Fatalf("expected no writes to destination")
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.HasPrefix(data, sentinel) {
+		t.Fatalf("destination modified")
 	}
 }


### PR DESCRIPTION
## Summary
- ensure transfer apply rejects mismatched UUIDs and mounted destinations without writing
- document device apply error handling in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: unexpected peer handshake / network unreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa6d800308323b4516cb71ab05be0