### PR TITLE
feat(compression): auto-select SIMD compression and threshold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,14 +124,14 @@ The `throughput` preset favors maximal transfer rates:
 ## Compression Policy
 
 - Sample 8 KiB from each chunk to estimate the compression ratio.
-- Skip compression when the ratio is greater than or equal to `--compress_threshold`.
-- Auto mode selects LZ4 for chunks under 256 KiB and Zstd level 1 for larger chunks on AVX2-capable CPUs.
-- Choose the algorithm with `--compress {auto|lz4|zstd|none}` and tune levels using `--zstd_level 1..5` or `--lz4_level {fast|hc}`.
+- Skip compression when the ratio is greater than or equal to `--compress-threshold`.
+- Auto mode selects LZ4 for chunks under 256 KiB and Zstd for larger chunks on CPUs with AVX2 or NEON support.
+- Choose the algorithm with `--compress {auto|lz4|zstd|none}` and tune levels using `--zstd-level 1..5` or `--lz4-level {fast|hc}`.
 
 Example configuration:
 
 ```sh
-lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
+lvmsync --compress auto --zstd-level 2 --compress-threshold 0.85
 ```
 
 ## Performance Libraries
@@ -157,7 +157,7 @@ lvmsync --compress auto --zstd_level 2 --compress_threshold 0.85
 ### Compression
 
 - Detect CPU features before selecting algorithms.
-- Sample 8 KiB per chunk to estimate ratios and honour `--compress_threshold`.
+- Sample 8 KiB per chunk to estimate ratios and honour `--compress-threshold`.
 - Benchmarks must cover algorithm choice and cache resets.
 
 ## Control Plane Flow

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Parallel Execution**: Configurable concurrency for optimal performance.
 - **Adaptive Transport Concurrency**: Maintains ~1–2×BDP of in-flight data and can be overridden with `--concurrency`.
 - **Rate-Limiting**: Control bandwidth usage during transfers.
-- **Compression**: Samples 8 KiB per chunk, skipping compression when the ratio exceeds a threshold. Auto mode selects LZ4 for chunks <256 KiB and Zstd level 1 for larger chunks on CPUs with AVX2 or NEON support.
+- **Compression**: Samples 8 KiB per chunk and skips compression when the ratio exceeds `--compress-threshold`. Auto mode selects LZ4 for chunks <256 KiB and Zstd for larger chunks on CPUs with AVX2 or NEON support. Compression levels are tuned via `--lz4-level` and `--zstd-level`.
 - **Checksum Verification**: Ensures data integrity using SHA-256 or BLAKE3, automatically selecting BLAKE3 on CPUs with AES-NI, AVX2/AVX-512, or NEON.
 - **Native LVM2 Integration**: Uses Go bindings to `liblvm2cmd` instead of shelling out.
 - **Generic Block Device Support**: Access raw `/dev/*` paths and regular files (including loopback images) through a unified device abstraction.
@@ -489,10 +489,10 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--bloom_fp_rate` | `LVMSYNC_DEDUP_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
 | `--bloom_mbits` | `LVMSYNC_DEDUP_BLOOM_MBITS` | `bloom_mbits` | Bloom filter m bits power |
 | `--compress` | `LVMSYNC_COMPRESSION_COMPRESS` | `compress` | Compression type: `none`, `lz4`, `zstd`, or `auto` |
-| `--zstd_level` | `LVMSYNC_COMPRESSION_ZSTD_LEVEL` | `zstd_level` | Zstd compression level (`1-5`) |
-| `--lz4_level` | `LVMSYNC_COMPRESSION_LZ4_LEVEL` | `lz4_level` | LZ4 compression level: `fast` or `hc` |
+| `--zstd-level` | `LVMSYNC_COMPRESSION_ZSTD_LEVEL` | `zstd_level` | Zstd compression level (`1-5`) |
+| `--lz4-level` | `LVMSYNC_COMPRESSION_LZ4_LEVEL` | `lz4_level` | LZ4 compression level: `fast` or `hc` |
 | `--compress_concurrency` | `LVMSYNC_COMPRESSION_COMPRESS_CONCURRENCY` | `compress_concurrency` | Compression concurrency (0 to use `GOMAXPROCS`) |
