### PR TITLE
fix: preserve close hook in manifest index initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - handshake: validate transport mismatch in handshakes
 - dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports
+- manifest: preserve injected close hooks in Create, Open, and Upgrade
 - remove placeholder error field from dial_start and listen_start logs for quic and ssh transports
 - propagate seek errors during block writes to prevent silent data loss
 - Remove obsolete gap and pruning entries after rerunning static analysis.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -50,19 +50,22 @@ type Index struct {
 type Options struct {
 	DetectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
 	CloseHook    func() error
-
-// IndexOption configures an Index on creation.
-type IndexOption func(*Index)
+}
 
 // WithCloseHook sets a hook invoked when Index.Close is called.
-func WithCloseHook(h func() error) IndexOption {
-	return func(i *Index) { i.closeHook = h }
+func WithCloseHook(h func() error) Options {
+	return Options{CloseHook: h}
 }
 
 func getOptions(opts []Options) Options {
 	var o Options
-	if len(opts) > 0 {
-		o = opts[0]
+	for _, opt := range opts {
+		if opt.DetectDevice != nil {
+			o.DetectDevice = opt.DetectDevice
+		}
+		if opt.CloseHook != nil {
+			o.CloseHook = opt.CloseHook
+		}
 	}
 	if o.DetectDevice == nil {
 		o.DetectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
@@ -173,10 +176,6 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Option
 		return nil, err
 	}
 	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
 	idx.hdr = Header{
 		Version:    Version,
 		BlockSize:  blockSize,
@@ -193,8 +192,6 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Option
 func Open(path string, opts ...Options) (*Index, error) {
 	o := getOptions(opts)
 
-func Open(path string, opts ...IndexOption) (*Index, error) {
-
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -212,11 +209,6 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 	}
 
 	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
 
 	if err := idx.readHeader(); err != nil {
 		idx.Close()
@@ -231,8 +223,6 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 func Upgrade(path string, opts ...Options) (*Index, error) {
 	o := getOptions(opts)
 
-func Upgrade(path string, opts ...IndexOption) (*Index, error) {
-
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -250,11 +240,6 @@ func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 	}
 
 	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
 
 	if err := idx.readHeader(); err != nil {
 		if !errors.Is(err, ErrVersionMismatch) {
@@ -342,14 +327,9 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
 func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...Options) (err error) {
 	o := getOptions(opts)
-
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) (err error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
-
 	if err = ctx.Err(); err != nil {
 		return err
 	}
@@ -385,11 +365,7 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	}
 	defer f.Close()
 	var idx *Index
-
 	idx, err = Create(output, id, size, blockSize, o)
-
-	idx, err = Create(output, id, size, blockSize, opts...)
-
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -282,11 +282,6 @@ func TestRebuildCloseOnce(t *testing.T) {
 	manPath := filepath.Join(dir, "closeonce.man")
 	count := 0
 
-	hook := func() error { count++; return nil }
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{CloseHook: hook}); err != nil {
-=======
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { count++; return nil })); err != nil {
@@ -314,11 +309,6 @@ func TestRebuildCloseError(t *testing.T) {
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeerr.man")
-
-	hook := func() error { return errors.New("close fail") }
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{CloseHook: hook}); err == nil || !strings.Contains(err.Error(), "close fail") {
 
 	hookErr := errors.New("close fail")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
## Summary
- ensure Create, Open, and Upgrade respect injected close hooks
- consolidate option handling into a single WithCloseHook helper
- document manifest close hook fix in changelog

## Testing
- `go build ./...` *(fails: method Conn.SetReadDeadline already declared at transport/quic/quic.go:304)*
- `go test ./manifest`


------
https://chatgpt.com/codex/tasks/task_e_689fb03e4808832391720d12cf740b67