### PR TITLE
fix(device): handle quoted freeze/thaw commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ logger.Info("snapshot complete",
 - Define flags within `pflag.FlagSet`s and bind them to `viper`; the standard library `flag` package is not used.
 - Expose configuration via both config files and environment variables for easy automation.
 - New flag groups must include tests demonstrating configuration precedence.
+- `--fs-freeze-command` and `--fs-thaw-command` values are split with shell-style quoting; tests should cover paths with spaces and README examples must quote such arguments.
 
 ### Flag Grouping Example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - device: reject freeze/thaw command paths with invalid characters and document allowed format
 - device: allow freeze/thaw command paths containing directories by validating basename only
 - dedup: ensure FastCDC chunks own their data slices to prevent cross-chunk mutation
+- device: parse freeze/thaw commands with shell-style quoting
 
 - manifest: fix close hook test to remove duplicate rebuild blocks
 - tcp+tls: log listener close errors during shutdown

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Examples:
 lvmsync --source-type lvm /dev/vg0/origin /tmp/dump
 lvmsync --dest-type raw dumpfile /dev/sdb
 lvmsync --source-type raw --offline /dev/sdb /tmp/dump
-lvmsync --source-type raw --fs-freeze-command "fsfreeze -f /mnt" --fs-thaw-command "fsfreeze -u /mnt" /dev/sdb /tmp/dump
+lvmsync --source-type raw --fs-freeze-command "fsfreeze -f '/mnt/data dir'" --fs-thaw-command "fsfreeze -u '/mnt/data dir'" /dev/sdb /tmp/dump
 ```
 
 ### Raw device safety
@@ -371,7 +371,7 @@ lvmsync --source-type raw --fs-freeze-command "fsfreeze -f /mnt" --fs-thaw-comma
 Reading from a live block device can corrupt data if writes occur during the transfer. Ensure a consistent view with one of the following options:
 
 - `--offline` – assert that no process will write to the source device.
-- `--fs-freeze-command`/`--fs-thaw-command` – run commands that freeze and thaw the filesystem around the read.
+- `--fs-freeze-command`/`--fs-thaw-command` – run commands that freeze and thaw the filesystem around the read. Arguments are parsed with shell-style quoting, so wrap paths containing spaces in quotes.
 - Time out freeze and thaw helpers with `--freeze-timeout` and `--thaw-timeout` (default `10s`).
 
 Freeze and thaw commands are validated before execution. The command name must match `^[a-zA-Z0-9._-]+$`, be set, free of NUL bytes, every argument must avoid NULs, and the executable must be discoverable in `$PATH`; otherwise lvmsync returns an error.
@@ -430,8 +430,8 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--source-type` | `LVMSYNC_SOURCE_TYPE` | `source-type` | Source device type: `auto`, `file`, `raw`, or `lvm` |
 | `--dest-type` | `LVMSYNC_DEST_TYPE` | `dest-type` | Destination device type: `auto`, `file`, `raw`, or `lvm` |
 | `--offline` | `LVMSYNC_OFFLINE` | `offline` | Assume source raw device is offline |
-| `--fs-freeze-command` | `LVMSYNC_FS_FREEZE_COMMAND` | `fs-freeze-command` | Command to freeze filesystem before reading raw source; executable name must match `^[a-zA-Z0-9._-]+$` |
-| `--fs-thaw-command` | `LVMSYNC_FS_THAW_COMMAND` | `fs-thaw-command` | Command to thaw filesystem after reading raw source; executable name must match `^[a-zA-Z0-9._-]+$` |
+| `--fs-freeze-command` | `LVMSYNC_FS_FREEZE_COMMAND` | `fs-freeze-command` | Command to freeze filesystem before reading raw source; arguments are split with shell-style quoting and executable name must match `^[a-zA-Z0-9._-]+$` |
+| `--fs-thaw-command` | `LVMSYNC_FS_THAW_COMMAND` | `fs-thaw-command` | Command to thaw filesystem after reading raw source; arguments are split with shell-style quoting and executable name must match `^[a-zA-Z0-9._-]+$` |
 | `--freeze-timeout` | `LVMSYNC_FREEZE_TIMEOUT` | `freeze_timeout` | Timeout for filesystem freeze command |
 | `--thaw-timeout` | `LVMSYNC_THAW_TIMEOUT` | `thaw_timeout` | Timeout for filesystem thaw command |
 | `--mode` | `LVMSYNC_MODE` | `mode` | Configuration preset: `default` or `throughput`; unknown modes fail validation |
@@ -953,8 +953,8 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
 | `--dry-run`         | Print actions without executing | `false`   |
 | `--offline`         | Assume source raw device is offline | `false`   |
-| `--fs-freeze-command` | Command to freeze filesystem before reading raw source | `""` |
-| `--fs-thaw-command`  | Command to thaw filesystem after reading raw source | `""` |
+| `--fs-freeze-command` | Command to freeze filesystem before reading raw source; arguments use shell-style quoting | `""` |
+| `--fs-thaw-command`  | Command to thaw filesystem after reading raw source; arguments use shell-style quoting | `""` |
 | `--freeze-timeout`   | Timeout for filesystem freeze command | `10s` |
 | `--thaw-timeout`     | Timeout for filesystem thaw command | `10s` |
 | `--transport`       | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) | `""`      |

