### PR TITLE
fix: ensure FastCDC chunks own data slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manifest: Rebuild defaults to `zap.NewNop()` and removes conditional logging checks
 - device: reject freeze/thaw command paths with invalid characters and document allowed format
 - device: allow freeze/thaw command paths containing directories by validating basename only
+- dedup: ensure FastCDC chunks own their data slices to prevent cross-chunk mutation
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -168,6 +168,10 @@ func FastCDC(r io.Reader, min, avg, max int) ([]Chunk, error) {
 		}
 		c.Offset = offset
 		offset += int64(c.Length)
+		// copy data so each chunk owns its slice
+		data := make([]byte, c.Length)
+		copy(data, c.Data)
+		c.Data = data
 		out = append(out, c)
 		if err == io.EOF {
 			break

--- a/dedup/chunker_test.go
+++ b/dedup/chunker_test.go
@@ -69,3 +69,25 @@ func TestNewChunkerValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestFastCDCDataIsolation(t *testing.T) {
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	chunks, err := FastCDC(bytes.NewReader(data), 64, 128, 256)
+	if err != nil {
+		t.Fatalf("FastCDC failed: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least two chunks, got %d", len(chunks))
+	}
+	if len(chunks[1].Data) == 0 {
+		t.Fatalf("second chunk has no data")
+	}
+	orig := chunks[1].Data[0]
+	chunks[0].Data[0] ^= 0xFF
+	if chunks[1].Data[0] != orig {
+		t.Fatalf("modifying first chunk altered second chunk data")
+	}
+}

--- a/dedup/hybrid_test.go
+++ b/dedup/hybrid_test.go
@@ -29,7 +29,7 @@ func TestHybridChunkerProducesChunks(t *testing.T) {
 	}
 }
 
-func TestHybridChunkerBufferReuse(t *testing.T) {
+func TestHybridChunkerBufferOwnership(t *testing.T) {
 	fixed := 1 << 16
 	data := bytes.Repeat([]byte("a"), fixed*2)
 	h := NewHybridChunker(fixed, 64, 128, 256)
@@ -49,8 +49,8 @@ func TestHybridChunkerBufferReuse(t *testing.T) {
 	if err != nil && err != io.EOF {
 		t.Fatalf("next chunk: %v", err)
 	}
-	if &c2.Data[0] != chunkPtr {
-		t.Fatalf("chunk buffer not reused")
+	if &c2.Data[0] == chunkPtr {
+		t.Fatalf("chunk buffer reused")
 	}
 
 	offset := c1.Length + c2.Length


### PR DESCRIPTION
## Summary
- copy data for each chunk emitted by FastCDC
- test that modifying one chunk does not affect others
- adjust hybrid chunker test for independent chunk data

## Testing
- `go build ./...` *(fails: manifest syntax errors and duplicate methods in transport/quic)*
- `go test -coverprofile=coverage.out ./...` *(fails: build errors in common and manifest packages)*
- `go test ./dedup`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689fb0578d0883238e96a96a166b735e