### PR TITLE
dedup: enforce minimum chunk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
 | `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer (separate `ssh_timeout`) |
 | `--dedup_strategy` | `LVMSYNC_DEDUP_STRATEGY` | `dedup_strategy` | Deduplication strategy: `none`, `auto`, `checksum`, `rolling_hash`, or `bloom` |
 | `--dedup_state_file` | `LVMSYNC_DEDUP_STATE_FILE` | `dedup_state_file` | Path to deduplication state file |
-| `--cdc-min` | `LVMSYNC_DEDUP_CDC_MIN` | `cdc_min` | Minimum chunk size for CDC |
+| `--cdc-min` | `LVMSYNC_DEDUP_CDC_MIN` | `cdc_min` | Minimum chunk size for CDC (must be at least 64 bytes) |
 | `--cdc-avg` | `LVMSYNC_DEDUP_CDC_AVG` | `cdc_avg` | Target average chunk size for CDC |
 | `--cdc-max` | `LVMSYNC_DEDUP_CDC_MAX` | `cdc_max` | Maximum chunk size for CDC |
 | `--bloom_entries` | `LVMSYNC_DEDUP_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
@@ -798,12 +798,12 @@ Hybrid dedup combines fixed-size and content-defined chunking. Enable it with `-
 
 | Flag (`--cdc-*`) | Environment variable | Config key | Description |
 |------------------|----------------------|------------|-------------|
-| `--cdc-min`      | `LVMSYNC_DEDUP_CDC_MIN`    | `cdc_min`  | Minimum chunk size |
+| `--cdc-min`      | `LVMSYNC_DEDUP_CDC_MIN`    | `cdc_min`  | Minimum chunk size (must be at least 64 bytes) |
 | `--cdc-avg`      | `LVMSYNC_DEDUP_CDC_AVG`    | `cdc_avg`  | Target average chunk size |
 | `--cdc-max`      | `LVMSYNC_DEDUP_CDC_MAX`    | `cdc_max`  | Maximum chunk size |
 
-The three values must be positive and satisfy `--cdc-min ≤ --cdc-avg ≤ --cdc-max`.
-LVMSync aborts when the sizes are non-positive or unordered.
+The three values must be positive, with `--cdc-min` at least 64 bytes, and satisfy `--cdc-min ≤ --cdc-avg ≤ --cdc-max`.
+LVMSync aborts when the sizes are non-positive, below the minimum, or unordered.
 
 The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom_entries` and desired false positive rate via `--bloom_fp_rate`. For an mmap-backed index, `--bloom_mbits` controls the bitmap size in megabits.
 

--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -41,9 +41,13 @@ type Chunker struct {
 // minimum, average, and maximum chunk sizes. All sizes are in bytes. The mask values are
 // derived from the average size.
 // The sizes must be positive and ordered such that minSize ≤ avgSize ≤ maxSize.
+// minSize must be at least 64 bytes to ensure the entropy window is initialized.
 func NewChunker(minSize, avgSize, maxSize int, seeds ...uint64) (*Chunker, error) {
-	if minSize <= 0 || avgSize <= 0 || maxSize <= 0 {
-		return nil, fmt.Errorf("chunk sizes must be positive: min=%d avg=%d max=%d", minSize, avgSize, maxSize)
+	if minSize < 64 {
+		return nil, fmt.Errorf("min size must be at least 64 bytes: min=%d", minSize)
+	}
+	if avgSize <= 0 || maxSize <= 0 {
+		return nil, fmt.Errorf("chunk sizes must be positive: avg=%d max=%d", avgSize, maxSize)
 	}
 	if minSize > avgSize || avgSize > maxSize {
 		return nil, fmt.Errorf("chunk sizes must satisfy min ≤ avg ≤ max: min=%d avg=%d max=%d", minSize, avgSize, maxSize)

--- a/dedup/chunker_test.go
+++ b/dedup/chunker_test.go
@@ -50,6 +50,7 @@ func TestNewChunkerValidation(t *testing.T) {
 		{"valid", 64, 128, 256, true},
 		{"zero", 0, 128, 256, false},
 		{"negative", -1, 128, 256, false},
+		{"too_small", 32, 128, 256, false},
 		{"min>avg", 128, 64, 256, false},
 		{"avg>max", 64, 256, 128, false},
 	}


### PR DESCRIPTION
## Summary
- require `minSize >= 64` in `dedup.NewChunker`
- reject too-small values in `NewChunker` tests
- document the 64-byte lower bound for CDC min size

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestQUICTransportSelectBestHandshake, TestSSHTransportSelectBestHandshake, TestTCPTLSTransportSelectBestHandshake, TestTCPTLSDialUnreachable)*
- `golangci-lint run` *(warn: Can't process result by diff processor)*

------
https://chatgpt.com/codex/tasks/task_e_68a0852fc284832382b41cee20a9adfe