### PR TITLE
feat(device): autodetect LVM, raw, or file devices and manage snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- device: detect LVM, raw, or file devices using blkid metadata
+- cmd: manage LVM snapshot lifecycle within dump and apply commands
 - Log dial and listen lifecycle events with duration_ms and error fields across transports, with tests covering handshake and teardown logs.
 - Log final handshake parameters for all transports.
 - Log manifest rebuild completion with size and duration metrics.
@@ -51,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- device: require --offline or freeze/thaw hooks for raw devices
 - device, transfer: require non-nil loggers and remove conditional logging
 - tests: fix O_DIRECT match and transport mismatch handshake validation tests
 - quic: remove redundant deadline methods and use Role.String for dial/listen

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -14,10 +14,13 @@ import (
 )
 
 // applyFunc allows tests to override the apply implementation.
-var applyFunc = func(cfg *config.Config, applyFile, destDevice string, logger *zap.Logger) error {
-	t := transfer.NewTransfer(logger, &sync.WaitGroup{})
-	return t.RunApply(cfg, applyFile, destDevice)
-}
+var (
+	applyFunc = func(cfg *config.Config, applyFile, destDevice string, logger *zap.Logger) error {
+		t := transfer.NewTransfer(logger, &sync.WaitGroup{})
+		return t.RunApply(cfg, applyFile, destDevice)
+	}
+	detectDevice = device.Detect
+)
 
 func init() {
 	rootcmd.RunApply = Run
@@ -30,23 +33,32 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	if len(args) < 1 {
 		return fmt.Errorf("no destination device specified for apply mode")
 	}
-	destDevice := args[0]
-	if cfg.DestType == "auto" {
-		if dev, err := device.Detect(context.Background(), destDevice, true, cfg.DestType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
-			switch dev.(type) {
-			case *device.RawDevice:
-				if !cfg.SkipSnapshotCreation {
-					dev.Close()
-					return fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
-				}
-				cfg.DestType = "raw"
-			case *device.LVMDevice:
-				cfg.DestType = "lvm"
-			case *device.FileDevice:
-				cfg.DestType = "file"
-			}
-			dev.Close()
-		}
+	destPath := args[0]
+	dev, err := detectDevice(context.Background(), destPath, cfg.Offline, cfg.DestType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
+	if err != nil {
+		return err
 	}
-	return applyFunc(cfg, applyFile, destDevice, logger)
+	switch dev.(type) {
+	case *device.RawDevice:
+		cfg.DestType = "raw"
+	case *device.LVMDevice:
+		cfg.DestType = "lvm"
+	case *device.FileDevice:
+		cfg.DestType = "file"
+	}
+	if cfg.DestType == "raw" && !cfg.SkipSnapshotCreation {
+		dev.Cleanup(context.Background())
+		dev.Close()
+		return fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
+	}
+	err = applyFunc(cfg, applyFile, dev.Path(), logger)
+	cleanupErr := dev.Cleanup(context.Background())
+	closeErr := dev.Close()
+	if err != nil {
+		return err
+	}
+	if cleanupErr != nil {
+		return cleanupErr
+	}
+	return closeErr
 }

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -1,12 +1,15 @@
 package apply
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 )
 
 func TestRun(t *testing.T) {
@@ -18,7 +21,8 @@ func TestRun(t *testing.T) {
 	dest := "/dev/null"
 
 	called := false
-	original := applyFunc
+	origApply := applyFunc
+	origDetect := detectDevice
 	applyFunc = func(c *config.Config, applyFileArg, destDevice string, _ *zap.Logger) error {
 		called = true
 		if applyFileArg != applyFile {
@@ -29,7 +33,10 @@ func TestRun(t *testing.T) {
 		}
 		return nil
 	}
-	defer func() { applyFunc = original }()
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+		return &fakeDevice{path: dest}, nil
+	}
+	defer func() { applyFunc = origApply; detectDevice = origDetect }()
 
 	if err := Run(cfg, applyFile, []string{dest}, zap.NewNop()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -58,9 +65,13 @@ func TestRunSyncsLogger(t *testing.T) {
 	logger := zap.New(core)
 	applyFile := "dumpfile"
 	dest := "/dev/null"
-	original := applyFunc
+	origApply := applyFunc
+	origDetect := detectDevice
 	applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
-	defer func() { applyFunc = original }()
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+		return &fakeDevice{path: dest}, nil
+	}
+	defer func() { applyFunc = origApply; detectDevice = origDetect }()
 	if err := Run(cfg, applyFile, []string{dest}, logger); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
@@ -68,3 +79,12 @@ func TestRunSyncsLogger(t *testing.T) {
 		t.Fatalf("expected Sync to be called once, got %d", core.count)
 	}
 }
+
+type fakeDevice struct{ path string }
+
+func (f *fakeDevice) Path() string                                            { return f.path }
+func (f *fakeDevice) SizeBytes() uint64                                       { return 0 }
+func (f *fakeDevice) BlockSize() uint64                                       { return 0 }
+func (f *fakeDevice) Snapshot(context.Context, string) (device.Device, error) { return f, nil }
+func (f *fakeDevice) Cleanup(context.Context) error                           { return nil }
+func (f *fakeDevice) Close() error                                            { return nil }

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -40,6 +40,7 @@ var (
 	}
 	newSSHClient = remote.NewSSHClient
 	openFile     = os.OpenFile
+	detectDevice = device.Detect
 )
 
 var copyBufferPool = sync.Pool{New: func() any {
@@ -130,9 +131,41 @@ func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io
 }
 
 // Run executes client mode transferring data to dest and returns the destination type.
-func Run(ctx context.Context, cfg *config.Config, snapshotDevice, dest string, logger *zap.Logger) (string, error) {
+func Run(ctx context.Context, cfg *config.Config, source, dest string, logger *zap.Logger) (string, error) {
 	defer rootcmd.SyncLogger(logger)
-	originDevice := snapshotDevice
+	dev, err := detectDevice(ctx, source, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
+	if err != nil {
+		return cfg.DestType, err
+	}
+	switch dev.(type) {
+	case *device.LVMDevice:
+		cfg.SourceType = "lvm"
+	case *device.RawDevice:
+		cfg.SourceType = "raw"
+	case *device.FileDevice:
+		cfg.SourceType = "file"
+	}
+	if cfg.SourceType == "raw" && !cfg.SkipSnapshotCreation {
+		dev.Close()
+		dev.Cleanup(ctx)
+		return cfg.DestType, fmt.Errorf("raw sources require --skip_snapshot_creation and either --offline or --fs-freeze-command/--fs-thaw-command")
+	}
+	snapDev, err := dev.Snapshot(ctx, cfg.SnapshotSize)
+	if err != nil {
+		dev.Cleanup(ctx)
+		dev.Close()
+		return cfg.DestType, err
+	}
+	snapshotDevice := snapDev.Path()
+	originDevice := dev.Path()
+	defer func() {
+		snapDev.Cleanup(ctx)
+		snapDev.Close()
+		if snapDev != dev {
+			dev.Cleanup(ctx)
+			dev.Close()
+		}
+	}()
 	if cfg.StdoutMode {
 		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)
 		return cfg.DestType, ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)

--- a/cmd/dump/fake_device_test.go
+++ b/cmd/dump/fake_device_test.go
@@ -1,0 +1,16 @@
+package dump
+
+import (
+	"context"
+
+	"lvmsync_go/device"
+)
+
+type fakeDevice struct{ path string }
+
+func (f *fakeDevice) Path() string                                            { return f.path }
+func (f *fakeDevice) SizeBytes() uint64                                       { return 0 }
+func (f *fakeDevice) BlockSize() uint64                                       { return 0 }
+func (f *fakeDevice) Snapshot(context.Context, string) (device.Device, error) { return f, nil }
+func (f *fakeDevice) Cleanup(context.Context) error                           { return nil }
+func (f *fakeDevice) Close() error                                            { return nil }

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	remotetest "lvmsync_go/remote/testutil"
 	"lvmsync_go/transfer"
 )
@@ -52,6 +53,11 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	origDetect := detectDevice
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+		return &fakeDevice{path: "/dev/snap"}, nil
+	}
+	defer func() { detectDevice = origDetect }()
 	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "dumpChanges") {
 		t.Fatalf("expected dumpChanges error, got %v", err)
@@ -101,6 +107,11 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	origDetect := detectDevice
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+		return &fakeDevice{path: "/dev/snap"}, nil
+	}
+	defer func() { detectDevice = origDetect }()
 	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil {
 		t.Fatalf("expected error from pre-script")
@@ -155,6 +166,11 @@ func TestRemotePostScriptContextError(t *testing.T) {
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	origDetect := detectDevice
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+		return &fakeDevice{path: "/dev/snap"}, nil
+	}
+	defer func() { detectDevice = origDetect }()
 	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "remote post-script context error") {
 		t.Fatalf("expected remote post-script context error, got %v", err)

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	"lvmsync_go/transfer"
 )
 
@@ -36,6 +37,11 @@ func TestRunLogsSaveStateError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	origDetect := detectDevice
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+		return &fakeDevice{path: "/dev/snap"}, nil
+	}
+	defer func() { detectDevice = origDetect }()
 	if _, err := Run(ctx, cfg, "/dev/snap", "", logger); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 	"lvmsync_go/transfer"
 )
 
