### PR TITLE
fix(manifest): return error for zero block size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,7 @@ Run these commands locally before opening a pull request:
  - [x] Transport logging: emit connection handshake and teardown events with `snake_case` fields and ensure callers `defer logger.Sync()`.
 - [ ] Manifest rebuild: add a subcommand to regenerate chunk digests when manifests are missing or out of date, exercising rebuild logic in tests.
 - [ ] Verify command: compare source and destination devices against manifest entries and surface mismatched digests with structured logs.
+- [x] Manifest: return error when block size is 0 during creation.
 - [x] Refactor `cmd/grpcd` to defer `syncLogger` for structured log flushing.
 - [x] Expand unit test coverage for remote execution and client signal handling, and run coverage reports (transports coverage ≥50%).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- manifest: return error when block size is zero
 - device: Detect, OpenFile, and OpenRaw return error when logger is nil
 - transport: return "unknown" or numeric string for unrecognized TLS versions
 - config: remove duplicate prefixes in LVMSYNC_DEDUP_* environment bindings.

--- a/README.md
+++ b/README.md
@@ -908,6 +908,7 @@ lvmsync manifest rebuild /dev/vg0/lv0
 Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
 The command times out after 1m unless overridden with `--manifest_timeout` (0 disables).
 Rebuild refuses to run if the device is mounted read-write; pass `--manifest-allow-mounted` to override.
+Rebuild fails if the device reports a block size of 0.
 
 Manifests embed a persistent device identifier in a fixed 64-byte field. The
 `manifest rebuild` command fails if the identifier exceeds this limit.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -185,6 +185,9 @@ func Create(path, deviceID string, size uint64, blockSize, cdcMin, cdcAvg, cdcMa
 	if len(deviceID) > 64 {
 		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
 	}
+	if blockSize == 0 {
+		return nil, fmt.Errorf("manifest: block size must be greater than zero")
+	}
 	chunkCount := (size + uint64(blockSize) - 1) / uint64(blockSize)
 	total := headerSize + entrySize*chunkCount
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -85,6 +85,14 @@ func TestDeviceIDLength(t *testing.T) {
 	}
 }
 
+func TestCreateZeroBlockSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "zero.man")
+	if _, err := Create(path, "dev", 4096, 0, 0, 0, 0, 0); err == nil {
+		t.Fatalf("expected error for zero block size")
+	}
+}
+
 func TestUpgrade(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "old.man")


### PR DESCRIPTION
## Summary
- error when manifest block size is zero
- test manifest creation with zero block size
- document block size validation in README and project guidelines

## Testing
- `go build ./...`
- `go test -short -coverprofile=coverage.out ./...` *(interrupted after long runtime)*
- `go tool cover -func=coverage.out`
- `go test ./manifest`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a041f8a7148323bfb90d1be7e49a8b