--- a/device/detect.go
+++ b/device/detect.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kballard/go-shellquote"
 	"go.uber.org/zap"
 
 	"lvmsync_go/lvm"
@@ -66,14 +67,20 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			var freezePath, thawPath string
 			var freezeArgs, thawArgs []string
 			if fsFreezeCmd != "" {
-				parts := strings.Fields(fsFreezeCmd)
+				parts, err := shellquote.Split(fsFreezeCmd)
+				if err != nil {
+					return nil, fmt.Errorf("invalid freeze command: %w", err)
+				}
 				if len(parts) > 0 {
 					freezePath = parts[0]
 					freezeArgs = parts[1:]
 				}
 			}
 			if fsThawCmd != "" {
-				parts := strings.Fields(fsThawCmd)
+				parts, err := shellquote.Split(fsThawCmd)
+				if err != nil {
+					return nil, fmt.Errorf("invalid thaw command: %w", err)
+				}
 				if len(parts) > 0 {
 					thawPath = parts[0]
 					thawArgs = parts[1:]
@@ -116,14 +123,20 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 		var freezePath, thawPath string
 		var freezeArgs, thawArgs []string
 		if fsFreezeCmd != "" {
-			parts := strings.Fields(fsFreezeCmd)
+			parts, err := shellquote.Split(fsFreezeCmd)
+			if err != nil {
+				return nil, fmt.Errorf("invalid freeze command: %w", err)
+			}
 			if len(parts) > 0 {
 				freezePath = parts[0]
 				freezeArgs = parts[1:]
 			}
 		}
 		if fsThawCmd != "" {
-			parts := strings.Fields(fsThawCmd)
+			parts, err := shellquote.Split(fsThawCmd)
+			if err != nil {
+				return nil, fmt.Errorf("invalid thaw command: %w", err)
+			}
 			if len(parts) > 0 {
 				thawPath = parts[0]
 				thawArgs = parts[1:]

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -199,3 +199,43 @@ func TestDetectLVM(t *testing.T) {
 	}
 	dev.Close()
 }
+
+func TestDetectRawCommandQuoting(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+	var calls []struct {
+		name string
+		args []string
+	}
+	origExec := execCommand
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls = append(calls, struct {
+			name string
+			args []string
+		}{name: name, args: append([]string(nil), args...)})
+		return exec.CommandContext(ctx, "/bin/true")
+	}
+	defer func() { execCommand = origExec }()
+	freeze := "/bin/echo 'freeze path with spaces'"
+	thaw := "/bin/echo 'thaw path with spaces'"
+	dev, err := Detect(context.Background(), loop, false, "raw", freeze, thaw, "", 0, 0, zap.NewNop())
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if err := dev.Cleanup(context.Background()); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 exec calls, got %d", len(calls))
+	}
+	if calls[0].name != "/bin/echo" || len(calls[0].args) != 1 || calls[0].args[0] != "freeze path with spaces" {
+		t.Fatalf("unexpected freeze command: %s %v", calls[0].name, calls[0].args)
+	}
+	if calls[1].name != "/bin/echo" || len(calls[1].args) != 1 || calls[1].args[0] != "thaw path with spaces" {
+		t.Fatalf("unexpected thaw command: %s %v", calls[1].name, calls[1].args)
+	}
+	dev.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/pierrec/lz4/v4 v4.1.22

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=


### PR DESCRIPTION
## Summary
- parse `--fs-freeze-command`/`--fs-thaw-command` with shell-style quoting
- document quoting expectations in README and AGENTS guidelines
- test raw device detection with quoted freeze/thaw commands

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: signal interrupt in lvmsync_go/grpc/server)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a03f226ac48323942ddc88773ed984