### PR TITLE
feat(transport): negotiate compression and digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport/h2: refactor Dial into dialTLS, performH2Handshake, and logDialResult with unit tests.
 - transport: tests covering SelectBest handshake negotiation with custom CDC settings, resume tokens, and O_DIRECT for ssh, tcp+tls, h2, and quic transports.
 - transport: test registry fallback dialing sequence with logged attempts.
+- common: add MergeHandshake helper for compressor and digest negotiation.
 - device: add raw device freeze/thaw tests with exec command stubs
 - device: centralize exec command helper for LVM and raw devices
 - device: add cleanup tests for thaw errors and timeouts
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - device: remove logger nil guards and default to `zap.NewNop()`
 - quic: propagate deadlines to connection for datagram reads.
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
+- handshake: validate digest mismatches in protocol negotiation
 - Enforce CDC chunk size ordering in handshake validation.
 - config: validate positive CDC tunables and ordering.
 - tcp+tls: ensure negotiation performs TLS handshake and only records ALPN/TLS version when negotiated.

--- a/common/handshake_merge.go
+++ b/common/handshake_merge.go
@@ -1,0 +1,19 @@
+package common
+
+// MergeHandshake selects preferred parameters from local and peer handshakes.
+//
+// Fields already set on local take precedence. When a field such as Transport,
+// Compress, or Digest is unset, MergeHandshake chooses the first common element
+// between the corresponding capability lists.
+func MergeHandshake(local, peer Handshake) Handshake {
+	if local.Transport == "" {
+		local.Transport = SelectBest(local.Transports, append(peer.Transports, peer.Transport))
+	}
+	if local.Compress == "" {
+		local.Compress = SelectBest(local.Compressors, append(peer.Compressors, peer.Compress))
+	}
+	if local.Digest == "" {
+		local.Digest = SelectBest(local.Digests, append(peer.Digests, peer.Digest))
+	}
+	return local
+}

--- a/common/handshake_merge_test.go
+++ b/common/handshake_merge_test.go
@@ -1,0 +1,21 @@
+package common
+
+import "testing"
+
+func TestMergeHandshakeSelectsBest(t *testing.T) {
+	local := Handshake{Compressors: []string{"zstd", "lz4"}, Digests: []string{"sha256", "blake3"}}
+	peer := Handshake{Compressors: []string{"lz4"}, Digests: []string{"blake3"}}
+	merged := MergeHandshake(local, peer)
+	if merged.Compress != "lz4" || merged.Digest != "blake3" {
+		t.Fatalf("unexpected merge result: %+v", merged)
+	}
+}
+
+func TestMergeHandshakePreservesLocal(t *testing.T) {
+	local := Handshake{Compress: "zstd", Digest: "sha256", Compressors: []string{"zstd"}, Digests: []string{"sha256"}}
+	peer := Handshake{Compressors: []string{"lz4"}, Digests: []string{"blake3"}}
+	merged := MergeHandshake(local, peer)
+	if merged.Compress != "zstd" || merged.Digest != "sha256" {
+		t.Fatalf("unexpected merge result: %+v", merged)
+	}
+}

--- a/common/handshake_validate.go
+++ b/common/handshake_validate.go
@@ -38,6 +38,9 @@ func ValidateHandshake(local, peer Handshake) error {
 	if peer.CompressLevel != 0 && local.CompressLevel != 0 && peer.CompressLevel != local.CompressLevel {
 		return fmt.Errorf("compression level mismatch: %d", peer.CompressLevel)
 	}
+	if peer.Digest != "" && local.Digest != "" && peer.Digest != local.Digest {
+		return fmt.Errorf("digest mismatch: %s", peer.Digest)
+	}
 	if peer.ODirect != local.ODirect {
 		return fmt.Errorf("o_direct mismatch: %v", peer.ODirect)
 	}

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -85,3 +85,11 @@ func TestValidateHandshakeTransportMismatch(t *testing.T) {
 		t.Fatal("expected transport mismatch error")
 	}
 }
+
+func TestValidateHandshakeDigestMismatch(t *testing.T) {
+	local := Handshake{Digest: "blake3"}
+	peer := Handshake{Digest: "sha256"}
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected digest mismatch error")
+	}
+}

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -362,6 +362,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}
@@ -375,6 +376,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -272,10 +272,21 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 	expDigest := common.SelectBest(srvDigest, cliDigest)
 	expDedup := common.SelectBest(srvDedup, cliDedup)
 
