### PR TITLE
feat(transport/h2): add handshake logging

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -87,7 +87,14 @@ func init() {
 
 func (t *Transport) Name() string { return "h2" }
 
-func dialTLS(ctx context.Context, address string, conf *tls.Config, _ *zap.Logger) (*tls.Conn, error) {
+func dialTLS(ctx context.Context, address string, conf *tls.Config, logger *zap.Logger) (*tls.Conn, error) {
+	role := "client"
+	logger.Info("tls_handshake_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+	)
+	start := time.Now()
 	d := net.Dialer{}
 	if dl, ok := ctx.Deadline(); ok {
 		d.Deadline = dl
@@ -99,30 +106,107 @@ func dialTLS(ctx context.Context, address string, conf *tls.Config, _ *zap.Logge
 			d.Deadline = dl
 		}
 	}
-	return tls.DialWithDialer(&d, "tcp", address, conf)
+	conn, err := tls.DialWithDialer(&d, "tcp", address, conf)
+	fields := []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+		logger.Error("tls_handshake_end", fields...)
+		return nil, err
+	}
+	logger.Info("tls_handshake_end", fields...)
+	return conn, nil
 }
 
 func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger) (*http2.Framer, error) {
+	role := "client"
+	address := conn.RemoteAddr().String()
+	logger.Info("h2_handshake_start",
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", 0),
+	)
+	start := time.Now()
 	fr := http2.NewFramer(conn, conn)
 	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	}
 	if err := fr.WriteSettings(); err != nil {
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	}
 	if f, err := fr.ReadFrame(); err != nil {
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	} else if _, ok := f.(*http2.SettingsFrame); !ok {
-		return nil, fmt.Errorf("expected settings frame")
+		err := fmt.Errorf("expected settings frame")
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		logger.Error("h2_handshake_end", fields...)
+		return nil, err
 	}
 	if err := fr.WriteSettingsAck(); err != nil {
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	}
 	if f, err := fr.ReadFrame(); err != nil {
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	} else if sf, ok := f.(*http2.SettingsFrame); !ok || !sf.IsAck() {
-		return nil, fmt.Errorf("expected settings ack")
+		err := fmt.Errorf("expected settings ack")
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		logger.Error("h2_handshake_end", fields...)
+		return nil, err
 	}
+	fields := []zap.Field{
+		zap.String("address", address),
+		zap.String("role", role),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+	}
+	logger.Info("h2_handshake_end", fields...)
 	return fr, nil
 }
 

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -105,15 +105,24 @@ func TestDialTLS(t *testing.T) {
 		io.ReadAll(conn)
 	}()
 	clientConf := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
-	if conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, zap.NewNop()); err != nil {
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	if conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, logger); err != nil {
 		t.Fatalf("dialTLS: %v", err)
 	} else {
 		conn.Close()
 	}
+	checkLogFields(t, logs, "tls_handshake_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "tls_handshake_end", 1, false, zapcore.InfoLevel)
+
 	badConf := &tls.Config{RootCAs: x509.NewCertPool(), MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
-	if _, err := dialTLS(context.Background(), ln.Addr().String(), badConf, zap.NewNop()); err == nil {
+	core2, logs2 := observer.New(zapcore.InfoLevel)
+	logger2 := zap.New(core2)
+	if _, err := dialTLS(context.Background(), ln.Addr().String(), badConf, logger2); err == nil {
 		t.Fatalf("expected error")
 	}
+	checkLogFields(t, logs2, "tls_handshake_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs2, "tls_handshake_end", 1, true, zapcore.ErrorLevel)
 }
 
 func TestPerformH2Handshake(t *testing.T) {
@@ -144,15 +153,20 @@ func TestPerformH2Handshake(t *testing.T) {
 		conn.Close()
 	}()
 	clientConf := &tls.Config{RootCAs: pool, NextProtos: []string{"h2"}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
-	conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, zap.NewNop())
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, logger)
 	if err != nil {
 		t.Fatalf("dialTLS: %v", err)
 	}
-	if _, err := performH2Handshake(context.Background(), conn, zap.NewNop()); err != nil {
+	if _, err := performH2Handshake(context.Background(), conn, logger); err != nil {
 		t.Fatalf("handshake: %v", err)
 	}
 	close(done)
 	conn.Close()
+
+	checkLogFields(t, logs, "h2_handshake_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "h2_handshake_end", 1, false, zapcore.InfoLevel)
 
 	// failing handshake: server closes connection immediately; dialTLS should fail
 	go func() {


### PR DESCRIPTION
## Summary
- add TLS and HTTP/2 handshake logging in h2 transport
- verify handshake log emission in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./transport/h2` *(fails: client negotiate: read handshake: EOF)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a06396558083238c9dc5d9e161cb6d