### PR TITLE
refactor(transport): centralize role and TLS helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- transport: add Role.String and shared TLSVersionString helpers.
 
 
 ### Fixed

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -274,7 +274,7 @@ func (l *listener) Addr() net.Addr { return l.ln.Addr() }
 
 // Negotiate exchanges LVMSync handshake messages over the HTTP/2 stream.
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
-	roleStr := roleString(role)
+	roleStr := role.String()
 	address := conn.RemoteAddr().String()
 	t.logger.Info("negotiate_start",
 		zap.String("address", address),
@@ -317,7 +317,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 
 	if h2c, ok := conn.(*Conn); ok {
 		negotiatedALPN := h2c.tlsState.NegotiatedProtocol
-		negotiatedVersion := tlsVersionString(h2c.tlsState.Version)
+		negotiatedVersion := transport.TLSVersionString(h2c.tlsState.Version)
 		if hs.ALPN != "" && negotiatedALPN != "" && hs.ALPN != negotiatedALPN {
 			return peer, fmt.Errorf("alpn mismatch: %s", negotiatedALPN)
 		}
@@ -329,7 +329,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	} else if tlsConn, ok := conn.(*tls.Conn); ok {
 		state := tlsConn.ConnectionState()
 		negotiatedALPN := state.NegotiatedProtocol
-		negotiatedVersion := tlsVersionString(state.Version)
+		negotiatedVersion := transport.TLSVersionString(state.Version)
 		if hs.ALPN != "" && negotiatedALPN != "" && hs.ALPN != negotiatedALPN {
 			return peer, fmt.Errorf("alpn mismatch: %s", negotiatedALPN)
 		}
@@ -456,29 +456,3 @@ func (c *Conn) Close() error {
 func (c *Conn) SetDeadline(t time.Time) error      { return c.Conn.SetDeadline(t) }
 func (c *Conn) SetReadDeadline(t time.Time) error  { return c.Conn.SetReadDeadline(t) }
 func (c *Conn) SetWriteDeadline(t time.Time) error { return c.Conn.SetWriteDeadline(t) }
-
-func tlsVersionString(v uint16) string {
-	switch v {
-	case tls.VersionTLS10:
-		return "1.0"
-	case tls.VersionTLS11:
-		return "1.1"
-	case tls.VersionTLS12:
-		return "1.2"
-	case tls.VersionTLS13:
-		return "1.3"
-	default:
-		return ""
-	}
-}
-
-func roleString(r transport.Role) string {
-	switch r {
-	case transport.Client:
-		return "client"
-	case transport.Server:
-		return "server"
-	default:
-		return ""
-	}
-}

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -533,8 +533,8 @@ func TestTLSVersionString(t *testing.T) {
 		{0xffff, ""},
 	}
 	for _, tt := range tests {
-		if got := tlsVersionString(tt.version); got != tt.want {
-			t.Errorf("tlsVersionString(%#x) = %q, want %q", tt.version, got, tt.want)
+		if got := transport.TLSVersionString(tt.version); got != tt.want {
+			t.Errorf("TLSVersionString(%#x) = %q, want %q", tt.version, got, tt.want)
 		}
 	}
 }
@@ -549,8 +549,8 @@ func TestRoleString(t *testing.T) {
 		{transport.Role(99), ""},
 	}
 	for _, tt := range tests {
-		if got := roleString(tt.role); got != tt.want {
-			t.Errorf("roleString(%v) = %q, want %q", tt.role, got, tt.want)
+		if got := tt.role.String(); got != tt.want {
+			t.Errorf("Role(%v).String() = %q, want %q", tt.role, got, tt.want)
 		}
 	}
 }

--- a/transport/interface.go
+++ b/transport/interface.go
@@ -15,6 +15,18 @@ const (
 	Server
 )
 
+// String returns the string representation of the Role.
+func (r Role) String() string {
+	switch r {
+	case Client:
+		return "client"
+	case Server:
+		return "server"
+	default:
+		return ""
+	}
+}
+
 // Interface defines the minimal methods required for transports.
 //
 // Implementations must establish a connection via Dial or Listen and then

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -168,7 +168,7 @@ func (l *listener) Addr() net.Addr { return l.ql.Addr() }
 
 // Negotiate performs the LVMSync handshake over the stream.
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
-	roleStr := roleString(role)
+	roleStr := role.String()
 	address := conn.RemoteAddr().String()
 	t.logger.Info("negotiate_start",
 		zap.String("address", address),
@@ -212,7 +212,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	if qc, ok := conn.(*Conn); ok {
 		state := qc.qconn.ConnectionState()
 		negotiatedALPN := state.TLS.NegotiatedProtocol
-		negotiatedVersion := tlsVersionString(state.TLS.Version)
+		negotiatedVersion := transport.TLSVersionString(state.TLS.Version)
 		if hs.ALPN != "" && negotiatedALPN != "" && hs.ALPN != negotiatedALPN {
 			return peer, fmt.Errorf("alpn mismatch: %s", negotiatedALPN)
 		}
@@ -287,21 +287,6 @@ func clearDeadline(conn net.Conn) {
 	_ = conn.SetDeadline(time.Time{})
 }
 
-func tlsVersionString(v uint16) string {
-	switch v {
-	case tls.VersionTLS10:
-		return "1.0"
-	case tls.VersionTLS11:
-		return "1.1"
-	case tls.VersionTLS12:
-		return "1.2"
-	case tls.VersionTLS13:
-		return "1.3"
-	default:
-		return ""
-	}
-}
-
 // Datagram APIs.
 
 // SendDatagram sends a datagram using the underlying QUIC connection.
@@ -331,14 +316,3 @@ func (c *Conn) SetDeadline(t time.Time) error {
 }
 func (c *Conn) SetReadDeadline(t time.Time) error  { return c.stream.SetReadDeadline(t) }
 func (c *Conn) SetWriteDeadline(t time.Time) error { return c.stream.SetWriteDeadline(t) }
-
-func roleString(r transport.Role) string {
-	switch r {
-	case transport.Client:
-		return "client"
-	case transport.Server:
-		return "server"
-	default:
-		return ""
-	}
-}

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -223,7 +223,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 }
 
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
-	roleStr := roleString(role)
+	roleStr := role.String()
 	address := conn.RemoteAddr().String()
 	t.logger.Info("negotiate_start",
 		zap.String("address", address),
@@ -377,17 +377,6 @@ func (s *serverConn) RemoteAddr() net.Addr               { return s.netConn.Remo
 func (s *serverConn) SetDeadline(t time.Time) error      { return s.netConn.SetDeadline(t) }
 func (s *serverConn) SetReadDeadline(t time.Time) error  { return s.netConn.SetReadDeadline(t) }
 func (s *serverConn) SetWriteDeadline(t time.Time) error { return s.netConn.SetWriteDeadline(t) }
-
-func roleString(r transport.Role) string {
-	switch r {
-	case transport.Client:
-		return "client"
-	case transport.Server:
-		return "server"
-	default:
-		return ""
-	}
-}
 
 func setDeadline(ctx context.Context, conn net.Conn) error {
 	if d, ok := ctx.Deadline(); ok {

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -185,7 +185,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 }
 
 func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (peer common.Handshake, err error) {
-	roleStr := roleString(role)
+	roleStr := role.String()
 	address := conn.RemoteAddr().String()
 	t.logger.Info("negotiate_start",
 		zap.String("address", address),
@@ -229,7 +229,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 	if tlsConn, ok := conn.(*tls.Conn); ok {
 		state := tlsConn.ConnectionState()
 		negotiatedALPN := state.NegotiatedProtocol
-		negotiatedVersion := tlsVersionString(state.Version)
+		negotiatedVersion := transport.TLSVersionString(state.Version)
 		if hs.ALPN != "" && negotiatedALPN != "" && hs.ALPN != negotiatedALPN {
 			return peer, fmt.Errorf("alpn mismatch: %s", negotiatedALPN)
 		}
@@ -302,30 +302,4 @@ func setDeadline(ctx context.Context, conn net.Conn) error {
 
 func clearDeadline(conn net.Conn) {
 	_ = conn.SetDeadline(time.Time{})
-}
-
-func tlsVersionString(v uint16) string {
-	switch v {
-	case tls.VersionTLS10:
-		return "1.0"
-	case tls.VersionTLS11:
-		return "1.1"
-	case tls.VersionTLS12:
-		return "1.2"
-	case tls.VersionTLS13:
-		return "1.3"
-	default:
-		return ""
-	}
-}
-
-func roleString(r transport.Role) string {
-	switch r {
-	case transport.Client:
-		return "client"
-	case transport.Server:
-		return "server"
-	default:
-		return ""
-	}
 }

--- a/transport/util.go
+++ b/transport/util.go
@@ -1,0 +1,19 @@
+package transport
+
+import "crypto/tls"
+
+// TLSVersionString returns a string representation of the TLS version number.
+func TLSVersionString(v uint16) string {
+	switch v {
+	case tls.VersionTLS10:
+		return "1.0"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS13:
+		return "1.3"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- add Role.String and TLSVersionString helpers
- replace per-transport helper functions with shared versions
- update tests for new helpers

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` (fails: TestRateLimitedWritersIndependent, TestTransportNegotiationMatrix, TestH2DialUnreachable, TestTCPTLSDialUnreachable)
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa69ff22083239eb5a5855190d65e