### PR TITLE
test(h2): accept timeout net errors in unreachable dial

### DIFF
--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -423,8 +423,13 @@ func TestH2DialUnreachable(t *testing.T) {
 	ctx := context.Background()
 	dctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	if _, err := tr.Dial(dctx, "203.0.113.1:1"); err == nil || (!errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "network is unreachable")) {
-		t.Fatalf("unexpected error: %v", err)
+	if _, err := tr.Dial(dctx, "203.0.113.1:1"); err == nil {
+		t.Fatalf("expected error")
+	} else {
+		var netErr net.Error
+		if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "network is unreachable") && (!errors.As(err, &netErr) || !netErr.Timeout()) {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow net.Error timeouts in TestH2DialUnreachable

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` (fails: client negotiate: read handshake: EOF)
- `golangci-lint run` (WARN [runner] Can't process result by diff processor: can't read from patch file path/to/patch/file)
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a057ea2528832382ea1c61aac12fff