### PR TITLE
feat(config): add flag group env bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,14 @@ Environment variables for the gRPC daemon use the `LVMSYNC_GRPC_` prefix with da
 LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 ```
 
+Grouped options use dedicated prefixes: `LVMSYNC_DEDUP_`,
+`LVMSYNC_COMPRESSION_`, `LVMSYNC_TRANSPORT_`, `LVMSYNC_LVM_`, and
+`LVMSYNC_GRPC_`. For example:
+
+```sh
+LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
+```
+
 ### Option reference
 
 | Flag | Environment variable | Config key | Description |
@@ -515,7 +523,7 @@ LVMSYNC_GRPC_GRPC_PORT=9443 LVMSYNC_GRPC_TLS_CERT=cert.pem lvmsync-grpcd
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
 | `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
 | `--target_vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
-| `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Print actions without executing |
+| `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Log estimated transfer bytes without sending data; uses manifest sampling when available |
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | `transport` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) |
 | `--tcp_port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |
 | `--tcp_parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | `tcp_parallel` | Number of parallel TCP connections |

--- a/config/config_yaml_test.go
+++ b/config/config_yaml_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"os"
 	"os/exec"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestConfigYAMLLint(t *testing.T) {
@@ -15,5 +18,22 @@ func TestConfigYAMLLint(t *testing.T) {
 		t.Fatalf("yamllint reported issues: %v\nOutput: %s", err, output)
 	} else if len(output) > 0 {
 		t.Fatalf("yamllint produced warnings:\n%s", output)
+	}
+}
+
+func TestConfigYAMLContainsGroups(t *testing.T) {
+	data, err := os.ReadFile("../config.yaml")
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	keys := []string{"dedup_strategy", "compress", "transport", "lvm_escalation", "grpc_port"}
+	for _, k := range keys {
+		if _, ok := cfg[k]; !ok {
+			t.Fatalf("missing %s key", k)
+		}
 	}
 }

--- a/config/flagsets.go
+++ b/config/flagsets.go
@@ -247,3 +247,45 @@ func bindCompressionEnv(fs *pflag.FlagSet, v *viper.Viper) error {
 	})
 	return err
 }
+
+// bindLVMEnv binds LVM flag names to environment variables with the
+// LVMSYNC_LVM_ prefix.
+func bindLVMEnv(fs *pflag.FlagSet, v *viper.Viper) error {
+	var err error
+	fs.VisitAll(func(f *pflag.Flag) {
+		if err != nil {
+			return
+		}
+		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+		name = strings.TrimPrefix(name, "LVM_")
+		env := "LVMSYNC_LVM"
+		if name != "" {
+			env += "_" + name
+		}
+		if e := v.BindEnv(f.Name, env); e != nil {
+			err = e
+		}
+	})
+	return err
+}
+
+// bindGRPCEnv binds gRPC flag names to environment variables with the
+// LVMSYNC_GRPC_ prefix.
+func bindGRPCEnv(fs *pflag.FlagSet, v *viper.Viper) error {
+	var err error
+	fs.VisitAll(func(f *pflag.Flag) {
+		if err != nil {
+			return
+		}
+		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+		name = strings.TrimPrefix(name, "GRPC_")
+		env := "LVMSYNC_GRPC"
+		if name != "" {
+			env += "_" + name
+		}
+		if e := v.BindEnv(f.Name, env); e != nil {
+			err = e
+		}
+	})
+	return err
+}

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func TestInitGeneralFlags(t *testing.T) {
@@ -255,5 +257,45 @@ func TestInitTransportFlags(t *testing.T) {
 		if f.DefValue != tt.want {
 			t.Fatalf("%s default %s want %s", tt.name, f.DefValue, tt.want)
 		}
+	}
+}
+
+func TestBindLVMEnv(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := initLVMFlags(cfg)
+	v := viper.New()
+	if err := bindLVMEnv(fs, v); err != nil {
+		t.Fatalf("bindLVMEnv: %v", err)
+	}
+	t.Setenv("LVMSYNC_LVM_SNAPSHOT_SIZE", "10%")
+	t.Setenv("LVMSYNC_LVM_ESCALATION", "doas")
+	if got := v.GetString("snapshot_size"); got != "10%" {
+		t.Fatalf("snapshot_size got %q want %q", got, "10%")
+	}
+	if got := v.GetString("lvm-escalation"); got != "doas" {
+		t.Fatalf("lvm-escalation got %q want %q", got, "doas")
+	}
+}
+
+func TestBindGRPCEnv(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := initGRPCFlags(cfg)
+	v := viper.New()
+	if err := bindGRPCEnv(fs, v); err != nil {
+		t.Fatalf("bindGRPCEnv: %v", err)
+	}
+	t.Setenv("LVMSYNC_GRPC_PORT", "9443")
+	t.Setenv("LVMSYNC_GRPC_TLS_CERT", "cert.pem")
+	if got := v.GetInt("grpc_port"); got != 9443 {
+		t.Fatalf("grpc_port got %d want %d", got, 9443)
+	}
+	if got := v.GetString("tls_cert"); got != "cert.pem" {
+		t.Fatalf("tls_cert got %q want %q", got, "cert.pem")
 	}
 }

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -313,6 +313,7 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 	v.RegisterAlias("zstd_level", "zstd-level")
 	v.RegisterAlias("lz4_level", "lz4-level")
 	v.RegisterAlias("compress_threshold", "compress-threshold")
+	v.RegisterAlias("lvm_escalation", "lvm-escalation")
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
 		return nil, err
 	}
@@ -320,6 +321,12 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 		return nil, err
 	}
 	if err := bindCompressionEnv(flagSets.Compression, v); err != nil {
+		return nil, err
+	}
+	if err := bindLVMEnv(flagSets.LVM, v); err != nil {
+		return nil, err
+	}
+	if err := bindGRPCEnv(flagSets.GRPC, v); err != nil {
 		return nil, err
 	}
 	if cfgFile := v.GetString("config"); cfgFile != "" {

--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -1,28 +1,28 @@
 // Package escalate implements a minimal, audited pattern to:
-//  1) Detect whether the process is already privileged (EUID==0).
-//  2) If not, re-exec itself via `sudo -n` with a tight argument allowlist
+//  1. Detect whether the process is already privileged (EUID==0).
+//  2. If not, re-exec itself via `sudo -n` with a tight argument allowlist
 //     and a hardened environment.
-//  3) Optionally drop back to the invoking user (SUDO_UID/GID) after doing
+//  3. Optionally drop back to the invoking user (SUDO_UID/GID) after doing
 //     the privileged section.
 //
 // Design goals:
-//  - Efficiency & correctness: zero reflection, zero global env mutation,
-//    no deprecated packages (uses x/sys/unix), strict allowlist behavior.
-//  - Testability: all external effects (geteuid, lookpath, exec) are overridable
-//    via Options; syscalls for dropping privileges are abstracted behind a tiny
-//    interface and are mocked in tests.
-//  - Maintainability: tiny API surface, clean separation between pure helpers
-//    and effectful code paths.
+//   - Efficiency & correctness: zero reflection, zero global env mutation,
+//     no deprecated packages (uses x/sys/unix), strict allowlist behavior.
+//   - Testability: all external effects (geteuid, lookpath, exec) are overridable
+//     via Options; syscalls for dropping privileges are abstracted behind a tiny
+//     interface and are mocked in tests.
+//   - Maintainability: tiny API surface, clean separation between pure helpers
+//     and effectful code paths.
 //
 // Typical usage:
 //
-//   reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{})
-//   if err != nil { log.Fatal(err) }
-//   if reexeced { return } // parent should exit after delegating to sudo
+//	reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{})
+//	if err != nil { log.Fatal(err) }
+//	if reexeced { return } // parent should exit after delegating to sudo
 //
-//   // ... privileged work ...
-//   if err := escalate.DropToInvokerIfSudo(); err != nil { log.Fatal(err) }
-//   // ... continue unprivileged work ...
+//	// ... privileged work ...
+//	if err := escalate.DropToInvokerIfSudo(); err != nil { log.Fatal(err) }
+//	// ... continue unprivileged work ...
 package escalate
 
 import (
@@ -48,11 +48,11 @@ type Options struct {
 	SanitizeEnv bool
 
 	// Dependency seams (optional; default to real OS functions):
-	Args       []string                                        // defaults to os.Args
-	Environ    func() []string                                 // defaults to os.Environ
-	Geteuid    func() int                                      // defaults to os.Geteuid
-	LookPath   func(file string) (string, error)               // defaults to exec.LookPath
-	ExecRunner func(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
+	Args       []string                          // defaults to os.Args
+	Environ    func() []string                   // defaults to os.Environ
+	Geteuid    func() int                        // defaults to os.Geteuid
+	LookPath   func(file string) (string, error) // defaults to exec.LookPath
+	ExecRunner func(name string, args, env []string, stdin io.Reader, stdout, stderr io.Writer) error
 	Stdin      io.Reader // defaults to nil (no prompting)
 	Stdout     io.Writer // defaults to os.Stdout
 	Stderr     io.Writer // defaults to os.Stderr
@@ -241,13 +241,13 @@ type syscallFacade interface {
 
 type unixFacade struct{}
 
-func (unixFacade) Setgroups(gids []int) error      { return unix.Setgroups(gids) }
-func (unixFacade) Setresgid(r, e, s int) error     { return unix.Setresgid(r, e, s) }
-func (unixFacade) Setresuid(r, e, s int) error     { return unix.Setresuid(r, e, s) }
+func (unixFacade) Setgroups(gids []int) error  { return unix.Setgroups(gids) }
+func (unixFacade) Setresgid(r, e, s int) error { return unix.Setresgid(r, e, s) }
+func (unixFacade) Setresuid(r, e, s int) error { return unix.Setresuid(r, e, s) }
 
 var sys syscallFacade = unixFacade{}
 
-func defaultExecRunner(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+func defaultExecRunner(name string, args, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	cmd := exec.Command(name, args...)
 	if env != nil {
 		cmd.Env = env

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -54,7 +54,7 @@ func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrate
 		verify:   verify,
 		checksum: checksum,
 		logger:   logger,
-		}, nil
+	}, nil
 }
 
 // write consumes block records from reader and writes them to the destination


### PR DESCRIPTION
## Summary
- add LVMSYNC_LVM_* and LVMSYNC_GRPC_* environment bindings
- document group prefixes and dry-run estimation
- cover YAML and env bindings in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestResumeModeTransitions, TestH2TransportSelectBestHandshake)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(warnings: Can't process result by diff processor: can't read from patch file path/to/patch/file: open path/to/patch/file: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a073bf4c648323a497c0c1cfcda227