### PR TITLE
refactor(manifest): unify index options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
 - tests: validate O_DIRECT mismatch and agreement in handshake validation.
 - transport: add Role.String and shared TLSVersionString helpers.
-- manifest: support dependency injection via Options for device detection and close hooks.
+- manifest: unify index options for device detection and close hooks across constructors.
 - hash: add Blake3Hasher tests covering keyed and unkeyed modes with state reset verification.
 - transfer: tests ensure mismatched device UUIDs and mounted devices return errors without writes.
 - grpc: tests cover ProgressStream, BuildManifest, and Verify logging and forwarding.

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -150,7 +150,7 @@ func TestRunAppliesManifestTimeout(t *testing.T) {
 	cfg.ManifestTimeout = 2 * time.Second
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.Options) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}
@@ -171,7 +171,7 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.Options) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}
@@ -198,7 +198,7 @@ func TestRunContextNoDeadline(t *testing.T) {
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.Options) error {
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -46,33 +46,42 @@ type Index struct {
 	closeHook func() error
 }
 
-// Options allows tests to inject dependencies for device detection and close hooks.
-type Options struct {
-	DetectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
-	CloseHook    func() error
+// indexOptions collects constructor options for Index and helpers like Rebuild.
+type indexOptions struct {
+	detectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
+	closeHook    func() error
+}
 
-// IndexOption configures an Index on creation.
-type IndexOption func(*Index)
+// IndexOption configures construction of an Index.
+type IndexOption func(*indexOptions)
+
+// defaultOptions returns the default option set.
+func defaultOptions() indexOptions {
+	return indexOptions{
+		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
+		},
+		closeHook: func() error { return nil },
+	}
+}
+
+// applyOptions applies supplied options to the defaults.
+func applyOptions(opts []IndexOption) indexOptions {
+	o := defaultOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// WithDetectDevice overrides the device detection function used by Rebuild.
+func WithDetectDevice(fn func(context.Context, string, *zap.Logger) (device.Device, error)) IndexOption {
+	return func(o *indexOptions) { o.detectDevice = fn }
+}
 
 // WithCloseHook sets a hook invoked when Index.Close is called.
 func WithCloseHook(h func() error) IndexOption {
-	return func(i *Index) { i.closeHook = h }
-}
-
-func getOptions(opts []Options) Options {
-	var o Options
-	if len(opts) > 0 {
-		o = opts[0]
-	}
-	if o.DetectDevice == nil {
-		o.DetectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
-		}
-	}
-	if o.CloseHook == nil {
-		o.CloseHook = func() error { return nil }
-	}
-	return o
+	return func(o *indexOptions) { o.closeHook = h }
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.
@@ -152,8 +161,8 @@ func (i *Index) Close() error {
 }
 
 // Create initializes a new manifest index at path for the given device.
-func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
+func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexOption) (*Index, error) {
+	o := applyOptions(opts)
 	if len(deviceID) > 64 {
 		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
 	}
@@ -172,11 +181,7 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Option
 		f.Close()
 		return nil, err
 	}
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
+	idx := &Index{f: f, data: data, closeHook: o.closeHook}
 	idx.hdr = Header{
 		Version:    Version,
 		BlockSize:  blockSize,
@@ -190,10 +195,8 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Option
 }
 
 // Open maps an existing manifest index file.
-func Open(path string, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
-
 func Open(path string, opts ...IndexOption) (*Index, error) {
+	o := applyOptions(opts)
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -210,14 +213,7 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 		f.Close()
 		return nil, err
 	}
-
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
-
+	idx := &Index{f: f, data: data, closeHook: o.closeHook}
 	if err := idx.readHeader(); err != nil {
 		idx.Close()
 		return nil, err
@@ -227,11 +223,8 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 
 // Upgrade opens the manifest at path, upgrading older versions in-place.
 // It returns an Index mapped to the upgraded file.
-
-func Upgrade(path string, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
-
 func Upgrade(path string, opts ...IndexOption) (*Index, error) {
+	o := applyOptions(opts)
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -248,14 +241,7 @@ func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 		f.Close()
 		return nil, err
 	}
-
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-	idx := &Index{f: f, data: data, closeHook: func() error { return nil }}
-	for _, opt := range opts {
-		opt(idx)
-	}
-
+	idx := &Index{f: f, data: data, closeHook: o.closeHook}
 	if err := idx.readHeader(); err != nil {
 		if !errors.Is(err, ErrVersionMismatch) {
 			idx.Close()
@@ -340,15 +326,11 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
 // The operation respects cancellation via ctx.
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...Options) (err error) {
-	o := getOptions(opts)
-
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool) (err error) {
+func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
+	o := applyOptions(opts)
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
 
 	if err = ctx.Err(); err != nil {
 		return err
@@ -360,8 +342,7 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	if mounted && !allowMounted {
 		return fmt.Errorf("manifest: %s is mounted read-write; use --manifest-allow-mounted to override", devicePath)
 	}
-	var dev device.Device
-	dev, err = o.DetectDevice(ctx, devicePath, logger)
+	dev, err := o.detectDevice(ctx, devicePath, logger)
 	if err != nil {
 		return err
 	}
@@ -378,18 +359,13 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	if err = ctx.Err(); err != nil {
 		return err
 	}
-	var f *os.File
-	f, err = os.Open(dev.Path())
+	f, err := os.Open(dev.Path())
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 	var idx *Index
-
-	idx, err = Create(output, id, size, blockSize, o)
-
 	idx, err = Create(output, id, size, blockSize, opts...)
-
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -123,6 +123,71 @@ func TestUpgrade(t *testing.T) {
 	}
 }
 
+func TestCreateCloseHook(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hook.man")
+	called := 0
+	idx, err := Create(path, "dev", 4096, 4096, WithCloseHook(func() error { called++; return nil }))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("expected close hook called once, got %d", called)
+	}
+}
+
+func TestOpenCloseHook(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hook.man")
+	idx, err := Create(path, "dev", 4096, 4096)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	called := 0
+	idx, err = Open(path, WithCloseHook(func() error { called++; return nil }))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("expected close hook called once, got %d", called)
+	}
+}
+
+func TestUpgradeCloseHook(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hook.man")
+	idx, err := Create(path, "dev", 4096, 4096)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	idx.hdr.Version = 0
+	idx.hdr.MAC = headerMAC(&idx.hdr)
+	idx.writeHeader()
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	called := 0
+	up, err := Upgrade(path, WithCloseHook(func() error { called++; return nil }))
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	if err := up.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("expected close hook called once, got %d", called)
+	}
+}
+
 func TestMatchXXHShortcut(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "shortcut.man")
@@ -263,7 +328,7 @@ func TestRebuild(t *testing.T) {
 	}
 }
 
-func TestRebuildCloseOnce(t *testing.T) {
+func TestRebuildCloseHook(t *testing.T) {
 	dir := t.TempDir()
 	file, err := os.CreateTemp(dir, "dev-*.img")
 	if err != nil {
@@ -281,12 +346,6 @@ func TestRebuildCloseOnce(t *testing.T) {
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeonce.man")
 	count := 0
-
-	hook := func() error { count++; return nil }
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{CloseHook: hook}); err != nil {
-=======
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { count++; return nil })); err != nil {
@@ -314,17 +373,10 @@ func TestRebuildCloseError(t *testing.T) {
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeerr.man")
-
-	hook := func() error { return errors.New("close fail") }
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{CloseHook: hook}); err == nil || !strings.Contains(err.Error(), "close fail") {
-
 	hookErr := errors.New("close fail")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { return hookErr })); err == nil || !strings.Contains(err.Error(), "close fail") {
-
 		t.Fatalf("expected close error, got %v", err)
 	}
 }
@@ -356,7 +408,7 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	manPath := filepath.Join(dir, "rebuildbs.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{DetectDevice: detect}); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithDetectDevice(detect)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -479,7 +531,7 @@ func TestRebuildCanceledContext(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		cancel()
 	}()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, Options{DetectDevice: detect}); !errors.Is(err, context.Canceled) {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithDetectDevice(detect)); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- consolidate manifest options into a unified IndexOption mechanism
- remove duplicate index initialization and apply options across Create/Open/Upgrade/Rebuild
- add close-hook propagation tests for Create, Open, Upgrade and Rebuild

## Testing
- `go build ./...` *(fails: method Conn.SetReadDeadline already declared at transport/quic/quic.go:304:16)*
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake_validate_test.go:77:1: expected statement, found '==')*
- `golangci-lint run` *(fails: method Conn.SetReadDeadline already declared at transport/quic/quic.go:304:16)*
- `go tool cover -func=coverage.out` *(fails: build failure)*

------
https://chatgpt.com/codex/tasks/task_e_689fb05691388323a04d77602b88bab8