-| `--compress_threshold` | `LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD` | `compress_threshold` | Skip compression when estimated ratio exceeds this value |
+| `--compress-threshold` | `LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD` | `compress_threshold` | Skip compression when estimated ratio exceeds this value |
 | `--skip_snapshot_creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
 | `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
@@ -627,7 +627,10 @@ ssh_host: backup          # SSH Options
 ssh_user: backup          # SSH Options
 remote_pre_script: pre.sh # Remote Options
 dedup_strategy: bloom     # Deduplication Options
-compress: zstd            # Compression Options
+compress: auto            # Compression Options
+zstd_level: 3             # Compression Options
+lz4_level: hc             # Compression Options
+compress_threshold: 0.9   # Compression Options
 snapshot_size: 20%        # LVM Options
 grpc_listen: ":8443"      # gRPC Options
 ```
@@ -639,7 +642,9 @@ Use `--config` to point to a different file.
 With flags:
 
 ```sh
-lvmsync run --parallel 8 --snapshot_size 10% /dev/vg0/snap0 /mnt/backup
+lvmsync run --parallel 8 \
+  --compress auto --zstd-level 3 --lz4-level hc --compress-threshold 0.9 \
+  --snapshot_size 10% /dev/vg0/snap0 /mnt/backup
 ```
 
 With environment variables:
@@ -737,7 +742,7 @@ LVMSync aborts when the sizes are non-positive or unordered.
 
 The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom_entries` and desired false positive rate via `--bloom_fp_rate`. For an mmap-backed index, `--bloom_mbits` controls the bitmap size in megabits.
 
-Compression samples 8 KiB from each chunk and skips when the estimated ratio exceeds `--compress_threshold`. `--compress auto` selects LZ4 for chunks under 256 KiB and Zstd for larger chunks when AVX2 or NEON is available, falling back to LZ4 otherwise.
+Compression samples 8 KiB from each chunk and skips when the estimated ratio exceeds `--compress-threshold`. `--compress auto` selects LZ4 for chunks under 256 KiB and Zstd for larger chunks when AVX2 or NEON is available, falling back to LZ4 otherwise.
 
 CLI:
 
@@ -1037,10 +1042,10 @@ timeouts or cancellations are reported separately.
 | Option                   | Description                                                       | Default  |
 | ------------------------ | ----------------------------------------------------------------- | -------- |
 | `--compress`             | Compression type (options: `"none"`, `"lz4"`, `"zstd"`, `"auto"`) | `"auto"` |
-| `--zstd_level`           | Zstd compression level (`1-5`)                                   | `1`      |
-| `--lz4_level`            | LZ4 compression level: `fast` or `hc`                            | `fast`   |
+| `--zstd-level`           | Zstd compression level (`1-5`)                                   | `1`      |
+| `--lz4-level`            | LZ4 compression level: `fast` or `hc`                            | `fast`   |
 | `--compress_concurrency` | Number of goroutines used for compression (`0` to use all cores)  | `0`      |
-| `--compress_threshold`   | Skip compression when estimated ratio exceeds this value         | `0.9`    |
+| `--compress-threshold`   | Skip compression when estimated ratio exceeds this value         | `0.9`    |
 
 #### LVM Options
 
@@ -1106,7 +1111,7 @@ lvmsync run --apply dumpfile.lvm /dev/vg0/data
 Estimate a sample of each chunk and compress only when it's worthwhile:
 
 ```sh
-lvmsync run --compress auto --zstd_level 2 --compress_threshold 0.85 /dev/vg0/snap0 /dev/vg0/data
+lvmsync run --compress auto --zstd-level 2 --compress-threshold 0.85 /dev/vg0/snap0 /dev/vg0/data
 ```
 
 #### Rate Limiting
