### PR TITLE
fix(config): validate CDC tunable ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.
+- config: validate positive CDC tunables and ordering.
 - validate block size mismatch in handshakes
 - dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports

--- a/README.md
+++ b/README.md
@@ -653,8 +653,8 @@ Hybrid dedup combines fixed-size and content-defined chunking. Enable it with `-
 | `--cdc-avg`      | `LVMSYNC_CDC_AVG`    | `cdc_avg`  | Target average chunk size |
 | `--cdc-max`      | `LVMSYNC_CDC_MAX`    | `cdc_max`  | Maximum chunk size |
 
-The three values must satisfy `--cdc-min ≤ --cdc-avg ≤ --cdc-max`. LVMSync aborts with
-`invalid local cdc ordering: min %d avg %d max %d` when the ordering is invalid.
+The three values must be positive and satisfy `--cdc-min ≤ --cdc-avg ≤ --cdc-max`.
+LVMSync aborts when the sizes are non-positive or unordered.
 
 The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom_entries` and desired false positive rate via `--bloom_fp_rate`. For an mmap-backed index, `--bloom_mbits` controls the bitmap size in megabits.
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -348,6 +348,9 @@ func TestConfigValidate(t *testing.T) {
 			HeartbeatInterval:    time.Second,
 			HeartbeatSendTimeout: time.Second,
 			TCPParallel:          1,
+			CDCMin:               64,
+			CDCAvg:               128,
+			CDCMax:               256,
 		}
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -360,49 +363,49 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second, TCPParallel: 1}
+		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidKeepalive", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+		cfg := &Config{Mode: "default", SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatInterval", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+		cfg := &Config{Mode: "default", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatSendTimeout", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0, TCPParallel: 1}
+		cfg := &Config{Mode: "default", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidGRPCSetupTimeout", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: 0, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+		cfg := &Config{Mode: "default", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: 0, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPParallel", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 5}
+		cfg := &Config{Mode: "default", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 5, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPLowat", func(t *testing.T) {
-		cfg := &Config{SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, TCPNotSentLowAt: -1}
+		cfg := &Config{Mode: "default", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, TCPNotSentLowAt: -1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -413,9 +416,51 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Millisecond, TCPParallel: 1}
+		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Millisecond, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected timeout error")
+		}
+	})
+}
+
+func TestConfigValidateCDC(t *testing.T) {
+	base := Config{
+		Mode:                 "default",
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		cfg := base
+		cfg.CDCMin = 1
+		cfg.CDCAvg = 1
+		cfg.CDCMax = 1
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("nonPositive", func(t *testing.T) {
+		cfg := base
+		cfg.CDCMin = 0
+		cfg.CDCAvg = 1
+		cfg.CDCMax = 1
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("unordered", func(t *testing.T) {
+		cfg := base
+		cfg.CDCMin = 4
+		cfg.CDCAvg = 2
+		cfg.CDCMax = 3
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
 		}
 	})
 }
@@ -479,7 +524,7 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{Mode: "default", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1}
+	cfg := &Config{Mode: "default", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 	if err := cfg.ValidateWith(geteuid); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -499,6 +544,9 @@ func TestValidateMode(t *testing.T) {
 		HeartbeatInterval:    time.Second,
 		HeartbeatSendTimeout: time.Second,
 		TCPParallel:          1,
+		CDCMin:               64,
+		CDCAvg:               128,
+		CDCMax:               256,
 	}
 
 	cases := []struct {

--- a/config/validation.go
+++ b/config/validation.go
@@ -42,6 +42,12 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.TCPNotSentLowAt < 0 {
 		return fmt.Errorf("tcp_lowat must be >= 0")
 	}
+	if c.CDCMin <= 0 || c.CDCAvg <= 0 || c.CDCMax <= 0 {
+		return fmt.Errorf("cdc sizes must be > 0")
+	}
+	if !(c.CDCMin <= c.CDCAvg && c.CDCAvg <= c.CDCMax) {
+		return fmt.Errorf("invalid cdc ordering: min %d avg %d max %d", c.CDCMin, c.CDCAvg, c.CDCMax)
+	}
 	if c.VolumeGroup != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), c.LVMTimeout)
 		defer cancel()


### PR DESCRIPTION
## Summary
- validate CDC sizes are positive and ordered
- test CDC tunable validation including boundary cases
- document CDC size constraints

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTransportNegotiationMatrix/tcp+tls, TestH2DialUnreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa6c865dc8323ad9a4879dd2e9aee