### PR TITLE
Require absolute paths for freeze/thaw commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Override automatic detection with `--source-type` and `--dest-type` when a devic
 ### Offline requirements
 
 Raw sources must be quiescent or provide filesystem freeze/thaw hooks using
-`--fs-freeze-command` and `--fs-thaw-command`. LVM snapshots are consistent by
-design, while regular files require no additional coordination.
+`--fs-freeze-command` and `--fs-thaw-command`. These command paths must be
+absolute. LVM snapshots are consistent by design, while regular files require
+no additional coordination.
 
 ## Transport Options
 
@@ -433,7 +434,7 @@ Examples:
 lvmsync --source-type lvm /dev/vg0/origin /tmp/dump
 lvmsync --dest-type raw dumpfile /dev/sdb
 lvmsync --source-type raw --offline /dev/sdb /tmp/dump
-lvmsync --source-type raw --fs-freeze-command "fsfreeze -f '/mnt/data dir'" --fs-thaw-command "fsfreeze -u '/mnt/data dir'" /dev/sdb /tmp/dump
+lvmsync --source-type raw --fs-freeze-command "/usr/sbin/fsfreeze -f '/mnt/data dir'" --fs-thaw-command "/usr/sbin/fsfreeze -u '/mnt/data dir'" /dev/sdb /tmp/dump
 ```
 
 ### Raw device safety
@@ -441,17 +442,17 @@ lvmsync --source-type raw --fs-freeze-command "fsfreeze -f '/mnt/data dir'" --fs
 Reading from a live block device can corrupt data if writes occur during the transfer. Ensure a consistent view with one of the following options:
 
 - `--offline` – assert that no process will write to the source device.
-- `--fs-freeze-command`/`--fs-thaw-command` – run commands that freeze and thaw the filesystem around the read. Arguments are parsed with shell-style quoting, so wrap paths containing spaces in quotes.
+- `--fs-freeze-command`/`--fs-thaw-command` – run commands that freeze and thaw the filesystem around the read. Command paths must be absolute. Arguments are parsed with shell-style quoting, so wrap paths containing spaces in quotes.
 - Time out freeze and thaw helpers with `--freeze-timeout` and `--thaw-timeout` (default `10s`).
 
-Freeze and thaw commands are validated before execution. The command name must match `^[a-zA-Z0-9._-]+$`, be set, free of NUL bytes, every argument must avoid NULs, and the executable must be discoverable in `$PATH`; otherwise lvmsync returns an error.
+Freeze and thaw commands are validated before execution. Paths must be absolute, command names must match `^[a-zA-Z0-9._-]+$`, be set, free of NUL bytes, every argument must avoid NULs, and the executable must exist; otherwise lvmsync returns an error.
 
 Example using the provided scripts:
 
 ```sh
 lvmsync --source-type raw \
