### PR TITLE
feat(transport): add dial fallback helper

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -7,10 +7,12 @@ Transports are tried in order until a connection is established. The default
 order is `quic,h2,tcp+tls,ssh`.
 
 Every session begins with a textual handshake starting with `lvmsync PROTO[3]`.
-Tokens advertise supported transports, compression algorithms, and digests. The
-handshake also carries a resume token (`resume:<token>`) so interrupted sessions
-can continue and a maximum in‑flight hint (`inflight:<n>`) to negotiate
-concurrency.
+Tokens advertise supported transports, compression algorithms, digests,
+endianness (`endian:<little|big>`), block sizes (`block:<n>`), deduplication
+mode (`dedup:<mode>`), content-defined chunking ranges (`cdcmin:<n>`
+`cdcavg:<n>` `cdcmax:<n>`), and O_DIRECT capability (`odirect`). The handshake
+also carries a resume token (`resume:<token>`) so interrupted sessions can
+continue and a maximum in-flight hint (`inflight:<n>`) to negotiate concurrency.
 
 ## Security Defaults
 
@@ -46,6 +48,7 @@ clients. Defaults:
 - ALPN negotiation using `lvmsync`
 - Bidirectional streams and datagram support
 - BBR congestion control
+- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`
 
 Example:
 
@@ -58,12 +61,14 @@ lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 - Runs over TLS 1.3 with mutual authentication
 - Provides stream-level back-pressure
 - Enforces context deadlines during connection and HTTP/2 handshakes
+- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`, `--tcp_port`
 
 ## TCP+TLS
 
 - Plain TCP encapsulated in TLS 1.3
 - Requires mutual TLS authentication
 - Logs a warning if listener shutdown encounters an error
+- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`, `--tcp_port`
 
 ## SSH
 
@@ -73,3 +78,4 @@ lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 - Verifies server host keys using `known_hosts` or an explicit `--ssh_host_key`; unknown hosts are rejected
 - Key authentication via `--ssh_key`/`LVMSYNC_SSH_KEY`
 - Optional agent auth with `--ssh_agent`/`LVMSYNC_SSH_AGENT` using `SSH_AUTH_SOCK`
+- Flags: `--ssh_user`, `--ssh_password`, `--ssh_key`, `--ssh_host_key`, `--ssh_host_key_path`, `--ssh_agent`, `--allow_insecure`

--- a/transport/interface.go
+++ b/transport/interface.go
@@ -32,8 +32,10 @@ func (r Role) String() string {
 // Implementations must establish a connection via Dial or Listen and then
 // perform a protocol negotiation using Negotiate. Dial should connect to the
 // remote address, while Listen should create a listener ready to accept
-// connections. Negotiate exchanges the protocol handshake and returns when the
-// connection is ready for use.
+// connections. Negotiate exchanges the LVMSync handshake covering endianness,
+// block size, deduplication mode, CDC parameters, compression, digest
+// algorithms, resume tokens, maximum in-flight hints, and O_DIRECT capability
+// before the connection is ready for use.
 type Interface interface {
 	Name() string
 	Dial(ctx context.Context, address string) (net.Conn, error)

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -1,8 +1,12 @@
 package transport
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"sync"
+
+	"go.uber.org/zap"
 )
 
 // Factory creates a transport implementation.
@@ -54,4 +58,31 @@ func GetOrdered(names []string, cfg Config) ([]Interface, error) {
 		trs = append(trs, tr)
 	}
 	return trs, nil
+}
+
+// DialWithFallback tries transports in order until one successfully dials.
+//
+// Each attempt is logged at info level with a corresponding success or failure
+// message. If all transports fail to dial, an error is returned.
+func DialWithFallback(ctx context.Context, address string, names []string, cfg Config) (Interface, net.Conn, error) {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	for _, name := range names {
+		logger.Info("dial_attempt", zap.String("transport", name))
+		tr, err := Get(name, cfg)
+		if err != nil {
+			logger.Warn("get_failed", zap.String("transport", name), zap.Error(err))
+			continue
+		}
+		conn, err := tr.Dial(ctx, address)
+		if err != nil {
+			logger.Warn("dial_failed", zap.String("transport", name), zap.Error(err))
+			continue
+		}
+		logger.Info("dial_success", zap.String("transport", name))
+		return tr, conn, nil
+	}
+	return nil, nil, fmt.Errorf("all transports failed")
 }

--- a/transport/registry_fallback_test.go
+++ b/transport/registry_fallback_test.go
@@ -39,27 +39,6 @@ func (s *stubTransport) Negotiate(ctx context.Context, conn net.Conn, role Role,
 	return common.Handshake{}, fmt.Errorf("not implemented")
 }
 
-// dialWithFallback tries transports in order until one successfully dials.
-func dialWithFallback(ctx context.Context, address string, names []string, logger *zap.Logger) (string, error) {
-	for _, name := range names {
-		logger.Info("dial_attempt", zap.String("transport", name))
-		tr, err := Get(name, Config{Logger: logger})
-		if err != nil {
-			logger.Warn("get_failed", zap.String("transport", name), zap.Error(err))
-			continue
-		}
-		conn, err := tr.Dial(ctx, address)
-		if err != nil {
-			logger.Warn("dial_failed", zap.String("transport", name), zap.Error(err))
-			continue
-		}
-		conn.Close()
-		logger.Info("dial_success", zap.String("transport", name))
-		return name, nil
-	}
-	return "", fmt.Errorf("all transports failed")
-}
-
 func TestRegistryDialFallbackSequence(t *testing.T) {
 	regMu.Lock()
 	original := registry
@@ -81,13 +60,14 @@ func TestRegistryDialFallbackSequence(t *testing.T) {
 	logger := zap.New(core)
 	defer logger.Sync()
 
-	name, err := dialWithFallback(context.Background(), "127.0.0.1:0", []string{"quic", "h2", "tcp+tls", "ssh"}, logger)
+	tr, conn, err := DialWithFallback(context.Background(), "127.0.0.1:0", []string{"quic", "h2", "tcp+tls", "ssh"}, Config{Logger: logger})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != "ssh" {
-		t.Fatalf("expected ssh, got %s", name)
+	if tr.Name() != "ssh" {
+		t.Fatalf("expected ssh, got %s", tr.Name())
 	}
+	conn.Close()
 
 	var seq []string
 	for _, entry := range obs.All() {


### PR DESCRIPTION
## Summary
- document handshake parameters and per-transport flags
- add DialWithFallback helper for ordered transport selection
- test fallback sequence across registered transports

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestNewSSHClient, TestH2TransportSelectBestHandshake)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68a05c8ea4e4832381ff1b8e196f502b