### PR TITLE
feat: validate non-interactive sudo escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document tasks for CDC chunker parameter validation and default logger initialization in `AGENTS.md`.
 - transport/h2: add tests for tlsVersionString and roleString helpers.
 - README: document CDC parameter ordering and the error when violated.
+- privilege: ensure non-interactive sudo escalation via `--lvm-escalation` flag with validation.
 - README: note that commands accept an explicit `*zap.Logger` defaulting to `zap.NewNop()`.
 - tests: validate O_DIRECT mismatch and agreement in handshake validation.
 - transport: add Role.String and shared TLSVersionString helpers.

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--skip_snapshot_creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
 | `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
-| `--lvm_escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands |
+| `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands |
 | `--lvm_timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations |
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
 | `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
@@ -1033,7 +1033,7 @@ timeouts or cancellations are reported separately.
 | `--volume_group` | Source volume group. Derived from the source device path when empty | "" |
 | `--target_volume_group` | Volume group name of the target LVM volume | "" |
 | `--target_vgs` | Candidate target volume groups for auto-selection | [] |
-| `--lvm_escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n") | "sudo -n" |
+| `--lvm-escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n") | "sudo -n" |
 | `--lvm_timeout` | Timeout for LVM operations | 10s |
 
 #### gRPC Options
@@ -1111,7 +1111,7 @@ lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data
 #### Full LVM Operation Example
 
 ```sh
-lvmsync run --skip_disk_check=false --snapshot_size "25%" --volume_group "vg_data" --lvm_escalation "sudo -n" /dev/vg_data/original /dev/vg_data/destination
+lvmsync run --skip_disk_check=false --snapshot_size "25%" --volume_group "vg_data" --lvm-escalation "sudo -n" /dev/vg_data/original /dev/vg_data/destination
 ```
 
 In this example, LVMSync will:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -512,7 +512,7 @@ func TestApplyThroughputMode(t *testing.T) {
 	}
 }
 
-func TestValidateEscalationCommandPath(t *testing.T) {
+func TestValidateEscalationCommand(t *testing.T) {
 	geteuid := func() int { return 1000 }
 
 	oldPath := os.Getenv("PATH")
@@ -520,18 +520,29 @@ func TestValidateEscalationCommandPath(t *testing.T) {
 
 	dir := t.TempDir()
 	exe := filepath.Join(dir, "sudo")
-	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755); err != nil {
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("failed to create dummy executable: %v", err)
 	}
 	os.Setenv("PATH", dir)
 
-	cfg := &Config{Mode: "default", LVMEscalation: "sudo", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
-	if err := cfg.ValidateWith(geteuid); err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	base := &Config{Mode: "default", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+
+	cfg := *base
+	cfg.LVMEscalation = "sudo -n"
+	if err := (&cfg).ValidateWith(geteuid); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg = *base
+	cfg.LVMEscalation = "sudo"
+	if err := (&cfg).ValidateWith(geteuid); err == nil {
+		t.Fatalf("expected error without -n")
 	}
 
 	os.Setenv("PATH", "")
-	if err := cfg.ValidateWith(geteuid); err == nil {
+	cfg = *base
+	cfg.LVMEscalation = "sudo -n"
+	if err := (&cfg).ValidateWith(geteuid); err == nil {
 		t.Fatalf("expected error when command missing")
 	}
 }

--- a/config/flags.go
+++ b/config/flags.go
@@ -144,7 +144,7 @@ func initLVMFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("skip_snapshot_creation", cfg.SkipSnapshotCreation, "Skip snapshot creation")
 	fs.Bool("skip_disk_check", cfg.SkipDiskCheck, "Skip disk space check")
 	fs.String("snapshot_size", cfg.SnapshotSize, "Snapshot size (bytes or percentage)")
-	fs.String("lvm_escalation", cfg.LVMEscalation, "Command to use for privilege escalation")
+	fs.String("lvm-escalation", cfg.LVMEscalation, "Command to use for privilege escalation")
 	fs.Duration("lvm_timeout", cfg.LVMTimeout, "Timeout for LVM commands")
 	fs.String("volume_group", cfg.VolumeGroup, "LVM volume group")
 	fs.String("target_volume_group", cfg.TargetVolumeGroup, "Target LVM volume group")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -163,7 +163,7 @@ func TestInitLVMFlags(t *testing.T) {
 		{"skip_snapshot_creation", strconv.FormatBool(cfg.SkipSnapshotCreation)},
 		{"skip_disk_check", strconv.FormatBool(cfg.SkipDiskCheck)},
 		{"snapshot_size", cfg.SnapshotSize},
-		{"lvm_escalation", cfg.LVMEscalation},
+		{"lvm-escalation", cfg.LVMEscalation},
 		{"lvm_timeout", cfg.LVMTimeout.String()},
 		{"volume_group", cfg.VolumeGroup},
 		{"target_volume_group", cfg.TargetVolumeGroup},

--- a/config/validation.go
+++ b/config/validation.go
@@ -70,6 +70,18 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 		if _, err := findInPath(parts[0]); err != nil {
 			return fmt.Errorf("lvm escalation command %q not found: %w", parts[0], err)
 		}
+		if parts[0] == "sudo" {
+			hasN := false
+			for _, p := range parts[1:] {
+				if p == "-n" {
+					hasN = true
+					break
+				}
+			}
+			if !hasN {
+				return fmt.Errorf("lvm escalation must use 'sudo -n'")
+			}
+		}
 	}
 	return nil
 }

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -27,6 +27,9 @@ func TestEnsureWithCaps(t *testing.T) {
 func TestEnsureWithSudo(t *testing.T) {
 	HasCaps = func() bool { return false }
 	lookPath = fakeLookPath(nil)
+	orig := execCommand
+	execCommand = fakeSudo(0)
+	defer func() { execCommand = orig }()
 	esc := New().(*sudoEscalator)
 	if !esc.useSudo {
 		t.Fatalf("expected sudo usage")
@@ -57,6 +60,18 @@ func TestCommand(t *testing.T) {
 	cmd = esc.Command("echo", "hi")
 	if cmd.Args[0] == "sudo" {
 		t.Fatalf("unexpected sudo prefix")
+	}
+}
+
+func TestEnsureSudoFailure(t *testing.T) {
+	HasCaps = func() bool { return false }
+	lookPath = fakeLookPath(nil)
+	orig := execCommand
+	execCommand = fakeSudo(1)
+	defer func() { execCommand = orig }()
+	esc := New().(*sudoEscalator)
+	if err := esc.Ensure(); err == nil {
+		t.Fatalf("expected error")
 	}
 }
 

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -16,6 +16,9 @@ func (s *sudoEscalator) Ensure() error {
 		if _, err := lookPath("sudo"); err != nil {
 			return fmt.Errorf("sudo not found: %w", err)
 		}
+		if err := execCommand("sudo", "-n", "true").Run(); err != nil {
+			return fmt.Errorf("sudo escalation failed: %w", err)
+		}
 		return nil
 	}
 	return checkCaps()


### PR DESCRIPTION
## Summary
- ensure privilege escalator verifies `sudo -n` availability and runs LVM/ioctl commands with non-interactive sudo
- add `--lvm-escalation` flag with validation and documentation
- test escalation success and failure paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fcd2f53a48323a3d311ffb0982b6d