### PR TITLE
feat(transfer): add resume checkpoint tracking and interruption tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - device: centralize exec command helper for LVM and raw devices
 - device: add cleanup tests for thaw errors and timeouts
 - transfer: add manifest index persistence test covering read/write, rebuild, and verify paths.
+- transfer: persist resume checkpoints with `--checkpoint-bytes` and `--checkpoint-interval` and add tests for interrupted transfers.
 - cmd: support `--source-type` and `--dest-type` flags and allow `device.Detect` to honor explicit type hints.
 - transfer: unify resume checkpoints across dedup modes and add resume tests for fixed, CDC, and hybrid modes.
 - transfer: add tests verifying resume state alignment across dedup mode transitions.

--- a/transfer/resume.go
+++ b/transfer/resume.go
@@ -1,0 +1,22 @@
+package transfer
+
+import "time"
+
+// resumeChunk stores the boundaries and digest of the last processed chunk.
+type resumeChunk struct {
+	Chunk  [32]byte
+	Offset uint64
+	Length uint32
+}
+
+// resumeCheckpoint represents the last processed chunk recorded on disk.
+type resumeCheckpoint struct {
+	resumeChunk
+}
+
+// resumeTracker tracks checkpoint progress for an ongoing transfer.
+type resumeTracker struct {
+	bytes int64
+	last  time.Time
+	resumeChunk
+}

--- a/transfer/resume_interrupted_test.go
+++ b/transfer/resume_interrupted_test.go
@@ -1,0 +1,83 @@
+package transfer
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+)
+
+func runInterrupted(t *testing.T, mode string) {
+	t.Helper()
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	tr.Tracker = &resumeTracker{}
+	blockSize := int64(1024)
+	snapshot := "vg-lv"
+	dir, src := createVolumeFiles(t, snapshot, blockSize, []int{0, 1, 2, 3})
+	resume := filepath.Join(dir, "resume")
+
+	cfg := &config.Config{
+		BlockSize:         int(blockSize),
+		Compress:          "none",
+		Parallel:          1,
+		ResumeState:       resume,
+		MaxRetries:        1,
+		ChecksumAlgorithm: "blake3",
+		Transport:         "ssh",
+		DedupMode:         mode,
+		CheckpointBytes:   1,
+	}
+
+	// simulate interrupted transfer: process one successful result then an error
+	results := make(chan *BlockResult, 2)
+	data := bytes.Repeat([]byte{1}, int(blockSize))
+	digest := blake3.Sum256(data)
+	results <- &BlockResult{Index: 0, Offset: 0, Size: uint32(blockSize), Data: data, ChunkID: digest}
+	results <- &BlockResult{Index: 1, Err: io.ErrUnexpectedEOF}
+	close(results)
+	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
+	bufOut := bufio.NewWriter(io.Discard)
+	if _, _, err := processParallelResults(cfg, results, bufOut, checksum, 0, time.Now(), zap.NewNop(), tr.Tracker); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	chk := readResumeState(cfg, zap.NewNop())
+	if chk.Offset != 0 || chk.Length == 0 || chk.Chunk != digest {
+		t.Fatalf("unexpected checkpoint %+v", chk)
+	}
+
+	var buf bytes.Buffer
+	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChangesParallel failed: %v", err)
+	}
+	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
+
+	offsets := parseOffsets(t, buf.Bytes(), blockSize)
+	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
+	expectedOffsets := []int64{blockSize, 2 * blockSize, 3 * blockSize}
+	if !reflect.DeepEqual(offsets, expectedOffsets) {
+		t.Fatalf("unexpected offsets %v, want %v", offsets, expectedOffsets)
+	}
+}
+
+func TestResumeInterruptedFixed(t *testing.T) {
+	runInterrupted(t, "fixed")
+}
+
+func TestResumeInterruptedCDC(t *testing.T) {
+	runInterrupted(t, "cdc")
+}
+
+func TestResumeInterruptedHybrid(t *testing.T) {
+	runInterrupted(t, "hybrid")
+}

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -22,22 +22,6 @@ type resumeState struct {
 	Chunk             string `json:"chunk"`
 }
 
-// resumeCheckpoint represents the last processed chunk on disk.
-type resumeCheckpoint struct {
-	Chunk  [32]byte
-	Offset uint64
-	Length uint32
-}
-
-// resumeTracker tracks checkpoint progress for an ongoing transfer.
-type resumeTracker struct {
-	bytes  int64
-	last   time.Time
-	chunk  [32]byte
-	offset uint64
-	length uint32
-}
-
 // writeResumeState persists resume state; logger must be non-nil.
 func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offset uint64, length uint32, chunk [32]byte) {
 	rs := resumeState{
@@ -67,12 +51,10 @@ func saveResumeState(cfg *config.Config, rt *resumeTracker, offset uint64, chunk
 		rt.last = time.Now()
 	}
 	rt.bytes += size
-	rt.chunk = chunk
-	rt.offset = offset
-	rt.length = uint32(size)
+	rt.resumeChunk = resumeChunk{Chunk: chunk, Offset: offset, Length: uint32(size)}
 	if (cfg.CheckpointBytes > 0 && rt.bytes >= int64(cfg.CheckpointBytes)) ||
 		(cfg.CheckpointInterval > 0 && time.Since(rt.last) >= cfg.CheckpointInterval) {
-		writeResumeState(cfg, logger, cfg.ResumeState, rt.offset, rt.length, rt.chunk)
+		writeResumeState(cfg, logger, cfg.ResumeState, rt.Offset, rt.Length, rt.Chunk)
 		rt.bytes = 0
 		rt.last = time.Now()
 	}


### PR DESCRIPTION
## Summary
- track last chunk boundaries and digests in new resume structs
- persist checkpoints via `--checkpoint-bytes`/`--checkpoint-interval`
- test resuming interrupted transfers for fixed, CDC, and hybrid modes

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fcd17d8848323b0b295f0fffce826