### PR TITLE
fix(tcp_tls): log listener close errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dedup: ensure FastCDC chunks own their data slices to prevent cross-chunk mutation
 
 - manifest: fix close hook test to remove duplicate rebuild blocks
+- tcp+tls: log listener close errors during shutdown
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -63,6 +63,7 @@ lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 
 - Plain TCP encapsulated in TLS 1.3
 - Requires mutual TLS authentication
+- Logs a warning if listener shutdown encounters an error
 
 ## SSH
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -163,7 +163,9 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		ln = tls.NewListener(ln, t.serverConf)
 		go func() {
 			<-ctx.Done()
-			ln.Close()
+			if err := ln.Close(); err != nil {
+				t.logger.Warn("listener_close_error", zap.Error(err))
+			}
 		}()
 	}
 	fields := []zap.Field{

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -492,6 +492,34 @@ func TestTCPTLSTransportRequiresClientCert(t *testing.T) {
 	}
 }
 
+func TestTCPTLSListenCloseErrorWarn(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	core, obs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	ctx, cancel := context.WithCancel(context.Background())
+	trIface, err := New(transport.Config{Logger: logger, Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+	entries := obs.FilterMessage("listener_close_error").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Fatalf("expected warn level, got %s", entries[0].Level)
+	}
+}
+
 func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
## Summary
- log TCP+TLS listener close errors on shutdown
- test listener close error warning
- document TCP+TLS shutdown warning

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: compressiondetect_test.go:71: expected lz4, got zstd)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689fd96665cc8323bedd72b46bc47f30