### PR TITLE
fix(transport): handle unknown TLS versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ command-line use, environment variables, and `config.yaml` files.
 - Do not log secrets or authentication tokens; scrub sensitive values before emitting them.
 - Callers using transports should `defer logger.Sync()` to ensure logs are flushed.
 
+### Logging utilities
+
+- `TLSVersionString` returns `"unknown"` or the numeric TLS version when the value is unrecognized to avoid empty strings in logs.
+
 ### Field Naming
 
 - Use `snake_case` for all field keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- transport: return "unknown" or numeric string for unrecognized TLS versions
 - config: remove duplicate prefixes in LVMSYNC_DEDUP_* environment bindings.
 - device: require --offline or freeze/thaw hooks for raw devices
 - device, transfer: require non-nil loggers and remove conditional logging

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -539,7 +539,8 @@ func TestTLSVersionString(t *testing.T) {
 		{tls.VersionTLS11, "1.1"},
 		{tls.VersionTLS12, "1.2"},
 		{tls.VersionTLS13, "1.3"},
-		{0xffff, ""},
+		{0, "unknown"},
+		{0xffff, "65535"},
 	}
 	for _, tt := range tests {
 		if got := transport.TLSVersionString(tt.version); got != tt.want {

--- a/transport/util.go
+++ b/transport/util.go
@@ -1,6 +1,9 @@
 package transport
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"strconv"
+)
 
 // TLSVersionString returns a string representation of the TLS version number.
 func TLSVersionString(v uint16) string {
@@ -14,6 +17,9 @@ func TLSVersionString(v uint16) string {
 	case tls.VersionTLS13:
 		return "1.3"
 	default:
-		return ""
+		if v == 0 {
+			return "unknown"
+		}
+		return strconv.FormatUint(uint64(v), 10)
 	}
 }

--- a/transport/util_test.go
+++ b/transport/util_test.go
@@ -11,7 +11,8 @@ func TestTLSVersionString(t *testing.T) {
 		tls.VersionTLS11: "1.1",
 		tls.VersionTLS12: "1.2",
 		tls.VersionTLS13: "1.3",
-		0:                "",
+		0:                "unknown",
+		0xffff:           "65535",
 	}
 	for v, want := range cases {
 		if got := TLSVersionString(v); got != want {


### PR DESCRIPTION
## Summary
- return "unknown" or numeric string for unrecognized TLS versions
- test TLSVersionString fallback handling
- document TLS version logging fallback

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: UDP receive buffer insufficient; QUIC handshake timeout)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_689fd961555083239a64b3333aca0ee1