### PR TITLE
docs: document manifest usage and transport defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ command-line use, environment variables, and `config.yaml` files.
 - Transport constructors must accept a `*zap.Logger`; avoid package-level loggers.
 - Pass loggers explicitly to commands and helpers; do not use `zap.L()` or other globals.
 - Log connection lifecycle events and errors with `snake_case` fields including units (e.g., `bytes_transferred`, `duration_ms`).
+- Do not log secrets or authentication tokens; scrub sensitive values before emitting them.
 - Callers using transports should `defer logger.Sync()` to ensure logs are flushed.
 
 ### Field Naming
@@ -52,6 +53,7 @@ logger.Info("snapshot complete",
 - Group related options into `FlagSet`s to share common configuration across commands.
 - Define flags within `pflag.FlagSet`s and bind them to `viper`; the standard library `flag` package is not used.
 - Expose configuration via both config files and environment variables for easy automation.
+- New flag groups must include tests demonstrating configuration precedence.
 
 ### Flag Grouping Example
 
@@ -221,6 +223,7 @@ Run these commands locally before opening a pull request:
 - `go test -coverprofile=coverage.out ./...`
 - `golangci-lint run`
 - `go tool cover -func=coverage.out` and ensure total coverage is at least 50%
+- Include unit tests covering success and failure paths for new functionality.
 
 ## Production Readiness Checklist
 
@@ -287,6 +290,8 @@ golangci-lint run
 - [ ] Ensure every new function has a dedicated unit test.
 - [ ] Run `go build ./...` and `go test ./...` before merging changes.
 - [ ] Maintain tests for compression detection, ensuring benchmark and cache logic remain correct.
+- [ ] Add end-to-end tests for resume and verify workflows.
+- [ ] Document flag grouping patterns and expand coverage for pflag/viper bindings.
 - [ ] Maintain tests for buffer alignment, hole punching, and NUMA pinning.
 - [ ] Enforce modular, single-responsibility design across packages.
 - [ ] Document each new CLI flag, environment variable, and configuration option in `README.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport: centralize handshake logging via `HandshakeFields` helper.
 - Warn when `AllowInsecure` is enabled for gRPC server, client, and transports.
 - manifest: allow custom close hook via index options, removing global hook.
+- Document manifest usage, transport security defaults, and resume/verify workflows.
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,6 +47,46 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 
 Override automatic detection with `--source-type` and `--dest-type` when a device's type is known in advance.
 
+## Transport Options
+
+LVMSync negotiates transports in the order provided by `--transport` (default
+`quic,h2,tcp+tls,ssh`). All transports require TLS 1.3 with mutual
+authentication unless `--allow-insecure` is set or the SSH transport is used.
+See [docs/transports.md](docs/transports.md) for details.
+
+| Transport | Security defaults | Notes |
+|-----------|------------------|-------|
+| `quic`    | TLS 1.3, BBR congestion | UDP-based transport |
+| `h2`      | TLS 1.3                | HTTP/2 streams |
+| `tcp+tls` | TLS 1.3                | Plain TCP wrapped in TLS |
+| `ssh`     | Host key verification  | Uses OpenSSH-style authentication |
+
+## Resume and Verify Workflows
+
+Resume interrupted transfers with a state file:
+
+```sh
+lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data
+```
+
+Verify devices against a manifest:
+
+```sh
+lvmsync verify --manifest_path snapshot.manifest /dev/vg0/snap0 /dev/vg0/data
+```
+
+Resume files track the last completed chunk and are removed after a successful
+transfer. See [docs/manifest.md](docs/manifest.md) for manifest and verification
+details.
+
+## Safety Notes
+
+- Run `manifest rebuild` and `verify` against quiescent devices.
+- Use `--offline` or freeze/thaw hooks when scanning live filesystems to keep
+  manifests consistent.
+- Network transports default to TLS 1.3; `--allow-insecure` should only be used
+  for testing.
+
 ## Supported Platforms
 
 LVMSync targets Linux systems only. Builds are tested on the `amd64` and `arm64` architectures.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -4,9 +4,27 @@ LVMSync writes a binary manifest alongside each transfer. The manifest tracks
 chunk offsets and digests so that interrupted sessions can resume and completed
 copies can be verified.
 
+## Usage
+
+- `lvmsync manifest rebuild <device>` regenerates a manifest when one is
+  missing or out of date.
+- `lvmsync verify --manifest_path <manifest> <source> <dest>` compares a source
+  and destination using the manifest.
+
 Chunk offsets are determined using FastCDC. The gear table now uses the
 standard 256-entry random values from the FastCDC specification, replacing the
 placeholder table previously used.
+
+## Security Defaults
+
+- The header MAC binds version, block size, device size, chunk count, and
+  device ID to detect tampering.
+- Rebuild aborts if the device is mounted read-write; override with
+  `--manifest-allow-mounted` only when the filesystem is quiesced.
+- Resume tokens encode the header MAC and last chunk to prevent resuming on a
+  different device.
+- Raw device scans require `--offline` or explicit freeze/thaw hooks to keep
+  data consistent.
 
 ## Layout and Versioning
 
@@ -44,18 +62,21 @@ The token encodes the header MAC and the last fully transferred chunk. This
 prevents resuming against the wrong device and permits the receiver to skip
 already replicated chunks.
 
-## Rebuilding
+## Examples
+
+### Rebuild
 
 Generate a manifest for an existing device when the index is missing or stale:
 
 ```sh
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
-Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
-The rebuild operation times out after 1m unless `--manifest_timeout` is set (0 disables).
-The command aborts if the device is mounted read-write. Override with `--manifest-allow-mounted` when rebuilding a live filesystem.
 
-## Verification
+Progress logs are emitted every 10s by default; adjust with
+`--manifest-progress-interval`. The rebuild operation times out after 1m unless
+`--manifest_timeout` is set (0 disables).
+
+### Verify
 
 Use a manifest to verify that a source and destination match:
 
@@ -63,14 +84,14 @@ Use a manifest to verify that a source and destination match:
 lvmsync verify --manifest_path snapshot.manifest /dev/vg0/snap0 /dev/null
 ```
 
-### Flags
+#### Flags
 
 | Flag | Environment variable | Config key | Description |
 |------|----------------------|------------|-------------|
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file |
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
 
-## Raw Device Safety
+### Freeze and Thaw Live Filesystems
 
 Working on a live block device can lead to inconsistent manifests if writes
 occur during the scan. To ensure a stable view:

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -1,26 +1,34 @@
 # Transports
 
+## Usage
+
 LVMSync supports multiple transports selectable with the `--transport` flag.
-Transports are tried in order until a connection is established.
+Transports are tried in order until a connection is established. The default
+order is `quic,h2,tcp+tls,ssh`.
 
-Default order: `quic,h2,tcp+tls,ssh`.
+Every session begins with a textual handshake starting with `lvmsync PROTO[3]`.
+Tokens advertise supported transports, compression algorithms, and digests. The
+handshake also carries a resume token (`resume:<token>`) so interrupted sessions
+can continue and a maximum in‑flight hint (`inflight:<n>`) to negotiate
+concurrency.
 
-Every session begins with a textual handshake starting with
-`lvmsync PROTO[3]`. Tokens advertise supported transports, compression
-algorithms and digests. The handshake also carries a resume token
-(`resume:<token>`) so interrupted sessions can continue and a maximum
-in‑flight hint (`inflight:<n>`) to negotiate concurrency.
+## Security Defaults
 
-Handshake validation rejects mismatched ALPN protocols or TLS versions to
-ensure both peers agree on the connection parameters.
+Handshake validation rejects mismatched ALPN protocols or TLS versions to ensure
+both peers agree on the connection parameters.
 
-TLS based transports enable mutual TLS by default and restrict cipher suites to
+TLS-based transports enable mutual TLS by default and restrict cipher suites to
 `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, and
-`TLS_CHACHA20_POLY1305_SHA256`.
+`TLS_CHACHA20_POLY1305_SHA256`. TLS transports require an explicit set of
+trusted CA roots. Connections are rejected if no roots are provided unless the
+transport configuration sets `AllowInsecure` to skip verification. Enabling this
+option logs a warning.
 
-TLS transports require an explicit set of trusted CA roots. Connections are
-rejected if no roots are provided unless the transport configuration sets
-`AllowInsecure` to skip verification. Enabling this option logs a warning.
+## Examples
+
+```sh
+lvmsync --transport quic,h2,tcp+tls,ssh --tcp-port 9443
+```
 
 ## gRPC keepalive and timeouts
 
@@ -64,9 +72,3 @@ lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 - Verifies server host keys using `known_hosts` or an explicit `--ssh_host_key`; unknown hosts are rejected
 - Key authentication via `--ssh_key`/`LVMSYNC_SSH_KEY`
 - Optional agent auth with `--ssh_agent`/`LVMSYNC_SSH_AGENT` using `SSH_AUTH_SOCK`
-
-Example selecting transports and custom port:
-
-```sh
-lvmsync --transport quic,h2,tcp+tls,ssh --tcp-port 9443
-```


### PR DESCRIPTION
## Summary
- document manifest usage and safety defaults
- expand transport guide and README for resume/verify workflows
- clarify contributor logging and flag grouping guidelines

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: expected context deadline exceeded, got network is unreachable)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fbfffeaa08323a12f2828f56d41ce