### PR TITLE
test(quic): bound handshake timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - manifest: fix close hook test to remove duplicate rebuild blocks
 - tcp+tls: log listener close errors during shutdown
+- tests: bound QUIC SelectBestHandshake dial and negotiate with timeouts and close server connection before reporting errors
 
 ## [v0.1.0] - 2025-02-27
 ### Added

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -170,7 +170,7 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 		CDCMax:      256,
 	}
 
-	srvErr := make(chan error)
+	srvErr := make(chan error, 1)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -183,16 +183,21 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 			buf := make([]byte, 1)
 			qconn.Read(buf)
 		}
-		srvErr <- err
 		qconn.Close()
+		srvErr <- err
 	}()
 
-	conn, err := tr.Dial(ctx, ln.Addr().String())
+	dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+	conn, err := tr.Dial(dialCtx, ln.Addr().String())
 	if err != nil {
+		cancel()
 		t.Fatalf("dial: %v", err)
 	}
+	defer cancel()
 	qconn := conn.(*Conn)
-	peer, err := tr.Negotiate(ctx, qconn, transport.Client, cliHS)
+	negCtx, cancel := context.WithTimeout(ctx, time.Second)
+	peer, err := tr.Negotiate(negCtx, qconn, transport.Client, cliHS)
+	cancel()
 	if err != nil {
 		qconn.Close()
 		t.Fatalf("client negotiate: %v", err)


### PR DESCRIPTION
## Summary
- bound QUIC SelectBestHandshake test with dial/negotiate timeouts
- close server connection before reporting handshake error

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./transport/quic -run TestQUICTransportSelectBestHandshake` *(fails: client negotiate: read handshake: Application error 0x0 (remote))*
- `go tool cover -func=coverage.out`
- `golangci-lint run`
- `go test -coverprofile=coverage.out ./...` *(fails: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a04f55b8908323baa57c97edd9e991