### PR TITLE
fix(quic): honor datagram read deadlines

### DIFF
--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -30,8 +30,9 @@ type Transport struct {
 // Conn wraps a QUIC connection and stream to satisfy net.Conn and expose
 // datagram APIs.
 type Conn struct {
-	qconn  quic.Connection
-	stream quic.Stream
+	qconn        quic.Connection
+	stream       quic.Stream
+	readDeadline time.Time
 }
 
 // listener adapts a quic.Listener to net.Listener by accepting a stream for
@@ -279,8 +280,18 @@ func (c *Conn) SendDatagram(b []byte) error {
 	return c.qconn.SendDatagram(b)
 }
 
-// ReceiveDatagram waits for the next datagram.
+// ReceiveDatagram waits for the next datagram while honoring read deadlines.
 func (c *Conn) ReceiveDatagram(ctx context.Context) ([]byte, error) {
+	if !c.readDeadline.IsZero() {
+		if time.Now().After(c.readDeadline) {
+			return nil, context.DeadlineExceeded
+		}
+		if dl, ok := ctx.Deadline(); !ok || c.readDeadline.Before(dl) {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithDeadline(ctx, c.readDeadline)
+			defer cancel()
+		}
+	}
 	return c.qconn.ReceiveDatagram(ctx)
 }
 
@@ -294,6 +305,7 @@ func (c *Conn) Close() error {
 func (c *Conn) LocalAddr() net.Addr  { return c.qconn.LocalAddr() }
 func (c *Conn) RemoteAddr() net.Addr { return c.qconn.RemoteAddr() }
 func (c *Conn) SetDeadline(t time.Time) error {
+	c.readDeadline = t
 	if err := c.stream.SetDeadline(t); err != nil {
 		return err
 	}
@@ -304,6 +316,7 @@ func (c *Conn) SetDeadline(t time.Time) error {
 }
 
 func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.readDeadline = t
 	if err := c.stream.SetReadDeadline(t); err != nil {
 		return err
 	}

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -373,14 +373,8 @@ func TestConnDatagramReadDeadline(t *testing.T) {
 		qconn := conn.(*Conn)
 		defer qconn.Close()
 		qconn.SetReadDeadline(time.Now().Add(-time.Second))
-		if _, err := qconn.ReceiveDatagram(ctx); err != nil {
-			var ne net.Error
-			if !errors.As(err, &ne) || !ne.Timeout() {
-				done <- fmt.Errorf("expected timeout error, got %v", err)
-				return
-			}
-		} else {
-			done <- errors.New("expected timeout error")
+		if _, err := qconn.ReceiveDatagram(ctx); !errors.Is(err, context.DeadlineExceeded) {
+			done <- fmt.Errorf("expected deadline exceeded, got %v", err)
 			return
 		}
 		qconn.SetReadDeadline(time.Time{})
@@ -408,6 +402,49 @@ func TestConnDatagramReadDeadline(t *testing.T) {
 	if err := qconn.SendDatagram([]byte("hi")); err != nil {
 		t.Fatalf("send datagram: %v", err)
 	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConnDatagramContextDeadline(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), ClientCert: cert, AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- fmt.Errorf("accept: %w", err)
+			return
+		}
+		qconn := conn.(*Conn)
+		defer qconn.Close()
+		qconn.SetReadDeadline(time.Now().Add(time.Second))
+		cctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+		if _, err := qconn.ReceiveDatagram(cctx); !errors.Is(err, context.DeadlineExceeded) {
+			done <- fmt.Errorf("expected context deadline exceeded, got %v", err)
+			return
+		}
+		done <- nil
+	}()
+
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn.Close()
 	if err := <-done; err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- ensure QUIC datagram reads respect net.Conn read deadlines
- add tests covering datagram read deadline and context deadline

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestH2TransportSelectBestHandshake)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a0637edfac8323929ba4d353c6da77