### PR TITLE
feat(grpc): add client helpers and gRPC docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,16 @@ lvmsync --transport quic,h2,tcp+tls,ssh --tcp-port 9443
 BDP-based autotuning keeps roughly one to two times the bandwidth–delay product
 in flight. Override the autotuned value with `--concurrency`.
 
+## gRPC Daemon
+
+- `cmd/grpcd` exposes replication operations over gRPC.
+- TLS 1.3 with mutual authentication is required by default; `AllowInsecure`
+  is for development only.
+- Flags: `--grpc-port`, `--tls-cert`, `--tls-key`, `--ca-cert`, and
+  `--allow-insecure` (defaults to false).
+- Configuration sources: flags, `LVMSYNC_GRPC_*` environment variables, and a
+  `grpcd.yaml` file. Precedence is flag > env > config file.
+
 ## Throughput Mode
 
 The `throughput` preset favors maximal transfer rates:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ See [docs/transports.md](docs/transports.md) for details.
 | `tcp+tls` | TLS 1.3                | Plain TCP wrapped in TLS |
 | `ssh`     | Host key verification  | Uses OpenSSH-style authentication |
 
+## gRPC Control Plane
+
+LVMSync ships a gRPC daemon for remote control. The daemon listens on the port
+specified by `--grpc-port` (default `9443`) and requires TLS 1.3 with mutual
+authentication. Provide certificate files with `--tls-cert`, `--tls-key`, and
+`--ca-cert`. Insecure mode can be enabled with `--allow-insecure`, but it is
+disabled by default and should only be used for testing.
+
+Configuration can be supplied via flags, environment variables prefixed with
+`LVMSYNC_GRPC_`, or a `grpcd.yaml` file; flag values override environment
+variables, which override configuration files.
+
 ## Resume and Verify Workflows
 
 Resume interrupted transfers with a state file:

--- a/config/precedence_binding_test.go
+++ b/config/precedence_binding_test.go
@@ -645,6 +645,64 @@ func TestGRPCPortEnvOverridesConfig(t *testing.T) {
 	}
 }
 
+func TestTLSCertCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "tls_cert: cfg.pem\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--tls_cert", "cli.pem"})
+	t.Setenv("LVMSYNC_TLS_CERT", "env.pem")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.TLSCert != "cli.pem" {
+		t.Fatalf("expected tls_cert cli.pem, got %s", conf.TLSCert)
+	}
+}
+
+func TestTLSCertEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "tls_cert: cfg.pem\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_TLS_CERT", "env.pem")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.TLSCert != "env.pem" {
+		t.Fatalf("expected tls_cert env.pem, got %s", conf.TLSCert)
+	}
+}
+
 // CLI flag should win over LVMSYNC_MANIFEST_PATH and manifest_path in YAML.
 func TestManifestPathCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "manifest_path: cfg.manifest\n")

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -118,3 +118,27 @@ func AckStream(ctx context.Context, c proto.ReplicationClient, sessionID string)
 func SendFinalManifest(ctx context.Context, c proto.ReplicationClient, sessionID string, manifest []byte) (*proto.StatusResponse, error) {
 	return c.SendFinalManifest(ctx, &proto.ManifestMessage{SessionId: sessionID, Manifest: manifest})
 }
+
+func Probe(ctx context.Context, c proto.ReplicationClient, volume string) (*proto.StatusResponse, error) {
+	return c.Probe(ctx, &proto.ProbeRequest{VolumeName: volume})
+}
+
+func StartSync(ctx context.Context, c proto.ReplicationClient, volume, requester string) (*proto.StatusResponse, error) {
+	return c.StartSync(ctx, &proto.StartSyncRequest{VolumeName: volume, Requester: requester})
+}
+
+func Cancel(ctx context.Context, c proto.ReplicationClient, sessionID string) (*proto.StatusResponse, error) {
+	return c.Cancel(ctx, &proto.CancelRequest{SessionId: sessionID})
+}
+
+func Progress(ctx context.Context, c proto.ReplicationClient, sessionID string) (proto.Replication_ProgressStreamClient, error) {
+	return c.ProgressStream(ctx, &proto.ProgressRequest{SessionId: sessionID})
+}
+
+func BuildManifest(ctx context.Context, c proto.ReplicationClient, sessionID string) (*proto.StatusResponse, error) {
+	return c.BuildManifest(ctx, &proto.BuildManifestRequest{SessionId: sessionID})
+}
+
+func Verify(ctx context.Context, c proto.ReplicationClient, sessionID string) (*proto.StatusResponse, error) {
+	return c.Verify(ctx, &proto.VerifyRequest{SessionId: sessionID})
+}

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"io"
 	"math/big"
 	"net"
 	"os"