@@ -41,6 +42,11 @@ func TestRunStdout(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	origDetect := detectDevice
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+		return &fakeDevice{path: "/dev/snap"}, nil
+	}
+	defer func() { detectDevice = origDetect }()
 	if _, err = Run(ctx, cfg, "/dev/snap", "", zap.NewNop()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -11,7 +11,6 @@ import (
 
 	"lvmsync_go/app"
 	"lvmsync_go/config"
-	"lvmsync_go/device"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/privilege"
 	"lvmsync_go/transport"
@@ -195,43 +194,7 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	}
 
 	snapshotPath = originalVolume
-	var (
-		monitorErrCh chan error
-		cleanup      = func() {}
-	)
-
-	if cfg.SourceType == "" || cfg.SourceType == "auto" {
-		dev, err := device.Detect(ctx, originalVolume, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
-		if err != nil {
-			return err
-		}
-		switch dev.(type) {
-		case *device.LVMDevice:
-			cfg.SourceType = "lvm"
-		case *device.RawDevice:
-			cfg.SourceType = "raw"
-		case *device.FileDevice:
-			cfg.SourceType = "file"
-		}
-		dev.Close()
-	}
-	switch cfg.SourceType {
-	case "lvm":
-		snapshotPath, monitorErrCh, cleanup, err = PrepareSnapshot(ctx, cfg, originalVolume, logger)
-		if err != nil {
-			return err
-		}
-	case "raw":
-		if !cfg.SkipSnapshotCreation {
-			return fmt.Errorf("raw sources require --skip_snapshot_creation and either --offline or --fs-freeze-command/--fs-thaw-command")
-		}
-	case "file":
-	default:
-		return fmt.Errorf("unknown source type %q", cfg.SourceType)
-	}
-	defer cleanup()
-
-	return ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
+	return ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, nil, logger)
 }
 
 // Execute is a helper that configures and runs the root command.