-	hs := common.Handshake{
+	srvHS := common.Handshake{
 		DedupMode:   expDedup,
-		Compress:    expCompress,
-		Digest:      expDigest,
+		Compressors: srvCompress,
+		Digests:     srvDigest,
+		ResumeToken: "tok",
+		ODirect:     true,
+		MaxInFlight: 8,
+		CDCMin:      64,
+		CDCAvg:      128,
+		CDCMax:      256,
+	}
+	cliHS := common.Handshake{
+		DedupMode:   expDedup,
+		Compressors: cliCompress,
+		Digests:     cliDigest,
 		ResumeToken: "tok",
 		ODirect:     true,
 		MaxInFlight: 8,
@@ -284,35 +295,32 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvCh := make(chan common.Handshake)
+	srvErr := make(chan error)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
-			t.Errorf("accept: %v", err)
+			srvErr <- err
 			return
 		}
-		peer, err := tr.Negotiate(ctx, conn, transport.Server, hs)
-		if err != nil {
-			t.Errorf("server negotiate: %v", err)
-		}
+		_, err = tr.Negotiate(ctx, conn, transport.Server, srvHS)
+		srvErr <- err
 		conn.Close()
-		srvCh <- peer
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peer, err := tr.Negotiate(ctx, conn, transport.Client, hs)
+	peer, err := tr.Negotiate(ctx, conn, transport.Client, cliHS)
 	conn.Close()
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	srvPeer := <-srvCh
-	for _, p := range []common.Handshake{peer, srvPeer} {
-		if p.DedupMode != expDedup || p.Compress != expCompress || p.Digest != expDigest || p.ResumeToken != "tok" || !p.ODirect || p.CDCMin != 64 || p.CDCAvg != 128 || p.CDCMax != 256 || p.ALPN != "h2" || p.TLSVersion != "1.3" {
-			t.Fatalf("unexpected peer handshake: %+v", p)
-		}
+	if err := <-srvErr; err != nil {
+		t.Fatalf("server negotiate: %v", err)
+	}
+	if peer.DedupMode != expDedup || peer.Compress != expCompress || peer.Digest != expDigest || peer.ResumeToken != "tok" || !peer.ODirect || peer.CDCMin != 64 || peer.CDCAvg != 128 || peer.CDCMax != 256 || peer.ALPN != "h2" || peer.TLSVersion != "1.3" {
+		t.Fatalf("unexpected peer handshake: %+v", peer)
 	}
 }
 

--- a/transport/negotiation_params_test.go
+++ b/transport/negotiation_params_test.go
@@ -236,6 +236,14 @@ func TestTransportNegotiationMatrix(t *testing.T) {
 			if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
 				t.Fatalf("expected tls version mismatch error")
 			}
+			// digest algorithm
+			serverHS = base
+			serverHS.Digest = "blake3"
+			clientHS = base
+			clientHS.Digest = "sha256"
+			if srv, cli := runNegotiation(t, tr, serverHS, clientHS); srv.err == nil || cli.err == nil {
+				t.Fatalf("expected digest mismatch error")
+			}
 		})
 	}
 }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -229,6 +229,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}
@@ -242,6 +243,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -147,10 +147,21 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 	expDigest := common.SelectBest(srvDigest, cliDigest)
 	expDedup := common.SelectBest(srvDedup, cliDedup)
 
