### PR TITLE
refactor(device): split Detect into helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@ practical. Break down large functions into focused helpers and test each helper 
 Logging and configuration are fully structured to keep behavior predictable across
 command-line use, environment variables, and `config.yaml` files.
 
+## Device Detection
+
+- `Detect` orchestrates `detectFileDevice`, `detectLVMDevice`, and `detectRawDevice`.
+- Each helper includes dedicated tests for success and error paths.
+
 ## Logging
 
 - Use [zap](https://github.com/uber-go/zap) for structured logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- device: split Detect into detectFileDevice, detectLVMDevice, and detectRawDevice helpers with dedicated tests
 - device: detect LVM, raw, or file devices using blkid metadata
 - cmd: manage LVM snapshot lifecycle within dump and apply commands
 - tests: add coverage for adaptive chunk sizing, index option application, TLS version helper, capability checks, and data size overflow; include loop device setup integration test.

--- a/README.md
+++ b/README.md
@@ -350,6 +350,13 @@ examines the path to select the correct handling:
 
 Override detection with `--source-type` and `--dest-type` when necessary.
 
+Internally, `device.Detect` delegates to dedicated helpers:
+
+```go
+dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, logger)
+// detectFileDevice, detectLVMDevice, or detectRawDevice is selected based on the path.
+```
+
 Snapshots provide a crash-consistent view of a device. LVM volumes are
 snapshotted automatically and removed after transfer. Raw block devices and
 regular files do not have a snapshot mechanism; to avoid inconsistent reads you

--- a/device/detect.go
+++ b/device/detect.go
@@ -14,6 +14,66 @@ import (
 	"lvmsync_go/lvm"
 )
 
+// openRawFunc allows tests to stub OpenRaw.
+var openRawFunc = OpenRaw
+
+// detectFileDevice opens a regular file as a device.
+func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
+	dev, err := OpenFile(path, logger)
+	if err != nil {
+		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", "file"), zap.Error(err))
+		return nil, err
+	}
+	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", "file"))
+	return dev, nil
+}
+
+// detectLVMDevice opens an LVM logical volume.
+func detectLVMDevice(path, lvmEscalation string, logger *zap.Logger) (Device, error) {
+	cache := lvm.NewDeviceFDCache(logger)
+	defer cache.Close()
+	dev, err := openLVMFunc(path, cache, lvmEscalation, logger)
+	if err != nil {
+		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", "lvm"), zap.Error(err))
+		return nil, err
+	}
+	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", "lvm"))
+	return dev, nil
+}
+
+// detectRawDevice opens a raw block device.
+func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
+	var freezePath, thawPath string
+	var freezeArgs, thawArgs []string
+	if fsFreezeCmd != "" {
+		parts, err := shellquote.Split(fsFreezeCmd)
+		if err != nil {
+			return nil, fmt.Errorf("invalid freeze command: %w", err)
+		}
+		if len(parts) > 0 {
+			freezePath = parts[0]
+			freezeArgs = parts[1:]
+		}
+	}
+	if fsThawCmd != "" {
+		parts, err := shellquote.Split(fsThawCmd)
+		if err != nil {
+			return nil, fmt.Errorf("invalid thaw command: %w", err)
+		}
+		if len(parts) > 0 {
+			thawPath = parts[0]
+			thawArgs = parts[1:]
+		}
+	}
+	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
+	if err != nil {
+		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", "raw"), zap.Error(err))
+		return nil, err
+	}
+	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", "raw"))
+	return dev, nil
+}
+
 // Detect inspects the path and returns the appropriate Device implementation.
 // Regular files return FileDevice, block devices are classified as either LVM
 // logical volumes or raw devices based on LVM metadata. When typeHint is not
@@ -23,7 +83,6 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 	if logger == nil {
 		return nil, fmt.Errorf("logger is nil")
 	}
-
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		logger.Error("device detect failed", zap.String("path", path), zap.String("device_type", "symlink"), zap.Error(err))
@@ -40,115 +99,31 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 			if !info.Mode().IsRegular() {
 				return nil, fmt.Errorf("expected regular file for type file: %s", resolved)
 			}
-			dev, err := OpenFile(resolved, logger)
-			if err != nil {
-				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
-				return nil, err
-			}
-			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
-			return dev, nil
+			return detectFileDevice(resolved, logger)
 		case "lvm":
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type lvm: %s", resolved)
 			}
-			cache := lvm.NewDeviceFDCache(logger)
-			defer cache.Close()
-			dev, err := openLVMFunc(resolved, cache, lvmEscalation, logger)
-			if err != nil {
-				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
-				return nil, err
-			}
-			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
-			return dev, nil
+			return detectLVMDevice(resolved, lvmEscalation, logger)
 		case "raw":
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
 			}