@@ -1267,16 +1272,16 @@ LVMSync automatically reloads this state file on startup. Delete it to reset ded
 #### Compression
 
 LVMSync samples 8 KiB from each chunk to gauge compression efficiency. If the
-compressed sample ratio is greater than or equal to `--compress_threshold`, the
+compressed sample ratio is greater than or equal to `--compress-threshold`, the
 chunk is sent uncompressed. In `auto` mode, chunks smaller than 256 KiB use LZ4,
 and larger ones select Zstd (levels 1–3) when AVX2 or NEON is available;
 otherwise LZ4.
-Levels can be tuned with `--zstd_level` (1-5) or `--lz4_level` (`fast` or `hc`).
+Levels can be tuned with `--zstd-level` (1-5) or `--lz4-level` (`fast` or `hc`).
 
 CLI:
 
 ```sh
-lvmsync run --compress auto --zstd_level 2 --compress_threshold 0.85 /dev/vg0/snap0 /dev/vg0/data
+lvmsync run --compress auto --zstd-level 2 --compress-threshold 0.85 /dev/vg0/snap0 /dev/vg0/data
 ```
 
 Environment:

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -67,7 +67,7 @@ type Config struct {
 	LZ4Level                 string        `mapstructure:"lz4_level"`
 	CompressLevel            int           `mapstructure:"-"`
 	CompressConcurrency      int           `mapstructure:"compress_concurrency"`
-	CompressThreshold        float64       `mapstructure:"compress_threshold"`
+	CompressThreshold        float64       `mapstructure:"compress_threshold"` // skip compression when estimated ratio exceeds this value
 	Speed                    string        `mapstructure:"speed"`
 	SpeedLimit               int           `mapstructure:"-"`
 	VerifyChecksum           bool          `mapstructure:"verify_checksum"`

--- a/config/flags.go
+++ b/config/flags.go
@@ -134,10 +134,10 @@ func initDedupFlags(cfg *Config) *pflag.FlagSet {
 func initCompressionFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Compression Options", pflag.ExitOnError)
 	fs.String("compress", cfg.Compress, fmt.Sprintf("Compression algorithm: %v", SupportedCompression))
-	fs.Int("zstd_level", cfg.ZstdLevel, "Zstd compression level (1-5)")
-	fs.String("lz4_level", cfg.LZ4Level, "LZ4 compression level: fast or hc")
+	fs.Int("zstd-level", cfg.ZstdLevel, "Zstd compression level (1-5)")
+	fs.String("lz4-level", cfg.LZ4Level, "LZ4 compression level: fast or hc")
 	fs.Int("compress_concurrency", cfg.CompressConcurrency, "Compression concurrency")
-	fs.Float64("compress_threshold", cfg.CompressThreshold, "Compression ratio threshold")
+	fs.Float64("compress-threshold", cfg.CompressThreshold, "Skip compression when estimated ratio exceeds this value")
 	return fs
 }
 

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -138,10 +138,10 @@ func TestInitCompressionFlags(t *testing.T) {
 	fs := initCompressionFlags(cfg)
 	cases := []struct{ name, want string }{
 		{"compress", cfg.Compress},
-		{"zstd_level", strconv.Itoa(cfg.ZstdLevel)},
-		{"lz4_level", cfg.LZ4Level},
+		{"zstd-level", strconv.Itoa(cfg.ZstdLevel)},
+		{"lz4-level", cfg.LZ4Level},
 		{"compress_concurrency", strconv.Itoa(cfg.CompressConcurrency)},
-		{"compress_threshold", strconv.FormatFloat(cfg.CompressThreshold, 'f', -1, 64)},
+		{"compress-threshold", strconv.FormatFloat(cfg.CompressThreshold, 'f', -1, 64)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -310,6 +310,9 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	v.RegisterAlias("cdc_avg", "cdc-avg")
 	v.RegisterAlias("cdc_max", "cdc-max")
 	v.RegisterAlias("chunk_seed", "chunk-seed")
+	v.RegisterAlias("zstd_level", "zstd-level")
+	v.RegisterAlias("lz4_level", "lz4-level")
+	v.RegisterAlias("compress_threshold", "compress-threshold")
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
 		return nil, err
 	}

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -76,29 +76,46 @@ const (
 )
 
 // selectAlgorithm chooses a compression algorithm and level based on the
-// requested strategy, chunk size, and CPU capabilities.
-func selectAlgorithm(chunkLen int, compress string, level int) (string, int) {
+// requested strategy, chunk size, and CPU capabilities. Separate level values
+// are accepted for LZ4 and Zstd to allow independent tuning via CLI flags.
+func selectAlgorithm(chunkLen int, compress string, lz4Level, zstdLevel int) (string, int) {
+	// Explicit selection uses the provided algorithm-specific level.
 	if compress != StrategyAuto {
-		return compress, level
+		switch compress {
+		case compressionLZ4:
+			if lz4Level == 0 {
+				lz4Level = int(lz4.Level1)
+			}
+			return compressionLZ4, lz4Level
+		case compressionZSTD:
+			if zstdLevel == 0 {
+				zstdLevel = defaultZstdLv
+			}
+			return compressionZSTD, zstdLevel
+		default:
+			return compress, lz4Level
+		}
 	}
+	// Automatic selection: small chunks favour LZ4.
 	if chunkLen < lz4MaxChunk {
-		if level == 0 {
-			level = int(lz4.Level1)
+		if lz4Level == 0 {
+			lz4Level = int(lz4.Level1)
 		}
-		return compressionLZ4, level
+		return compressionLZ4, lz4Level
 	}
+	// Larger chunks choose Zstd when SIMD support is available.
 	if hasAVX2() || hasNEON() {
-		if level <= 0 {
-			level = defaultZstdLv
-		} else if level > maxAutoZstdLv {
-			level = maxAutoZstdLv
+		if zstdLevel <= 0 {
+			zstdLevel = defaultZstdLv
+		} else if zstdLevel > maxAutoZstdLv {
+			zstdLevel = maxAutoZstdLv
 		}
-		return compressionZSTD, level
+		return compressionZSTD, zstdLevel
 	}
-	if level == 0 {
-		level = int(lz4.Level1)
+	if lz4Level == 0 {
+		lz4Level = int(lz4.Level1)
 	}
-	return compressionLZ4, level
+	return compressionLZ4, lz4Level
 }
 
 // estimateRatio compresses a sample of the data using the selected algorithm
@@ -128,12 +145,12 @@ func estimateRatio(data []byte, algo string, level, concurrency int) (float64, e
 // settings. Compression is skipped when the estimated ratio exceeds the
 // threshold. The returned string indicates the algorithm used; "none" means no
 // compression was applied. Decisions are logged using the provided logger.
-func CompressChunk(data []byte, compress string, level, concurrency int, threshold float64, logger *zap.Logger) ([]byte, string, error) {
+func CompressChunk(data []byte, compress string, lz4Level, zstdLevel, concurrency int, threshold float64, logger *zap.Logger) ([]byte, string, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	algo, lvl := selectAlgorithm(len(data), compress, level)
+	algo, lvl := selectAlgorithm(len(data), compress, lz4Level, zstdLevel)
 	if algo == "none" {
 		logger.Debug("compression_disabled")
 		return data, "none", nil

--- a/transfer/compression_selection_test.go
+++ b/transfer/compression_selection_test.go
@@ -1,9 +1,12 @@
 package transfer
 
 import (
+	"bytes"
+	"crypto/rand"
 	"testing"
 
 	"github.com/pierrec/lz4/v4"
+	"go.uber.org/zap"
 )
 
 func TestSelectAlgorithm(t *testing.T) {
@@ -11,13 +14,13 @@ func TestSelectAlgorithm(t *testing.T) {
 	defer func() { hasAVX2, hasNEON = origAVX2, origNEON }()
 
 	// Non-auto strategy uses provided values.
-	algo, lvl := selectAlgorithm(1024, "lz4", 3)
+	algo, lvl := selectAlgorithm(1024, "lz4", 3, 0)
 	if algo != "lz4" || lvl != 3 {
 		t.Fatalf("expected lz4 level 3, got %s level %d", algo, lvl)
 	}
 
 	// Small chunks use LZ4 with default level when level is zero.
-	algo, lvl = selectAlgorithm(128*1024, StrategyAuto, 0)
+	algo, lvl = selectAlgorithm(128*1024, StrategyAuto, 0, 0)
 	if algo != compressionLZ4 || lvl != int(lz4.Level1) {
 		t.Fatalf("expected lz4 level1, got %s level %d", algo, lvl)
 	}
@@ -25,7 +28,7 @@ func TestSelectAlgorithm(t *testing.T) {
 	// AVX2 enables Zstd with capped level.
 	hasAVX2 = func() bool { return true }
 	hasNEON = func() bool { return false }
-	algo, lvl = selectAlgorithm(512*1024, StrategyAuto, 5)
+	algo, lvl = selectAlgorithm(512*1024, StrategyAuto, 0, 5)
 	if algo != compressionZSTD || lvl != maxAutoZstdLv {
 		t.Fatalf("expected zstd level %d, got %s level %d", maxAutoZstdLv, algo, lvl)
 	}
@@ -33,7 +36,7 @@ func TestSelectAlgorithm(t *testing.T) {
 	// NEON also enables Zstd.
 	hasAVX2 = func() bool { return false }
 	hasNEON = func() bool { return true }
-	algo, lvl = selectAlgorithm(512*1024, StrategyAuto, 0)
+	algo, lvl = selectAlgorithm(512*1024, StrategyAuto, 0, 0)
 	if algo != compressionZSTD || lvl != defaultZstdLv {
 		t.Fatalf("expected zstd level %d via NEON, got %s level %d", defaultZstdLv, algo, lvl)
 	}
@@ -41,8 +44,44 @@ func TestSelectAlgorithm(t *testing.T) {
 	// Without SIMD features, fall back to LZ4.
 	hasAVX2 = func() bool { return false }
 	hasNEON = func() bool { return false }
-	algo, lvl = selectAlgorithm(512*1024, StrategyAuto, 0)
+	algo, lvl = selectAlgorithm(512*1024, StrategyAuto, 0, 0)
 	if algo != compressionLZ4 || lvl != int(lz4.Level1) {
 		t.Fatalf("expected lz4 level1 fallback, got %s level %d", algo, lvl)
+	}
+}
+
+func TestCompressChunkThreshold(t *testing.T) {
+	origAVX2, origNEON := hasAVX2, hasNEON
+	hasAVX2 = func() bool { return false }
+	hasNEON = func() bool { return false }
+	defer func() { hasAVX2, hasNEON = origAVX2, origNEON }()
+
+	// Highly compressible data should be compressed.
+	src := bytes.Repeat([]byte{0}, 64*1024)
+	out, algo, err := CompressChunk(src, StrategyAuto, 0, 0, 1, 0.8, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if algo == "none" {
+		t.Fatalf("expected compression, got none")
+	}
+	if len(out) >= len(src) {
+		t.Fatalf("expected compressed output smaller than input")
+	}
+
+	// Random data should skip compression when ratio exceeds threshold.
+	random := make([]byte, 64*1024)
+	if _, err := rand.Read(random); err != nil {
+		t.Fatalf("rand read failed: %v", err)
+	}
+	out, algo, err = CompressChunk(random, StrategyAuto, 0, 0, 1, 0.8, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if algo != "none" {
+		t.Fatalf("expected no compression, got %s", algo)
+	}
+	if !bytes.Equal(out, random) {
+		t.Fatalf("data should be unchanged when compression is skipped")
 	}
 }


### PR DESCRIPTION
## Summary
- detect AVX2/NEON and choose Zstd or LZ4 accordingly
- add compression level flags and threshold to skip low gain chunks
- document compression policy and new flags

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestH2TransportSelectBestHandshake)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a06065955483239591a2b54600db0f