### PR TITLE
test(common): cover endianness mismatch in handshake validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,7 @@ golangci-lint run
 ```
 
 - [x] Ensure SSH agent connections use context timeouts and cover SSHManager reuse in tests.
+- [x] common: add endianness mismatch handshake validation test.
 
 - [ ] Review CLI argument parsing: prefer `pflag`, bind flags to `viper`, and group related options into reusable `FlagSet`s. Further flag-binding audits remain for commands beyond `config` and `cmd/grpcd`.
 - [ ] Implement QUIC `serve` command with minimal flags and `zap`-only logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transport: tests covering SelectBest handshake negotiation with custom CDC settings, resume tokens, and O_DIRECT for ssh, tcp+tls, h2, and quic transports.
 - transport: test registry fallback dialing sequence with logged attempts.
 - common: add MergeHandshake helper for compressor and digest negotiation.
+- common: add handshake validation test for endianness mismatches.
 - device: add raw device freeze/thaw tests with exec command stubs
 - device: centralize exec command helper for LVM and raw devices
 - device: add cleanup tests for thaw errors and timeouts

--- a/common/handshake_validate_test.go
+++ b/common/handshake_validate_test.go
@@ -86,6 +86,14 @@ func TestValidateHandshakeTransportMismatch(t *testing.T) {
 	}
 }
 
+func TestValidateHandshakeEndiannessMismatch(t *testing.T) {
+	local := Handshake{Endianness: "little"}
+	peer := Handshake{Endianness: "big"}
+	if err := ValidateHandshake(local, peer); err == nil {
+		t.Fatal("expected endianness mismatch error")
+	}
+}
+
 func TestValidateHandshakeDigestMismatch(t *testing.T) {
 	local := Handshake{Digest: "blake3"}
 	peer := Handshake{Digest: "sha256"}


### PR DESCRIPTION
## Summary
- add handshake validation test for mismatched endianness
- document the test in CHANGELOG and AGENTS TODO

## Testing
- `go build ./...`
- `go test -short -coverprofile=coverage.out ./...` *(transport tests timed out; see logs)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a04f32ac1c8323b3d5cbb4bb81b938