### PR TITLE
feat(manifest): rebuild and verify via manifest index

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ Resume interrupted transfers with a state file:
 lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data
 ```
 
-Verify devices against a manifest:
+Generate a manifest and verify a destination:
 
 ```sh
-lvmsync verify --manifest_path snapshot.manifest /dev/vg0/snap0 /dev/vg0/data
+lvmsync manifest rebuild /dev/vg0/snap0
+lvmsync verify /dev/vg0/snap0 /dev/vg0/data
 ```
 
 Resume files track the last completed chunk and are removed after a successful
-transfer. See [docs/manifest.md](docs/manifest.md) for manifest and verification
-details.
+transfer. See [docs/manifest.md](docs/manifest.md) for manifest and verification details.
 
 ## Safety Notes
 
@@ -937,7 +937,7 @@ lvmsync verify --dry-run /dev/vg0/source /dev/vg1/target
 To verify using 4 KiB blocks and a manifest generated earlier:
 
 ```sh
-lvmsync verify --block_size 4K --manifest_path snapshot.manifest /dev/vg0/source /dev/vg1/target
+lvmsync verify --block_size 4K /dev/vg0/source /dev/vg1/target
 ```
 
 Flags are parsed via Viper, so the same settings can be provided through

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -237,5 +238,29 @@ func TestRunSyncsLoggerDryRun(t *testing.T) {
 	}
 	if logs.FilterMessage("Logger sync error").Len() != 1 {
 		t.Fatalf("expected sync error log")
+	}
+}
+
+func TestRunWritesVersion(t *testing.T) {
+	dir := t.TempDir()
+	devicePath := filepath.Join(dir, "dev.img")
+	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+	restore := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "uuid", nil })
+	defer device.SetUUIDFunc(restore)
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	if err := Run(cfg, []string{"rebuild", devicePath}, zap.NewNop()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	data, err := os.ReadFile(devicePath + ".manifest")
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if v := binary.LittleEndian.Uint32(data[:4]); v != manifestpkg.Version {
+		t.Fatalf("version mismatch: got %d want %d", v, manifestpkg.Version)
 	}
 }

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -15,13 +16,15 @@ import (
 
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/config"
-	"lvmsync_go/manifest"
+	manifestpkg "lvmsync_go/manifest"
 	"lvmsync_go/transfer"
 )
 
 func init() {
 	rootcmd.RunVerify = Run
 }
+
+var rebuildFn = manifestpkg.Rebuild
 
 // Run executes the verify command with the provided arguments and logger.
 // Args should exclude the "verify" subcommand itself.
@@ -76,11 +79,30 @@ func Run(args []string, logger *zap.Logger) error {
 	return cmd.Execute()
 }
 
-func verifyDevices(cfg *config.Config, src, dst, manifest string, logger *zap.Logger) error {
-	if manifest != "" {
-		return verifyWithManifest(cfg, src, manifest, logger)
+func verifyDevices(cfg *config.Config, src, dst, manifestPath string, logger *zap.Logger) error {
+	if manifestPath == "" {
+		manifestPath = src + ".manifest"
 	}
-	return verifyFull(cfg, src, dst, logger)
+	if _, err := os.Stat(manifestPath); err != nil {
+		if os.IsNotExist(err) {
+			ctx := context.Background()
+			if cfg.ManifestTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, cfg.ManifestTimeout)
+				defer cancel()
+			}
+			hybridFixed := uint32(0)
+			if cfg.DedupMode == "hybrid" {
+				hybridFixed = uint32(cfg.BlockSize)
+			}
+			if err := rebuildFn(ctx, src, manifestPath, logger, cfg.ManifestProgressInterval, cfg.ManifestAllowMounted, uint32(cfg.CDCMin), uint32(cfg.CDCAvg), uint32(cfg.CDCMax), hybridFixed); err != nil {
+				return fmt.Errorf("rebuild manifest: %w", err)
+			}
+		} else {
+			return fmt.Errorf("stat manifest: %w", err)
+		}
+	}
+	return verifyWithManifest(cfg, dst, manifestPath, logger)
 }
 
 func digestFunc(cfg *config.Config) func([]byte) [32]byte {
@@ -147,15 +169,15 @@ func verifyFull(cfg *config.Config, src, dst string, logger *zap.Logger) error {
 	return nil
 }
 
-func verifyWithManifest(cfg *config.Config, src, manifestPath string, logger *zap.Logger) error {
-	idx, err := manifest.Open(manifestPath)
+func verifyWithManifest(cfg *config.Config, devicePath, manifestPath string, logger *zap.Logger) error {
+	idx, err := manifestpkg.Open(manifestPath)
 	if err != nil {
 		return fmt.Errorf("open manifest: %w", err)
 	}
 	defer idx.Close()
-	fSrc, err := os.Open(src)
+	fSrc, err := os.Open(devicePath)
 	if err != nil {
-		return fmt.Errorf("open source: %w", err)
+		return fmt.Errorf("open device: %w", err)
 	}
 	defer fSrc.Close()
 

--- a/cmd/verify/verify_mismatch_test.go
+++ b/cmd/verify/verify_mismatch_test.go
@@ -1,12 +1,17 @@
 package verify
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	manifestpkg "lvmsync_go/manifest"
 )
 
 func TestRunLogsMismatchBlock(t *testing.T) {
@@ -21,12 +26,25 @@ func TestRunLogsMismatchBlock(t *testing.T) {
 	}
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
+	orig := rebuildFn
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+		idx, err := manifestpkg.Create(output, "dev", 3, 4096, 0, 0, 0, 0)
+		if err != nil {
+			return err
+		}
+		digest := blake3.Sum256([]byte("foo"))
+		if err := idx.Set(0, 3, 0, 0, digest); err != nil {
+			return err
+		}
+		return idx.Close()
+	}
+	defer func() { rebuildFn = orig }()
 	err := Run([]string{src, dst}, logger)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
-	if logs.FilterMessage("mismatched_block").Len() == 0 {
-		t.Fatalf("expected mismatched_block log, got %v", logs.All())
+	if logs.FilterMessage("digest_mismatch").Len() == 0 {
+		t.Fatalf("expected digest_mismatch log, got %v", logs.All())
 	}
 }
 
@@ -42,11 +60,24 @@ func TestRunLogsMismatchBlockSHA256(t *testing.T) {
 	}
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
+	orig := rebuildFn
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+		idx, err := manifestpkg.Create(output, "dev", 3, 4096, 0, 0, 0, 0)
+		if err != nil {
+			return err
+		}
+		digest := blake3.Sum256([]byte("foo"))
+		if err := idx.Set(0, 3, 0, 0, digest); err != nil {
+			return err
+		}
+		return idx.Close()
+	}
+	defer func() { rebuildFn = orig }()
 	err := Run([]string{"--checksum_algorithm", "sha256", src, dst}, logger)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
-	if logs.FilterMessage("mismatched_block").Len() == 0 {
-		t.Fatalf("expected mismatched_block log, got %v", logs.All())
+	if logs.FilterMessage("digest_mismatch").Len() == 0 {
+		t.Fatalf("expected digest_mismatch log, got %v", logs.All())
 	}
 }

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -2,10 +2,12 @@ package verify
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
@@ -13,7 +15,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/config"
-	"lvmsync_go/manifest"
+	manifestpkg "lvmsync_go/manifest"
 )
 
 type syncTrackerCore struct {
@@ -94,7 +96,7 @@ func TestVerifyWithManifestAllocations(t *testing.T) {
 	size := blockSize * 3
 	src := createTestFile(t, size)
 	manifestPath := filepath.Join(t.TempDir(), "manifest")
-	idx, err := manifest.Create(manifestPath, "dev", uint64(size), uint32(blockSize), 0, 0, 0, 0)
+	idx, err := manifestpkg.Create(manifestPath, "dev", uint64(size), uint32(blockSize), 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("manifest create: %v", err)
 	}
@@ -123,5 +125,39 @@ func TestVerifyWithManifestAllocations(t *testing.T) {
 	})
 	if allocs >= 40 {
 		t.Fatalf("expected fewer allocations, got %f", allocs)
+	}
+}
+
+func TestVerifyDevicesRebuildsManifest(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("foo"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("foo"), 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	called := false
+	orig := rebuildFn
+	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+		called = true
+		idx, err := manifestpkg.Create(output, "dev", uint64(len("foo")), 4096, 0, 0, 0, 0)
+		if err != nil {
+			return err
+		}
+		digest := blake3.Sum256([]byte("foo"))
+		if err := idx.Set(0, uint32(len("foo")), 0, 0, digest); err != nil {
+			return err
+		}
+		return idx.Close()
+	}
+	defer func() { rebuildFn = orig }()
+	cfg := &config.Config{}
+	if err := verifyDevices(cfg, src, dst, "", zap.NewNop()); err != nil {
+		t.Fatalf("verifyDevices: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected rebuild invoked")
 	}
 }

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -4,12 +4,20 @@ LVMSync writes a binary manifest alongside each transfer. The manifest tracks
 chunk offsets and digests so that interrupted sessions can resume and completed
 copies can be verified.
 
+## Lifecycle
+
+1. Rebuild a manifest for the source device:
+   `lvmsync manifest rebuild <device>`
+2. Run a transfer using `lvmsync run`.
+3. Verify that the destination matches the manifest:
+   `lvmsync verify <source> <dest>`
+
 ## Usage
 
 - `lvmsync manifest rebuild <device>` regenerates a manifest when one is
   missing or out of date.
-- `lvmsync verify --manifest_path <manifest> <source> <dest>` compares a source
-  and destination using the manifest.
+- `lvmsync verify <source> <dest>` compares a destination against the manifest
+  for the source. Override the manifest path with `--manifest_path` if needed.
 
 Chunk offsets are determined using FastCDC. The gear table now uses the
 standard 256-entry random values from the FastCDC specification, replacing the
@@ -85,7 +93,7 @@ Progress logs are emitted every 10s by default; adjust with
 Use a manifest to verify that a source and destination match:
 
 ```sh
-lvmsync verify --manifest_path snapshot.manifest /dev/vg0/snap0 /dev/null
+lvmsync verify /dev/vg0/snap0 /dev/null
 ```
 
 #### Flags

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -311,7 +311,7 @@ func TestRebuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open manifest: %v", err)
 	}
-	if idx.hdr.BlockSize != 4096 || idx.hdr.ChunkCount != 2 || idx.hdr.SizeBytes != 8192 {
+	if idx.hdr.Version != Version || idx.hdr.BlockSize != 4096 || idx.hdr.ChunkCount != 2 || idx.hdr.SizeBytes != 8192 {
 		t.Fatalf("header mismatch: %+v", idx.hdr)
 	}
 	if id := string(bytes.TrimRight(idx.hdr.DeviceID[:], "\x00")); id != "uuid-test" {


### PR DESCRIPTION
## Summary
- rebuild manifests and verify destinations using manifest index
- document manifest lifecycle and verification workflow
- test manifest versioning and CLI rebuild behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestH2TransportSelectBestHandshake, TestQUICTransportSelectBestHandshake)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a05ac6ce2083239486309328f12974