### PR TITLE
refactor(manifest): unify index options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
 - tests: validate O_DIRECT mismatch and agreement in handshake validation.
 - transport: add Role.String and shared TLSVersionString helpers.
-- manifest: support dependency injection via Options for device detection and close hooks.
+- manifest: use functional IndexOption for device detection and close hooks.
 - hash: add Blake3Hasher tests covering keyed and unkeyed modes with state reset verification.
 - transfer: tests ensure mismatched device UUIDs and mounted devices return errors without writes.
 - grpc: tests cover ProgressStream, BuildManifest, and Verify logging and forwarding.

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -150,7 +150,7 @@ func TestRunAppliesManifestTimeout(t *testing.T) {
 	cfg.ManifestTimeout = 2 * time.Second
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.Options) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}
@@ -171,7 +171,7 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.Options) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}
@@ -198,7 +198,7 @@ func TestRunContextNoDeadline(t *testing.T) {
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.Options) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -46,33 +46,39 @@ type Index struct {
 	closeHook func() error
 }
 
-// Options allows tests to inject dependencies for device detection and close hooks.
-type Options struct {
-	DetectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
-	CloseHook    func() error
+// IndexOption configures an Index or related helpers.
+type IndexOption func(*indexOptions)
 
-// IndexOption configures an Index on creation.
-type IndexOption func(*Index)
+type indexOptions struct {
+	detectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
+	closeHook    func() error
+}
+
+func defaultIndexOptions() indexOptions {
+	return indexOptions{
+		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
+		},
+		closeHook: func() error { return nil },
+	}
+}
+
+func applyOptions(opts []IndexOption) indexOptions {
+	cfg := defaultIndexOptions()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
 
 // WithCloseHook sets a hook invoked when Index.Close is called.
 func WithCloseHook(h func() error) IndexOption {
-	return func(i *Index) { i.closeHook = h }
+	return func(o *indexOptions) { o.closeHook = h }
 }
 
-func getOptions(opts []Options) Options {
-	var o Options
-	if len(opts) > 0 {
-		o = opts[0]
-	}
-	if o.DetectDevice == nil {
-		o.DetectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
-		}
-	}
-	if o.CloseHook == nil {
-		o.CloseHook = func() error { return nil }
-	}
-	return o
+// WithDetectDevice overrides device detection for Rebuild.
+func WithDetectDevice(f func(context.Context, string, *zap.Logger) (device.Device, error)) IndexOption {
+	return func(o *indexOptions) { o.detectDevice = f }
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.
@@ -152,8 +158,8 @@ func (i *Index) Close() error {
 }
 
 // Create initializes a new manifest index at path for the given device.
-func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
+func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexOption) (*Index, error) {
+	cfg := applyOptions(opts)
 	if len(deviceID) > 64 {
 		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
 	}
@@ -172,11 +178,7 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Option
 		f.Close()
 		return nil, err
 	}
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
+	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
 	idx.hdr = Header{
 		Version:    Version,
 		BlockSize:  blockSize,
@@ -190,10 +192,8 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Option
 }
 
 // Open maps an existing manifest index file.
-func Open(path string, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
-
 func Open(path string, opts ...IndexOption) (*Index, error) {
+	cfg := applyOptions(opts)
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -211,13 +211,7 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 		return nil, err
 	}
 
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
-
+	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
 	if err := idx.readHeader(); err != nil {
 		idx.Close()
 		return nil, err
@@ -227,11 +221,8 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 
 // Upgrade opens the manifest at path, upgrading older versions in-place.
 // It returns an Index mapped to the upgraded file.
-
-func Upgrade(path string, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
-
 func Upgrade(path string, opts ...IndexOption) (*Index, error) {
+	cfg := applyOptions(opts)
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -249,13 +240,7 @@ func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 		return nil, err
 	}
 
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
-
+	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
 	if err := idx.readHeader(); err != nil {
 		if !errors.Is(err, ErrVersionMismatch) {
 			idx.Close()
@@ -340,15 +325,11 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
 // The operation respects cancellation via ctx.
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...Options) (err error) {
-	o := getOptions(opts)
-
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) (err error) {
+func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
+	cfg := applyOptions(opts)
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
 
 	if err = ctx.Err(); err != nil {
 		return err
@@ -360,8 +341,7 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	if mounted && !allowMounted {
 		return fmt.Errorf("manifest: %s is mounted read-write; use --manifest-allow-mounted to override", devicePath)
 	}
-	var dev device.Device
-	dev, err = o.DetectDevice(ctx, devicePath, logger)
+	dev, err := cfg.detectDevice(ctx, devicePath, logger)
 	if err != nil {
 		return err
 	}
@@ -378,18 +358,14 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	if err = ctx.Err(); err != nil {
 		return err
 	}
-	var f *os.File
-	f, err = os.Open(dev.Path())
+	f, err := os.Open(dev.Path())
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 	var idx *Index
 
-	idx, err = Create(output, id, size, blockSize, o)
-
 	idx, err = Create(output, id, size, blockSize, opts...)
-
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -285,11 +285,7 @@ func TestRebuildCloseOnce(t *testing.T) {
 	hook := func() error { count++; return nil }
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{CloseHook: hook}); err != nil {
-=======
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { count++; return nil })); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(hook)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if count != 1 {
@@ -318,13 +314,7 @@ func TestRebuildCloseError(t *testing.T) {
 	hook := func() error { return errors.New("close fail") }
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{CloseHook: hook}); err == nil || !strings.Contains(err.Error(), "close fail") {
-
-	hookErr := errors.New("close fail")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { return hookErr })); err == nil || !strings.Contains(err.Error(), "close fail") {
-
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(hook)); err == nil || !strings.Contains(err.Error(), "close fail") {
 		t.Fatalf("expected close error, got %v", err)
 	}
 }
@@ -356,7 +346,7 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	manPath := filepath.Join(dir, "rebuildbs.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{DetectDevice: detect}); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithDetectDevice(detect)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -479,7 +469,7 @@ func TestRebuildCanceledContext(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		cancel()
 	}()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{DetectDevice: detect}); !errors.Is(err, context.Canceled) {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithDetectDevice(detect)); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- replace Options with functional IndexOption
- update manifest helpers and callers to accept IndexOption
- adjust tests for new option style

## Testing
- `go build ./manifest ./cmd/manifest`
- `go build ./...` *(fails: method Conn.SetReadDeadline already declared)*
- `go test ./manifest ./cmd/manifest`


------
https://chatgpt.com/codex/tasks/task_e_689fb03e79188323826a61440b966d60