### PR TITLE
refactor(logging): require non-nil loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- device, transfer: require non-nil loggers and remove conditional logging
 - quic: remove redundant deadline methods and use Role.String for dial/listen
 - device: remove logger nil guards and default to `zap.NewNop()`
 - quic: propagate deadlines to connection for datagram reads.

--- a/device/detect.go
+++ b/device/detect.go
@@ -17,20 +17,16 @@ import (
 // Regular files return FileDevice, block devices are classified as either LVM
 // logical volumes or raw devices based on LVM metadata. When typeHint is not
 // empty or "auto", Detect will attempt to open the device using the explicit
-// type and will not perform auto detection.
+// type and will not perform auto detection. logger must be non-nil.
 func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCmd, fsThawCmd, lvmEscalation string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		if logger != nil {
-			logger.Error("device detect failed", zap.String("path", path), zap.String("device_type", "symlink"), zap.Error(err))
-		}
+		logger.Error("device detect failed", zap.String("path", path), zap.String("device_type", "symlink"), zap.Error(err))
 		return nil, err
 	}
 	info, err := os.Stat(resolved)
 	if err != nil {
-		if logger != nil {
-			logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
-		}
+		logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
 		return nil, err
 	}
 	if typeHint != "" && typeHint != "auto" {
@@ -41,14 +37,10 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			}
 			dev, err := OpenFile(resolved, logger)
 			if err != nil {
-				if logger != nil {
-					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
-				}
+				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
 				return nil, err
 			}
-			if logger != nil {
-				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
-			}
+			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
 			return dev, nil
 		case "lvm":
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
@@ -58,14 +50,10 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			defer cache.Close()
 			dev, err := OpenLVM(resolved, cache, lvmEscalation, logger)
 			if err != nil {
-				if logger != nil {
-					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
-				}
+				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
 				return nil, err
 			}
-			if logger != nil {
-				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
-			}
+			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
 			return dev, nil
 		case "raw":
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
@@ -89,14 +77,10 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			}
 			dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
 			if err != nil {
-				if logger != nil {
-					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
-				}
+				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
 				return nil, err
 			}
-			if logger != nil {
-				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
-			}
+			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
 			return dev, nil
 		default:
 			return nil, fmt.Errorf("unknown device type %q", typeHint)
@@ -105,14 +89,10 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 	if info.Mode().IsRegular() {
 		dev, err := OpenFile(resolved, logger)
 		if err != nil {
-			if logger != nil {
-				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
-			}
+			logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
 			return nil, err
 		}
-		if logger != nil {
-			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
-		}
+		logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
 		return dev, nil
 	}
 	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
@@ -121,19 +101,13 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			defer cache.Close()
 			dev, err := OpenLVM(resolved, cache, lvmEscalation, logger)
 			if err != nil {
-				if logger != nil {
-					logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
-				}
+				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
 				return nil, err
 			}
-			if logger != nil {
-				logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
-			}
+			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
 			return dev, nil
 		} else {
-			if logger != nil {
-				logger.Debug("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
-			}
+			logger.Debug("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
 		}
 		var freezePath, thawPath string
 		var freezeArgs, thawArgs []string
@@ -153,19 +127,13 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 		}
 		dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
 		if err != nil {
-			if logger != nil {
-				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
-			}
+			logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
 			return nil, err
 		}
-		if logger != nil {
-			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
-		}
+		logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
 		return dev, nil
 	}
 	err = fmt.Errorf("unsupported path type: %s", resolved)
-	if logger != nil {
-		logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))
-	}
+	logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))
 	return nil, err
 }

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -73,7 +73,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(context.Background(), lvPath, true, "", "", "", "", 0, 0, nil)
+	dev, err := Detect(context.Background(), lvPath, true, "", "", "", "", 0, 0, zap.NewNop())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/file.go
+++ b/device/file.go
@@ -18,10 +18,8 @@ type FileDevice struct {
 }
 
 // OpenFile opens a regular file and reports its size and filesystem block size.
