### PR TITLE
feat(config): bind compression flags to environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log manifest rebuild completion with size and duration metrics.
 - Add handshake parsing tests for unknown and malformed tokens.
 - Bind LVMSYNC_DEDUP_* environment variables and extend tests for dedup flag precedence.
+- Bind LVMSYNC_COMPRESSION_* environment variables and add tests for compression flag precedence.
 - Privilege escalation tests covering sudo success and failure modes.
 - device: tests for GetUUID and IsMountedRW
 - device: persist thaw command configuration for raw devices
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- config: remove duplicate prefixes in LVMSYNC_DEDUP_* environment bindings.
 - device: require --offline or freeze/thaw hooks for raw devices
 - device, transfer: require non-nil loggers and remove conditional logging
 - tests: fix O_DIRECT match and transport mismatch handshake validation tests

--- a/README.md
+++ b/README.md
@@ -467,17 +467,17 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer (separate `ssh_timeout`) |
 | `--dedup_strategy` | `LVMSYNC_DEDUP_STRATEGY` | `dedup_strategy` | Deduplication strategy: `none`, `auto`, `checksum`, `rolling_hash`, or `bloom` |
 | `--dedup_state_file` | `LVMSYNC_DEDUP_STATE_FILE` | `dedup_state_file` | Path to deduplication state file |
-| `--cdc-min` | `LVMSYNC_CDC_MIN` | `cdc_min` | Minimum chunk size for CDC |
-| `--cdc-avg` | `LVMSYNC_CDC_AVG` | `cdc_avg` | Target average chunk size for CDC |
-| `--cdc-max` | `LVMSYNC_CDC_MAX` | `cdc_max` | Maximum chunk size for CDC |
-| `--bloom_entries` | `LVMSYNC_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
-| `--bloom_fp_rate` | `LVMSYNC_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
-| `--bloom_mbits` | `LVMSYNC_BLOOM_MBITS` | `bloom_mbits` | Bloom filter m bits power |
-| `--compress` | `LVMSYNC_COMPRESS` | `compress` | Compression type: `none`, `lz4`, `zstd`, or `auto` |
-| `--zstd_level` | `LVMSYNC_ZSTD_LEVEL` | `zstd_level` | Zstd compression level (`1-5`) |
-| `--lz4_level` | `LVMSYNC_LZ4_LEVEL` | `lz4_level` | LZ4 compression level: `fast` or `hc` |
-| `--compress_concurrency` | `LVMSYNC_COMPRESS_CONCURRENCY` | `compress_concurrency` | Compression concurrency (0 to use `GOMAXPROCS`) |
-| `--compress_threshold` | `LVMSYNC_COMPRESS_THRESHOLD` | `compress_threshold` | Skip compression when estimated ratio exceeds this value |
+| `--cdc-min` | `LVMSYNC_DEDUP_CDC_MIN` | `cdc_min` | Minimum chunk size for CDC |
+| `--cdc-avg` | `LVMSYNC_DEDUP_CDC_AVG` | `cdc_avg` | Target average chunk size for CDC |
+| `--cdc-max` | `LVMSYNC_DEDUP_CDC_MAX` | `cdc_max` | Maximum chunk size for CDC |
+| `--bloom_entries` | `LVMSYNC_DEDUP_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
+| `--bloom_fp_rate` | `LVMSYNC_DEDUP_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
+| `--bloom_mbits` | `LVMSYNC_DEDUP_BLOOM_MBITS` | `bloom_mbits` | Bloom filter m bits power |
+| `--compress` | `LVMSYNC_COMPRESSION_COMPRESS` | `compress` | Compression type: `none`, `lz4`, `zstd`, or `auto` |
+| `--zstd_level` | `LVMSYNC_COMPRESSION_ZSTD_LEVEL` | `zstd_level` | Zstd compression level (`1-5`) |
+| `--lz4_level` | `LVMSYNC_COMPRESSION_LZ4_LEVEL` | `lz4_level` | LZ4 compression level: `fast` or `hc` |
+| `--compress_concurrency` | `LVMSYNC_COMPRESSION_COMPRESS_CONCURRENCY` | `compress_concurrency` | Compression concurrency (0 to use `GOMAXPROCS`) |
+| `--compress_threshold` | `LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD` | `compress_threshold` | Skip compression when estimated ratio exceeds this value |
 | `--skip_snapshot_creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
 | `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
