### PR TITLE
device: refine type detection and add LVM tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 
 Override automatic detection with `--source-type` and `--dest-type` when a device's type is known in advance.
 
+### Offline requirements
+
+Raw sources must be quiescent or provide filesystem freeze/thaw hooks using
+`--fs-freeze-command` and `--fs-thaw-command`. LVM snapshots are consistent by
+design, while regular files require no additional coordination.
+
 ## Transport Options
 
 LVMSync negotiates transports in the order provided by `--transport` (default

--- a/device/detect.go
+++ b/device/detect.go
@@ -21,10 +21,10 @@ var openRawFunc = OpenRaw
 func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
 	dev, err := OpenFile(path, logger)
 	if err != nil {
-		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", "file"), zap.Error(err))
+		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeFile), zap.Error(err))
 		return nil, err
 	}
-	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", "file"))
+	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", TypeFile))
 	return dev, nil
 }
 
@@ -34,10 +34,10 @@ func detectLVMDevice(path, lvmEscalation string, logger *zap.Logger) (Device, er
 	defer cache.Close()
 	dev, err := openLVMFunc(path, cache, lvmEscalation, logger)
 	if err != nil {
-		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", "lvm"), zap.Error(err))
+		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
 	}
-	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", "lvm"))
+	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", TypeLVM))
 	return dev, nil
 }
 
@@ -67,19 +67,20 @@ func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd
 	}
 	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
 	if err != nil {
-		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", "raw"), zap.Error(err))
+		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err
 	}
-	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", "raw"))
+	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", TypeRaw))
 	return dev, nil
 }
 
 // Detect inspects the path and returns the appropriate Device implementation.
 // Regular files return FileDevice, block devices are classified as either LVM
-// logical volumes or raw devices based on LVM metadata. When typeHint is not
-// empty or "auto", Detect will attempt to open the device using the explicit
-// type and will not perform auto detection. logger must be non-nil.
-func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCmd, fsThawCmd, lvmEscalation string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
+// logical volumes or raw devices based on LVM metadata. When explicitType is
+// set via --source-type or --dest-type and is not TypeAuto, Detect will attempt
+// to open the device using the explicit type without auto detection. logger
+// must be non-nil.
+func Detect(ctx context.Context, path string, offline bool, explicitType, fsFreezeCmd, fsThawCmd, lvmEscalation string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
 	if logger == nil {
 		return nil, fmt.Errorf("logger is nil")
 	}
@@ -93,25 +94,25 @@ func Detect(ctx context.Context, path string, offline bool, typeHint, fsFreezeCm
 		logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
 		return nil, err
 	}
-	if typeHint != "" && typeHint != "auto" {
-		switch typeHint {
-		case "file":
+	if explicitType != "" && explicitType != TypeAuto {
+		switch explicitType {
+		case TypeFile:
 			if !info.Mode().IsRegular() {
 				return nil, fmt.Errorf("expected regular file for type file: %s", resolved)
 			}
 			return detectFileDevice(resolved, logger)
-		case "lvm":
+		case TypeLVM:
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type lvm: %s", resolved)
 			}
 			return detectLVMDevice(resolved, lvmEscalation, logger)
-		case "raw":
+		case TypeRaw:
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
 			}
 			return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger)
 		default:
-			return nil, fmt.Errorf("unknown device type %q", typeHint)
+			return nil, fmt.Errorf("unknown device type %q", explicitType)
 		}
 	}
 	if info.Mode().IsRegular() {

--- a/device/device.go
+++ b/device/device.go
@@ -19,3 +19,11 @@ type Device interface {
 	// Close releases any resources associated with the device.
 	Close() error
 }
+
+// Device type identifiers for Detect and CLI hints.
+const (
+	TypeAuto = "auto"
+	TypeFile = "file"
+	TypeLVM  = "lvm"
+	TypeRaw  = "raw"
+)

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package device
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/lvm"
+)
+
+func TestOpenLVM(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+	cache := lvm.NewDeviceFDCache(zap.NewNop())
+	defer cache.Close()
+	dev, err := OpenLVM(loop, cache, "", zap.NewNop())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if dev.Path() != loop {
+		t.Fatalf("path = %s, want %s", dev.Path(), loop)
+	}
+	if dev.SizeBytes() == 0 || dev.BlockSize() == 0 {
+		t.Fatalf("unexpected size or block size")
+	}
+	dev.Close()
+}
+
+func TestOpenLVMNonBlockDevice(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "file")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	cache := lvm.NewDeviceFDCache(zap.NewNop())
+	defer cache.Close()
+	if _, err := OpenLVM(f.Name(), cache, "", zap.NewNop()); err == nil {
+		t.Fatalf("expected error for non-block device")
+	}
+}
+
+func TestRunLVMPrivilegeEscalation(t *testing.T) {
+	ctx := context.Background()
+	var gotName string
+	var gotArgs []string
+	origExec := execCommand
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() { execCommand = origExec })
+	origEuid := geteuid
+	geteuid = func() int { return 1 }
+	t.Cleanup(func() { geteuid = origEuid })
+	if err := runLVM(ctx, "doas -n", "lvremove", "-f", "/dev/vg0/snap"); err != nil {
+		t.Fatalf("runLVM: %v", err)
+	}
+	if gotName != "doas" || !reflect.DeepEqual(gotArgs, []string{"-n", "lvremove", "-f", "/dev/vg0/snap"}) {
+		t.Fatalf("unexpected command: %s %v", gotName, gotArgs)
+	}
+}
+
+func TestRunLVMFailure(t *testing.T) {
+	ctx := context.Background()
+	origExec := execCommand
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "false")
+	}
+	t.Cleanup(func() { execCommand = origExec })
+	if err := runLVM(ctx, "", "lvremove", "-f", "/dev/vg0/snap"); err == nil {
+		t.Fatalf("expected error from runLVM")
+	}
+}


### PR DESCRIPTION
## Summary
- add device type constants and document offline/raw handling in README
- honor --source-type/--dest-type in device detection
- add tests covering LVM open, error, and privilege escalation

## Testing
- `go test ./device -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a05adccfdc83238e392575db2846b1