### PR TITLE
feat(transfer): validate destination before apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ transfer. See [docs/manifest.md](docs/manifest.md) for manifest and verification
   manifests consistent.
 - Network transports default to TLS 1.3; `--allow-insecure` should only be used
   for testing.
+- Apply refuses to write when the destination's identity or size differs from the
+  manifest or when the device is mounted read-write; use `--force` to override the
+  mount check.
 
 ## Supported Platforms
 

--- a/device/info.go
+++ b/device/info.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/moby/sys/mountinfo"
+	"go.uber.org/zap"
 )
 
 const uuidTimeout = 5 * time.Second
@@ -132,4 +133,18 @@ func defaultMountFunc(path string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// SizeBytes returns the total size of the device at path in bytes.
+// If ctx has no deadline, a default timeout is applied.
+func SizeBytes(ctx context.Context, path string) (uint64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	dev, err := Detect(ctx, path, true, "", "", "", "", 0, 0, zap.NewNop())
+	if err != nil {
+		return 0, err
+	}
+	defer dev.Close()
+	return dev.SizeBytes(), nil
 }

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -97,3 +97,32 @@ func TestSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("commands = %v, want %v", cmds, want)
 	}
 }
+
+func TestSnapshotLVCreateFailure(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("root required")
+	}
+	ctx := context.Background()
+	var cmds []string
+	origCmd := execCommand
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmds = append(cmds, name+" "+strings.Join(args, " "))
+		if strings.Contains(strings.Join(args, " "), "lvcreate") {
+			return exec.CommandContext(ctx, "false")
+		}
+		return exec.CommandContext(ctx, "true")
+	}
+	defer func() { execCommand = origCmd }()
+
+	origEuid := geteuid
+	geteuid = func() int { return 1 }
+	defer func() { geteuid = origEuid }()
+
+	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop()}
+	if _, err := lvd.Snapshot(ctx, "1G"); err == nil {
+		t.Fatalf("expected error from lvcreate failure")
+	}
+	if len(cmds) != 1 || !strings.Contains(cmds[0], "lvcreate") {
+		t.Fatalf("unexpected commands: %v", cmds)
+	}
+}

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -12,10 +11,10 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/config"
-	"lvmsync_go/device"
 )
 
 func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
+	defer func() { _ = t.Logger.Sync() }()
 	bufReader := bufio.NewReader(in)
 	var hs common.Handshake
 	hs, err = readAndValidateHandshake(cfg, bufReader, dedup, verify)
@@ -35,21 +34,8 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 
 	reader := bufio.NewReader(decReader)
 
-	if cfg.DeviceUUID != "" {
-		uuid, err2 := device.GetDeviceID(context.Background(), destPath)
-		if err2 != nil {
-			return fmt.Errorf("read destination uuid: %w", err2)
-		}
-		if uuid != cfg.DeviceUUID {
-			return fmt.Errorf("destination device uuid %s does not match expected %s", uuid, cfg.DeviceUUID)
-		}
-	}
-	mounted, err2 := device.IsMountedRW(destPath)
-	if err2 != nil {
-		return fmt.Errorf("check mount status: %w", err2)
-	}
-	if mounted && !cfg.Force {
-		return fmt.Errorf("destination device %s is mounted read-write", destPath)
+	if err := t.verifyDestination(cfg, destPath); err != nil {
+		return err
 	}
 
 	var destFile *os.File
@@ -83,12 +69,12 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 		return err
 	}
 
-	elapsed := time.Since(startTime).Seconds()
+	elapsed := time.Since(startTime)
 	if t.Logger != nil {
-		t.Logger.Info("Applied changes",
-			zap.Int64("bytes", totalBytes),
-			zap.Float64("seconds", elapsed),
-			zap.Float64("MB/s", float64(totalBytes)/elapsed/1048576.0))
+		t.Logger.Info("applied_changes",
+			zap.Int64("size_bytes", totalBytes),
+			zap.Int64("duration_ms", elapsed.Milliseconds()),
+			zap.Float64("mb_per_s", float64(totalBytes)/elapsed.Seconds()/1048576.0))
 	}
 	return nil
 }

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,4 +65,57 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 	if skipped != 2 {
 		t.Fatalf("expected 2 skipped blocks, got %d", skipped)
 	}
