### PR TITLE
fix(quic): propagate connection deadlines to datagram reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- quic: propagate deadlines to connection for datagram reads.
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.
 - validate block size mismatch in handshakes

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -327,10 +327,31 @@ func (c *Conn) SetDeadline(t time.Time) error {
 	if err := c.stream.SetDeadline(t); err != nil {
 		return err
 	}
+	if d, ok := c.qconn.(interface{ SetDeadline(time.Time) error }); ok {
+		return d.SetDeadline(t)
+	}
 	return nil
 }
-func (c *Conn) SetReadDeadline(t time.Time) error  { return c.stream.SetReadDeadline(t) }
-func (c *Conn) SetWriteDeadline(t time.Time) error { return c.stream.SetWriteDeadline(t) }
+
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	if err := c.stream.SetReadDeadline(t); err != nil {
+		return err
+	}
+	if d, ok := c.qconn.(interface{ SetReadDeadline(time.Time) error }); ok {
+		return d.SetReadDeadline(t)
+	}
+	return nil
+}
+
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	if err := c.stream.SetWriteDeadline(t); err != nil {
+		return err
+	}
+	if d, ok := c.qconn.(interface{ SetWriteDeadline(time.Time) error }); ok {
+		return d.SetWriteDeadline(t)
+	}
+	return nil
+}
 
 func roleString(r transport.Role) string {
 	switch r {

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"math/big"
 	"net"
 	"testing"
@@ -317,6 +318,71 @@ func TestQUICTransportRequiresClientCert(t *testing.T) {
 	}
 	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, AllowInsecure: true}); err != nil {
 		t.Fatalf("allow insecure should permit missing client cert: %v", err)
+	}
+}
+
+func TestConnDatagramReadDeadline(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), ClientCert: cert, AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- fmt.Errorf("accept: %w", err)
+			return
+		}
+		qconn := conn.(*Conn)
+		defer qconn.Close()
+		qconn.SetReadDeadline(time.Now().Add(-time.Second))
+		if _, err := qconn.ReceiveDatagram(ctx); err != nil {
+			var ne net.Error
+			if !errors.As(err, &ne) || !ne.Timeout() {
+				done <- fmt.Errorf("expected timeout error, got %v", err)
+				return
+			}
+		} else {
+			done <- errors.New("expected timeout error")
+			return
+		}
+		qconn.SetReadDeadline(time.Time{})
+		close(ready)
+		b, err := qconn.ReceiveDatagram(ctx)
+		if err != nil {
+			done <- fmt.Errorf("receive datagram: %w", err)
+			return
+		}
+		if string(b) != "hi" {
+			done <- fmt.Errorf("unexpected datagram %q", b)
+			return
+		}
+		done <- nil
+	}()
+
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	qconn := conn.(*Conn)
+	defer qconn.Close()
+
+	<-ready
+	if err := qconn.SendDatagram([]byte("hi")); err != nil {
+		t.Fatalf("send datagram: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- forward deadline setters to quic connection so datagram reads time out
- cover datagram read deadlines in quic transport tests
- note datagram deadline fix in changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: unexpected peer handshake; expected context deadline exceeded)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fa697f7a083239634381ef865d6a0