### PR TITLE
test(ssh): add timeout and close conn in handshake test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - manifest: fix close hook test to remove duplicate rebuild blocks
 - tcp+tls: log listener close errors during shutdown
+- tests: use timeouts and close connections before returning errors in SSH handshake selection test
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -401,23 +401,27 @@ func TestSSHTransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvErr := make(chan error)
+	srvErr := make(chan error, 1)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
 			srvErr <- err
 			return
 		}
-		_, err = server.Negotiate(ctx, conn, transport.Server, srvHS)
-		srvErr <- err
+		srvCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		_, err = server.Negotiate(srvCtx, conn, transport.Server, srvHS)
 		conn.Close()
+		srvErr <- err
 	}()
 
 	conn, err := client.Dial(ctx, ln.Addr().String())
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peer, err := client.Negotiate(ctx, conn, transport.Client, cliHS)
+	cliCtx, cancel := context.WithTimeout(ctx, time.Second)
+	peer, err := client.Negotiate(cliCtx, conn, transport.Client, cliHS)
+	cancel()
 	conn.Close()
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)


### PR DESCRIPTION
## Summary
- ensure SSH handshake selection test closes connections before sending errors
- cover server and client negotiation with context timeouts

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a04f57da608323a5592ef1d12cfbb3