### PR TITLE
fix(manifest): consolidate option handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tests: validate O_DIRECT mismatch and agreement in handshake validation.
 - transport: add Role.String and shared TLSVersionString helpers.
 - manifest: unify index options for device detection and close hooks across constructors.
+- manifest: consolidate option handling and add tests for custom DetectDevice and CloseHook.
 - manifest: use functional IndexOption for device detection and close hooks.
 - hash: add Blake3Hasher tests covering keyed and unkeyed modes with state reset verification.
 - transfer: tests ensure mismatched device UUIDs and mounted devices return errors without writes.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -52,50 +52,14 @@ type indexOptions struct {
 	closeHook    func() error
 }
 
-// IndexOption configures construction of an Index.
+// IndexOption configures construction of an Index or related helpers.
 type IndexOption func(*indexOptions)
 
 // defaultOptions returns the default option set.
 func defaultOptions() indexOptions {
 	return indexOptions{
 		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-=======
-// IndexOption configures an Index or related helpers.
-type IndexOption func(*indexOptions)
-
-type indexOptions struct {
-	detectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
-	closeHook    func() error
-}
-
-func defaultIndexOptions() indexOptions {
-	return indexOptions{
-		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-// Options allows tests to inject dependencies for device detection and close hooks.
-type Options struct {
-	DetectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
-	CloseHook    func() error
-}
-
-// WithCloseHook sets a hook invoked when Index.Close is called.
-func WithCloseHook(h func() error) Options {
-	return Options{CloseHook: h}
-}
-
-func getOptions(opts []Options) Options {
-	var o Options
-	for _, opt := range opts {
-		if opt.DetectDevice != nil {
-			o.DetectDevice = opt.DetectDevice
-		}
-		if opt.CloseHook != nil {
-			o.CloseHook = opt.CloseHook
-		}
-	}
-	if o.DetectDevice == nil {
-		o.DetectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-
-      return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
+			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
 		},
 		closeHook: func() error { return nil },
 	}
@@ -106,13 +70,8 @@ func applyOptions(opts []IndexOption) indexOptions {
 	o := defaultOptions()
 	for _, opt := range opts {
 		opt(&o)
-=======
-func applyOptions(opts []IndexOption) indexOptions {
-	cfg := defaultIndexOptions()
-	for _, opt := range opts {
-		opt(&cfg)
 	}
-	return cfg
+	return o
 }
 
 // WithCloseHook sets a hook invoked when Index.Close is called.
@@ -123,16 +82,6 @@ func WithCloseHook(h func() error) IndexOption {
 // WithDetectDevice overrides device detection for Rebuild.
 func WithDetectDevice(f func(context.Context, string, *zap.Logger) (device.Device, error)) IndexOption {
 	return func(o *indexOptions) { o.detectDevice = f }
-}
-
-// WithDetectDevice overrides the device detection function used by Rebuild.
-func WithDetectDevice(fn func(context.Context, string, *zap.Logger) (device.Device, error)) IndexOption {
-	return func(o *indexOptions) { o.detectDevice = fn }
-}
-
-// WithCloseHook sets a hook invoked when Index.Close is called.
-func WithCloseHook(h func() error) IndexOption {
-	return func(o *indexOptions) { o.closeHook = h }
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.
@@ -213,10 +162,7 @@ func (i *Index) Close() error {
 
 // Create initializes a new manifest index at path for the given device.
 func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexOption) (*Index, error) {
-
 	o := applyOptions(opts)
-=======
-	cfg := applyOptions(opts)
 
 	if len(deviceID) > 64 {
 		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
@@ -236,13 +182,7 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexO
 		f.Close()
 		return nil, err
 	}
-
 	idx := &Index{f: f, data: data, closeHook: o.closeHook}
-=======
-
-	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
-=======
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
 
 	idx.hdr = Header{
 		Version:    Version,
@@ -260,14 +200,6 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexO
 
 func Open(path string, opts ...IndexOption) (*Index, error) {
 	o := applyOptions(opts)
-=======
-
-func Open(path string, opts ...IndexOption) (*Index, error) {
-	cfg := applyOptions(opts)
-=======
-func Open(path string, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
-
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -284,14 +216,7 @@ func Open(path string, opts ...Options) (*Index, error) {
 		f.Close()
 		return nil, err
 	}
-
 	idx := &Index{f: f, data: data, closeHook: o.closeHook}
-=======
-
-	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
-=======
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
 
 	if err := idx.readHeader(); err != nil {
 		idx.Close()
@@ -302,18 +227,8 @@ func Open(path string, opts ...Options) (*Index, error) {
 
 // Upgrade opens the manifest at path, upgrading older versions in-place.
 // It returns an Index mapped to the upgraded file.
-
 func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 	o := applyOptions(opts)
-=======
-
-func Upgrade(path string, opts ...IndexOption) (*Index, error) {
-	cfg := applyOptions(opts)
-=======
-
-func Upgrade(path string, opts ...Options) (*Index, error) {
-	o := getOptions(opts)
-
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -330,16 +245,7 @@ func Upgrade(path string, opts ...Options) (*Index, error) {
 		f.Close()
 		return nil, err
 	}
-
 	idx := &Index{f: f, data: data, closeHook: o.closeHook}
-=======
-
-
-	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
-=======
-	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-
 
 	if err := idx.readHeader(); err != nil {
 		if !errors.Is(err, ErrVersionMismatch) {
@@ -426,25 +332,10 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // The operation respects cancellation via ctx.
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
 func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
-
 	o := applyOptions(opts)
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-
-=======
-	cfg := applyOptions(opts)
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-
-=======
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...Options) (err error) {
-	o := getOptions(opts)
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-
 	if err = ctx.Err(); err != nil {
 		return err
 	}
@@ -457,9 +348,6 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	}
 
 	dev, err := o.detectDevice(ctx, devicePath, logger)
-=======
-	dev, err := cfg.detectDevice(ctx, devicePath, logger)
-
 	if err != nil {
 		return err
 	}
@@ -482,14 +370,7 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	}
 	defer f.Close()
 	var idx *Index
-
 	idx, err = Create(output, id, size, blockSize, opts...)
-=======
-
-	idx, err = Create(output, id, size, blockSize, opts...)
-=======
-	idx, err = Create(output, id, size, blockSize, o)
-
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -346,11 +346,6 @@ func TestRebuildCloseHook(t *testing.T) {
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeonce.man")
 	count := 0
-
-	hook := func() error { count++; return nil }
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(hook)); err != nil {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { count++; return nil })); err != nil {
@@ -378,17 +373,51 @@ func TestRebuildCloseError(t *testing.T) {
 	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeerr.man")
-
-
-	hook := func() error { return errors.New("close fail") }
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(hook)); err == nil || !strings.Contains(err.Error(), "close fail") {
 	hookErr := errors.New("close fail")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { return hookErr })); err == nil || !strings.Contains(err.Error(), "close fail") {
 		t.Fatalf("expected close error, got %v", err)
+	}
+}
+
+func TestRebuildOptionApplication(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "dev-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	data := make([]byte, 4096)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	file.Close()
+
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid-test", nil })
+	defer device.SetUUIDFunc(prevUUID)
+
+	calledDetect := false
+	detect := func(context.Context, string, *zap.Logger) (device.Device, error) {
+		calledDetect = true
+		return &mockDevice{path: file.Name(), size: uint64(len(data)), blockSize: 4096}, nil
+	}
+	calledHook := false
+	hook := func() error { calledHook = true; return nil }
+
+	manPath := filepath.Join(dir, "options.man")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithDetectDevice(detect), WithCloseHook(hook)); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if !calledDetect {
+		t.Fatalf("detect not called")
+	}
+	if !calledHook {
+		t.Fatalf("close hook not called")
 	}
 }
 


### PR DESCRIPTION
## Summary
- unify index option processing and remove duplicate definitions
- test custom DetectDevice and CloseHook options

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake_validate_test.go:77:1: expected statement, found '==')*
- `go test -coverprofile=coverage.out ./manifest`
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fb7cc69a48323a234b79ca8ccf1e5