### PR TITLE
fix(common): validate transport mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes
+- handshake: validate transport mismatch in handshakes
 - dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports
 - remove placeholder error field from dial_start and listen_start logs for quic and ssh transports

--- a/common/handshake_validate.go
+++ b/common/handshake_validate.go
@@ -47,6 +47,9 @@ func ValidateHandshake(local, peer Handshake) error {
 	if peer.MaxInFlight > 0 && local.MaxInFlight > 0 && peer.MaxInFlight != local.MaxInFlight {
 		return fmt.Errorf("max in-flight mismatch: %d", peer.MaxInFlight)
 	}
+	if peer.Transport != "" && local.Transport != "" && peer.Transport != local.Transport {
+		return fmt.Errorf("transport mismatch: %s", peer.Transport)
+	}
 	if peer.ALPN != "" && local.ALPN != "" && peer.ALPN != local.ALPN {
 		return fmt.Errorf("alpn mismatch: %s", peer.ALPN)
 	}

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -60,3 +60,12 @@ func TestValidateHandshakeTLSVersionMismatch(t *testing.T) {
 		t.Fatal("expected tls version mismatch error")
 	}
 }
+
+func TestValidateHandshakeTransportMismatch(t *testing.T) {
+	local := Handshake{Transport: "quic"}
+	peer := local
+	peer.Transport = "h2"
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected transport mismatch error")
+	}
+}


### PR DESCRIPTION
## Summary
- validate transport field during handshake validation
- test transport mismatch case
- document transport validation in changelog

## Testing
- `go test ./common`
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTransportNegotiationMatrix, TestH2DialUnreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa71868a88323b5a90a0acd6dcfa3