### PR TITLE
fix(h2): surface write errors on close

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 
@@ -450,9 +451,10 @@ func (c *Conn) Write(p []byte) (int, error) {
 
 func (c *Conn) Close() error {
 	c.writeMu.Lock()
-	_ = c.fr.WriteData(c.streamID, true, nil)
+	err1 := c.fr.WriteData(c.streamID, true, nil)
 	c.writeMu.Unlock()
-	return c.Conn.Close()
+	err2 := c.Conn.Close()
+	return multierr.Append(err1, err2)
 }
 
 func (c *Conn) SetDeadline(t time.Time) error      { return c.Conn.SetDeadline(t) }

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -570,3 +570,50 @@ func TestRoleString(t *testing.T) {
 		}
 	}
 }
+
+type errConn struct {
+	writeErr error
+	closeErr error
+}
+
+func (e *errConn) Read(_ []byte) (int, error)  { return 0, io.EOF }
+func (e *errConn) Write(_ []byte) (int, error) { return 0, e.writeErr }
+func (e *errConn) Close() error                { return e.closeErr }
+func (e *errConn) LocalAddr() net.Addr         { return nil }
+func (e *errConn) RemoteAddr() net.Addr        { return nil }
+func (e *errConn) SetDeadline(time.Time) error { return nil }
+func (e *errConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+func (e *errConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func TestConnCloseWriteError(t *testing.T) {
+	writeErr := errors.New("write fail")
+	closeErr := errors.New("close fail")
+
+	tests := []struct {
+		name     string
+		wc       *errConn
+		wantErrs []error
+	}{
+		{"write_error", &errConn{writeErr: writeErr}, []error{writeErr}},
+		{"write_and_close_error", &errConn{writeErr: writeErr, closeErr: closeErr}, []error{writeErr, closeErr}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Conn{Conn: tt.wc, fr: http2.NewFramer(tt.wc, tt.wc), streamID: 1}
+			err := c.Close()
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			for _, we := range tt.wantErrs {
+				if !errors.Is(err, we) {
+					t.Fatalf("expected error %v, got %v", we, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- capture `WriteData` errors during HTTP/2 connection close
- combine `WriteData` and `Conn.Close` errors using `multierr`
- add tests ensuring close surfaces write failures

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./transport/h2 -run TestConnCloseWriteError`
- `go tool cover -func=coverage.out`
- `golangci-lint run`
- `go test -coverprofile=coverage.out ./...` *(fails: client negotiate: read handshake: EOF)*

------
https://chatgpt.com/codex/tasks/task_e_68a063a716f88323b2ed1f64e68593d6