### PR TITLE
feat(ssh): support host key path configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,8 @@ Run these commands locally before opening a pull request:
 golangci-lint run
 ```
 
+- [ ] Add precedence tests for `ssh_host_key_path` flag, environment variable, and YAML configuration.
+
 - [x] Ensure SSH agent connections use context timeouts and cover SSHManager reuse in tests.
 
 - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log manifest rebuild completion with size and duration metrics.
 - Add handshake parsing tests for unknown and malformed tokens.
 - Bind LVMSYNC_DEDUP_* environment variables and extend tests for dedup flag precedence.
+- ssh: allow specifying host key path and load host keys from disk
 - Bind LVMSYNC_COMPRESSION_* environment variables and add tests for compression flag precedence.
 - Privilege escalation tests covering sudo success and failure modes.
 - device: tests for GetUUID and IsMountedRW

--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--ssh_host` | `LVMSYNC_SSH_HOST` | `ssh_host` | SSH host |
 | `--ssh_user` | `LVMSYNC_SSH_USER` | `ssh_user` | SSH username |
 | `--ssh_key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key |
+| `--ssh_host_key_path` | `LVMSYNC_SSH_HOST_KEY_PATH` | `ssh_host_key_path` | Path to SSH host private key |
 | `--ssh_agent` | `LVMSYNC_SSH_AGENT` | `ssh_agent` | Use SSH agent for authentication |
 | `--ssh_port` | `LVMSYNC_SSH_PORT` | `ssh_port` | SSH port |
 | `--ssh_timeout` | `LVMSYNC_SSH_TIMEOUT` | `ssh_timeout` | SSH connection timeout |
@@ -975,6 +976,7 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--ssh_host`              | SSH host                                                        | `"localhost"`            |
 | `--ssh_user`              | SSH username                                                    | `"root"`                 |
 | `--ssh_key`               | Path to SSH private key                                          | `""`                     |
+| `--ssh_host_key_path`     | Path to SSH host private key (generates one if empty)            | `""`                     |
 | `--ssh_agent`             | Use the SSH agent for authentication                            | `false`                  |
 | `--ssh_port`              | SSH port number                                                 | `22`                     |
 | `--known_hosts`           | Path to known_hosts file (defaults to `$HOME/.ssh/known_hosts`) | `$HOME/.ssh/known_hosts` |
