### PR TITLE
docs: mark CDC validation task complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,7 +307,8 @@ golangci-lint run
 - [x] Finalize hybrid deduplication and document CDC tuning knobs.
 - [x] Integrate adaptive compression sampling with configurable thresholds and unit benchmarks.
 - [x] Fail fast when unsupported transports are requested and document `--transport` as reserved.
-- [ ] Add validation for CDC chunker parameters and corresponding tests.
+- [x] Add validation for CDC chunker parameters and corresponding tests.
+  - Covered by `config/validation.go` tests.
 - [ ] Ensure all commands default to a non-nil `zap.Logger` (use `zap.NewNop()`), eliminating nil checks.
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- mark CDC chunker validation backlog item as complete
- note that CDC parameter checks are covered by config validation tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(interrupted: lvmsync_go/transport/h2 tests exceeded time limit)*
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689fd96d1d94832386c437a540f77322