### PR TITLE
test(config): set LVM escalation command in CDC validation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmd/dump: handle context cancellation during pipe copies to avoid incomplete writes
 - rename dry run log field to `eta_seconds` and log durations in seconds
 - transfer: replace global checkpoint state with per-transfer resume trackers
+- tests: set LVMEscalation in CDC validation test
 - cmd/dump: detect destination type locally without mutating configuration
 - manifest: propagate close errors when rebuilding indexes
 - log sync errors in manifest and verify commands

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -439,6 +439,7 @@ func TestConfigValidateCDC(t *testing.T) {
 		cfg.CDCMin = 1
 		cfg.CDCAvg = 1
 		cfg.CDCMax = 1
+		cfg.LVMEscalation = "sudo"
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}


### PR DESCRIPTION
## Summary
- set `LVMEscalation` in CDC validation test to ensure validation passes
- document change in changelog

## Testing
- `go test ./config`
- `go build ./...` *(fails: manifest/manifest.go syntax error)*
- `go test -coverprofile=coverage.out ./...` *(fails: common and manifest build issues, transport tests timeouts)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fba5f89088323a16b45f7ada9583f