### PR TITLE
feat(resume): persist chunk boundaries across modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1121,7 +1121,7 @@ lvmsync run --speed 50MB /dev/vg0/snap0 /dev/vg0/data
 
 #### Resuming a Transfer
 
-Resume an interrupted transfer using a resume state file. The file records the deduplication mode, the digest of the last successful chunk, and its CDC boundaries. Progress is checkpointed every `--checkpoint-bytes` or `--checkpoint-interval`, and the resume file is removed on successful completion:
+Resume an interrupted transfer using a resume state file. The file records the last chunk boundaries and digests for fixed, CDC, and hybrid modes. Progress is checkpointed every `--checkpoint-bytes` or `--checkpoint-interval`, and the resume file is removed on successful completion. Changing the transport, compression, checksum algorithm, or dedup mode invalidates the checkpoint:
 
 ```sh
 lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -76,7 +76,7 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
-	bw := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger)
+	bw := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger, t.Tracker)
 	var totalBytes int64
 	totalBytes, err = bw.write(reader)
 	if err != nil {

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
@@ -20,10 +21,11 @@ type blockWriter struct {
 	checksum  ChecksumStrategy
 	logger    *zap.Logger
 	sinceSync int64
+	rt        *resumeTracker
 }
 
 // newBlockWriter constructs a blockWriter.
-func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger) *blockWriter {
+func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, rt *resumeTracker) *blockWriter {
 	return &blockWriter{
 		cfg:      cfg,
 		dest:     dest,
@@ -31,6 +33,7 @@ func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrate
 		verify:   verify,
 		checksum: checksum,
 		logger:   logger,
+		rt:       rt,
 	}
 }
 
@@ -60,6 +63,12 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		if err != nil {
 			return total, err
 		}
+		var chunkID [32]byte
+		if data != nil {
+			chunkID = blake3.Sum256(data)
+		} else {
+			chunkID = zeroHash(int(chunkSize))
+		}
 		written, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.verify, bw.checksum, offset, transmitted, data, chunkSize, bw.logger)
 		if bw.cfg.ODirect {
 			if data != nil {
@@ -71,6 +80,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		if err != nil {
 			return total, err
 		}
+		saveResumeState(bw.cfg, bw.rt, offset, chunkID, int64(chunkSize), bw.logger)
 		if written {
 			total += int64(chunkSize)
 			bw.sinceSync += int64(chunkSize)

--- a/transfer/block_writer_apply_test.go
+++ b/transfer/block_writer_apply_test.go
@@ -42,7 +42,7 @@ func TestBlockWriterSyncInterval(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw := newBlockWriter(cfg, f, nil, false, checksum, zap.NewNop())
+	bw := newBlockWriter(cfg, f, nil, false, checksum, zap.NewNop(), nil)
 	blocks := [][]byte{{1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}}
 
 	calls := 0
@@ -76,7 +76,7 @@ func TestBlockWriterMACVerification(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop())
+	bw := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop(), nil)
 	data := []byte{1, 2, 3, 4}
 	reader := buildBlockStream(t, true, checksum, [][]byte{data})
 	if _, err := bw.write(reader); err != nil {

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -53,9 +53,9 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	stateFile := filepath.Join(tmp, "resume")
 	digest := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{ResumeState: stateFile, Compress: "none", ChecksumAlgorithm: "blake3", DedupMode: "fixed"}
-	writeResumeState(cfg, logger, stateFile, 0, 0, digest)
+	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: resumeChunk{Chunk: digest}})
 
-	val := readResumeState(cfg, logger)
+	val := readResumeState(cfg, logger).Fixed
 	if val.Chunk != digest {
 		t.Fatalf("expected digest match")
 	}

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -99,7 +99,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 		CheckpointBytes:   1,
 	}
 	digest0 := blake3.Sum256(srcData0)
-	writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
 
 	ctx := context.Background()
 	tr, err := transport.Get("ssh", transport.Config{Logger: zap.NewNop(), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true})
@@ -212,7 +212,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 		CheckpointBytes:   1,
 	}
 	digest0 := blake3.Sum256(srcData0)
-	writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
 
 	ctx := context.Background()
 	tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
@@ -353,7 +353,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
 
 			ctx := context.Background()
 			tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
@@ -474,7 +474,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
 
 			ctx := context.Background()
 			tcfg := transport.Config{Logger: zap.NewNop()}
@@ -652,7 +652,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest0)
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
 
 			ctx := context.Background()
 			tr, err := transport.Get("ssh", transport.Config{Logger: zap.NewNop(), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true})

--- a/transfer/resume.go
+++ b/transfer/resume.go
@@ -9,14 +9,43 @@ type resumeChunk struct {
 	Length uint32
 }
 
+// resumeChunks groups the last processed chunks for each deduplication mode.
+type resumeChunks struct {
+	Fixed  resumeChunk
+	CDC    resumeChunk
+	Hybrid resumeChunk
+}
+
 // resumeCheckpoint represents the last processed chunk recorded on disk.
 type resumeCheckpoint struct {
-	resumeChunk
+	resumeChunks
 }
 
 // resumeTracker tracks checkpoint progress for an ongoing transfer.
 type resumeTracker struct {
 	bytes int64
 	last  time.Time
-	resumeChunk
+	resumeChunks
+}
+
+func (rt *resumeTracker) chunk(mode string) *resumeChunk {
+	switch mode {
+	case "cdc":
+		return &rt.CDC
+	case "hybrid":
+		return &rt.Hybrid
+	default:
+		return &rt.Fixed
+	}
+}
+
+func (rc resumeCheckpoint) chunk(mode string) resumeChunk {
+	switch mode {
+	case "cdc":
+		return rc.CDC
+	case "hybrid":
+		return rc.Hybrid
+	default:
+		return rc.Fixed
+	}
 }

--- a/transfer/resume_cdc.go
+++ b/transfer/resume_cdc.go
@@ -7,7 +7,7 @@ import (
 )
 
 // findResumeIndexCDC resumes scanning using CDC; logger must be non-nil.
-func findResumeIndexCDC(cfg *config.Config, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+func findResumeIndexCDC(cfg *config.Config, ranges []Range, chk resumeChunk, logger *zap.Logger) int {
 	next := chk.Offset + uint64(chk.Length)
 	for i := range ranges {
 		if next < ranges[i].Start {

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -21,7 +21,7 @@ func TestResumeCDCOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, 80, 40, digest)
+	writeResumeState(cfg, logger, state, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: 80, Length: 40}})
 
 	chk := readResumeState(cfg, logger)
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -43,7 +43,7 @@ func TestResumeCDCSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, uint64(blockSize), uint32(blockSize), digest)
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
@@ -56,5 +56,29 @@ func TestResumeCDCSequential(t *testing.T) {
 	expected := []int64{2 * blockSize, 3 * blockSize}
 	if !reflect.DeepEqual(offsets, expected) {
 		t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
+	}
+}
+
+func TestResumeCDCIdempotent(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	blockSize := int64(1024)
+	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
+	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
+	var first, second bytes.Buffer
+	for i := 0; i < 2; i++ {
+		tr.Tracker = &resumeTracker{}
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+		buf := &first
+		if i == 1 {
+			buf = &second
+		}
+		if err := tr.DumpChangesParallel(cfg, snapshot, src, buf); err != nil {
+			t.Fatalf("DumpChangesParallel failed: %v", err)
+		}
+		finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
+	}
+	if !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatalf("resume output mismatch")
 	}
 }

--- a/transfer/resume_fixed.go
+++ b/transfer/resume_fixed.go
@@ -17,16 +17,16 @@ func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, chk r
 	}
 	switch cfg.DedupMode {
 	case "cdc":
-		return findResumeIndexCDC(cfg, ranges, chk, logger)
+		return findResumeIndexCDC(cfg, ranges, chk.CDC, logger)
 	case "hybrid":
-		return findResumeIndexHybrid(cfg, ranges, chk, logger)
+		return findResumeIndexHybrid(cfg, ranges, chk.Hybrid, logger)
 	default:
-		return findResumeIndexFixed(cfg, srcFile, ranges, chk, logger)
+		return findResumeIndexFixed(cfg, srcFile, ranges, chk.Fixed, logger)
 	}
 }
 
 // findResumeIndexFixed finds resume index using fixed-size blocks; logger must be non-nil.
-func findResumeIndexFixed(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+func findResumeIndexFixed(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeChunk, logger *zap.Logger) int {
 	if chk.Chunk == [32]byte{} {
 		return 0
 	}

--- a/transfer/resume_fixed_test.go
+++ b/transfer/resume_fixed_test.go
@@ -1,0 +1,38 @@
+package transfer
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+)
+
+func TestResumeFixedIdempotent(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	blockSize := int64(1024)
+	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
+
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "fixed"}
+
+	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
+	var first, second bytes.Buffer
+	for i := 0; i < 2; i++ {
+		tr.Tracker = &resumeTracker{}
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+		buf := &first
+		if i == 1 {
+			buf = &second
+		}
+		if err := tr.DumpChangesParallel(cfg, snapshot, src, buf); err != nil {
+			t.Fatalf("DumpChangesParallel failed: %v", err)
+		}
+		finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
+	}
+	if !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatalf("resume output mismatch")
+	}
+}

--- a/transfer/resume_hybrid.go
+++ b/transfer/resume_hybrid.go
@@ -6,6 +6,6 @@ import (
 	"lvmsync_go/config"
 )
 
-func findResumeIndexHybrid(cfg *config.Config, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+func findResumeIndexHybrid(cfg *config.Config, ranges []Range, chk resumeChunk, logger *zap.Logger) int {
 	return findResumeIndexCDC(cfg, ranges, chk, logger)
 }

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -21,7 +21,7 @@ func TestResumeHybridOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, 80, 40, digest)
+	writeResumeState(cfg, logger, state, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: 80, Length: 40}})
 
 	chk := readResumeState(cfg, logger)
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -43,7 +43,7 @@ func TestResumeHybridSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, uint64(blockSize), uint32(blockSize), digest)
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
@@ -56,5 +56,29 @@ func TestResumeHybridSequential(t *testing.T) {
 	expected := []int64{2 * blockSize, 3 * blockSize}
 	if !reflect.DeepEqual(offsets, expected) {
 		t.Fatalf("unexpected offsets %v, want %v", offsets, expected)
+	}
+}
+
+func TestResumeHybridIdempotent(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	blockSize := int64(1024)
+	src, snapshot, resume := createTestFiles(t, blockSize, 4, "blake3")
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
+	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
+	var first, second bytes.Buffer
+	for i := 0; i < 2; i++ {
+		tr.Tracker = &resumeTracker{}
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+		buf := &first
+		if i == 1 {
+			buf = &second
+		}
+		if err := tr.DumpChangesParallel(cfg, snapshot, src, buf); err != nil {
+			t.Fatalf("DumpChangesParallel failed: %v", err)
+		}
+		finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
+	}
+	if !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatalf("resume output mismatch")
 	}
 }

--- a/transfer/resume_interrupted_test.go
+++ b/transfer/resume_interrupted_test.go
@@ -51,7 +51,7 @@ func runInterrupted(t *testing.T, mode string) {
 		t.Fatalf("expected error")
 	}
 
-	chk := readResumeState(cfg, zap.NewNop())
+	chk := readResumeState(cfg, zap.NewNop()).chunk(mode)
 	if chk.Offset != 0 || chk.Length == 0 || chk.Chunk != digest {
 		t.Fatalf("unexpected checkpoint %+v", chk)
 	}

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -12,26 +12,39 @@ import (
 )
 
 // resumeState persists transfer checkpoints allowing interrupted transfers to resume.
+type resumeChunkState struct {
+	Offset uint64 `json:"offset"`
+	Length uint32 `json:"length"`
+	Chunk  string `json:"chunk"`
+}
+
 type resumeState struct {
-	Transport         string `json:"transport"`
-	Compress          string `json:"compress"`
-	ChecksumAlgorithm string `json:"checksum_algorithm"`
-	DedupMode         string `json:"dedup_mode"`
-	Offset            uint64 `json:"offset"`
-	Length            uint32 `json:"length"`
-	Chunk             string `json:"chunk"`
+	Transport         string           `json:"transport"`
+	Compress          string           `json:"compress"`
+	ChecksumAlgorithm string           `json:"checksum_algorithm"`
+	DedupMode         string           `json:"dedup_mode"`
+	Fixed             resumeChunkState `json:"fixed"`
+	CDC               resumeChunkState `json:"cdc"`
+	Hybrid            resumeChunkState `json:"hybrid"`
 }
 
 // writeResumeState persists resume state; logger must be non-nil.
-func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, offset uint64, length uint32, chunk [32]byte) {
+func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunks resumeChunks) {
+	toState := func(ch resumeChunk) resumeChunkState {
+		return resumeChunkState{
+			Offset: ch.Offset,
+			Length: ch.Length,
+			Chunk:  hex.EncodeToString(ch.Chunk[:]),
+		}
+	}
 	rs := resumeState{
 		Transport:         cfg.Transport,
 		Compress:          cfg.Compress,
 		ChecksumAlgorithm: cfg.ChecksumAlgorithm,
 		DedupMode:         cfg.DedupMode,
-		Offset:            offset,
-		Length:            length,
-		Chunk:             hex.EncodeToString(chunk[:]),
+		Fixed:             toState(chunks.Fixed),
+		CDC:               toState(chunks.CDC),
+		Hybrid:            toState(chunks.Hybrid),
 	}
 	data, err := json.Marshal(rs)
 	if err != nil {
@@ -51,10 +64,11 @@ func saveResumeState(cfg *config.Config, rt *resumeTracker, offset uint64, chunk
 		rt.last = time.Now()
 	}
 	rt.bytes += size
-	rt.resumeChunk = resumeChunk{Chunk: chunk, Offset: offset, Length: uint32(size)}
+	rc := rt.chunk(cfg.DedupMode)
+	*rc = resumeChunk{Chunk: chunk, Offset: offset, Length: uint32(size)}
 	if (cfg.CheckpointBytes > 0 && rt.bytes >= int64(cfg.CheckpointBytes)) ||
 		(cfg.CheckpointInterval > 0 && time.Since(rt.last) >= cfg.CheckpointInterval) {
-		writeResumeState(cfg, logger, cfg.ResumeState, rt.Offset, rt.Length, rt.Chunk)
+		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunks{Fixed: rt.Fixed, CDC: rt.CDC, Hybrid: rt.Hybrid})
 		rt.bytes = 0
 		rt.last = time.Now()
 	}
@@ -72,6 +86,7 @@ func finalizeResumeState(cfg *config.Config, rt *resumeTracker, logger *zap.Logg
 	}
 	rt.bytes = 0
 	rt.last = time.Time{}
+	rt.resumeChunks = resumeChunks{}
 }
 
 func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
@@ -91,16 +106,32 @@ func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
 		rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm {
 		return out
 	}
-	b, err := hex.DecodeString(rs.Chunk)
-	if err != nil || len(b) != 32 {
-		return out
+	decode := func(cs resumeChunkState) (resumeChunk, bool) {
+		b, err := hex.DecodeString(cs.Chunk)
+		if err != nil || len(b) != 32 {
+			return resumeChunk{}, false
+		}
+		var ch resumeChunk
+		copy(ch.Chunk[:], b)
+		ch.Offset = cs.Offset
+		ch.Length = cs.Length
+		return ch, true
 	}
-	copy(out.Chunk[:], b)
-	out.Offset = rs.Offset
-	out.Length = rs.Length
-	logger.Info("Resuming from chunk",
-		zap.String("resume_chunk", hex.EncodeToString(out.Chunk[:])),
-		zap.Uint64("resume_offset", out.Offset),
-		zap.Uint32("resume_length", out.Length))
+	if ch, ok := decode(rs.Fixed); ok {
+		out.Fixed = ch
+	}
+	if ch, ok := decode(rs.CDC); ok {
+		out.CDC = ch
+	}
+	if ch, ok := decode(rs.Hybrid); ok {
+		out.Hybrid = ch
+	}
+	rc := out.chunk(cfg.DedupMode)
+	if rc != (resumeChunk{}) {
+		logger.Info("Resuming from chunk",
+			zap.String("resume_chunk", hex.EncodeToString(rc.Chunk[:])),
+			zap.Uint64("resume_offset", rc.Offset),
+			zap.Uint32("resume_length", rc.Length))
+	}
 	return out
 }

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -39,7 +39,7 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int, algo string)
 		digest = blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
 	}
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: algo, DedupMode: "fixed"}
-	writeResumeState(cfg, zap.NewNop(), resumePath, 0, uint32(blockSize), digest)
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: 0, Length: uint32(blockSize)}})
 	return srcPath, snapshot, resumePath
 }
 
@@ -140,7 +140,17 @@ func TestResumeModeTransitions(t *testing.T) {
 
 			cfgStart := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.from}
 			digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-			writeResumeState(cfgStart, zap.NewNop(), resume, uint64(blockSize), uint32(blockSize), digest)
+			rc := resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}
+			chunks := resumeChunks{}
+			switch trc.from {
+			case "cdc":
+				chunks.CDC = rc
+			case "hybrid":
+				chunks.Hybrid = rc
+			default:
+				chunks.Fixed = rc
+			}
+			writeResumeState(cfgStart, zap.NewNop(), resume, chunks)
 
 			cfgResume := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.to}
 

--- a/transfer/run_apply.go
+++ b/transfer/run_apply.go
@@ -65,5 +65,7 @@ func (t *Transfer) RunApply(cfg *config.Config, applyFile, destDevice string) (e
 		return err
 	}
 	defer common.CloseWithErr(rc, &err, "close apply file")
-	return t.applyData(cfg, rc, destDevice)
+	err = t.applyData(cfg, rc, destDevice)
+	finalizeResumeState(cfg, t.Tracker, t.Logger)
+	return err
 }


### PR DESCRIPTION
## Summary
- track last chunk boundaries and digests for fixed, CDC, and hybrid modes
- checkpoint apply progress and finalize resume state
- document resume usage and add idempotent resume tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestH2TransportSelectBestHandshake: read handshake EOF)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a0607116a08323993c2f30c994eb97