### PR TITLE
test(common): fix transport mismatch test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tcp+tls: ensure negotiation performs TLS handshake and only records ALPN/TLS version when negotiated.
 - config: enforce CDC chunk size ordering during validation.
 - validate block size mismatch in handshakes
+- tests: restore transport mismatch check in handshake validation
 - handshake: validate transport mismatch in handshakes
 - dedup: validate chunker size parameters.
 - remove placeholder error field from dial_start and listen_start logs for h2 and tcp+tls transports

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -74,13 +74,14 @@ func TestValidateHandshakeODirectMatch(t *testing.T) {
 	peer := Handshake{ODirect: true}
 	if err := ValidateHandshake(local, peer); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-=======
+	}
+}
+
 func TestValidateHandshakeTransportMismatch(t *testing.T) {
 	local := Handshake{Transport: "quic"}
 	peer := local
 	peer.Transport = "h2"
 	if err := ValidateHandshake(local, peer); err == nil {
 		t.Fatal("expected transport mismatch error")
-
 	}
 }


### PR DESCRIPTION
## Summary
- fix TestValidateHandshakeODirectMatch to close properly
- add explicit transport mismatch validation test
- document test restoration in changelog

## Testing
- `go test ./common`


------
https://chatgpt.com/codex/tasks/task_e_689fba5e68588323b55ffeea4ef9663d