+}
+
+func TestProcessDumpDataRejectsManifestMismatch(t *testing.T) {
+	dir := t.TempDir()
+	src, err := os.CreateTemp(dir, "src-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	data := make([]byte, 8192)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := src.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	src.Close()
+	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
+	defer device.SetUUIDFunc(prevUUID)
+	manPath := filepath.Join(dir, "src.man")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manifestpkg.Rebuild(ctx, src.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	tr := NewTransfer(zap.NewNop(), nil)
+	cfg := &config.Config{BlockSize: 4096, ManifestPath: manPath, MaxRetries: 1, Compress: "none"}
+
+	t.Run("id mismatch", func(t *testing.T) {
+		dest := filepath.Join(dir, "dest-id")
+		if err := os.WriteFile(dest, make([]byte, 8192), 0o600); err != nil {
+			t.Fatalf("write dest: %v", err)
+		}
+		prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "wrong", nil })
+		defer device.SetUUIDFunc(prev)
+		err := tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+		if err == nil || !strings.Contains(err.Error(), "does not match manifest") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("size mismatch", func(t *testing.T) {
+		dest := filepath.Join(dir, "dest-size")
+		if err := os.WriteFile(dest, make([]byte, 4096), 0o600); err != nil {
+			t.Fatalf("write dest: %v", err)
+		}
+		prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
+		defer device.SetUUIDFunc(prev)
+		err := tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+		if err == nil || !strings.Contains(err.Error(), "size") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -1,17 +1,24 @@
 package transfer
 
 import (
+	"bytes"
+	"context"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
 	"lvmsync_go/common"
 	"lvmsync_go/config"
+	"lvmsync_go/device"
+	manifestpkg "lvmsync_go/manifest"
 )
 
 // Transfer encapsulates transfer state shared across operations.
@@ -174,4 +181,85 @@ func (t *Transfer) DumpChanges(cfg *config.Config, snapshot, source string, out 
 	}
 	t.Logger.Info("Deduplication disabled, performing full block transfer")
 	return t.DumpChangesSequential(cfg, snapshot, source, out)
+}
+
+const manifestHeaderSize = 136
+
+func manifestHeaderMAC(h *manifestpkg.Header) [32]byte {
+	var buf [manifestHeaderSize - 32]byte
+	binary.LittleEndian.PutUint32(buf[0:4], h.Version)
+	binary.LittleEndian.PutUint32(buf[4:8], h.BlockSize)
+	binary.LittleEndian.PutUint64(buf[8:16], h.SizeBytes)
+	binary.LittleEndian.PutUint64(buf[16:24], h.ChunkCount)
+	binary.LittleEndian.PutUint32(buf[24:28], h.MinChunkSize)
+	binary.LittleEndian.PutUint32(buf[28:32], h.AvgChunkSize)
+	binary.LittleEndian.PutUint32(buf[32:36], h.MaxChunkSize)
+	binary.LittleEndian.PutUint32(buf[36:40], h.HybridFixedSize)
+	copy(buf[40:], h.DeviceID[:])
+	return blake3.Sum256(buf[:])
+}
+
+func readManifestHeader(path string) (*manifestpkg.Header, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var hdr manifestpkg.Header
+	if err := binary.Read(f, binary.LittleEndian, &hdr); err != nil {
+		return nil, fmt.Errorf("read manifest header: %w", err)
+	}
+	if mac := manifestHeaderMAC(&hdr); !bytes.Equal(mac[:], hdr.MAC[:]) {
+		return nil, fmt.Errorf("manifest: header MAC mismatch")
+	}
+	if hdr.Version != manifestpkg.Version {
+		return nil, fmt.Errorf("manifest: version mismatch")
+	}
+	return &hdr, nil
+}
+
+func (t *Transfer) verifyDestination(cfg *config.Config, destPath string) error {
+	if cfg.ManifestPath != "" {
+		hdr, err := readManifestHeader(cfg.ManifestPath)
+		if err != nil {
+			return err
+		}
+		id, err := device.GetDeviceID(context.Background(), destPath)
+		if err != nil {
+			return fmt.Errorf("read destination id: %w", err)
+		}
+		manID := strings.TrimRight(string(hdr.DeviceID[:]), "\x00")
+		if id != manID {
+			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", manID), zap.String("resource_id", id))
+			return fmt.Errorf("destination device id %s does not match manifest %s", id, manID)
+		}
+		size, err := device.SizeBytes(context.Background(), destPath)
+		if err != nil {
+			return fmt.Errorf("read destination size: %w", err)
+		}
+		if size != hdr.SizeBytes {
+			t.Logger.Error("device_size_mismatch", zap.Uint64("expected_size_bytes", hdr.SizeBytes), zap.Uint64("size_bytes", size))
+			return fmt.Errorf("destination device size %d does not match manifest %d", size, hdr.SizeBytes)
+		}
+		t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
+	} else if cfg.DeviceUUID != "" {
+		id, err := device.GetDeviceID(context.Background(), destPath)
+		if err != nil {
+			return fmt.Errorf("read destination uuid: %w", err)
+		}
+		if id != cfg.DeviceUUID {
+			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", cfg.DeviceUUID), zap.String("resource_id", id))
+			return fmt.Errorf("destination device uuid %s does not match expected %s", id, cfg.DeviceUUID)
+		}
+		t.Logger.Info("destination_validated", zap.String("resource_id", id))
+	}
+	mounted, err := device.IsMountedRW(destPath)
+	if err != nil {
+		return fmt.Errorf("check mount status: %w", err)
+	}
+	if mounted && !cfg.Force {
+		t.Logger.Error("destination_mounted_rw", zap.String("path", destPath))
+		return fmt.Errorf("destination device %s is mounted read-write", destPath)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- verify destination device ID and size against manifest before applying writes
- refuse writes to mounted devices unless `--force`
- add integration tests for manifest and snapshot error paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: no common compression algorithm; TestResumeModeTransitions; handshake failures in transport tests)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a073ce3de083239a9384ffaf41a6f5