### PR TITLE
fix(manifest): default rebuild logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - log sync errors in manifest and verify commands
 - ensure apply and dump commands flush logs with deferred SyncLogger
 - h2: ensure unreachable dial test uses context timeout and expects deadline exceeded
-- manifest: default rebuild command to a no-op logger and remove conditional logging checks
+- manifest: Rebuild defaults to `zap.NewNop()` and removes conditional logging checks
 - device: reject freeze/thaw command paths with invalid characters and document allowed format
 
 ## [v0.1.0] - 2025-02-27

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -285,6 +285,9 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // The operation respects cancellation via ctx.
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
 func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) (err error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	if err = ctx.Err(); err != nil {
 		return err
 	}
@@ -349,7 +352,7 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 		if err = idx.Set(off, uint32(n), xx, b3); err != nil {
 			return err
 		}
-		if logger != nil && (progressInterval == 0 || time.Since(lastLog) >= progressInterval) {
+		if progressInterval == 0 || time.Since(lastLog) >= progressInterval {
 			if err = ctx.Err(); err != nil {
 				return err
 			}
@@ -363,11 +366,9 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 			break
 		}
 	}
-	if logger != nil {
-		logger.Info("rebuild_complete",
-			zap.Uint64("size_bytes", size),
-			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
-		)
-	}
+	logger.Info("rebuild_complete",
+		zap.Uint64("size_bytes", size),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	)
 	return err
 }


### PR DESCRIPTION
## Summary
- default Rebuild to zap.NewNop when no logger provided
- remove conditional logging checks in Rebuild
- document change in changelog

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...` *(failed: interrupt in lvmsync_go/grpc/server)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa6948a308323b8e9ee7c4f90be53