@@ -713,9 +713,9 @@ Hybrid dedup combines fixed-size and content-defined chunking. Enable it with `-
 
 | Flag (`--cdc-*`) | Environment variable | Config key | Description |
 |------------------|----------------------|------------|-------------|
-| `--cdc-min`      | `LVMSYNC_CDC_MIN`    | `cdc_min`  | Minimum chunk size |
-| `--cdc-avg`      | `LVMSYNC_CDC_AVG`    | `cdc_avg`  | Target average chunk size |
-| `--cdc-max`      | `LVMSYNC_CDC_MAX`    | `cdc_max`  | Maximum chunk size |
+| `--cdc-min`      | `LVMSYNC_DEDUP_CDC_MIN`    | `cdc_min`  | Minimum chunk size |
+| `--cdc-avg`      | `LVMSYNC_DEDUP_CDC_AVG`    | `cdc_avg`  | Target average chunk size |
+| `--cdc-max`      | `LVMSYNC_DEDUP_CDC_MAX`    | `cdc_max`  | Maximum chunk size |
 
 The three values must be positive and satisfy `--cdc-min ≤ --cdc-avg ≤ --cdc-max`.
 LVMSync aborts when the sizes are non-positive or unordered.
@@ -734,9 +734,9 @@ Environment:
 
 ```sh
 LVMSYNC_DEDUP=hybrid \
-LVMSYNC_CDC_MIN=4096 \
-LVMSYNC_CDC_AVG=65536 \
-LVMSYNC_CDC_MAX=1048576 \
+LVMSYNC_DEDUP_CDC_MIN=4096 \
+LVMSYNC_DEDUP_CDC_AVG=65536 \
+LVMSYNC_DEDUP_CDC_MAX=1048576 \
 lvmsync run /dev/vg0/snap0 /mnt/backup
 ```
 
@@ -1263,7 +1263,7 @@ lvmsync run --compress auto --zstd_level 2 --compress_threshold 0.85 /dev/vg0/sn
 Environment:
 
 ```sh
-LVMSYNC_COMPRESS=auto LVMSYNC_ZSTD_LEVEL=2 LVMSYNC_COMPRESS_THRESHOLD=0.85 lvmsync run /dev/vg0/snap0 /dev/vg0/data
+LVMSYNC_COMPRESSION_COMPRESS=auto LVMSYNC_COMPRESSION_ZSTD_LEVEL=2 LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD=0.85 lvmsync run /dev/vg0/snap0 /dev/vg0/data
 ```
 
 YAML:

--- a/config/flags.go
+++ b/config/flags.go
@@ -217,7 +217,28 @@ func bindDedupEnv(fs *pflag.FlagSet, v *viper.Viper) error {
 		if err != nil {
 			return
 		}
-		env := "LVMSYNC_DEDUP_" + strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+		name = strings.TrimPrefix(name, "DEDUP_")
+		env := "LVMSYNC_DEDUP"
+		if name != "" {
+			env += "_" + name
+		}
+		if e := v.BindEnv(f.Name, env); e != nil {
+			err = e
+		}
+	})
+	return err
+}
+
+// bindCompressionEnv binds compression flag names to environment variables with the
+// LVMSYNC_COMPRESSION_ prefix.
+func bindCompressionEnv(fs *pflag.FlagSet, v *viper.Viper) error {
+	var err error
+	fs.VisitAll(func(f *pflag.Flag) {
+		if err != nil {
+			return
+		}
+		env := "LVMSYNC_COMPRESSION_" + strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 		if e := v.BindEnv(f.Name, env); e != nil {
 			err = e
 		}

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -529,6 +529,64 @@ func TestCDCMinEnvOverridesConfig(t *testing.T) {
 	}
 }
 
+func TestCompressCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "compress: zstd\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--compress", "lz4"})
+	t.Setenv("LVMSYNC_COMPRESSION_COMPRESS", "none")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.Compress != "lz4" {
+		t.Fatalf("expected compress lz4, got %s", conf.Compress)
+	}
+}
+
+func TestCompressEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "compress: zstd\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_COMPRESSION_COMPRESS", "none")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.Compress != "none" {
+		t.Fatalf("expected compress none, got %s", conf.Compress)
+	}
+}
+
 func TestGRPCPortCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "grpc_port: 1111\n")
 	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--grpc_port", "3333"})

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -278,6 +278,9 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	if err := bindDedupEnv(flagSets.Dedup, v); err != nil {
 		return nil, err
 	}
+	if err := bindCompressionEnv(flagSets.Compression, v); err != nil {
+		return nil, err
+	}
 	if cfgFile := v.GetString("config"); cfgFile != "" {
 		v.SetConfigFile(cfgFile)
 		if err := v.ReadInConfig(); err != nil {


### PR DESCRIPTION
## Summary
- bind compression flags to viper with LVMSYNC_COMPRESSION_ env vars
- trim duplicated prefixes for LVMSYNC_DEDUP_* env bindings
- document updated env vars and examples

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: signal interrupt in transport/h2)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fd1cc64248323b93a0ffb32b54170