### PR TITLE
feat(ssh): log connection teardown events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Run these commands locally before opening a pull request:
 - [ ] Monitor elimination of `fmt.Print*` calls to keep progress logging fully structured.
 - [ ] Review QUIC constructor refactor and expand tests for sender/receiver coverage.
 - [ ] LVM device support: plumb snapshot creation through the device abstraction, allow raw device fallbacks, and unit test LVM vs. file paths.
-- [ ] Transport logging: emit connection handshake and teardown events with `snake_case` fields and ensure callers `defer logger.Sync()`.
+ - [x] Transport logging: emit connection handshake and teardown events with `snake_case` fields and ensure callers `defer logger.Sync()`.
 - [ ] Manifest rebuild: add a subcommand to regenerate chunk digests when manifests are missing or out of date, exercising rebuild logic in tests.
 - [ ] Verify command: compare source and destination devices against manifest entries and surface mismatched digests with structured logs.
 - [x] Refactor `cmd/grpcd` to defer `syncLogger` for structured log flushing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmd: manage LVM snapshot lifecycle within dump and apply commands
 - tests: add coverage for adaptive chunk sizing, index option application, TLS version helper, capability checks, and data size overflow; include loop device setup integration test.
 - Log dial and listen lifecycle events with duration_ms and error fields across transports, with tests covering handshake and teardown logs.
+- ssh: log connection close events with address, role, and duration fields.
 - Log final handshake parameters for all transports.
 - Log manifest rebuild completion with size and duration metrics.
 - Add handshake parsing tests for unknown and malformed tokens.

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -191,7 +191,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	}
 	go ssh.DiscardRequests(chReqs)
 	t.logger.Info("dial_end", fields...)
-	return &sshConn{netConn: raw, channel: ch, client: client}, nil
+	return &sshConn{netConn: raw, channel: ch, client: client, logger: t.logger}, nil
 }
 
 func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, error) {
@@ -300,13 +300,34 @@ type sshConn struct {
 	netConn net.Conn
 	channel ssh.Channel
 	client  *ssh.Client
+	logger  *zap.Logger
 }
 
 func (s *sshConn) Read(b []byte) (int, error)  { return s.channel.Read(b) }
 func (s *sshConn) Write(b []byte) (int, error) { return s.channel.Write(b) }
 func (s *sshConn) Close() error {
+	role := "client"
+	address := s.netConn.RemoteAddr().String()
+	s.logger.Info("close_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+	)
+	start := time.Now()
+	err := s.client.Close()
 	s.channel.Close()
-	return s.client.Close()
+	fields := []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+		s.logger.Error("close_end", fields...)
+	} else {
+		s.logger.Info("close_end", fields...)
+	}
+	return err
 }
 func (s *sshConn) LocalAddr() net.Addr                { return s.netConn.LocalAddr() }
 func (s *sshConn) RemoteAddr() net.Addr               { return s.netConn.RemoteAddr() }
@@ -342,20 +363,41 @@ func (l *sshListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 	go ssh.DiscardRequests(chReqs)
-	return &serverConn{sshConn: sc, netConn: raw, channel: ch}, nil
+	return &serverConn{sshConn: sc, netConn: raw, channel: ch, logger: l.logger}, nil
 }
 
 type serverConn struct {
 	sshConn *ssh.ServerConn
 	netConn net.Conn
 	channel ssh.Channel
+	logger  *zap.Logger
 }
 
 func (s *serverConn) Read(b []byte) (int, error)  { return s.channel.Read(b) }
 func (s *serverConn) Write(b []byte) (int, error) { return s.channel.Write(b) }
 func (s *serverConn) Close() error {
+	role := "server"
+	address := s.netConn.RemoteAddr().String()
+	s.logger.Info("close_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+	)
+	start := time.Now()
+	err := s.sshConn.Close()
 	s.channel.Close()
-	return s.sshConn.Close()
+	fields := []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+		s.logger.Error("close_end", fields...)
+	} else {
+		s.logger.Info("close_end", fields...)
+	}
+	return err
 }
 func (s *serverConn) LocalAddr() net.Addr                { return s.netConn.LocalAddr() }
 func (s *serverConn) RemoteAddr() net.Addr               { return s.netConn.RemoteAddr() }

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -258,6 +258,8 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "close_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "close_end", 2, false, zapcore.InfoLevel)
 	checkHandshakeFields(t, logs, "negotiate_end", 2)
 }
 
@@ -343,6 +345,8 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_start", 2, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "negotiate_end", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "close_start", 2, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "close_end", 2, false, zapcore.InfoLevel)
 }
 
 func TestSSHTransportSelectBestHandshake(t *testing.T) {


### PR DESCRIPTION
## Summary
- log SSH connection closure with address, role, and duration fields
- test SSH close logging on auth and key auth paths
- mark transport teardown logging TODO as complete

## Testing
- `go build ./...`
- `go test -run 'TestSSHTransportAuthSuccess|TestSSHTransportKeyAuth' ./transport/ssh`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`
- `go test -coverprofile=coverage.out ./...` *(fails: signal: interrupt; FAIL lvmsync_go/transport/h2 127.844s)*

------
https://chatgpt.com/codex/tasks/task_e_689fd96425588323a0930890d0075c15