### PR TITLE
fix(manifest): clean close hook tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - device: allow freeze/thaw command paths containing directories by validating basename only
 - dedup: ensure FastCDC chunks own their data slices to prevent cross-chunk mutation
 
+- manifest: fix close hook test to remove duplicate rebuild blocks
+
 ## [v0.1.0] - 2025-02-27
 ### Added
 - Initial release of LVMSync with a pluggable transport registry supporting QUIC, HTTP/2, TCP+TLS, and SSH.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -46,31 +46,6 @@ type Index struct {
 	closeHook func() error
 }
 
-// indexOptions collects constructor options for Index and helpers like Rebuild.
-type indexOptions struct {
-	detectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
-	closeHook    func() error
-}
-
-// IndexOption configures construction of an Index.
-type IndexOption func(*indexOptions)
-
-// defaultOptions returns the default option set.
-func defaultOptions() indexOptions {
-	return indexOptions{
-		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-=======
-// IndexOption configures an Index or related helpers.
-type IndexOption func(*indexOptions)
-
-type indexOptions struct {
-	detectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
-	closeHook    func() error
-}
-
-func defaultIndexOptions() indexOptions {
-	return indexOptions{
-		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
 // Options allows tests to inject dependencies for device detection and close hooks.
 type Options struct {
 	DetectDevice func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)
@@ -80,6 +55,11 @@ type Options struct {
 // WithCloseHook sets a hook invoked when Index.Close is called.
 func WithCloseHook(h func() error) Options {
 	return Options{CloseHook: h}
+}
+
+// WithDetectDevice overrides the device detection used by Rebuild and constructors.
+func WithDetectDevice(f func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error)) Options {
+	return Options{DetectDevice: f}
 }
 
 func getOptions(opts []Options) Options {
@@ -94,45 +74,13 @@ func getOptions(opts []Options) Options {
 	}
 	if o.DetectDevice == nil {
 		o.DetectDevice = func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-
-      return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
-		},
-		closeHook: func() error { return nil },
+			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
+		}
 	}
-}
-
-// applyOptions applies supplied options to the defaults.
-func applyOptions(opts []IndexOption) indexOptions {
-	o := defaultOptions()
-	for _, opt := range opts {
-		opt(&o)
-=======
-func applyOptions(opts []IndexOption) indexOptions {
-	cfg := defaultIndexOptions()
-	for _, opt := range opts {
-		opt(&cfg)
+	if o.CloseHook == nil {
+		o.CloseHook = func() error { return nil }
 	}
-	return cfg
-}
-
-// WithCloseHook sets a hook invoked when Index.Close is called.
-func WithCloseHook(h func() error) IndexOption {
-	return func(o *indexOptions) { o.closeHook = h }
-}
-
-// WithDetectDevice overrides device detection for Rebuild.
-func WithDetectDevice(f func(context.Context, string, *zap.Logger) (device.Device, error)) IndexOption {
-	return func(o *indexOptions) { o.detectDevice = f }
-}
-
-// WithDetectDevice overrides the device detection function used by Rebuild.
-func WithDetectDevice(fn func(context.Context, string, *zap.Logger) (device.Device, error)) IndexOption {
-	return func(o *indexOptions) { o.detectDevice = fn }
-}
-
-// WithCloseHook sets a hook invoked when Index.Close is called.
-func WithCloseHook(h func() error) IndexOption {
-	return func(o *indexOptions) { o.closeHook = h }
+	return o
 }
 
 // ErrVersionMismatch is returned when a manifest file uses an unsupported version.
@@ -212,12 +160,8 @@ func (i *Index) Close() error {
 }
 
 // Create initializes a new manifest index at path for the given device.
-func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexOption) (*Index, error) {
-
-	o := applyOptions(opts)
-=======
-	cfg := applyOptions(opts)
-
+func Create(path, deviceID string, size uint64, blockSize uint32, opts ...Options) (*Index, error) {
+	o := getOptions(opts)
 	if len(deviceID) > 64 {
 		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
 	}
@@ -236,14 +180,7 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexO
 		f.Close()
 		return nil, err
 	}
-
-	idx := &Index{f: f, data: data, closeHook: o.closeHook}
-=======
-
-	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
-=======
 	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
 	idx.hdr = Header{
 		Version:    Version,
 		BlockSize:  blockSize,
@@ -257,17 +194,8 @@ func Create(path, deviceID string, size uint64, blockSize uint32, opts ...IndexO
 }
 
 // Open maps an existing manifest index file.
-
-func Open(path string, opts ...IndexOption) (*Index, error) {
-	o := applyOptions(opts)
-=======
-
-func Open(path string, opts ...IndexOption) (*Index, error) {
-	cfg := applyOptions(opts)
-=======
 func Open(path string, opts ...Options) (*Index, error) {
 	o := getOptions(opts)
-
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -285,13 +213,7 @@ func Open(path string, opts ...Options) (*Index, error) {
 		return nil, err
 	}
 
-	idx := &Index{f: f, data: data, closeHook: o.closeHook}
-=======
-
-	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
-=======
 	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
 
 	if err := idx.readHeader(); err != nil {
 		idx.Close()
@@ -303,17 +225,8 @@ func Open(path string, opts ...Options) (*Index, error) {
 // Upgrade opens the manifest at path, upgrading older versions in-place.
 // It returns an Index mapped to the upgraded file.
 
-func Upgrade(path string, opts ...IndexOption) (*Index, error) {
-	o := applyOptions(opts)
-=======
-
-func Upgrade(path string, opts ...IndexOption) (*Index, error) {
-	cfg := applyOptions(opts)
-=======
-
 func Upgrade(path string, opts ...Options) (*Index, error) {
 	o := getOptions(opts)
-
 
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
@@ -331,15 +244,7 @@ func Upgrade(path string, opts ...Options) (*Index, error) {
 		return nil, err
 	}
 
-	idx := &Index{f: f, data: data, closeHook: o.closeHook}
-=======
-
-
-	idx := &Index{f: f, data: data, closeHook: cfg.closeHook}
-=======
 	idx := &Index{f: f, data: data, closeHook: o.CloseHook}
-
-
 
 	if err := idx.readHeader(); err != nil {
 		if !errors.Is(err, ErrVersionMismatch) {
@@ -425,26 +330,11 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
 // The operation respects cancellation via ctx.
 // When allowMounted is false, Rebuild aborts if the device is mounted read-write.
-func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...IndexOption) (err error) {
-
-	o := applyOptions(opts)
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-
-=======
-	cfg := applyOptions(opts)
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-
-=======
 func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger, progressInterval time.Duration, allowMounted bool, opts ...Options) (err error) {
 	o := getOptions(opts)
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-
 	if err = ctx.Err(); err != nil {
 		return err
 	}
@@ -455,11 +345,8 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	if mounted && !allowMounted {
 		return fmt.Errorf("manifest: %s is mounted read-write; use --manifest-allow-mounted to override", devicePath)
 	}
-
-	dev, err := o.detectDevice(ctx, devicePath, logger)
-=======
-	dev, err := cfg.detectDevice(ctx, devicePath, logger)
-
+	var dev device.Device
+	dev, err = o.DetectDevice(ctx, devicePath, logger)
 	if err != nil {
 		return err
 	}
@@ -476,20 +363,14 @@ func Rebuild(ctx context.Context, devicePath, output string, logger *zap.Logger,
 	if err = ctx.Err(); err != nil {
 		return err
 	}
-	f, err := os.Open(dev.Path())
+	var f *os.File
+	f, err = os.Open(dev.Path())
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 	var idx *Index
-
-	idx, err = Create(output, id, size, blockSize, opts...)
-=======
-
-	idx, err = Create(output, id, size, blockSize, opts...)
-=======
 	idx, err = Create(output, id, size, blockSize, o)
-
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -351,9 +351,6 @@ func TestRebuildCloseHook(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(hook)); err != nil {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { count++; return nil })); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if count != 1 {
@@ -379,15 +376,11 @@ func TestRebuildCloseError(t *testing.T) {
 	defer device.SetUUIDFunc(prevUUID)
 	manPath := filepath.Join(dir, "closeerr.man")
 
-
-	hook := func() error { return errors.New("close fail") }
+	hookErr := errors.New("close fail")
+	hook := func() error { return hookErr }
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(hook)); err == nil || !strings.Contains(err.Error(), "close fail") {
-	hookErr := errors.New("close fail")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, WithCloseHook(func() error { return hookErr })); err == nil || !strings.Contains(err.Error(), "close fail") {
 		t.Fatalf("expected close error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- remove duplicate context and rebuild blocks in close hook tests
- restore manifest options with `WithDetectDevice` helper
- document close hook test fix in changelog

## Testing
- `go build ./...`
- `go test ./manifest`
- `go test -coverprofile=coverage.out ./...` *(fails: common/handshake_validate_test.go:77:1: expected statement, found '==')*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fba5d2c3483239852adb7c7afd14a