+// logger must be non-nil.
 func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	info, err := os.Stat(path)
 	if err != nil {
 		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -60,7 +60,7 @@ func TestOpenFile(t *testing.T) {
 
 func TestOpenFileRejectsNonRegular(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := OpenFile(dir, nil); err == nil {
+	if _, err := OpenFile(dir, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for directory")
 	}
 }
@@ -82,7 +82,7 @@ func TestFileSnapshotIdentityAndFDLeak(t *testing.T) {
 	path := f.Name()
 	f.Close()
 
-	d, err := OpenFile(path, nil)
+	d, err := OpenFile(path, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestFileSnapshotClosedDevice(t *testing.T) {
 	path := f.Name()
 	f.Close()
 
-	d, err := OpenFile(path, nil)
+	d, err := OpenFile(path, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -33,7 +33,7 @@ type RawDevice struct {
 
 // OpenRaw opens a block device at the given path and queries its size and block
 // size. If offline is false, fsFreezeCmdPath and fsThawCmdPath must be commands
-// that successfully freeze and thaw the filesystem around the device access.
+// that successfully freeze and thaw the filesystem around the device access. logger must be non-nil.
 func OpenRaw(
 	ctx context.Context,
 	path string,
@@ -46,9 +46,6 @@ func OpenRaw(
 	thawTimeout time.Duration,
 	logger *zap.Logger,
 ) (_ *RawDevice, err error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	d := &RawDevice{
 		logger: logger, freezeTimeout: freezeTimeout, thawTimeout: thawTimeout,
 		thawCmdPath: fsThawCmdPath, thawCmdArgs: fsThawCmdArgs,

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -86,14 +86,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, 0, 0, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, 0, 0, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, nil); err == nil {
+		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, zap.NewNop()); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -102,13 +102,13 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, zap.NewNop()); err == nil {
 		t.Fatalf("expected offline or freeze command error")
 	}
 }
 
 func TestOpenRawFreezeCommandFailure(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, time.Second, time.Second, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, time.Second, time.Second, zap.NewNop()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -120,7 +120,7 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 	freezeArgs := []string{freezeTmp}
 	thawCmdPath := "touch"
 	thawArgs := []string{thawTmp}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, time.Second, time.Second, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, time.Second, time.Second, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {
@@ -153,7 +153,7 @@ func TestOpenRawFreezeTimeout(t *testing.T) {
 	if _, err := exec.LookPath("sleep"); err != nil {
 		t.Skip("sleep command not found")
 	}
-	_, err := OpenRaw(context.Background(), "/dev/null", false, "sleep", []string{"2"}, "true", nil, 100*time.Millisecond, time.Second, nil)
+	_, err := OpenRaw(context.Background(), "/dev/null", false, "sleep", []string{"2"}, "true", nil, 100*time.Millisecond, time.Second, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze command to be killed, got %v", err)
 	}
@@ -176,7 +176,7 @@ func TestOpenRawStoresThawConfig(t *testing.T) {
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
 	thawTmp := filepath.Join(t.TempDir(), "thaw")
-	d, err := OpenRaw(context.Background(), loop, false, "true", nil, "touch", []string{thawTmp}, time.Second, time.Second, nil)
+	d, err := OpenRaw(context.Background(), loop, false, "true", nil, "touch", []string{thawTmp}, time.Second, time.Second, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -25,7 +25,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	fd, err := OpenFile(f.Name(), nil)
+	fd, err := OpenFile(f.Name(), zap.NewNop())
 	if err != nil {
 		t.Fatalf("open file: %v", err)
 	}

--- a/transfer/block_common.go
+++ b/transfer/block_common.go
@@ -41,6 +41,8 @@ func ReadBlock(src *os.File, offset int64, size int) ([]byte, error) {
 	return buf, nil
 }
 
+// ReadBlockWithRetries reads a block with retries; logger must be non-nil.
+//
 //nolint:revive // high complexity is acceptable for this low-level function
 func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
 	if useZeroCopy {
@@ -49,6 +51,8 @@ func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZer
 	return retryRead(cfg, src, offset, logger)
 }
 
+// readWithZeroCopy uses zero-copy transfers; logger must be non-nil.
+//
 //revive:disable-next-line:cognitive-complexity
 func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
 	blockSize := cfg.BlockSize
@@ -61,16 +65,12 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 		atomic.AddInt64(&PipeCreationCount, 1)
 		defer func() {
 			if closeErr := syscall.Close(pipeFds[0]); closeErr != nil {
-				if logger != nil {
-					logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
-				}
+				logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
 			}
 		}()
 		defer func() {
 			if closeErr := syscall.Close(pipeFds[1]); closeErr != nil {
-				if logger != nil {
-					logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
-				}
+				logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
 			}
 		}()
 	}
@@ -81,9 +81,7 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 	}
 	defer func() {
 		if closeErr := r.Close(); closeErr != nil {
-			if logger != nil {
-				logger.Warn("pipe read close", zap.Error(closeErr))
-			}
+			logger.Warn("pipe read close", zap.Error(closeErr))
 		}
 	}()
 
@@ -93,13 +91,11 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 			break
 		}
 
-		if logger != nil {
-			logger.Warn("Zero-copy transfer failed",
-				zap.Int64("offset", offset),
-				zap.Int("size_bytes", blockSize),
-				zap.Int("attempt", attempt+1),
-				zap.Error(err))
-		}
+		logger.Warn("Zero-copy transfer failed",
+			zap.Int64("offset", offset),
+			zap.Int("size_bytes", blockSize),
+			zap.Int("attempt", attempt+1),
+			zap.Error(err))
 
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -144,13 +140,11 @@ func retryRead(cfg *config.Config, src *os.File, offset int64, logger *zap.Logge
 			return buf, nil
 		}
 
-		if logger != nil {
-			logger.Warn("Failed to read block",
-				zap.Int64("offset", offset),
-				zap.Int("size_bytes", blockSize),
-				zap.Int("attempt", attempt+1),
-				zap.Error(err))
-		}
+		logger.Warn("Failed to read block",
+			zap.Int64("offset", offset),
+			zap.Int("size_bytes", blockSize),
+			zap.Int("attempt", attempt+1),
+			zap.Error(err))
 
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -31,6 +31,7 @@ var createStateFile = func(name string) (io.WriteCloser, error) {
 	return f, nil
 }
 
+// saveStateFile writes dedup state to the provided path; logger must be non-nil.
 func saveStateFile(logger *zap.Logger, path string, write func(io.Writer) error) error {
 	file, err := createStateFile(path)
 	if err != nil {
@@ -38,9 +39,7 @@ func saveStateFile(logger *zap.Logger, path string, write func(io.Writer) error)
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			if logger != nil {
-				logger.Warn("failed to close state file", zap.Error(closeErr))
-			}
+			logger.Warn("failed to close state file", zap.Error(closeErr))
 		}
 	}()
 	return write(file)
@@ -125,16 +124,12 @@ func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) Deduplicat
 			logger:    logger,
 		}
 		if err := d.loadState(); err != nil {
-			if logger != nil {
-				logger.Warn("failed to load dedup state", zap.Error(err))
-			}
+			logger.Warn("failed to load dedup state", zap.Error(err))
 		}
 		return d
 	case "bloom":
 		if cfg.BloomEntries < 0 || uint64(cfg.BloomEntries) > uint64(math.MaxUint) {
-			if logger != nil {
-				logger.Warn("invalid bloom entries", zap.Int("entries", cfg.BloomEntries))
-			}
+			logger.Warn("invalid bloom entries", zap.Int("entries", cfg.BloomEntries))
 			return nil
 		}
 		entries := uint(cfg.BloomEntries)
@@ -147,9 +142,7 @@ func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) Deduplicat
 			logger:    logger,
 		}
 		if err := d.loadState(); err != nil {
-			if logger != nil {
-				logger.Warn("failed to load dedup state", zap.Error(err))
-			}
+			logger.Warn("failed to load dedup state", zap.Error(err))
 		}
 		return d
 	default:
@@ -160,9 +153,7 @@ func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) Deduplicat
 			logger:    logger,
 		}
 		if err := d.loadState(); err != nil {
-			if logger != nil {
-				logger.Warn("failed to load dedup state", zap.Error(err))
-			}
+			logger.Warn("failed to load dedup state", zap.Error(err))
 		}
 		return d
 	}
@@ -215,9 +206,7 @@ func (c *ChecksumDedup) loadState() error {
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			if c.logger != nil {
-				c.logger.Warn("failed to close state file", zap.Error(closeErr))
-			}
+			c.logger.Warn("failed to close state file", zap.Error(closeErr))
 		}
 	}()
 
@@ -257,9 +246,7 @@ func (r *RollingHashDedup) computeHash(data []byte) (uint64, error) {
 func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
 	h, err := r.computeHash(data)
 	if err != nil {
-		if r.logger != nil {
-			r.logger.Error("compute hash failed", zap.Error(err))
-		}
+		r.logger.Error("compute hash failed", zap.Error(err))
 		return true
 	}
 
@@ -273,9 +260,7 @@ func (r *RollingHashDedup) ShouldTransfer(offset int64, data []byte) bool {
 func (r *RollingHashDedup) RecordTransfer(offset int64, data []byte) {
 	h, err := r.computeHash(data)
 	if err != nil {
-		if r.logger != nil {
-			r.logger.Error("compute hash failed", zap.Error(err))
-		}
+		r.logger.Error("compute hash failed", zap.Error(err))
 		return
 	}
 
@@ -315,9 +300,7 @@ func (r *RollingHashDedup) loadState() error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			if r.logger != nil {
-				r.logger.Warn("failed to close state file", zap.Error(err))
-			}
+			r.logger.Warn("failed to close state file", zap.Error(err))
 		}
 	}()
 
@@ -389,9 +372,7 @@ func (b *BloomFilterDedup) loadState() error {
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			if b.logger != nil {
-				b.logger.Warn("failed to close state file", zap.Error(closeErr))
-			}
+			b.logger.Warn("failed to close state file", zap.Error(closeErr))
 		}
 	}()
 

--- a/transfer/numa_linux.go
+++ b/transfer/numa_linux.go
@@ -85,16 +85,14 @@ func parseCPUList(list string) []int {
 
 // pinWorkerToDevice pins the current goroutine to the NUMA node associated
 // with the source device when cfg.NumaPin is true. The returned function must
-// be deferred to release the thread lock.
+// be deferred to release the thread lock. logger must be non-nil.
 func pinWorkerToDevice(cfg *config.Config, src *os.File, logger *zap.Logger) func() {
 	if cfg == nil || !cfg.NumaPin {
 		return func() {}
 	}
 	runtime.LockOSThread()
 	if err := pinCurrentThreadToDevice(src); err != nil {
-		if logger != nil {
-			logger.Warn("numa pin failed", zap.Error(err))
-		}
+		logger.Warn("numa pin failed", zap.Error(err))
 	}
 	return runtime.UnlockOSThread
 }

--- a/transfer/resume_cdc.go
+++ b/transfer/resume_cdc.go
@@ -6,6 +6,7 @@ import (
 	"lvmsync_go/config"
 )
 
+// findResumeIndexCDC resumes scanning using CDC; logger must be non-nil.
 func findResumeIndexCDC(cfg *config.Config, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
 	next := chk.Offset + uint64(chk.Length)
 	for i := range ranges {
@@ -14,9 +15,7 @@ func findResumeIndexCDC(cfg *config.Config, ranges []Range, chk resumeCheckpoint
 		}
 		if next <= ranges[i].End {
 			ranges[i].Start = next
-			if logger != nil {
-				logger.Info("Resuming after offset", zap.Uint64("resume_offset", next))
-			}
+			logger.Info("Resuming after offset", zap.Uint64("resume_offset", next))
 			return i
 		}
 	}

--- a/transfer/resume_fixed.go
+++ b/transfer/resume_fixed.go
@@ -25,6 +25,7 @@ func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, chk r
 	}
 }
 
+// findResumeIndexFixed finds resume index using fixed-size blocks; logger must be non-nil.
 func findResumeIndexFixed(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
 	if chk.Chunk == [32]byte{} {
 		return 0
@@ -47,9 +48,7 @@ func findResumeIndexFixed(cfg *config.Config, srcFile *os.File, ranges []Range, 
 		}
 		putBlockBuffer(data)
 		if sum == chk.Chunk {
-			if logger != nil {
-				logger.Info("Resuming after index", zap.Int("resume_index", i+1))
-			}
+			logger.Info("Resuming after index", zap.Int("resume_index", i+1))
 			return i + 1
 		}
 	}

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -38,6 +38,7 @@ type resumeTracker struct {
 	length uint32
 }
 
+// writeResumeState persists resume state; logger must be non-nil.
 func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offset uint64, length uint32, chunk [32]byte) {
 	rs := resumeState{
 		Transport:         cfg.Transport,
@@ -50,15 +51,11 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offse
 	}
 	data, err := json.Marshal(rs)
 	if err != nil {
-		if logger != nil {
-			logger.Warn("Failed to marshal resume state", zap.Error(err))
-		}
+		logger.Warn("Failed to marshal resume state", zap.Error(err))
 		return
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
-		if logger != nil {
-			logger.Warn("Failed to update resume state", zap.Error(err))
-		}
+		logger.Warn("Failed to update resume state", zap.Error(err))
 	}
 }
 
@@ -89,9 +86,7 @@ func finalizeResumeState(cfg *config.Config, rt *resumeTracker, logger *zap.Logg
 		return
 	}
 	if err := os.Remove(cfg.ResumeState); err != nil && !os.IsNotExist(err) {
-		if logger != nil {
-			logger.Warn("Failed to remove resume state", zap.Error(err))
-		}
+		logger.Warn("Failed to remove resume state", zap.Error(err))
 	}
 	rt.bytes = 0
 	rt.last = time.Time{}
@@ -121,11 +116,9 @@ func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
 	copy(out.Chunk[:], b)
 	out.Offset = rs.Offset
 	out.Length = rs.Length
-	if logger != nil {
-		logger.Info("Resuming from chunk",
-			zap.String("resume_chunk", hex.EncodeToString(out.Chunk[:])),
-			zap.Uint64("resume_offset", out.Offset),
-			zap.Uint32("resume_length", out.Length))
-	}
+	logger.Info("Resuming from chunk",
+		zap.String("resume_chunk", hex.EncodeToString(out.Chunk[:])),
+		zap.Uint64("resume_offset", out.Offset),
+		zap.Uint32("resume_length", out.Length))
 	return out
 }

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -22,7 +22,7 @@ type Transfer struct {
 }
 
 // NewTransfer creates a Transfer with the provided logger and wait group.
-// When wg is nil, a new instance is allocated.
+// When wg is nil, a new instance is allocated. logger must be non-nil.
 func NewTransfer(logger *zap.Logger, wg *sync.WaitGroup) *Transfer {
 	if wg == nil {
 		wg = &sync.WaitGroup{}
@@ -62,6 +62,8 @@ func LoadChecksumState(filename string) (state *ChecksumState, err error) {
 	return state, nil
 }
 
+// SaveChecksumState persists block checksums; logger must be non-nil.
+//
 //revive:disable-next-line:cognitive-complexity
 func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger) (err error) {
 	var file *os.File
@@ -71,9 +73,7 @@ func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger
 	}
 	if err = file.Chmod(0o600); err != nil {
 		if closeErr := file.Close(); closeErr != nil {
-			if logger != nil {
-				logger.Warn("Failed to close checksum state file", zap.Error(closeErr))
-			}
+			logger.Warn("Failed to close checksum state file", zap.Error(closeErr))
 			return fmt.Errorf("chmod checksum state: %v; close checksum state: %w", err, closeErr)
 		}
 		return fmt.Errorf("chmod checksum state: %w", err)
@@ -87,6 +87,7 @@ func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger
 	return nil
 }
 
+// dumpChangesCore handles core transfer logic; logger must be non-nil.
 func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
 	ranges, err := prepareRanges(cfg, snapshot, source, t.Logger)
 	if err != nil {
@@ -129,12 +130,10 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 
 	logSequentialSummary(t.Logger, totalBytesTransferred, skippedBlocks, startTime)
 	finalizeResumeState(cfg, t.Tracker, t.Logger)
-	if len(finalDigest) > 0 && t.Logger != nil {
+	if len(finalDigest) > 0 {
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}
-	if t.Logger != nil {
-		_ = t.Logger.Sync()
-	}
+	_ = t.Logger.Sync()
 	return nil
 }
 
@@ -144,9 +143,7 @@ func (t *Transfer) setupDedup(cfg *config.Config) (DeduplicationStrategy, func()
 	if dedup != nil {
 		cleanup = func() {
 			if err := dedup.SaveState(); err != nil {
-				if t.Logger != nil {
-					t.Logger.Error("Failed to save dedup state", zap.Error(err))
-				}
+				t.Logger.Error("Failed to save dedup state", zap.Error(err))
 			}
 		}
 	}
@@ -172,13 +169,9 @@ func (t *Transfer) DumpChanges(cfg *config.Config, snapshot, source string, out 
 	dedup, cleanup := t.setupDedup(cfg)
 	if dedup != nil {
 		defer cleanup()
-		if t.Logger != nil {
-			t.Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
-		}
+		t.Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
 		return t.DumpChangesWithDeduplication(cfg, snapshot, source, out, dedup)
 	}
-	if t.Logger != nil {
-		t.Logger.Info("Deduplication disabled, performing full block transfer")
-	}
+	t.Logger.Info("Deduplication disabled, performing full block transfer")
 	return t.DumpChangesSequential(cfg, snapshot, source, out)
 }

--- a/transfer/worker.go
+++ b/transfer/worker.go
@@ -14,6 +14,7 @@ import (
 	"lvmsync_go/internal/blocksize"
 )
 
+// detectBlockSize sets cfg.BlockSize by probing source; logger must be non-nil.
 func detectBlockSize(cfg *config.Config, source string, logger *zap.Logger) error {
 	if cfg.BlockSize != 0 {
 		return nil
@@ -23,12 +24,11 @@ func detectBlockSize(cfg *config.Config, source string, logger *zap.Logger) erro
 		return fmt.Errorf("auto-detect block size: %w", err)
 	}
 	cfg.BlockSize = bs
-	if logger != nil {
-		logger.Info("Auto-detected block size", zap.Int("block_size_bytes", cfg.BlockSize))
-	}
+	logger.Info("Auto-detected block size", zap.Int("block_size_bytes", cfg.BlockSize))
 	return nil
 }
 
+// gatherChangedRanges returns ranges of changed blocks; logger must be non-nil.
 func gatherChangedRanges(snapshot string, blockSize int64, logger *zap.Logger) ([]Range, error) {
 	metadataDevice := GetMetadataDevice(snapshot)
 	if metadataDevice == "" {
@@ -38,19 +38,16 @@ func gatherChangedRanges(snapshot string, blockSize int64, logger *zap.Logger) (
 	if err != nil {
 		return nil, fmt.Errorf("error getting differences: %w", err)
 	}
-	if logger != nil {
-		logger.Info("Changed blocks determined", zap.Int("block_count", len(ranges)))
-	}
+	logger.Info("Changed blocks determined", zap.Int("block_count", len(ranges)))
 	return ranges, nil
 }
 
+// prepareRanges calculates changed block ranges; logger must be non-nil.
 func prepareRanges(cfg *config.Config, snapshot, source string, logger *zap.Logger) ([]Range, error) {
 	if err := detectBlockSize(cfg, source, logger); err != nil {
 		return nil, err
 	}
-	if logger != nil {
-		logger.Info("Using block size", zap.Int("block_size_bytes", cfg.BlockSize))
-	}
+	logger.Info("Using block size", zap.Int("block_size_bytes", cfg.BlockSize))
 
 	_, blockSize, err := validateOffsetAndSize(0, cfg.BlockSize)
 	if err != nil {
@@ -84,6 +81,7 @@ func setupSourceFile(cfg *config.Config, source string) (*os.File, error) {
 	return srcFile, nil
 }
 
+// setupPipe initializes optional zero-copy pipe; logger must be non-nil.
 func setupPipe(cfg *config.Config, logger *zap.Logger) ([2]int, func(), error) {
 	var pipeFds [2]int
 	cleanup := func() {}
@@ -93,14 +91,10 @@ func setupPipe(cfg *config.Config, logger *zap.Logger) ([2]int, func(), error) {
 		}
 		cleanup = func() {
 			if closeErr := syscall.Close(pipeFds[0]); closeErr != nil {
-				if logger != nil {
-					logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
-				}
+				logger.Warn("close pipe", zap.Int("fd", pipeFds[0]), zap.Error(closeErr))
 			}
 			if closeErr := syscall.Close(pipeFds[1]); closeErr != nil {
-				if logger != nil {
-					logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
-				}
+				logger.Warn("close pipe", zap.Int("fd", pipeFds[1]), zap.Error(closeErr))
 			}
 		}
 	} else {
@@ -109,6 +103,7 @@ func setupPipe(cfg *config.Config, logger *zap.Logger) ([2]int, func(), error) {
 	return pipeFds, cleanup, nil
 }
 
+// startParallelWorkers launches worker goroutines; logger must be non-nil.
 func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, resumeStart int, logger *zap.Logger) <-chan *BlockResult {
 	numBlocks := len(ranges)
 	taskBuf := cfg.Parallel
@@ -133,11 +128,10 @@ func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ra
 	return results
 }
 
+// DumpChangesParallel streams changes in parallel; logger must be non-nil.
 func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
 	if cfg.ZeroCopy {
-		if t.Logger != nil {
-			t.Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
-		}
+		t.Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
 		return t.DumpChangesSequential(cfg, snapshot, source, out)
 	}
 
@@ -178,11 +172,9 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 	finalizeProgress(cfg, t.Logger)
 	logParallelSummary(t.Logger, totalBytesTransferred, startTime)
 	finalizeResumeState(cfg, t.Tracker, t.Logger)
-	if len(finalDigest) > 0 && t.Logger != nil {
+	if len(finalDigest) > 0 {
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}
-	if t.Logger != nil {
-		_ = t.Logger.Sync()
-	}
+	_ = t.Logger.Sync()
 	return nil
 }

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -25,16 +25,13 @@ func prepareOutputWriter(out io.Writer, cfg *config.Config, logger *zap.Logger) 
 	return compWriter, bufOut, nil
 }
 
+// cleanupOutput flushes and closes writers; logger must be non-nil.
 func cleanupOutput(buf *bufio.Writer, w io.WriteCloser, logger *zap.Logger) {
 	if err := buf.Flush(); err != nil {
-		if logger != nil {
-			logger.Warn("Failed to flush output", zap.Error(err))
-		}
+		logger.Warn("Failed to flush output", zap.Error(err))
 	}
 	if err := w.Close(); err != nil {
-		if logger != nil {
-			logger.Warn("Failed to close writer", zap.Error(err))
-		}
+		logger.Warn("Failed to close writer", zap.Error(err))
 	}
 }
 
@@ -100,14 +97,13 @@ func verifyChecksum(verify bool, checksum ChecksumStrategy, data, transmitted []
 
 // writeData seeks to offset and writes the provided data to destFile.
 // If seeking fails, no write occurs and the seek error is returned.
+// writeData writes data at offset; logger must be non-nil.
 func writeData(destFile *os.File, offset uint64, data []byte, logger *zap.Logger) error {
 	if offset > math.MaxInt64 {
 		return fmt.Errorf("offset %d overflows int64", offset)
 	}
 	if _, err := destFile.Seek(int64(offset), io.SeekStart); err != nil {
-		if logger != nil {
-			logger.Warn("Seek error", zap.Uint64("offset", offset), zap.Error(err))
-		}
+		logger.Warn("Seek error", zap.Uint64("offset", offset), zap.Error(err))
 		return fmt.Errorf("failed to seek to offset %d: %w", offset, err)
 	}
 	if _, err := destFile.Write(data); err != nil {


### PR DESCRIPTION
## Summary
- document logger non-nil requirement and remove conditional checks
- update device and transfer tests to use zap.NewNop

## Testing
- `go build ./...` *(fails: manifest/manifest.go syntax error)*
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake_validate_test.go syntax error)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_689fb7ce95948323ae1c069439ee22bd