### PR TITLE
feat(lvm): validate escalation command at startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ command-line use, environment variables, and `config.yaml` files.
 
 - `Detect` orchestrates `detectFileDevice`, `detectLVMDevice`, and `detectRawDevice`.
 - Each helper includes dedicated tests for success and error paths.
+- Non-root runs escalate LVM operations using `--lvm-escalation` (default `sudo -n`). The command is validated at startup and detection fails if escalation is unavailable.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,8 @@ snapshotted automatically and removed after transfer. Raw block devices and
 regular files do not have a snapshot mechanism; to avoid inconsistent reads you
 must either take them offline with `--offline` or freeze the filesystem with
 `--fs-freeze-command` and `--fs-thaw-command`. Snapshot creation requires root privileges, so non-root
-invocations must permit escalation via `sudo -n`.
+invocations must permit escalation via `sudo -n`. The escalation command is checked during device detection and
+operations abort immediately if escalation fails.
 
 Examples:
 
@@ -497,7 +498,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--skip_snapshot_creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
 | `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
-| `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands |
+| `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; validated at startup |
 | `--lvm_timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations |
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
 | `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
@@ -1058,7 +1059,7 @@ timeouts or cancellations are reported separately.
 | `--volume_group` | Source volume group. Derived from the source device path when empty | "" |
 | `--target_volume_group` | Volume group name of the target LVM volume | "" |
 | `--target_vgs` | Candidate target volume groups for auto-selection | [] |
-| `--lvm-escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n") | "sudo -n" |
+| `--lvm-escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n"); validated at startup | "sudo -n" |
 | `--lvm_timeout` | Timeout for LVM operations | 10s |
 
 #### gRPC Options

--- a/device/detect.go
+++ b/device/detect.go
@@ -30,6 +30,10 @@ func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
 
 // detectLVMDevice opens an LVM logical volume.
 func detectLVMDevice(path, lvmEscalation string, logger *zap.Logger) (Device, error) {
+	if err := lvm.VerifyEscalationCommand(lvmEscalation); err != nil {
+		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
+		return nil, err
+	}
 	cache := lvm.NewDeviceFDCache(logger)
 	defer cache.Close()
 	dev, err := openLVMFunc(path, cache, lvmEscalation, logger)

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -87,6 +87,24 @@ func TestDetectLVMDeviceError(t *testing.T) {
 	}
 }
 
+func TestDetectLVMDeviceEscalationError(t *testing.T) {
+	restore := lvm.SetEscalationChecker(func(string) error { return errors.New("escalate fail") })
+	defer restore()
+	orig := openLVMFunc
+	called := false
+	openLVMFunc = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+		called = true
+		return &LVMDevice{path: "/dev/test", logger: zap.NewNop()}, nil
+	}
+	defer func() { openLVMFunc = orig }()
+	if _, err := detectLVMDevice("/dev/test", "sudo -n", zap.NewNop()); err == nil {
+		t.Fatalf("expected error")
+	}
+	if called {
+		t.Fatalf("openLVMFunc should not be called on escalation failure")
+	}
+}
+
 func TestDetectRawDeviceSuccess(t *testing.T) {
 	orig := openRawFunc
 	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (*RawDevice, error) {

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -70,6 +70,9 @@ var (
 )
 
 func runLVM(ctx context.Context, escalation, cmdName string, args ...string) error {
+	if err := lvm.VerifyEscalationCommand(escalation); err != nil {
+		return err
+	}
 	if geteuid() != 0 {
 		parts := strings.Fields(escalation)
 		if len(parts) > 0 {

--- a/lvm/escalation.go
+++ b/lvm/escalation.go
@@ -1,0 +1,45 @@
+package lvm
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// execCommand is used for running external commands and can be overridden in tests.
+var execCommand = exec.Command
+
+// verifyEscalation checks that the escalation command succeeds when not running as root.
+func verifyEscalation(escalation string) error {
+	if os.Geteuid() == 0 {
+		return nil
+	}
+	parts := strings.Fields(escalation)
+	if len(parts) == 0 {
+		return fmt.Errorf("insufficient privileges: LVM operations require root privileges")
+	}
+	cmd := execCommand(parts[0], append(parts[1:], "true")...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("escalation command failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+var checkEscalation = verifyEscalation
+
+// VerifyEscalationCommand validates that the escalation command is available.
+func VerifyEscalationCommand(escalation string) error { return checkEscalation(escalation) }
+
+// SetEscalationChecker overrides the default escalation check function. It returns
+// a restore function to reset the original behavior.
+func SetEscalationChecker(fn func(string) error) func() {
+	orig := checkEscalation
+	if fn == nil {
+		checkEscalation = verifyEscalation
+	} else {
+		checkEscalation = fn
+	}
+	return func() { checkEscalation = orig }
+}


### PR DESCRIPTION
## Summary
- verify LVM escalation command before performing operations
- abort detection when escalation is unavailable
- document non-root escalation behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestDetectOptimalCompressionBenchmarkFallback, TestResumeModeTransitions, TestH2TransportSelectBestHandshake, TestQUICTransportSelectBestHandshake)*
- `go tool cover -func=coverage.out | tail -n 5`
- `golangci-lint run` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a067d833c88323a75fcd8857302647