### PR TITLE
refactor: split root run responsibilities

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -137,42 +137,38 @@ func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPa
 }
 
 // Run orchestrates the command execution.
-func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
+func dispatchSubcommand(cfg *config.Config, args []string, logger *zap.Logger) (bool, error) {
 	if len(args) > 0 {
 		switch args[0] {
 		case "manifest":
-			return RunManifest(cfg, args[1:], logger)
+			return true, RunManifest(cfg, args[1:], logger)
 		case "verify":
-			return RunVerify(args[1:], logger)
+			return true, RunVerify(args[1:], logger)
 		}
 	}
-
 	if cfg.ApplyMode != "" {
 		if err := RunApply(cfg, cfg.ApplyMode, args, logger); err != nil {
-			return fmt.Errorf("apply operation failed: %w", err)
+			return true, fmt.Errorf("apply operation failed: %w", err)
 		}
-		return nil
+		return true, nil
 	}
+	return false, nil
+}
 
+func prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (context.Context, func(), string, string, chan error, error) {
 	if _, err := SelectTransport(cfg, logger); err != nil {
-		return fmt.Errorf("select transport: %w", err)
+		return nil, nil, "", "", nil, fmt.Errorf("select transport: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.GRPCSetupTimeout)
 	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(ctx, cfg, logger)
 	if err != nil {
 		cancel()
-		return err
+		return nil, nil, "", "", nil, err
 	}
-	defer func() {
-		cancel()
-		cleanupSrv()
-	}()
-	defer cleanupClient()
 
 	var snapshotPath string
 	signals, sigErrCh := setupSignalHandle(ctx, cfg, &snapshotPath, logger)
-	defer signal.Stop(signals)
 
 	if hbErrCh != nil {
 		go func() {
@@ -185,16 +181,45 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 
 	if (cfg.StdoutMode && len(args) < 1) || (!cfg.StdoutMode && len(args) < 2) {
 		pflag.Usage()
-		return fmt.Errorf("invalid arguments")
+		cancel()
+		cleanupSrv()
+		cleanupClient()
+		signal.Stop(signals)
+		return nil, nil, "", "", nil, fmt.Errorf("invalid arguments")
 	}
 	originalVolume := args[0]
 	destPath := ""
 	if !cfg.StdoutMode {
 		destPath = args[1]
 	}
-
 	snapshotPath = originalVolume
+
+	cleanup := func() {
+		signal.Stop(signals)
+		cancel()
+		cleanupSrv()
+		cleanupClient()
+	}
+	return ctx, cleanup, snapshotPath, destPath, sigErrCh, nil
+}
+
+func executeSync(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh chan error, logger *zap.Logger) error {
 	return ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, nil, logger)
+}
+
+func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
+	handled, err := dispatchSubcommand(cfg, args, logger)
+	if handled || err != nil {
+		return err
+	}
+
+	ctx, cleanup, snapshotPath, destPath, sigErrCh, err := prepareClient(cfg, args, logger)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return executeSync(ctx, cfg, snapshotPath, destPath, sigErrCh, logger)
 }
 
 // Execute is a helper that configures and runs the root command.

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -19,6 +19,116 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestDispatchSubcommandManifest(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	called := false
+	origManifest := RunManifest
+	defer func() { RunManifest = origManifest }()
+	RunManifest = func(c *config.Config, args []string, l *zap.Logger) error {
+		called = true
+		if args[0] != "arg" {
+			t.Fatalf("unexpected arg")
+		}
+		return nil
+	}
+	handled, err := dispatchSubcommand(cfg, []string{"manifest", "arg"}, logger)
+	if err != nil || !handled || !called {
+		t.Fatalf("dispatch failed")
+	}
+}
+
+func TestDispatchSubcommandApplyError(t *testing.T) {
+	cfg := &config.Config{ApplyMode: "apply"}
+	logger := zap.NewNop()
+	origApply := RunApply
+	defer func() { RunApply = origApply }()
+	RunApply = func(*config.Config, string, []string, *zap.Logger) error { return errors.New("boom") }
+	handled, err := dispatchSubcommand(cfg, []string{"vol"}, logger)
+	if !handled || err == nil || err.Error() != "apply operation failed: boom" {
+		t.Fatalf("expected wrapped apply error, got %v", err)
+	}
+}
+
+func TestPrepareClientSuccess(t *testing.T) {
+	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second, SourceType: "file"}
+	logger := zap.NewNop()
+	selectCalled := false
+	srvClean := false
+	clientClean := false
+	origSelect := SelectTransport
+	origStart := startGRPCServer
+	origClient := clientHandshake
+	origSetup := setupSignalHandle
+	defer func() {
+		SelectTransport = origSelect
+		startGRPCServer = origStart
+		clientHandshake = origClient
+		setupSignalHandle = origSetup
+	}()
+	SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) {
+		selectCalled = true
+		return nil, nil
+	}
+	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
+		ch := make(chan error, 1)
+		go func() {
+			ch <- nil
+			close(ch)
+		}()
+		return func() { srvClean = true }, ch, nil
+	}
+	clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
+		return func() { clientClean = true }, nil, nil
+	}
+	setupSignalHandle = func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+		return make(chan os.Signal), make(chan error)
+	}
+	ctx, cleanup, snap, dest, sigErrCh, err := prepareClient(cfg, []string{"vol"}, logger)
+	if err != nil || ctx == nil || cleanup == nil || snap != "vol" || dest != "" || sigErrCh == nil || !selectCalled {
+		t.Fatalf("prepareClient failed: %v", err)
+	}
+	cleanup()
+	if !srvClean || !clientClean {
+		t.Fatalf("cleanup not called")
+	}
+}
+
+func TestPrepareClientSelectTransportError(t *testing.T) {
+	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second, SourceType: "file"}
+	logger := zap.NewNop()
+	origSelect := SelectTransport
+	defer func() { SelectTransport = origSelect }()
+	SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) {
+		return nil, errors.New("bad")
+	}
+	_, _, _, _, _, err := prepareClient(cfg, []string{"vol"}, logger)
+	if err == nil || err.Error() != "select transport: bad" {
+		t.Fatalf("expected select transport error, got %v", err)
+	}
+}
+
+func TestExecuteSync(t *testing.T) {
+	cfg := &config.Config{}
+	logger := zap.NewNop()
+	called := false
+	origExec := executeClientFn
+	defer func() { executeClientFn = origExec }()
+	executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error) error {
+		called = true
+		return nil
+	}
+	if err := executeSync(context.Background(), cfg, "s", "d", nil, logger); err != nil || !called {
+		t.Fatalf("executeSync failed: %v", err)
+	}
+	executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error) error {
+		return errors.New("x")
+	}
+	if err := executeSync(context.Background(), cfg, "s", "d", nil, logger); err == nil || err.Error() != "x" {
+		t.Fatalf("expected error")
+	}
+}
+
 func TestSetupGRPCSuccess(t *testing.T) {
 	cfg := &config.Config{SourceType: "file"}
 	logger := zap.NewNop()


### PR DESCRIPTION
## Summary
- decompose cmd/root Run into dispatchSubcommand, prepareClient, and executeSync helpers
- test success and failure paths for the new helpers

## Testing
- `go build ./...`
- `go test -cover ./...` (fails: TestH2TransportSelectBestHandshake)
- `golangci-lint run` (fails: TestQUICTransportSelectBestHandshake)


------
https://chatgpt.com/codex/tasks/task_e_68a085543740832380294e37a11275f1