### PR TITLE
fix(device): error on nil logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ command-line use, environment variables, and `config.yaml` files.
 - Always call `Sync()` (e.g., `defer logger.Sync()`) before program exit to flush buffers.
 - Transport constructors must accept a `*zap.Logger`; avoid package-level loggers.
 - Pass loggers explicitly to commands and helpers; do not use `zap.L()` or other globals.
+- Use `zap.NewNop()` instead of `nil` when no logging is needed.
 - Log connection lifecycle events and errors with `snake_case` fields including units (e.g., `bytes_transferred`, `duration_ms`).
 - Do not log secrets or authentication tokens; scrub sensitive values before emitting them.
 - Callers using transports should `defer logger.Sync()` to ensure logs are flushed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- device: Detect, OpenFile, and OpenRaw return error when logger is nil
 - transport: return "unknown" or numeric string for unrecognized TLS versions
 - config: remove duplicate prefixes in LVMSYNC_DEDUP_* environment bindings.
 - device: require --offline or freeze/thaw hooks for raw devices

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ tooling to track transfer completion.
 - Pass loggers explicitly to commands and helpers; `cmd/lvmsync.Execute` requires a
   `*zap.Logger` argument instead of relying on `zap.L()`.
 - All commands receive an explicit `*zap.Logger` and default to `zap.NewNop()` when no logger is supplied.
+- Device constructors return an error when the logger is `nil`; use `zap.NewNop()` to disable logging.
 - Log field keys in `snake_case` and include units where relevant (for example, `duration_ms`).
 - Provide raw byte values alongside human-readable sizes (for example, `block_size` and `block_size_bytes`).
 - Always defer `syncLogger(logger)` to flush buffers and log if the sync fails.

--- a/device/detect.go
+++ b/device/detect.go
@@ -19,6 +19,10 @@ import (
 // empty or "auto", Detect will attempt to open the device using the explicit
 // type and will not perform auto detection. logger must be non-nil.
 func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCmd, fsThawCmd, lvmEscalation string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("logger is nil")
+	}
+
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		logger.Error("device detect failed", zap.String("path", path), zap.String("device_type", "symlink"), zap.Error(err))

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -65,6 +65,12 @@ func TestDetectFile(t *testing.T) {
 	}
 }
 
+func TestDetectNilLogger(t *testing.T) {
+	if _, err := Detect(context.Background(), "", true, "", "", "", "", 0, 0, nil); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
+}
+
 func TestDetectFileSymlink(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "file")
 	if err != nil {

--- a/device/file.go
+++ b/device/file.go
@@ -20,6 +20,9 @@ type FileDevice struct {
 // OpenFile opens a regular file and reports its size and filesystem block size.
 // logger must be non-nil.
 func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("logger is nil")
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -65,6 +65,17 @@ func TestOpenFileRejectsNonRegular(t *testing.T) {
 	}
 }
 
+func TestOpenFileNilLogger(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "file")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	if _, err := OpenFile(f.Name(), nil); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
+}
+
 func fdCount(t *testing.T) int {
 	t.Helper()
 	entries, err := os.ReadDir("/proc/self/fd")

--- a/device/raw.go
+++ b/device/raw.go
@@ -115,6 +115,9 @@ func OpenRaw(
 	thawTimeout time.Duration,
 	logger *zap.Logger,
 ) (_ *RawDevice, err error) {
+	if logger == nil {
+		return nil, fmt.Errorf("logger is nil")
+	}
 	d := &RawDevice{
 		logger: logger, freezeTimeout: freezeTimeout, thawTimeout: thawTimeout,
 		thawCmdPath: fsThawCmdPath, thawCmdArgs: fsThawCmdArgs,

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -57,6 +57,12 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	}
 }
 
+func TestOpenRawNilLogger(t *testing.T) {
+	if _, err := OpenRaw(context.Background(), "", true, "", nil, "", nil, 0, 0, nil); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
+}
+
 func TestRawDeviceCloseErrorLogging(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root")


### PR DESCRIPTION
## Summary
- fail fast in Detect, OpenFile, and OpenRaw when logger is nil
- test nil-logger paths for device constructors
- document zap.NewNop usage and nil-logger behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a03c8381148323a3009def895d7ad6