### PR TITLE
test(tcp_tls): add timeouts and cleanup in handshake selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tests: assert context deadline exceeded for tcp+tls unreachable dial
 - handshake: validate digest mismatches in protocol negotiation
 - Enforce CDC chunk size ordering in handshake validation.
+- tests: add timeouts and connection cleanup in tcp+tls handshake selection test.
 - config: validate positive CDC tunables and ordering.
 - tcp+tls: ensure negotiation performs TLS handshake and only records ALPN/TLS version when negotiated.
 - config: enforce CDC chunk size ordering during validation.

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -175,23 +175,29 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvErr := make(chan error)
+	srvErr := make(chan error, 1)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
 			srvErr <- err
 			return
 		}
-		_, err = tr.Negotiate(ctx, conn, transport.Server, srvHS)
-		srvErr <- err
+		nctx, cancel := context.WithTimeout(ctx, time.Second)
+		_, err = tr.Negotiate(nctx, conn, transport.Server, srvHS)
+		cancel()
 		conn.Close()
+		srvErr <- err
 	}()
 
-	conn, err := tr.Dial(ctx, ln.Addr().String())
+	dctx, cancel := context.WithTimeout(ctx, time.Second)
+	conn, err := tr.Dial(dctx, ln.Addr().String())
+	cancel()
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peer, err := tr.Negotiate(ctx, conn, transport.Client, cliHS)
+	nctx, cancel := context.WithTimeout(ctx, time.Second)
+	peer, err := tr.Negotiate(nctx, conn, transport.Client, cliHS)
+	cancel()
 	conn.Close()
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)


### PR DESCRIPTION
## Summary
- ensure TCP+TLS handshake selection test closes server connection before signaling error
- add context timeouts for dialing and negotiating to avoid blocking
- document test reliability improvements

## Testing
- `go build ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out`
- `go test -coverprofile=coverage.out ./...` *(fails: failed to sufficiently increase receive buffer size and QUIC handshake timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a04f596f108323ab118a34a73f0990