### PR TITLE
Add ssh_host_key_path precedence tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,7 +1061,7 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--ssh_host_key`          | Expected SSH host public key (authorized_keys format)          | `""`                    |
 
 Unknown hosts are rejected unless their keys are present in `known_hosts` or match `--ssh_host_key`.
-The host key can also be supplied via `LVMSYNC_SSH_HOST_KEY_PATH` or the `ssh_host_key_path` YAML option.
+The host key can also be supplied via `LVMSYNC_SSH_HOST_KEY_PATH` or the `ssh_host_key_path` YAML option; precedence follows flags over environment variables over YAML.
 
 Programmatic use of the SSH transport requires a configuration populated with
 fields like `SSHUser`, `SSHKeyPath`, `HostKeyPath`, `SSHUseAgent`, `SSHPort`, `KnownHosts`,

--- a/config/ssh_host_key_path_test.go
+++ b/config/ssh_host_key_path_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestSSHHostKeyPathCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "ssh_host_key_path: config.key\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh_host_key_path", "cli.key"})
+	t.Setenv("LVMSYNC_SSH_HOST_KEY_PATH", "env.key")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.SSHHostKeyPath != "cli.key" {
+		t.Fatalf("expected ssh_host_key_path cli.key, got %s", conf.SSHHostKeyPath)
+	}
+}
+
+func TestSSHHostKeyPathEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "ssh_host_key_path: config.key\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_SSH_HOST_KEY_PATH", "env.key")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &Builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.SSHHostKeyPath != "env.key" {
+		t.Fatalf("expected ssh_host_key_path env.key, got %s", conf.SSHHostKeyPath)
+	}
+}


### PR DESCRIPTION
## Summary
- document ssh_host_key_path precedence
- test precedence for ssh_host_key_path flag, env var, and YAML

## Testing
- `go build -v ./...`
- `go test -cover ./...` *(fails: lvmsync_go/grpc/server tests hang)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a08a01d3c083238c6444aaff29fdd5