-	hs := common.Handshake{
+	srvHS := common.Handshake{
 		DedupMode:   expDedup,
-		Compress:    expCompress,
-		Digest:      expDigest,
+		Compressors: srvCompress,
+		Digests:     srvDigest,
+		ResumeToken: "tok",
+		ODirect:     true,
+		MaxInFlight: 8,
+		CDCMin:      64,
+		CDCAvg:      128,
+		CDCMax:      256,
+	}
+	cliHS := common.Handshake{
+		DedupMode:   expDedup,
+		Compressors: cliCompress,
+		Digests:     cliDigest,
 		ResumeToken: "tok",
 		ODirect:     true,
 		MaxInFlight: 8,
@@ -159,24 +170,21 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvCh := make(chan common.Handshake)
+	srvErr := make(chan error)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
-			t.Errorf("accept: %v", err)
+			srvErr <- err
 			return
 		}
 		qconn := conn.(*Conn)
-		peer, err := tr.Negotiate(ctx, qconn, transport.Server, hs)
-		if err != nil {
-			t.Errorf("server negotiate: %v", err)
-			qconn.Close()
-			return
+		_, err = tr.Negotiate(ctx, qconn, transport.Server, srvHS)
+		if err == nil {
+			buf := make([]byte, 1)
+			qconn.Read(buf)
 		}
-		buf := make([]byte, 1)
-		qconn.Read(buf)
+		srvErr <- err
 		qconn.Close()
-		srvCh <- peer
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -184,18 +192,18 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	qconn := conn.(*Conn)
-	peer, err := tr.Negotiate(ctx, qconn, transport.Client, hs)
+	peer, err := tr.Negotiate(ctx, qconn, transport.Client, cliHS)
 	if err != nil {
 		qconn.Close()
 		t.Fatalf("client negotiate: %v", err)
 	}
 	qconn.Write([]byte{1})
 	qconn.Close()
-	srvPeer := <-srvCh
-	for _, p := range []common.Handshake{peer, srvPeer} {
-		if p.DedupMode != expDedup || p.Compress != expCompress || p.Digest != expDigest || p.ResumeToken != "tok" || !p.ODirect || p.CDCMin != 64 || p.CDCAvg != 128 || p.CDCMax != 256 {
-			t.Fatalf("unexpected peer handshake: %+v", p)
-		}
+	if err := <-srvErr; err != nil {
+		t.Fatalf("server negotiate: %v", err)
+	}
+	if peer.DedupMode != expDedup || peer.Compress != expCompress || peer.Digest != expDigest || peer.ResumeToken != "tok" || !peer.ODirect || peer.CDCMin != 64 || peer.CDCAvg != 128 || peer.CDCMax != 256 {
+		t.Fatalf("unexpected peer handshake: %+v", peer)
 	}
 }
 

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -41,3 +41,17 @@ func Get(name string, cfg Config) (Interface, error) {
 	}
 	return nil, fmt.Errorf("transport %q not registered", name)
 }
+
+// GetOrdered returns transports in the provided order using cfg for construction.
+// An error is returned if any named transport is not registered.
+func GetOrdered(names []string, cfg Config) ([]Interface, error) {
+	trs := make([]Interface, 0, len(names))
+	for _, n := range names {
+		tr, err := Get(n, cfg)
+		if err != nil {
+			return nil, err
+		}
+		trs = append(trs, tr)
+	}
+	return trs, nil
+}

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -1,12 +1,29 @@
 package transport
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 
 	"go.uber.org/zap"
+
+	"lvmsync_go/common"
 )
+
+type orderStub struct{ name string }
+
+func (s *orderStub) Name() string { return s.name }
+func (s *orderStub) Dial(context.Context, string) (net.Conn, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *orderStub) Listen(context.Context, string) (net.Listener, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *orderStub) Negotiate(context.Context, net.Conn, Role, common.Handshake) (common.Handshake, error) {
+	return common.Handshake{}, fmt.Errorf("not implemented")
+}
 
 func TestConcurrentRegister(t *testing.T) {
 	const goroutines = 50
@@ -53,4 +70,27 @@ func TestMustRegisterDuplicate(t *testing.T) {
 		}
 	}()
 	MustRegister(name, func(Config) (Interface, error) { return nil, nil })