-  --fs-freeze-command "fsfreeze-freeze.sh /mnt" \
-  --fs-thaw-command "fsfreeze-thaw.sh /mnt" \
+  --fs-freeze-command "$(pwd)/docs/fsfreeze-freeze.sh /mnt" \
+  --fs-thaw-command "$(pwd)/docs/fsfreeze-thaw.sh /mnt" \
   /dev/sdb /tmp/dump
 ```
 
@@ -508,8 +509,8 @@ LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
 | `--source-type` | `LVMSYNC_SOURCE_TYPE` | `source-type` | Source device type: `auto`, `file`, `raw`, or `lvm` |
 | `--dest-type` | `LVMSYNC_DEST_TYPE` | `dest-type` | Destination device type: `auto`, `file`, `raw`, or `lvm` |
 | `--offline` | `LVMSYNC_OFFLINE` | `offline` | Assume source raw device is offline |
-| `--fs-freeze-command` | `LVMSYNC_FS_FREEZE_COMMAND` | `fs-freeze-command` | Command to freeze filesystem before reading raw source; arguments are split with shell-style quoting and executable name must match `^[a-zA-Z0-9._-]+$` |
-| `--fs-thaw-command` | `LVMSYNC_FS_THAW_COMMAND` | `fs-thaw-command` | Command to thaw filesystem after reading raw source; arguments are split with shell-style quoting and executable name must match `^[a-zA-Z0-9._-]+$` |
+| `--fs-freeze-command` | `LVMSYNC_FS_FREEZE_COMMAND` | `fs-freeze-command` | Command to freeze filesystem before reading raw source; path must be absolute, arguments are split with shell-style quoting and executable name must match `^[a-zA-Z0-9._-]+$` |
+| `--fs-thaw-command` | `LVMSYNC_FS_THAW_COMMAND` | `fs-thaw-command` | Command to thaw filesystem after reading raw source; path must be absolute, arguments are split with shell-style quoting and executable name must match `^[a-zA-Z0-9._-]+$` |
 | `--freeze-timeout` | `LVMSYNC_FREEZE_TIMEOUT` | `freeze_timeout` | Timeout for filesystem freeze command |
 | `--thaw-timeout` | `LVMSYNC_THAW_TIMEOUT` | `thaw_timeout` | Timeout for filesystem thaw command |
 | `--mode` | `LVMSYNC_MODE` | `mode` | Configuration preset: `default` or `throughput`; unknown modes fail validation |
@@ -1039,8 +1040,8 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
 | `--dry-run`         | Print actions without executing | `false`   |
 | `--offline`         | Assume source raw device is offline | `false`   |
-| `--fs-freeze-command` | Command to freeze filesystem before reading raw source; arguments use shell-style quoting | `""` |
-| `--fs-thaw-command`  | Command to thaw filesystem after reading raw source; arguments use shell-style quoting | `""` |
+| `--fs-freeze-command` | Command to freeze filesystem before reading raw source; path must be absolute and arguments use shell-style quoting | `""` |
+| `--fs-thaw-command`  | Command to thaw filesystem after reading raw source; path must be absolute and arguments use shell-style quoting | `""` |
 | `--freeze-timeout`   | Timeout for filesystem freeze command | `10s` |
 | `--thaw-timeout`     | Timeout for filesystem thaw command | `10s` |
 | `--transport`       | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) | `""`      |

--- a/device/raw.go
+++ b/device/raw.go
@@ -202,6 +202,9 @@ func validateCmd(path string, args []string) error {
 	if path == "" {
 		return fmt.Errorf("command path is empty")
 	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("command path must be absolute")
+	}
 	if strings.ContainsRune(path, '\x00') {
 		return fmt.Errorf("command path contains NUL byte")
 	}

--- a/device/raw_helpers_test.go
+++ b/device/raw_helpers_test.go
@@ -3,6 +3,7 @@ package device
 import (
 	"context"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -10,7 +11,11 @@ import (
 )
 
 func TestPrepareFreezeSuccess(t *testing.T) {
-	issued, err := prepareFreeze(context.Background(), false, "true", nil, "true", nil, time.Second, zap.NewNop())
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	issued, err := prepareFreeze(context.Background(), false, truePath, nil, truePath, nil, time.Second, zap.NewNop())
 	if err != nil {
 		t.Fatalf("prepareFreeze: %v", err)
 	}
@@ -20,7 +25,15 @@ func TestPrepareFreezeSuccess(t *testing.T) {
 }
 
 func TestPrepareFreezeFailure(t *testing.T) {
-	if _, err := prepareFreeze(context.Background(), false, "false", nil, "true", nil, time.Second, zap.NewNop()); err == nil {
+	falsePath, err := exec.LookPath("false")
+	if err != nil {
+		t.Fatalf("missing false binary: %v", err)
+	}
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	if _, err := prepareFreeze(context.Background(), false, falsePath, nil, truePath, nil, time.Second, zap.NewNop()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -16,13 +16,11 @@ import (
 
 func helperCommand(t *testing.T) string {
 	dir := t.TempDir()
-	name := "cmdhelper"
-	link := filepath.Join(dir, name)
+	link := filepath.Join(dir, "cmdhelper")
 	if err := os.Symlink(os.Args[0], link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return name
+	return link
 }
 
 func TestOpenRawLogsInfoAndClose(t *testing.T) {
@@ -114,7 +112,15 @@ func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
 }
 
 func TestOpenRawFreezeCommandFailure(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "false", nil, "true", nil, time.Second, time.Second, zap.NewNop()); err == nil {
+	falsePath, err := exec.LookPath("false")
+	if err != nil {
+		t.Fatalf("missing false binary: %v", err)
+	}
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, falsePath, nil, truePath, nil, time.Second, time.Second, zap.NewNop()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -122,11 +128,13 @@ func TestOpenRawFreezeCommandFailure(t *testing.T) {
 func TestOpenRawThawsOnFailure(t *testing.T) {
 	freezeTmp := filepath.Join(t.TempDir(), "freeze")
 	thawTmp := filepath.Join(t.TempDir(), "thaw")
-	freezeCmdPath := "touch"
+	touchPath, err := exec.LookPath("touch")
+	if err != nil {
+		t.Fatalf("missing touch binary: %v", err)
+	}
 	freezeArgs := []string{freezeTmp}
-	thawCmdPath := "touch"
 	thawArgs := []string{thawTmp}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, freezeCmdPath, freezeArgs, thawCmdPath, thawArgs, time.Second, time.Second, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, touchPath, freezeArgs, touchPath, thawArgs, time.Second, time.Second, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {
@@ -139,7 +147,11 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 
 func TestCleanupRunsThawCommand(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "thaw")
-	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: "touch", thawCmdArgs: []string{tmp}}
+	touchPath, err := exec.LookPath("touch")
+	if err != nil {
+		t.Fatalf("missing touch binary: %v", err)
+	}
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: touchPath, thawCmdArgs: []string{tmp}}
 	if err := d.Cleanup(context.Background()); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
@@ -149,27 +161,37 @@ func TestCleanupRunsThawCommand(t *testing.T) {
 }
 
 func TestCleanupThawCommandFailure(t *testing.T) {
-	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: "false"}
+	falsePath, err := exec.LookPath("false")
+	if err != nil {
+		t.Fatalf("missing false binary: %v", err)
+	}
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: falsePath}
 	if err := d.Cleanup(context.Background()); err == nil {
 		t.Fatalf("expected thaw command failure")
 	}
 }
 
 func TestOpenRawFreezeTimeout(t *testing.T) {
-	if _, err := exec.LookPath("sleep"); err != nil {
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
 		t.Skip("sleep command not found")
 	}
-	_, err := OpenRaw(context.Background(), "/dev/null", false, "sleep", []string{"2"}, "true", nil, 100*time.Millisecond, time.Second, zap.NewNop())
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	_, err = OpenRaw(context.Background(), "/dev/null", false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze command to be killed, got %v", err)
 	}
 }
 
 func TestCleanupThawTimeout(t *testing.T) {
-	if _, err := exec.LookPath("sleep"); err != nil {
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
 		t.Skip("sleep command not found")
 	}
-	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawTimeout: 100 * time.Millisecond, thawCmdPath: "sleep", thawCmdArgs: []string{"2"}}
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawTimeout: 100 * time.Millisecond, thawCmdPath: sleepPath, thawCmdArgs: []string{"2"}}
 	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected thaw command to be killed, got %v", err)
 	}
@@ -182,11 +204,19 @@ func TestOpenRawStoresThawConfig(t *testing.T) {
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
 	thawTmp := filepath.Join(t.TempDir(), "thaw")
-	d, err := OpenRaw(context.Background(), loop, false, "true", nil, "touch", []string{thawTmp}, time.Second, time.Second, zap.NewNop())
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	touchPath, err := exec.LookPath("touch")
+	if err != nil {
+		t.Fatalf("missing touch binary: %v", err)
+	}
+	d, err := OpenRaw(context.Background(), loop, false, truePath, nil, touchPath, []string{thawTmp}, time.Second, time.Second, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if d.thawCmdPath != "touch" || len(d.thawCmdArgs) != 1 || d.thawCmdArgs[0] != thawTmp {
+	if d.thawCmdPath != touchPath || len(d.thawCmdArgs) != 1 || d.thawCmdArgs[0] != thawTmp {
 		t.Fatalf("thaw configuration not stored")
 	}
 	if err := d.Cleanup(context.Background()); err != nil {
@@ -271,7 +301,11 @@ func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 	execCommand = fakeExecCommandContext
 	t.Cleanup(func() { execCommand = oldExec })
 	helper := helperCommand(t)
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, "true", nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
 		t.Fatalf("expected freeze output in error, got %v", err)
 	}
 	entries := logs.FilterMessage("fs freeze failed").All()

--- a/device/raw_validate_cmd_test.go
+++ b/device/raw_validate_cmd_test.go
@@ -24,20 +24,20 @@ func TestValidateCmd(t *testing.T) {
 			wantErr: "command path is empty",
 		},
 		{
+			name:    "relative command path",
+			path:    "true",
+			wantErr: "command path must be absolute",
+		},
+		{
 			name:    "nul in path",
-			path:    "true\x00",
+			path:    "/true\x00",
 			wantErr: "command path contains NUL byte",
 		},
 		{
 			name:    "nul in arg",
-			path:    "true",
+			path:    truePath,
 			args:    []string{"foo\x00"},
 			wantErr: "command argument contains NUL byte",
-		},
-		{
-			name:    "invalid characters",
-			path:    "tr ue",
-			wantErr: "command path tr ue contains invalid characters",
 		},
 		{
 			name:    "invalid characters in basename",
@@ -46,12 +46,8 @@ func TestValidateCmd(t *testing.T) {
 		},
 		{
 			name:    "nonexistent command",
-			path:    "does-not-exist",
-			wantErr: "does-not-exist: exec: \"does-not-exist\": executable file not found in $PATH",
-		},
-		{
-			name: "valid command",
-			path: "true",
+			path:    "/does-not-exist",
+			wantErr: "/does-not-exist: exec: \"/does-not-exist\": stat /does-not-exist: no such file or directory",
 		},
 		{
 			name: "valid absolute path",

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -133,7 +133,8 @@ occur during the scan. To ensure a stable view:
 
 - `--offline` asserts that no process will modify the device while it is read.
 - `--fs-freeze-command`/`--fs-thaw-command` run commands that freeze the
-  filesystem and thaw it once the read completes.
+  filesystem and thaw it once the read completes. Command paths must be
+  absolute.
 
 Example scripts in this repository:
 
@@ -143,5 +144,5 @@ Example scripts in this repository:
 Use them together:
 
 ```sh
-lvmsync manifest rebuild --fs-freeze-command "./docs/fsfreeze-freeze.sh /mnt" --fs-thaw-command "./docs/fsfreeze-thaw.sh /mnt" /dev/sdb
+lvmsync manifest rebuild --fs-freeze-command "$(pwd)/docs/fsfreeze-freeze.sh /mnt" --fs-thaw-command "$(pwd)/docs/fsfreeze-thaw.sh /mnt" /dev/sdb
 ```


### PR DESCRIPTION
## Summary
- require filesystem freeze/thaw commands to use absolute paths
- adjust tests for absolute vs relative command validation
- document absolute path requirement for fs freeze/thaw commands

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake: client negotiate: read handshake: EOF)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a08543b088832381ff6c2667ab853f