@@ -394,6 +395,214 @@ func TestAckStreamError(t *testing.T) {
 	c := fakeAckClient{}
 	if _, err := AckStream(context.Background(), c, "sess"); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+type fakeProbeClient struct {
+	stubClient
+	resp *proto.StatusResponse
+	err  error
+}
+
+func (f *fakeProbeClient) Probe(ctx context.Context, _ *proto.ProbeRequest, _ ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return f.resp, f.err
+}
+
+func TestProbe(t *testing.T) {
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{"success", &fakeProbeClient{resp: &proto.StatusResponse{Ok: true}}, false},
+		{"rpcError", &fakeProbeClient{err: errors.New("fail")}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Probe(context.Background(), tc.client, "vol")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type fakeStartSyncClient struct {
+	stubClient
+	resp *proto.StatusResponse
+	err  error
+}
+
+func (f *fakeStartSyncClient) StartSync(ctx context.Context, _ *proto.StartSyncRequest, _ ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return f.resp, f.err
+}
+
+func TestStartSync(t *testing.T) {
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{"success", &fakeStartSyncClient{resp: &proto.StatusResponse{Ok: true}}, false},
+		{"rpcError", &fakeStartSyncClient{err: errors.New("fail")}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := StartSync(context.Background(), tc.client, "vol", "req")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type fakeCancelClient struct {
+	stubClient
+	resp *proto.StatusResponse
+	err  error
+}
+
+func (f *fakeCancelClient) Cancel(ctx context.Context, _ *proto.CancelRequest, _ ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return f.resp, f.err
+}
+
+func TestCancel(t *testing.T) {
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{"success", &fakeCancelClient{resp: &proto.StatusResponse{Ok: true}}, false},
+		{"rpcError", &fakeCancelClient{err: errors.New("fail")}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Cancel(context.Background(), tc.client, "sess")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type fakeProgressClient struct {
+	stubClient
+	stream proto.Replication_ProgressStreamClient
+	err    error
+}
+
+func (f *fakeProgressClient) ProgressStream(ctx context.Context, _ *proto.ProgressRequest, _ ...grpc.CallOption) (proto.Replication_ProgressStreamClient, error) {
+	return f.stream, f.err
+}
+
+type fakeProgressStream struct{ grpc.ClientStream }
+
+func (fakeProgressStream) Recv() (*proto.Progress, error) { return nil, io.EOF }
+
+func TestProgress(t *testing.T) {
+	ps := &fakeProgressStream{}
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{"success", &fakeProgressClient{stream: ps}, false},
+		{"rpcError", &fakeProgressClient{err: errors.New("fail")}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stream, err := Progress(context.Background(), tc.client, "sess")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if stream != ps {
+				t.Fatalf("unexpected stream")
+			}
+		})
+	}
+}
+
+type fakeBuildManifestClient struct {
+	stubClient
+	resp *proto.StatusResponse
+	err  error
+}
+
+func (f *fakeBuildManifestClient) BuildManifest(ctx context.Context, _ *proto.BuildManifestRequest, _ ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return f.resp, f.err
+}
+
+func TestBuildManifest(t *testing.T) {
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{"success", &fakeBuildManifestClient{resp: &proto.StatusResponse{Ok: true}}, false},
+		{"rpcError", &fakeBuildManifestClient{err: errors.New("fail")}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildManifest(context.Background(), tc.client, "sess")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type fakeVerifyClient struct {
+	stubClient
+	resp *proto.StatusResponse
+	err  error
+}
+
+func (f *fakeVerifyClient) Verify(ctx context.Context, _ *proto.VerifyRequest, _ ...grpc.CallOption) (*proto.StatusResponse, error) {
+	return f.resp, f.err
+}
+
+func TestVerify(t *testing.T) {
+	cases := []struct {
+		name    string
+		client  proto.ReplicationClient
+		wantErr bool
+	}{
+		{"success", &fakeVerifyClient{resp: &proto.StatusResponse{Ok: true}}, false},
+		{"rpcError", &fakeVerifyClient{err: errors.New("fail")}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Verify(context.Background(), tc.client, "sess")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add client helpers for probe, sync lifecycle and manifest RPCs
- document gRPC daemon security defaults and configuration precedence
- test TLS cert precedence and client helper success/error paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestResumeModeTransitions, TestH2TransportSelectBestHandshake, TestQUICTransportSelectBestHandshake, TestSSHTransportSelectBestHandshake, TestTCPTLSTransportSelectBestHandshake)*
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a067e0aa908323b674194550534837