### PR TITLE
test(h2): flush handshake data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- tests: flush H2 handshake data by buffering server errors, closing connections before sending, and applying context timeouts
 - manifest: return error when block size is zero
 - device: Detect, OpenFile, and OpenRaw return error when logger is nil
 - device: parse mount info using github.com/moby/sys/mountinfo to handle spaces and special characters

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -255,7 +255,8 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 		t.Fatalf("new transport: %v", err)
 	}
 	tr := trIface.(*Transport)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -295,7 +296,7 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvErr := make(chan error)
+	srvErr := make(chan error, 1)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -303,8 +304,8 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 			return
 		}
 		_, err = tr.Negotiate(ctx, conn, transport.Server, srvHS)
-		srvErr <- err
 		conn.Close()
+		srvErr <- err
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())


### PR DESCRIPTION
## Summary
- buffer server error channel and close connections before signaling to flush HTTP/2 handshake data
- bound handshake negotiation to a timeout in select best handshake test

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: signal interrupt in grpc/server)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68a04f537248832384dc032eedafbeae