+}
+
+func TestGetOrdered(t *testing.T) {
+	regMu.Lock()
+	original := registry
+	registry = map[string]Factory{}
+	regMu.Unlock()
+	defer func() {
+		regMu.Lock()
+		registry = original
+		regMu.Unlock()
+	}()
+
+	Register("a", func(Config) (Interface, error) { return &orderStub{name: "a"}, nil })
+	Register("b", func(Config) (Interface, error) { return &orderStub{name: "b"}, nil })
+
+	trs, err := GetOrdered([]string{"b", "a"}, Config{Logger: zap.NewNop()})
+	if err != nil {
+		t.Fatalf("get ordered: %v", err)
+	}
+	if len(trs) != 2 || trs[0].Name() != "b" || trs[1].Name() != "a" {
+		t.Fatalf("unexpected order: %v %v", trs[0].Name(), trs[1].Name())
+	}
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -267,6 +267,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}
@@ -279,6 +280,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -374,10 +374,21 @@ func TestSSHTransportSelectBestHandshake(t *testing.T) {
 	expDigest := common.SelectBest(srvDigest, cliDigest)
 	expDedup := common.SelectBest(srvDedup, cliDedup)
 
-	hs := common.Handshake{
+	srvHS := common.Handshake{
 		DedupMode:   expDedup,
-		Compress:    expCompress,
-		Digest:      expDigest,
+		Compressors: srvCompress,
+		Digests:     srvDigest,
+		ResumeToken: "tok",
+		ODirect:     true,
+		MaxInFlight: 8,
+		CDCMin:      64,
+		CDCAvg:      128,
+		CDCMax:      256,
+	}
+	cliHS := common.Handshake{
+		DedupMode:   expDedup,
+		Compressors: cliCompress,
+		Digests:     cliDigest,
 		ResumeToken: "tok",
 		ODirect:     true,
 		MaxInFlight: 8,
@@ -386,35 +397,32 @@ func TestSSHTransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvCh := make(chan common.Handshake)
+	srvErr := make(chan error)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
-			t.Errorf("accept: %v", err)
+			srvErr <- err
 			return
 		}
-		peer, err := server.Negotiate(ctx, conn, transport.Server, hs)
-		if err != nil {
-			t.Errorf("server negotiate: %v", err)
-		}
+		_, err = server.Negotiate(ctx, conn, transport.Server, srvHS)
+		srvErr <- err
 		conn.Close()
-		srvCh <- peer
 	}()
 
 	conn, err := client.Dial(ctx, ln.Addr().String())
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peer, err := client.Negotiate(ctx, conn, transport.Client, hs)
+	peer, err := client.Negotiate(ctx, conn, transport.Client, cliHS)
 	conn.Close()
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	srvPeer := <-srvCh
-	for _, p := range []common.Handshake{peer, srvPeer} {
-		if p.DedupMode != expDedup || p.Compress != expCompress || p.Digest != expDigest || p.ResumeToken != "tok" || !p.ODirect || p.CDCMin != 64 || p.CDCAvg != 128 || p.CDCMax != 256 {
-			t.Fatalf("unexpected peer handshake: %+v", p)
-		}
+	if err := <-srvErr; err != nil {
+		t.Fatalf("server negotiate: %v", err)
+	}
+	if peer.DedupMode != expDedup || peer.Compress != expCompress || peer.Digest != expDigest || peer.ResumeToken != "tok" || !peer.ODirect || peer.CDCMin != 64 || peer.CDCAvg != 128 || peer.CDCMax != 256 {
+		t.Fatalf("unexpected peer handshake: %+v", peer)
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -256,6 +256,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}
@@ -269,6 +270,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 		if err != nil {
 			return peer, err
 		}
+		hs = common.MergeHandshake(hs, peer)
 		if err := common.ValidateHandshake(hs, peer); err != nil {
 			return peer, err
 		}

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -152,10 +152,21 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 	expDigest := common.SelectBest(srvDigest, cliDigest)
 	expDedup := common.SelectBest(srvDedup, cliDedup)
 
-	hs := common.Handshake{
+	srvHS := common.Handshake{
 		DedupMode:   expDedup,
-		Compress:    expCompress,
-		Digest:      expDigest,
+		Compressors: srvCompress,
+		Digests:     srvDigest,
+		ResumeToken: "tok",
+		ODirect:     true,
+		MaxInFlight: 8,
+		CDCMin:      64,
+		CDCAvg:      128,
+		CDCMax:      256,
+	}
+	cliHS := common.Handshake{
+		DedupMode:   expDedup,
+		Compressors: cliCompress,
+		Digests:     cliDigest,
 		ResumeToken: "tok",
 		ODirect:     true,
 		MaxInFlight: 8,
@@ -164,35 +175,32 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvCh := make(chan common.Handshake)
+	srvErr := make(chan error)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
-			t.Errorf("accept: %v", err)
+			srvErr <- err
 			return
 		}
-		peer, err := tr.Negotiate(ctx, conn, transport.Server, hs)
-		if err != nil {
-			t.Errorf("server negotiate: %v", err)
-		}
+		_, err = tr.Negotiate(ctx, conn, transport.Server, srvHS)
+		srvErr <- err
 		conn.Close()
-		srvCh <- peer
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peer, err := tr.Negotiate(ctx, conn, transport.Client, hs)
+	peer, err := tr.Negotiate(ctx, conn, transport.Client, cliHS)
 	conn.Close()
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
-	srvPeer := <-srvCh
-	for _, p := range []common.Handshake{peer, srvPeer} {
-		if p.DedupMode != expDedup || p.Compress != expCompress || p.Digest != expDigest || p.ResumeToken != "tok" || !p.ODirect || p.CDCMin != 64 || p.CDCAvg != 128 || p.CDCMax != 256 {
-			t.Fatalf("unexpected peer handshake: %+v", p)
-		}
+	if err := <-srvErr; err != nil {
+		t.Fatalf("server negotiate: %v", err)
+	}
+	if peer.DedupMode != expDedup || peer.Compress != expCompress || peer.Digest != expDigest || peer.ResumeToken != "tok" || !peer.ODirect || peer.CDCMin != 64 || peer.CDCAvg != 128 || peer.CDCMax != 256 {
+		t.Fatalf("unexpected peer handshake: %+v", peer)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add MergeHandshake helper and digest mismatch validation
- negotiate compression/digest from capability lists in all transports
- retrieve transports in requested order via GetOrdered

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fc7949f988323bc4eda502c663354