### PR TITLE
feat(transfer): add block writer options and sparse holes

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,9 @@ Recent refactors added several configuration options:
 
 ### I/O tuning
 
-- `--odirect` uses O_DIRECT with block-size aligned buffers.
+- `--block_size` selects the transfer block size. Use `auto` to match the destination's physical sector size.
 - `--sync-interval` sets how many bytes are written between `fdatasync` calls (flag uses underscores in the CLI: `--sync_interval`).
+- `--odirect` uses O_DIRECT with block-size aligned buffers.
 - `--numa_pin` pins worker goroutines to CPUs local to the source device's NUMA node.
 
 ### Device types

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -76,7 +76,10 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
-	bw := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger)
+	bw, err := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger)
+	if err != nil {
+		return err
+	}
 	var totalBytes int64
 	totalBytes, err = bw.write(reader)
 	if err != nil {

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -2,12 +2,14 @@ package transfer
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/internal/sizeparse"
 )
 
 // blockWriter streams block records to a destination file, optionally
@@ -22,8 +24,27 @@ type blockWriter struct {
 	sinceSync int64
 }
 
-// newBlockWriter constructs a blockWriter.
-func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger) *blockWriter {
+// newBlockWriter constructs a blockWriter, detecting the destination's physical
+// block size when the configured block size is "auto" (0) and parsing the
+// sync interval when provided as a string. It validates that the configured
+// block size is aligned to the underlying sector size.
+func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger) (*blockWriter, error) {
+	if cfg.BlockSize <= 0 || cfg.ODirect {
+		sector, err := DetectSectorSize(dest)
+		if err != nil {
+			return nil, fmt.Errorf("detect sector size: %w", err)
+		}
+		if cfg.BlockSize <= 0 {
+			cfg.BlockSize = sector
+		} else if cfg.ODirect && cfg.BlockSize%sector != 0 {
+			return nil, fmt.Errorf("block size %d not multiple of sector %d", cfg.BlockSize, sector)
+		}
+	}
+	if cfg.SyncIntervalBytes == 0 && cfg.SyncInterval != "" {
+		if val, _, err := sizeparse.Parse(cfg.SyncInterval); err == nil {
+			cfg.SyncIntervalBytes = int(val)
+		}
+	}
 	return &blockWriter{
 		cfg:      cfg,
 		dest:     dest,
@@ -31,7 +52,7 @@ func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrate
 		verify:   verify,
 		checksum: checksum,
 		logger:   logger,
-	}
+	}, nil
 }
 
 // write consumes block records from reader and writes them to the destination

--- a/transfer/block_writer_apply_test.go
+++ b/transfer/block_writer_apply_test.go
@@ -42,7 +42,10 @@ func TestBlockWriterSyncInterval(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw := newBlockWriter(cfg, f, nil, false, checksum, zap.NewNop())
+	bw, err := newBlockWriter(cfg, f, nil, false, checksum, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newBlockWriter: %v", err)
+	}
 	blocks := [][]byte{{1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}}
 
 	calls := 0
@@ -76,7 +79,10 @@ func TestBlockWriterMACVerification(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop())
+	bw, err := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newBlockWriter: %v", err)
+	}
 	data := []byte{1, 2, 3, 4}
 	reader := buildBlockStream(t, true, checksum, [][]byte{data})
 	if _, err := bw.write(reader); err != nil {

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -133,13 +133,8 @@ func processBlock(
 		return false, err
 	}
 	if chunkSize == 0 || isAllZero(data) {
-		if err := punchHole(destFile, offset, cfg.BlockSize); err != nil {
-			zero := getAlignedBlockBuffer(cfg.BlockSize)
-			if err := writeData(destFile, offset, zero, logger); err != nil {
-				putAlignedBlockBuffer(zero)
-				return false, err
-			}
-			putAlignedBlockBuffer(zero)
+		if err := writeZeroBlock(cfg, destFile, offset, logger); err != nil {
+			return false, err
 		}
 		return true, nil
 	}

--- a/transfer/zero.go
+++ b/transfer/zero.go
@@ -2,9 +2,13 @@ package transfer
 
 import (
 	"bytes"
+	"os"
 	"sync"
 
 	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
 )
 
 // zeroBufCache stores zero-filled buffers keyed by their size to avoid repeated
@@ -36,4 +40,26 @@ func zeroHash(size int) [32]byte {
 // using memcmp semantics via bytes.Equal.
 func isAllZero(b []byte) bool {
 	return bytes.Equal(b, zeroBuf(len(b)))
+}
+
+// writeZeroBlock attempts to punch a sparse hole at the given offset. If the
+// filesystem does not support hole punching it falls back to writing a zero
+// filled buffer. The buffer respects the O_DIRECT setting by using aligned
+// allocations when necessary.
+func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *zap.Logger) error {
+	if err := punchHole(dest, offset, cfg.BlockSize); err == nil {
+		return nil
+	}
+	var zero []byte
+	if cfg.ODirect {
+		zero = getAlignedBlockBuffer(cfg.BlockSize)
+		defer putAlignedBlockBuffer(zero)
+	} else {
+		zero = getBlockBuffer(cfg.BlockSize)
+		defer putBlockBuffer(zero)
+	}
+	if err := writeData(dest, offset, zero, logger); err != nil {
+		return err
+	}
+	return nil
 }

--- a/transfer/zero_test.go
+++ b/transfer/zero_test.go
@@ -1,9 +1,14 @@
 package transfer
 
 import (
+	"bytes"
+	"os"
 	"testing"
 
 	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
 )
 
 func TestIsAllZero(t *testing.T) {
@@ -28,5 +33,36 @@ func TestZeroHashLargeBuffer(t *testing.T) {
 	buf[123] = 1
 	if isAllZero(buf) {
 		t.Fatalf("expected detection of non-zero buffer")
+	}
+}
+
+func TestWriteZeroBlockPunchesHole(t *testing.T) {
+	cfg := &config.Config{BlockSize: 4096, ODirect: true}
+	tmp := t.TempDir()
+	path := tmp + "/hole"
+	f, direct, err := openFileODirect(path, os.O_RDWR|os.O_CREATE)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !direct {
+		t.Skip("O_DIRECT unsupported")
+	}
+	defer f.Close()
+
+	data := bytes.Repeat([]byte{1}, cfg.BlockSize*2)
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), zap.NewNop()); err != nil {
+		t.Fatalf("writeZeroBlock: %v", err)
+	}
+
+	buf := make([]byte, cfg.BlockSize)
+	if _, err := f.ReadAt(buf, int64(cfg.BlockSize)); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !isAllZero(buf) {
+		t.Fatalf("expected zeros after punching hole")
 	}
 }


### PR DESCRIPTION
## Summary
- detect sector size and parse sync interval in block writer
- punch sparse holes for zero runs with O_DIRECT support
- document writer options for block size and sync interval

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a06100dbc48323a4d9d399a4553f15