### PR TITLE
fix: ensure TLS handshake is complete before negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.
+- tcp+tls: ensure negotiation performs TLS handshake and only records ALPN/TLS version when negotiated.
 - validate block size mismatch in handshakes
 - dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports

--- a/transport/negotiation_params_test.go
+++ b/transport/negotiation_params_test.go
@@ -146,7 +146,12 @@ func TestTransportNegotiationMatrix(t *testing.T) {
 				if cli.peer.DedupMode != m || cli.peer.Compress != "zstd" || cli.peer.ODirect != true ||
 					cli.peer.CDCMin != base.CDCMin || cli.peer.CDCAvg != base.CDCAvg || cli.peer.CDCMax != base.CDCMax ||
 					cli.peer.ALPN != base.ALPN || cli.peer.TLSVersion != base.TLSVersion {
-					t.Fatalf("unexpected peer handshake: %+v", cli.peer)
+					t.Fatalf("unexpected client peer handshake: %+v", cli.peer)
+				}
+				if srv.peer.DedupMode != m || srv.peer.Compress != "zstd" || srv.peer.ODirect != true ||
+					srv.peer.CDCMin != base.CDCMin || srv.peer.CDCAvg != base.CDCAvg || srv.peer.CDCMax != base.CDCMax ||
+					srv.peer.ALPN != base.ALPN || srv.peer.TLSVersion != base.TLSVersion {
+					t.Fatalf("unexpected server peer handshake: %+v", srv.peer)
 				}
 			}
 			// mismatch cases

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -228,6 +228,12 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 
 	if tlsConn, ok := conn.(*tls.Conn); ok {
 		state := tlsConn.ConnectionState()
+		if !state.HandshakeComplete {
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				return peer, err
+			}
+			state = tlsConn.ConnectionState()
+		}
 		negotiatedALPN := state.NegotiatedProtocol
 		negotiatedVersion := tlsVersionString(state.Version)
 		if hs.ALPN != "" && negotiatedALPN != "" && hs.ALPN != negotiatedALPN {
@@ -236,8 +242,12 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if hs.TLSVersion != "" && negotiatedVersion != "" && hs.TLSVersion != negotiatedVersion {
 			return peer, fmt.Errorf("tls version mismatch: %s", negotiatedVersion)
 		}
-		hs.ALPN = negotiatedALPN
-		hs.TLSVersion = negotiatedVersion
+		if negotiatedALPN != "" {
+			hs.ALPN = negotiatedALPN
+		}
+		if negotiatedVersion != "" {
+			hs.TLSVersion = negotiatedVersion
+		}
 	}
 
 	hs.Version = common.ProtocolVersion


### PR DESCRIPTION
## Summary
- complete TLS handshake in `tcp+tls` negotiation when needed
- only record ALPN/TLS version after a negotiated handshake
- verify both peers report negotiated ALPN and TLS version

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestH2DialUnreachable expected context deadline exceeded)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(warnings about diff processor)*
- `go test ./transport/...` *(fails: TestH2DialUnreachable expected context deadline exceeded)*
- `go test ./transport -run TestTransportNegotiationMatrix -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689fa718344c83239b3e10b697318b40