### PR TITLE
test(common): fix handshake validation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- tests: fix O_DIRECT match and transport mismatch handshake validation tests
 - quic: remove redundant deadline methods and use Role.String for dial/listen
 - device: remove logger nil guards and default to `zap.NewNop()`
 - quic: propagate deadlines to connection for datagram reads.

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -74,13 +74,14 @@ func TestValidateHandshakeODirectMatch(t *testing.T) {
 	peer := Handshake{ODirect: true}
 	if err := ValidateHandshake(local, peer); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-=======
+	}
+}
+
 func TestValidateHandshakeTransportMismatch(t *testing.T) {
 	local := Handshake{Transport: "quic"}
 	peer := local
 	peer.Transport = "h2"
 	if err := ValidateHandshake(local, peer); err == nil {
 		t.Fatal("expected transport mismatch error")
-
 	}
 }


### PR DESCRIPTION
## Summary
- remove merge conflict marker and finish O_DIRECT handshake test
- add transport mismatch handshake test
- document fix in changelog

## Testing
- `go build ./...` *(fails: manifest/manifest.go syntax errors)*
- `go test -coverprofile=coverage.out ./...` *(fails: manifest package test setup and transport/h2 tests)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`
- `go test ./common`


------
https://chatgpt.com/codex/tasks/task_e_689fb7d0b15c8323b6512e8a68c160ee