### PR TITLE
docs: expand manifest lifecycle and transport docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,3 +348,16 @@ golangci-lint run
 - [ ] Provide `FlagSet`-grouped CLI options bound to Viper, with parity across flags, environment variables, and config files.
 - [ ] Ensure each new function includes unit tests and documentation updates in README.md.
 - [ ] Maintain modular, single-responsibility design to ease future maintenance.
+
+## TODO
+
+### Coding Conventions for New Packages
+- [ ] Document file layout, naming, and single-purpose design for new packages.
+
+### Testing Expectations
+- [ ] Include unit tests for success and failure paths.
+- [ ] Run `go build ./...`, `go test -coverprofile=coverage.out ./...`, and `golangci-lint run` before submitting patches.
+
+### Logging Rules
+- [ ] Use zap for structured logging with snake_case fields.
+- [ ] Call `logger.Sync()` on shutdown and avoid `fmt.Print*` for progress output.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,50 @@ See [docs/transports.md](docs/transports.md) for details.
 | `tcp+tls` | TLS 1.3                | Plain TCP wrapped in TLS |
 | `ssh`     | Host key verification  | Uses OpenSSH-style authentication |
 
+### Examples
+
+Select multiple transports and a custom port:
+
+```sh
+lvmsync run --transport quic,h2,tcp+tls,ssh --tcp-port 9443 /dev/vg0/source /dev/vg0/backup
+```
+
+Force SSH only:
+
+```sh
+lvmsync run --transport ssh user@backup:/dev/vg1/target /dev/vg0/source
+```
+
+The CLI groups transport flags using [`pflag`](https://github.com/spf13/pflag) and binds them to [`viper`](https://github.com/spf13/viper) while emitting structured logs via [`zap`](https://github.com/uber-go/zap):
+
+```go
+import (
+    "github.com/spf13/pflag"
+    "github.com/spf13/viper"
+    "go.uber.org/zap"
+)
+
+func main() {
+    logger, _ := zap.NewProduction()
+    defer logger.Sync()
+
+    transport := pflag.NewFlagSet("transport", pflag.ExitOnError)
+    transport.String("transport", "quic,h2,tcp+tls,ssh", "ordered transports")
+    transport.Int("tcp-port", 9443, "TCP listener port")
+
+    v := viper.New()
+    v.BindPFlags(transport)
+}
+```
+
+## Manifest Lifecycle
+
+Transfers rely on a manifest that tracks chunk offsets and digests:
+
+1. `lvmsync manifest rebuild <device>` refreshes or creates the manifest.
+2. `lvmsync run <source> <destination>` streams blocks, skipping chunks already recorded in the manifest.
+3. `lvmsync verify <source> <destination>` compares the destination with the manifest and logs any mismatches.
+
 ## gRPC Control Plane
 
 LVMSync ships a gRPC daemon for remote control. The daemon listens on the port
@@ -100,14 +144,10 @@ transfer. See [docs/manifest.md](docs/manifest.md) for manifest and verification
 ## Safety Notes
 
 - Run `manifest rebuild` and `verify` against quiescent devices.
-- Use `--offline` or freeze/thaw hooks when scanning live filesystems to keep
-  manifests consistent.
-- Network transports default to TLS 1.3; `--allow-insecure` should only be used
-  for testing.
-- Apply refuses to write when the destination's identity or size differs from the
-  manifest or when the device is mounted read-write; use `--force` to override the
-  mount check.
-
+- Use `--offline` or freeze/thaw hooks when scanning live filesystems to keep manifests consistent.
+- Network transports default to TLS 1.3; `--allow-insecure` should only be used for testing.
+- Apply refuses to write when the destination's identity or size differs from the manifest or when the device is mounted read-write; use `--force` to override the mount check.
+- Back up destination data before running apply; writes are destructive.
 ## Supported Platforms
 
 LVMSync targets Linux systems only. Builds are tested on the `amd64` and `arm64` architectures.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -19,6 +19,29 @@ copies can be verified.
 - `lvmsync verify <source> <dest>` compares a destination against the manifest
   for the source. Override the manifest path with `--manifest_path` if needed.
 
+Manifest commands group flags with pflag and bind them to Viper while logging progress with zap.
+
+## Flag Group Example
+
+```go
+import (
+    "github.com/spf13/pflag"
+    "github.com/spf13/viper"
+    "go.uber.org/zap"
+)
+
+func initFlags() {
+    logger, _ := zap.NewProduction()
+    defer logger.Sync()
+
+    fs := pflag.NewFlagSet("manifest", pflag.ExitOnError)
+    fs.String("manifest-path", "", "path to manifest file")
+
+    v := viper.New()
+    v.BindPFlags(fs)
+}
+```
+
 Chunk offsets are determined using FastCDC. The gear table now uses the
 standard 256-entry random values from the FastCDC specification, replacing the
 placeholder table previously used.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -14,6 +14,31 @@ mode (`dedup:<mode>`), content-defined chunking ranges (`cdcmin:<n>`
 also carries a resume token (`resume:<token>`) so interrupted sessions can
 continue and a maximum in-flight hint (`inflight:<n>`) to negotiate concurrency.
 
+
+Transport configuration groups flags with pflag, binds them to Viper, and logs connection events with zap.
+
+## Flag Group Example
+
+```go
+import (
+    "github.com/spf13/pflag"
+    "github.com/spf13/viper"
+    "go.uber.org/zap"
+)
+
+func initTransports() {
+    logger, _ := zap.NewProduction()
+    defer logger.Sync()
+
+    fs := pflag.NewFlagSet("transport", pflag.ExitOnError)
+    fs.String("transport", "quic,h2,tcp+tls,ssh", "ordered transports")
+    fs.Int("tcp-port", 9443, "TCP listener port")
+
+    v := viper.New()
+    v.BindPFlags(fs)
+}
+```
+
 ## Security Defaults
 
 Handshake validation rejects mismatched ALPN protocols or TLS versions to ensure


### PR DESCRIPTION
## Summary
- add transport flag examples and manifest lifecycle to README
- document manifest and transport flag groups with zap logging
- note coding, testing, and logging conventions in AGENTS TODOs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: client negotiate: read handshake: EOF; test timed out: TestConnDatagramReadDeadline)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_68a07d3a773c8323b36217f678537cbe