### PR TITLE
feat(dedup): add cdc tunables and chunk seed

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -21,6 +21,12 @@ import (
 type RunOptions struct {
 	DryRun    bool
 	Transport string
+	DedupMode string
+	BlockSize int
+	CDCMin    int
+	CDCAvg    int
+	CDCMax    int
+	ChunkSeed uint64
 }
 
 var (
@@ -68,6 +74,12 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 			opts := RunOptions{
 				DryRun:    cfg.DryRun,
 				Transport: cfg.Transport,
+				DedupMode: cfg.DedupMode,
+				BlockSize: cfg.BlockSize,
+				CDCMin:    cfg.CDCMin,
+				CDCAvg:    cfg.CDCAvg,
+				CDCMax:    cfg.CDCMax,
+				ChunkSeed: cfg.ChunkSeed,
 			}
 			return runCommand(remaining[0], remaining[1], opts, logger)
 		},
@@ -91,7 +103,6 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 			flagSets := config.NewFlagSets(defaults)
 			flagSets.SSH = pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
 			flagSets.Remote = pflag.NewFlagSet("Remote Options", pflag.ExitOnError)
-			flagSets.Dedup = pflag.NewFlagSet("Deduplication Options", pflag.ExitOnError)
 			flagSets.Compression = pflag.NewFlagSet("Compression Options", pflag.ExitOnError)
 			flagSets.LVM = pflag.NewFlagSet("LVM Options", pflag.ExitOnError)
 			flagSets.GRPC = pflag.NewFlagSet("gRPC Options", pflag.ExitOnError)

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -32,7 +32,6 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	flagSets := config.NewFlagSets(cfg)
 	flagSets.SSH = pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
 	flagSets.Remote = pflag.NewFlagSet("Remote Options", pflag.ExitOnError)
-	flagSets.Dedup = pflag.NewFlagSet("Deduplication Options", pflag.ExitOnError)
 	flagSets.Compression = pflag.NewFlagSet("Compression Options", pflag.ExitOnError)
 	flagSets.LVM = pflag.NewFlagSet("LVM Options", pflag.ExitOnError)
 	flagSets.GRPC = pflag.NewFlagSet("gRPC Options", pflag.ExitOnError)

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -42,7 +42,6 @@ func Run(args []string, logger *zap.Logger) error {
 			flagSets := config.NewFlagSets(defaults)
 			flagSets.SSH = pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
 			flagSets.Remote = pflag.NewFlagSet("Remote Options", pflag.ExitOnError)
-			flagSets.Dedup = pflag.NewFlagSet("Deduplication Options", pflag.ExitOnError)
 			flagSets.Compression = pflag.NewFlagSet("Compression Options", pflag.ExitOnError)
 			flagSets.LVM = pflag.NewFlagSet("LVM Options", pflag.ExitOnError)
 			flagSets.GRPC = pflag.NewFlagSet("gRPC Options", pflag.ExitOnError)

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -88,6 +88,7 @@ type Config struct {
 	CDCMin                   int           `mapstructure:"cdc_min"`
 	CDCAvg                   int           `mapstructure:"cdc_avg"`
 	CDCMax                   int           `mapstructure:"cdc_max"`
+	ChunkSeed                uint64        `mapstructure:"chunk_seed"`
 	DedupStrategy            string        `mapstructure:"dedup_strategy"`
 	DedupStateFile           string        `mapstructure:"dedup_state_file"`
 	BloomEntries             int           `mapstructure:"bloom_entries"`
@@ -221,6 +222,7 @@ func DefaultConfig() (*Config, error) {
 		CDCMin:                   4 * 1024,
 		CDCAvg:                   64 * 1024,
 		CDCMax:                   1 * 1024 * 1024,
+		ChunkSeed:                0,
 		DedupStrategy:            "none",
 		DedupStateFile:           filepath.Join(homeDir, ".lvmsync_dedup"),
 		BloomEntries:             1000000,

--- a/config/flags.go
+++ b/config/flags.go
@@ -122,6 +122,7 @@ func initDedupFlags(cfg *Config) *pflag.FlagSet {
 	fs.Int("cdc-min", cfg.CDCMin, "Minimum chunk size for CDC")
 	fs.Int("cdc-avg", cfg.CDCAvg, "Average chunk size for CDC")
 	fs.Int("cdc-max", cfg.CDCMax, "Maximum chunk size for CDC")
+	fs.Uint64("chunk-seed", cfg.ChunkSeed, "Seed for chunking")
 	fs.String("dedup_strategy", cfg.DedupStrategy, fmt.Sprintf("Deduplication strategy: %v", SupportedDedupStrategies))
 	fs.String("dedup_state_file", cfg.DedupStateFile, "Path to deduplication state file")
 	fs.Int("bloom_entries", cfg.BloomEntries, "Bloom filter entries")

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -65,6 +65,64 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 }
 
+func TestCDCMinCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "cdc_min: 64\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--cdc-min", "128"})
+	t.Setenv("LVMSYNC_DEDUP_CDC_MIN", "96")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.CDCMin != 128 {
+		t.Fatalf("expected cdc_min 128, got %d", conf.CDCMin)
+	}
+}
+
+func TestCDCMinEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "cdc_min: 64\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_DEDUP_CDC_MIN", "96")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.CDCMin != 96 {
+		t.Fatalf("expected cdc_min 96, got %d", conf.CDCMin)
+	}
+}
+
 func TestFlagSetsBindToViper(t *testing.T) {
 	args := []string{
 		"--parallel", "5",
@@ -468,64 +526,6 @@ func TestDedupStrategyEnvOverridesConfig(t *testing.T) {
 	}
 	if conf.DedupStrategy != "bloom" {
 		t.Fatalf("expected dedup_strategy bloom, got %s", conf.DedupStrategy)
-	}
-}
-
-func TestCDCMinCLIOverridesEnvAndConfig(t *testing.T) {
-	cfgPath := writeTempConfig(t, "cdc_min: 512\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--cdc-min", "2048"})
-	t.Setenv("LVMSYNC_DEDUP_CDC_MIN", "1024")
-
-	defaults, err := DefaultConfig()
-	if err != nil {
-		t.Fatalf("DefaultConfig: %v", err)
-	}
-	fs := NewFlagSets(defaults)
-	registerFlags(fs, rootFS)
-	if err := rootFS.Parse(args); err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-
-	v, err := buildViper(fs)
-	if err != nil {
-		t.Fatalf("buildViper: %v", err)
-	}
-	builder := &Builder{v: v, defaults: defaults}
-	conf, err := builder.Build()
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	if conf.CDCMin != 2048 {
-		t.Fatalf("expected cdc_min 2048, got %d", conf.CDCMin)
-	}
-}
-
-func TestCDCMinEnvOverridesConfig(t *testing.T) {
-	cfgPath := writeTempConfig(t, "cdc_min: 512\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath})
-	t.Setenv("LVMSYNC_DEDUP_CDC_MIN", "1024")
-
-	defaults, err := DefaultConfig()
-	if err != nil {
-		t.Fatalf("DefaultConfig: %v", err)
-	}
-	fs := NewFlagSets(defaults)
-	registerFlags(fs, rootFS)
-	if err := rootFS.Parse(args); err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-
-	v, err := buildViper(fs)
-	if err != nil {
-		t.Fatalf("buildViper: %v", err)
-	}
-	builder := &Builder{v: v, defaults: defaults}
-	conf, err := builder.Build()
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	if conf.CDCMin != 1024 {
-		t.Fatalf("expected cdc_min 1024, got %d", conf.CDCMin)
 	}
 }
 

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -98,6 +98,9 @@ func (b *Builder) applyDefaults(conf *Config) error {
 	if conf.CDCMax == 0 {
 		conf.CDCMax = b.defaults.CDCMax
 	}
+	if conf.ChunkSeed == 0 {
+		conf.ChunkSeed = b.defaults.ChunkSeed
+	}
 
 	bs, raw, err := b.parseBlockSize()
 	if err != nil {
@@ -306,6 +309,7 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	v.RegisterAlias("cdc_min", "cdc-min")
 	v.RegisterAlias("cdc_avg", "cdc-avg")
 	v.RegisterAlias("cdc_max", "cdc-max")
+	v.RegisterAlias("chunk_seed", "chunk-seed")
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
 		return nil, err
 	}

--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -32,13 +32,16 @@ type Chunker struct {
 
 	// reusable buffer to avoid per-chunk allocations
 	buf []byte
+
+	// gear table allowing deterministic seeding
+	gear [256]uint64
 }
 
 // NewChunker returns a new chunker configured with the provided
 // minimum, average, and maximum chunk sizes. All sizes are in bytes. The mask values are
 // derived from the average size.
 // The sizes must be positive and ordered such that minSize ≤ avgSize ≤ maxSize.
-func NewChunker(minSize, avgSize, maxSize int) (*Chunker, error) {
+func NewChunker(minSize, avgSize, maxSize int, seeds ...uint64) (*Chunker, error) {
 	if minSize <= 0 || avgSize <= 0 || maxSize <= 0 {
 		return nil, fmt.Errorf("chunk sizes must be positive: min=%d avg=%d max=%d", minSize, avgSize, maxSize)
 	}
@@ -47,6 +50,13 @@ func NewChunker(minSize, avgSize, maxSize int) (*Chunker, error) {
 	}
 
 	c := &Chunker{Min: minSize, Avg: avgSize, Max: maxSize}
+	copy(c.gear[:], defaultGear[:])
+	if len(seeds) > 0 {
+		seed := seeds[0]
+		for i := range c.gear {
+			c.gear[i] ^= seed
+		}
+	}
 	// derive masks for different entropy levels. The mask controls the
 	// probability of finding a boundary. Higher mask -> larger chunks.
 	bits := uint64(math.Log2(float64(avgSize)))
@@ -114,7 +124,7 @@ func (c *Chunker) NextChunk(r io.Reader) (Chunk, error) {
 		buf[size] = b[0]
 		size++
 		// update rolling hash
-		h = (h << 1) + gear[b[0]]
+		h = (h << 1) + c.gear[b[0]]
 		// update entropy window and determine mask
 		e := c.updateEntropy(b[0], &counts)
 		mask := c.selectMask(e)
@@ -151,8 +161,8 @@ func (c *Chunker) selectMask(e float64) uint64 {
 
 // FastCDC chunks the entirety of r using the FastCDC algorithm with the
 // provided size targets. It returns all detected chunks.
-func FastCDC(r io.Reader, min, avg, max int) ([]Chunk, error) {
-	ch, err := NewChunker(min, avg, max)
+func FastCDC(r io.Reader, min, avg, max int, seeds ...uint64) ([]Chunk, error) {
+	ch, err := NewChunker(min, avg, max, seeds...)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +192,7 @@ func FastCDC(r io.Reader, min, avg, max int) ([]Chunk, error) {
 
 // gear table of 256 random 64-bit values as specified by FastCDC.
 // gear table generated using Python random seed 1 (FastCDC reference).
-var gear = [256]uint64{
+var defaultGear = [256]uint64{
 	0x91b7584a2265b1f5,
 	0xcd613e30d8f16adf,
 	0x1027c4d1c386bbc4,

--- a/dedup/chunker_test.go
+++ b/dedup/chunker_test.go
@@ -91,3 +91,21 @@ func TestFastCDCDataIsolation(t *testing.T) {
 		t.Fatalf("modifying first chunk altered second chunk data")
 	}
 }
+
+func TestChunkerSeedAffectsBoundaries(t *testing.T) {
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	chunks1, err := FastCDC(bytes.NewReader(data), 64, 128, 256, 1)
+	if err != nil {
+		t.Fatalf("FastCDC seed1: %v", err)
+	}
+	chunks2, err := FastCDC(bytes.NewReader(data), 64, 128, 256, 2)
+	if err != nil {
+		t.Fatalf("FastCDC seed2: %v", err)
+	}
+	if reflect.DeepEqual(chunks1, chunks2) {
+		t.Fatalf("expected different chunk boundaries with different seeds")
+	}
+}

--- a/dedup/hybrid.go
+++ b/dedup/hybrid.go
@@ -2,6 +2,7 @@ package dedup
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 )
 
@@ -13,15 +14,27 @@ type HybridChunker struct {
 	cdcMin  int
 	cdcAvg  int
 	cdcMax  int
+	seed    uint64
 	pending []Chunk
 	// reusable buffer for fixed-size block reads
 	buf []byte
 }
 
 // NewHybridChunker returns a HybridChunker configured with the given block
-// size and CDC window parameters.
-func NewHybridChunker(fixed, min, avg, max int) *HybridChunker {
-	return &HybridChunker{fixed: fixed, cdcMin: min, cdcAvg: avg, cdcMax: max}
+// size and CDC window parameters. A seed may optionally be supplied for
+// deterministic chunking.
+func NewHybridChunker(fixed, min, avg, max int, seeds ...uint64) (*HybridChunker, error) {
+	if fixed <= 0 || min <= 0 || avg <= 0 || max <= 0 {
+		return nil, fmt.Errorf("sizes must be positive: fixed=%d min=%d avg=%d max=%d", fixed, min, avg, max)
+	}
+	if min > avg || avg > max {
+		return nil, fmt.Errorf("sizes must satisfy min ≤ avg ≤ max: min=%d avg=%d max=%d", min, avg, max)
+	}
+	h := &HybridChunker{fixed: fixed, cdcMin: min, cdcAvg: avg, cdcMax: max}
+	if len(seeds) > 0 {
+		h.seed = seeds[0]
+	}
+	return h, nil
 }
 
 // NextChunk returns the next chunk from r. The reader is only consulted when
@@ -54,7 +67,7 @@ func (h *HybridChunker) NextChunk(r io.Reader) (Chunk, error) {
 		buf = buf[:n]
 	}
 
-	chunks, err := FastCDC(bytes.NewReader(buf), h.cdcMin, h.cdcAvg, h.cdcMax)
+	chunks, err := FastCDC(bytes.NewReader(buf), h.cdcMin, h.cdcAvg, h.cdcMax, h.seed)
 	if err != nil && err != io.EOF {
 		return Chunk{}, err
 	}

--- a/dedup/hybrid_test.go
+++ b/dedup/hybrid_test.go
@@ -8,7 +8,10 @@ import (
 
 func TestHybridChunkerProducesChunks(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), 1<<20)
-	h := NewHybridChunker(1<<16, 64, 128, 256)
+	h, err := NewHybridChunker(1<<16, 64, 128, 256)
+	if err != nil {
+		t.Fatalf("NewHybridChunker: %v", err)
+	}
 	r := bytes.NewReader(data)
 	count := 0
 	for {
@@ -32,7 +35,10 @@ func TestHybridChunkerProducesChunks(t *testing.T) {
 func TestHybridChunkerBufferOwnership(t *testing.T) {
 	fixed := 1 << 16
 	data := bytes.Repeat([]byte("a"), fixed*2)
-	h := NewHybridChunker(fixed, 64, 128, 256)
+	h, err := NewHybridChunker(fixed, 64, 128, 256)
+	if err != nil {
+		t.Fatalf("NewHybridChunker: %v", err)
+	}
 	r := bytes.NewReader(data)
 
 	c1, err := h.NextChunk(r)
@@ -71,5 +77,17 @@ func TestHybridChunkerBufferOwnership(t *testing.T) {
 	}
 	if !bytes.Equal(c3.Data, data[offset:offset+c3.Length]) {
 		t.Fatalf("unexpected chunk data")
+	}
+}
+
+func TestHybridChunkerValidation(t *testing.T) {
+	if _, err := NewHybridChunker(0, 1, 2, 3); err == nil {
+		t.Fatalf("expected error for zero fixed size")
+	}
+	if _, err := NewHybridChunker(1, 4, 3, 5); err == nil {
+		t.Fatalf("expected error for min>avg")
+	}
+	if _, err := NewHybridChunker(1, 2, 3, 2); err == nil {
+		t.Fatalf("expected error for avg>max")
 	}
 }

--- a/transfer/dedup_cdc.go
+++ b/transfer/dedup_cdc.go
@@ -37,7 +37,7 @@ type CDCDedup struct {
 // NewCDCDedup constructs a CDCDedup using the tunables provided in cfg.
 func NewCDCDedup(cfg *config.Config) (*CDCDedup, error) {
 	bf := bloom.NewWithEstimates(uint(cfg.BloomEntries), cfg.BloomFpRate)
-	ch, err := dedup.NewChunker(cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax)
+	ch, err := dedup.NewChunker(cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax, cfg.ChunkSeed)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- expose chunk seed and CDC size flags in configuration
- support seeded FastCDC and hybrid chunkers
- thread dedup options through CLI commands

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./transport/h2` *(fails: client negotiate: read handshake: EOF)*
- `go test -coverprofile=coverage.out ./...` *(fails: client negotiate: read handshake: EOF)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(warn: Can't process result by diff processor: can't read from patch file path/to/patch/file: open path/to/patch/file: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a05ac06d488323b36acd27528e25b3