@@ -982,9 +984,10 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--ssh_host_key`          | Expected SSH host public key (authorized_keys format)          | `""`                    |
 
 Unknown hosts are rejected unless their keys are present in `known_hosts` or match `--ssh_host_key`.
+The host key can also be supplied via `LVMSYNC_SSH_HOST_KEY_PATH` or the `ssh_host_key_path` YAML option.
 
 Programmatic use of the SSH transport requires a configuration populated with
-fields like `SSHUser`, `SSHKeyPath`, `SSHUseAgent`, `SSHPort`, `KnownHosts`,
+fields like `SSHUser`, `SSHKeyPath`, `HostKeyPath`, `SSHUseAgent`, `SSHPort`, `KnownHosts`,
 `StrictHostKeyCheck`, `SSHTimeout`, `SSHKeepAliveInterval`, and `MaxRetries`.
 The constructor also requires a `*zap.Logger`:
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -396,6 +396,7 @@ func SelectTransport(cfg *config.Config, logger *zap.Logger) (transport.Interfac
 				SSHPassword:   cfg.SSHPassword,
 				SSHKnownHosts: cfg.KnownHosts,
 				SSHHostKey:    cfg.SSHHostKey,
+				HostKeyPath:   cfg.SSHHostKeyPath,
 				AllowInsecure: cfg.AllowInsecure,
 			},
 		)

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -56,6 +56,7 @@ type Config struct {
 	SSHTimeout               time.Duration `mapstructure:"ssh_timeout"`
 	SSHKeepAliveInterval     time.Duration `mapstructure:"ssh_keepalive"`
 	SSHHostKey               string        `mapstructure:"ssh_host_key"`
+	SSHHostKeyPath           string        `mapstructure:"ssh_host_key_path"`
 	KnownHosts               string        `mapstructure:"known_hosts"`
 	StrictHostKeyCheck       bool          `mapstructure:"strict_host_key_checking"`
 	LVMSyncPath              string        `mapstructure:"lvmsync_path"`
@@ -188,6 +189,7 @@ func DefaultConfig() (*Config, error) {
 		SSHTimeout:               10 * time.Second,
 		SSHKeepAliveInterval:     30 * time.Second,
 		SSHHostKey:               "",
+		SSHHostKeyPath:           "",
 		KnownHosts:               filepath.Join(homeDir, ".ssh", "known_hosts"),
 		StrictHostKeyCheck:       true,
 		LVMSyncPath:              "lvmsync",

--- a/config/flags.go
+++ b/config/flags.go
@@ -98,6 +98,7 @@ func initSSHFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("ssh_host", cfg.SSHHost, "SSH host")
 	fs.String("ssh_user", cfg.SSHUser, "SSH username")
 	fs.String("ssh_key", cfg.SSHKeyPath, "Path to SSH private key or use agent")
+	fs.String("ssh_host_key_path", cfg.SSHHostKeyPath, "Path to SSH host private key")
 	fs.Int("ssh_port", cfg.SSHPort, "SSH port")
 	fs.Duration("ssh_timeout", cfg.SSHTimeout, "SSH connection timeout")
 	fs.Duration("ssh_keepalive", cfg.SSHKeepAliveInterval, "SSH keepalive interval")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -61,6 +61,7 @@ func TestInitSSHFlags(t *testing.T) {
 		{"ssh_host", cfg.SSHHost},
 		{"ssh_user", cfg.SSHUser},
 		{"ssh_key", cfg.SSHKeyPath},
+		{"ssh_host_key_path", cfg.SSHHostKeyPath},
 		{"ssh_port", strconv.Itoa(cfg.SSHPort)},
 		{"ssh_timeout", cfg.SSHTimeout.String()},
 		{"ssh_keepalive", cfg.SSHKeepAliveInterval.String()},

--- a/transport/config.go
+++ b/transport/config.go
@@ -21,5 +21,6 @@ type Config struct {
 	SSHKnownHosts string
 	SSHHostKey    string
 	SSHKeyPath    string
+	HostKeyPath   string
 	SSHUseAgent   bool
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -37,7 +37,11 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.SSHUser == "" {
 		return nil, fmt.Errorf("ssh user is required")
 	}
-	var keySigner ssh.Signer
+	var (
+		keySigner  ssh.Signer
+		hostSigner ssh.Signer
+		err        error
+	)
 	if cfg.SSHKeyPath != "" {
 		keyBytes, err := os.ReadFile(cfg.SSHKeyPath)
 		if err != nil {
@@ -49,13 +53,24 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		}
 	}
 
-	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, err
-	}
-	hostSigner, err := ssh.NewSignerFromKey(hostKey)
-	if err != nil {
-		return nil, err
+	if cfg.HostKeyPath != "" {
+		hostBytes, err := os.ReadFile(cfg.HostKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		hostSigner, err = ssh.ParsePrivateKey(hostBytes)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return nil, err
+		}
+		hostSigner, err = ssh.NewSignerFromKey(hostKey)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	serverConf := &ssh.ServerConfig{

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -168,6 +169,47 @@ func TestNewWithHostKey(t *testing.T) {
 	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", SSHHostKey: hostKey}
 	if _, err := New(cfg); err != nil {
 		t.Fatalf("New: %v", err)
+	}
+}
+
+func TestNewWithHostKeyPath(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_rsa")
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	privBytes := x509.MarshalPKCS1PrivateKey(priv)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes})
+	if err := os.WriteFile(keyPath, pemBytes, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", HostKeyPath: keyPath, AllowInsecure: true}
+	trIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tr := trIface.(*Transport)
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("NewSignerFromKey: %v", err)
+	}
+	if !bytes.Equal(tr.hostSigner.PublicKey().Marshal(), signer.PublicKey().Marshal()) {
+		t.Fatalf("loaded host key does not match file")
+	}
+}
+
+func TestNewGeneratesHostKey(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", AllowInsecure: true}
+	trIface, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tr := trIface.(*Transport)
+	if tr.hostSigner == nil {
+		t.Fatalf("expected generated host key")
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow SSH transport to load host keys from disk when `HostKeyPath` is set
- expose `--ssh_host_key_path` flag/env/YAML option and pass through configuration
- document host key path option and add TODO for precedence tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestH2TransportSelectBestHandshake: read handshake EOF; TestQUICTransportSelectBestHandshake timeout)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_68a0516cfd5c83239ca73489545f6f1b