--- a/device/detect.go
+++ b/device/detect.go
@@ -48,7 +48,7 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			}
 			cache := lvm.NewDeviceFDCache(logger)
 			defer cache.Close()
-			dev, err := OpenLVM(resolved, cache, lvmEscalation, logger)
+			dev, err := openLVMFunc(resolved, cache, lvmEscalation, logger)
 			if err != nil {
 				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
 				return nil, err
@@ -96,18 +96,18 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 		return dev, nil
 	}
 	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
-		if _, err := lvm.GetVolumeGroupName(resolved); err == nil {
+		out, err := execCommand(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
+		fsType := strings.TrimSpace(string(out))
+		if err == nil && fsType == "LVM2_member" {
 			cache := lvm.NewDeviceFDCache(logger)
 			defer cache.Close()
-			dev, err := OpenLVM(resolved, cache, lvmEscalation, logger)
+			dev, err := openLVMFunc(resolved, cache, lvmEscalation, logger)
 			if err != nil {
 				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
 				return nil, err
 			}
 			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
 			return dev, nil
-		} else {
-			logger.Debug("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
 		}
 		var freezePath, thawPath string
 		var freezeArgs, thawArgs []string

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -10,6 +10,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/lvm"
 )
 
 func setupLoop(t *testing.T, size int64) (string, func()) {
@@ -159,6 +161,35 @@ func TestDetectLVMSymlink(t *testing.T) {
 	}
 	if _, ok := dev.(*RawDevice); !ok {
 		t.Fatalf("expected RawDevice, got %T", dev)
+	}
+	dev.Close()
+}
+
+func TestDetectLVM(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+	origExec := execCommand
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name == "blkid" {
+			return exec.CommandContext(ctx, "sh", "-c", "echo LVM2_member")
+		}
+		return exec.CommandContext(ctx, name, args...)
+	}
+	defer func() { execCommand = origExec }()
+	origOpen := openLVMFunc
+	openLVMFunc = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+		return &LVMDevice{path: p, logger: zap.NewNop()}, nil
+	}
+	defer func() { openLVMFunc = origOpen }()
+	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, zap.NewNop())
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if _, ok := dev.(*LVMDevice); !ok {
+		t.Fatalf("expected LVMDevice, got %T", dev)
 	}
 	dev.Close()
 }


### PR DESCRIPTION
## Summary
- detect LVM, raw, or file devices using blkid metadata
- require freeze/thaw hooks for raw devices unless offline
- manage LVM snapshot lifecycle through dump and apply commands

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fc3e51b4c8323bb1c4dd3915fbcd2