### PR TITLE
test(common): add o_direct handshake validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
+- tests: validate O_DIRECT mismatch and agreement in handshake validation.
 
 
 ### Fixed

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -60,3 +60,19 @@ func TestValidateHandshakeTLSVersionMismatch(t *testing.T) {
 		t.Fatal("expected tls version mismatch error")
 	}
 }
+
+func TestValidateHandshakeODirectMismatch(t *testing.T) {
+	local := Handshake{ODirect: true}
+	peer := Handshake{}
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected o_direct mismatch error")
+	}
+}
+
+func TestValidateHandshakeODirectMatch(t *testing.T) {
+	local := Handshake{ODirect: true}
+	peer := Handshake{ODirect: true}
+	if err := ValidateHandshake(local, peer); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests covering O_DIRECT handshake mismatch and match
- document new tests in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: unexpected peer handshake and h2 dial expectation)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fa6ca5fa48323ae98fad9d05416ca