### PR TITLE
fix(quic): streamline deadlines and roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- quic: remove redundant deadline methods and use Role.String for dial/listen
 - quic: propagate deadlines to connection for datagram reads.
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - Enforce CDC chunk size ordering in handshake validation.

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -88,17 +88,17 @@ func (t *Transport) Name() string { return "quic" }
 
 // Dial dials a QUIC connection and opens a bidirectional stream.
 func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) {
-	role := "client"
+	role := transport.Client
 	t.logger.Info("dial_start",
 		zap.String("address", address),
-		zap.String("role", role),
+		zap.String("role", role.String()),
 		zap.Int64("duration_ms", 0),
 	)
 	start := time.Now()
 	qconn, err := quic.DialAddr(ctx, address, t.clientTLS, t.qconf)
 	fields := []zap.Field{
 		zap.String("address", address),
-		zap.String("role", role),
+		zap.String("role", role.String()),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 	}
 	if err != nil {
@@ -109,7 +109,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	stream, err := qconn.OpenStreamSync(ctx)
 	fields = []zap.Field{
 		zap.String("address", address),
-		zap.String("role", role),
+		zap.String("role", role.String()),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 	}
 	if err != nil {
@@ -124,17 +124,17 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 
 // Listen starts a QUIC listener.
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
-	role := "server"
+	role := transport.Server
 	t.logger.Info("listen_start",
 		zap.String("address", address),
-		zap.String("role", role),
+		zap.String("role", role.String()),
 		zap.Int64("duration_ms", 0),
 	)
 	start := time.Now()
 	ql, err := quic.ListenAddr(address, t.serverTLS, t.qconf)
 	fields := []zap.Field{
 		zap.String("address", address),
-		zap.String("role", role),
+		zap.String("role", role.String()),
 		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 	}
 	if err != nil {
@@ -320,18 +320,3 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 	}
 	return nil
 }
-
-func roleString(r transport.Role) string {
-	switch r {
-	case transport.Client:
-		return "client"
-	case transport.Server:
-		return "server"
-	default:
-		return ""
-	}
-}
-
-func (c *Conn) SetReadDeadline(t time.Time) error  { return c.stream.SetReadDeadline(t) }
-func (c *Conn) SetWriteDeadline(t time.Time) error { return c.stream.SetWriteDeadline(t) }
-

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -400,6 +400,80 @@ func TestConnDatagramReadDeadline(t *testing.T) {
 	}
 }
 
+func TestConnStreamDeadlines(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), ClientCert: cert, AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- fmt.Errorf("accept: %w", err)
+			return
+		}
+		qconn := conn.(*Conn)
+		defer qconn.Close()
+		hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		if _, err := tr.Negotiate(ctx, qconn, transport.Server, hs); err != nil {
+			done <- fmt.Errorf("server negotiate: %w", err)
+			return
+		}
+		if qconn.LocalAddr() == nil || qconn.RemoteAddr() == nil {
+			done <- fmt.Errorf("missing addr")
+			return
+		}
+		close(ready)
+		qconn.SetDeadline(time.Now().Add(-time.Millisecond))
+		buf := make([]byte, 1)
+		if _, err := qconn.Read(buf); err == nil {
+			done <- errors.New("expected read timeout")
+			return
+		} else if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+			done <- fmt.Errorf("expected timeout error, got %v", err)
+			return
+		}
+		qconn.SetDeadline(time.Time{})
+		qconn.SetWriteDeadline(time.Now().Add(-time.Millisecond))
+		if _, err := qconn.Write([]byte{1}); err == nil {
+			done <- errors.New("expected write timeout")
+			return
+		} else if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+			done <- fmt.Errorf("expected timeout error, got %v", err)
+			return
+		}
+		done <- nil
+	}()
+
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	qconn := conn.(*Conn)
+	defer qconn.Close()
+	hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	if _, err := tr.Negotiate(ctx, qconn, transport.Client, hs); err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	<-ready
+	if qconn.LocalAddr() == nil || qconn.RemoteAddr() == nil {
+		t.Fatalf("missing addr")
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestQUICNegotiateContextCancel(t *testing.T) {
 	tr := &Transport{logger: zap.NewNop()}
 	c1, c2 := net.Pipe()


### PR DESCRIPTION
## Summary
- remove duplicate deadline methods
- use Role.String when dialing/listening
- add Conn deadline test

## Testing
- `go build ./...` *(fails: manifest/manifest.go:55:1: syntax error)*
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake_validate_test.go:77:1: expected statement, found '==')*
- `golangci-lint run`
- `go test -run TestConnStreamDeadlines -count=1 ./transport/quic -v`
- `go test -run TestConnStreamDeadlines -coverprofile=coverage.out ./transport/quic`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fb058ee54832389c1b438b0efd902