### PR TITLE
fix: allow resume after dedup mode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: add manifest index persistence test covering read/write, rebuild, and verify paths.
 - cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 - transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.
+- transfer: add tests verifying resume state alignment across dedup mode transitions.
 - manifest: add `manifest_timeout` option to control rebuild timeout.
 - device: allow configurable LVM privilege escalation command.
 - tests: verify ALPN and TLS version round-trip in handshake and transport negotiation.
@@ -53,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove legacy dedup manifest in favor of manifest.Index
 - device: surface freeze/thaw command output when raw device operations fail
 - transfer: give each writer an independent rate limiter
+- allow resuming transfers after changing dedup modes
 - cmd/dump: handle context cancellation during pipe copies to avoid incomplete writes
 - rename dry run log field to `eta_seconds` and log durations in seconds
 - transfer: replace global checkpoint state with per-transfer resume trackers

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -111,7 +111,7 @@ func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
 		return out
 	}
 	if rs.Transport != cfg.Transport || rs.Compress != cfg.Compress ||
-		rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm || rs.DedupMode != cfg.DedupMode {
+		rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm {
 		return out
 	}
 	b, err := hex.DecodeString(rs.Chunk)

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -121,3 +121,41 @@ func TestResumeParallel(t *testing.T) {
 	// resume state file contains the digest of the last transferred chunk
 	// to allow recovery after interruptions.
 }
+
+func TestResumeModeTransitions(t *testing.T) {
+	transitions := []struct {
+		from string
+		to   string
+	}{
+		{"fixed", "cdc"},
+		{"cdc", "hybrid"},
+		{"hybrid", "fixed"},
+	}
+	for _, trc := range transitions {
+		t.Run(trc.from+"_to_"+trc.to, func(t *testing.T) {
+			tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+			tr.Tracker = &resumeTracker{}
+			blockSize := int64(1024)
+			src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
+
+			cfgStart := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.from}
+			digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
+			writeResumeState(cfgStart, zap.NewNop(), resume, uint64(blockSize), uint32(blockSize), digest)
+
+			cfgResume := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.to}
+
+			var buf bytes.Buffer
+			if err := tr.DumpChangesParallel(cfgResume, snapshot, src, &buf); err != nil {
+				t.Fatalf("DumpChangesParallel failed: %v", err)
+			}
+			finalizeResumeState(cfgResume, tr.Tracker, zap.NewNop())
+
+			offsets := parseOffsets(t, buf.Bytes(), blockSize)
+			sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
+			expected := []int64{2 * blockSize, 3 * blockSize}
+			if !reflect.DeepEqual(offsets, expected) {
+				t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- allow resume state to be loaded even when dedup mode changes
- test resuming after switching dedup modes

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` (fails: TestRateLimitedWritersIndependent, TestTransportNegotiationMatrix/tcp+tls, TestH2DialUnreachable)
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` (warnings about exclusion paths)


------
https://chatgpt.com/codex/tasks/task_e_689fa6d1a39c8323a16919b33cacd073