### PR TITLE
Remove nil logger checks from progress

### DIFF
--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -9,15 +9,12 @@ import (
 )
 
 func finalizeProgress(cfg *config.Config, logger *zap.Logger) {
-	if cfg.Progress && logger != nil {
+	if cfg.Progress {
 		logger.Info("progress complete")
 	}
 }
 
 func reportProgress(cfg *config.Config, transferred, total int64, index int, start time.Time, logger *zap.Logger) {
-	if logger == nil {
-		return
-	}
 	if cfg.Progress {
 		progressPercent := float64(transferred) / float64(total) * 100.0
 
@@ -33,9 +30,6 @@ func reportProgress(cfg *config.Config, transferred, total int64, index int, sta
 }
 
 func logSequentialSummary(logger *zap.Logger, bytes int64, skipped int, start time.Time) {
-	if logger == nil {
-		return
-	}
 	elapsed := time.Since(start).Seconds()
 	logger.Info("Sequential transfer complete",
 		zap.Int64("size_bytes", bytes),
@@ -45,9 +39,6 @@ func logSequentialSummary(logger *zap.Logger, bytes int64, skipped int, start ti
 }
 
 func logParallelSummary(logger *zap.Logger, bytes int64, start time.Time) {
-	if logger == nil {
-		return
-	}
 	elapsed := time.Since(start).Seconds()
 	logger.Info("Parallel transfer complete",
 		zap.Int64("size_bytes", bytes),

--- a/transfer/progress_test.go
+++ b/transfer/progress_test.go
@@ -30,6 +30,20 @@ func TestReportProgress(t *testing.T) {
 	}
 }
 
+func TestReportProgressVerbose(t *testing.T) {
+	core, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(core)
+	cfg := &config.Config{Progress: true, Verbose: 1}
+	start := time.Now().Add(-time.Second)
+	reportProgress(cfg, 1024, 2048, 100, start, logger)
+	if logs.FilterMessage("transfer progress").Len() != 1 {
+		t.Fatalf("expected transfer progress log, got %d", logs.FilterMessage("transfer progress").Len())
+	}
+	if logs.FilterMessage("parallel dump progress").Len() != 1 {
+		t.Fatalf("expected parallel dump progress log, got %d", logs.FilterMessage("parallel dump progress").Len())
+	}
+}
+
 func TestLogSummaries(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)


### PR DESCRIPTION
## Summary
- remove logger nil checks from progress helpers
- add verbose progress logging test

## Testing
- `go build -v ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake: read handshake EOF)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a08a1015448323be9b98156fd8bdef