-			var freezePath, thawPath string
-			var freezeArgs, thawArgs []string
-			if fsFreezeCmd != "" {
-				parts, err := shellquote.Split(fsFreezeCmd)
-				if err != nil {
-					return nil, fmt.Errorf("invalid freeze command: %w", err)
-				}
-				if len(parts) > 0 {
-					freezePath = parts[0]
-					freezeArgs = parts[1:]
-				}
-			}
-			if fsThawCmd != "" {
-				parts, err := shellquote.Split(fsThawCmd)
-				if err != nil {
-					return nil, fmt.Errorf("invalid thaw command: %w", err)
-				}
-				if len(parts) > 0 {
-					thawPath = parts[0]
-					thawArgs = parts[1:]
-				}
-			}
-			dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
-			if err != nil {
-				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
-				return nil, err
-			}
-			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
-			return dev, nil
+			return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger)
 		default:
 			return nil, fmt.Errorf("unknown device type %q", typeHint)
 		}
 	}
 	if info.Mode().IsRegular() {
-		dev, err := OpenFile(resolved, logger)
-		if err != nil {
-			logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "file"), zap.Error(err))
-			return nil, err
-		}
-		logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "file"))
-		return dev, nil
+		return detectFileDevice(resolved, logger)
 	}
 	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
 		out, err := execCommand(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
 		fsType := strings.TrimSpace(string(out))
 		if err == nil && fsType == "LVM2_member" {
-			cache := lvm.NewDeviceFDCache(logger)
-			defer cache.Close()
-			dev, err := openLVMFunc(resolved, cache, lvmEscalation, logger)
-			if err != nil {
-				logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "lvm"), zap.Error(err))
-				return nil, err
-			}
-			logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "lvm"))
-			return dev, nil
+			return detectLVMDevice(resolved, lvmEscalation, logger)
 		}
-		var freezePath, thawPath string
-		var freezeArgs, thawArgs []string
-		if fsFreezeCmd != "" {
-			parts, err := shellquote.Split(fsFreezeCmd)
-			if err != nil {
-				return nil, fmt.Errorf("invalid freeze command: %w", err)
-			}
-			if len(parts) > 0 {
-				freezePath = parts[0]
-				freezeArgs = parts[1:]
-			}
-		}
-		if fsThawCmd != "" {
-			parts, err := shellquote.Split(fsThawCmd)
-			if err != nil {
-				return nil, fmt.Errorf("invalid thaw command: %w", err)
-			}
-			if len(parts) > 0 {
-				thawPath = parts[0]
-				thawArgs = parts[1:]
-			}
-		}
-		dev, err := OpenRaw(ctx, resolved, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
-		if err != nil {
-			logger.Error("detect device failed", zap.String("path", resolved), zap.String("device_type", "raw"), zap.Error(err))
-			return nil, err
-		}
-		logger.Info("detect device success", zap.String("path", resolved), zap.String("device_type", "raw"))
-		return dev, nil
+		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger)
 	}
 	err = fmt.Errorf("unsupported path type: %s", resolved)
 	logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -1,0 +1,126 @@
+package device
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/lvm"
+)
+
+func TestDetectFileDeviceSuccess(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "file")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	dev, err := detectFileDevice(f.Name(), logger)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if _, ok := dev.(*FileDevice); !ok {
+		t.Fatalf("expected FileDevice, got %T", dev)
+	}
+	dev.Close()
+	entries := logs.FilterMessage("detect device success").All()
+	found := false
+	for _, e := range entries {
+		if e.ContextMap()["device_type"] == "file" && e.ContextMap()["path"] == f.Name() {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected success log")
+	}
+}
+
+func TestDetectFileDeviceError(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := detectFileDevice(dir, zap.NewNop()); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestDetectLVMDeviceSuccess(t *testing.T) {
+	orig := openLVMFunc
+	openLVMFunc = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+		return &LVMDevice{path: p, logger: zap.NewNop()}, nil
+	}
+	defer func() { openLVMFunc = orig }()
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	dev, err := detectLVMDevice("/dev/test", "", logger)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if _, ok := dev.(*LVMDevice); !ok {
+		t.Fatalf("expected LVMDevice, got %T", dev)
+	}
+	dev.Close()
+	entries := logs.FilterMessage("detect device success").All()
+	found := false
+	for _, e := range entries {
+		if e.ContextMap()["device_type"] == "lvm" && e.ContextMap()["path"] == "/dev/test" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected success log")
+	}
+}
+
+func TestDetectLVMDeviceError(t *testing.T) {
+	orig := openLVMFunc
+	openLVMFunc = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+		return nil, errors.New("fail")
+	}
+	defer func() { openLVMFunc = orig }()
+	if _, err := detectLVMDevice("/dev/test", "", zap.NewNop()); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestDetectRawDeviceSuccess(t *testing.T) {
+	orig := openRawFunc
+	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (*RawDevice, error) {
+		f, err := os.CreateTemp(t.TempDir(), "raw")
+		if err != nil {
+			return nil, err
+		}
+		return &RawDevice{f: f, logger: logger}, nil
+	}
+	defer func() { openRawFunc = orig }()
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	dev, err := detectRawDevice(context.Background(), "/dev/test", true, "", "", 0, 0, logger)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if _, ok := dev.(*RawDevice); !ok {
+		t.Fatalf("expected RawDevice, got %T", dev)
+	}
+	dev.Close()
+	entries := logs.FilterMessage("detect device success").All()
+	found := false
+	for _, e := range entries {
+		if e.ContextMap()["device_type"] == "raw" && e.ContextMap()["path"] == "/dev/test" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected success log")
+	}
+}
+
+func TestDetectRawDeviceError(t *testing.T) {
+	if _, err := detectRawDevice(context.Background(), "/dev/null", true, "", "", 0, 0, zap.NewNop()); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- refactor Detect into detectFileDevice, detectLVMDevice, and detectRawDevice helpers
- add unit tests for each detection helper
- document new detection helpers in AGENTS and README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: interrupt in lvmsync_go/transport/h2 after 330s)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a04d5b59388323a5f3444dfdb64481