### PR TITLE
Thread context through verifyDestination

### DIFF
--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +14,7 @@ import (
 	"lvmsync_go/config"
 )
 
-func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
+func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
 	defer func() { _ = t.Logger.Sync() }()
 	bufReader := bufio.NewReader(in)
 	var hs common.Handshake
@@ -34,7 +35,7 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 
 	reader := bufio.NewReader(decReader)
 
-	if err := t.verifyDestination(cfg, destPath); err != nil {
+	if err := t.verifyDestination(ctx, cfg, destPath); err != nil {
 		return err
 	}
 
@@ -80,11 +81,11 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 }
 
 // ProcessDumpDataWithDeduplication applies a dump stream to destPath using the given dedup strategy without checksum verification, updating the strategy's state.
-func (t *Transfer) ProcessDumpDataWithDeduplication(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy) error {
-	return t.processDumpDataCore(cfg, in, destPath, dedup, false)
+func (t *Transfer) ProcessDumpDataWithDeduplication(ctx context.Context, cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy) error {
+	return t.processDumpDataCore(ctx, cfg, in, destPath, dedup, false)
 }
 
 // ProcessDumpData applies a dump stream to destPath with checksum verification for each block before writing.
-func (t *Transfer) ProcessDumpData(cfg *config.Config, in io.Reader, destPath string) error {
-	return t.processDumpDataCore(cfg, in, destPath, nil, true)
+func (t *Transfer) ProcessDumpData(ctx context.Context, cfg *config.Config, in io.Reader, destPath string) error {
+	return t.processDumpDataCore(ctx, cfg, in, destPath, nil, true)
 }

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"lvmsync_go/common"
 	"lvmsync_go/config"
@@ -54,7 +55,7 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 		t.Fatalf("stat before: %v", err)
 	}
 
-	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for uuid mismatch")
 	}
@@ -106,7 +107,7 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 		t.Fatalf("stat before: %v", err)
 	}
 
-	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for mounted device")
 	}
@@ -129,7 +130,7 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 	}
 
 	cfg.Force = true
-	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err != nil {
 		t.Fatalf("unexpected error with force: %v", err)
 	}
@@ -237,6 +238,57 @@ func TestApplyDataMountedDevice(t *testing.T) {
 	if !after.ModTime().Equal(before.ModTime()) || after.Size() != before.Size() {
 		t.Fatalf("expected no writes to destination")
 	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.HasPrefix(data, sentinel) {
+		t.Fatalf("destination modified")
+	}
+}
+func TestProcessDumpDataCanceledContext(t *testing.T) {
+	prevLVM := device.SetLVMUUIDFunc(func(context.Context, string) (string, error) { return "", errors.New("no lvm") })
+	defer device.SetLVMUUIDFunc(prevLVM)
+	prevUUID := device.SetUUIDFunc(func(ctx context.Context, _ string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	defer device.SetUUIDFunc(prevUUID)
+	prevMount := device.SetMountFunc(func(string) (bool, error) { return false, nil })
+	defer device.SetMountFunc(prevMount)
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true}
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	f, err := os.Create(dest)
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	sentinel := []byte("original")
+	if _, err := f.Write(sentinel); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	if err := f.Truncate(1024); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.ProcessDumpData(ctx, cfg, bytes.NewReader(minimalStream(t)), dest) }()
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled, got %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("ProcessDumpData did not respect context cancellation")
+	}
+
 	data, err := os.ReadFile(dest)
 	if err != nil {
 		t.Fatalf("read dest: %v", err)

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"os"
@@ -164,7 +165,7 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 	destFile.Close()
 
 	cfgProcess := &config.Config{BlockSize: int(blockSize), Compress: "zstd,lz4", MaxRetries: 1}
-	if err = tr.ProcessDumpData(cfgProcess, bytes.NewReader(data), dest); err != nil {
+	if err = tr.ProcessDumpData(context.Background(), cfgProcess, bytes.NewReader(data), dest); err != nil {
 		t.Fatalf("ProcessDumpData failed: %v", err)
 	}
 

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -127,7 +127,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 			SyncIntervalBytes: 512,
 		}
 		tt := NewTransfer(zap.NewNop(), nil)
-		done <- tt.ProcessDumpData(applyCfg, conn, destLoop)
+		done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, destLoop)
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -240,7 +240,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 			SyncIntervalBytes: 512,
 		}
 		tt := NewTransfer(zap.NewNop(), nil)
-		done <- tt.ProcessDumpData(applyCfg, conn, dstLoop)
+		done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, dstLoop)
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -385,7 +385,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 					SyncIntervalBytes: 512,
 				}
 				tt := NewTransfer(zap.NewNop(), nil)
-				done <- tt.ProcessDumpData(applyCfg, conn, destLoop)
+				done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, destLoop)
 			}()
 
 			conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -510,7 +510,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 					SyncIntervalBytes: 512,
 				}
 				tt := NewTransfer(zap.NewNop(), nil)
-				done <- tt.ProcessDumpData(applyCfg, conn, dstLoop)
+				done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, dstLoop)
 			}()
 
 			conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -684,7 +684,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 					SyncIntervalBytes: 512,
 				}
 				tt := NewTransfer(zap.NewNop(), nil)
-				done <- tt.ProcessDumpData(applyCfg, conn, dstLoop)
+				done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, dstLoop)
 			}()
 
 			conn, err := tr.Dial(ctx, ln.Addr().String())

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -100,7 +100,7 @@ func TestProcessDumpDataRejectsManifestMismatch(t *testing.T) {
 		}
 		prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "wrong", nil })
 		defer device.SetUUIDFunc(prev)
-		err := tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+		err := tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 		if err == nil || !strings.Contains(err.Error(), "does not match manifest") {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -113,7 +113,7 @@ func TestProcessDumpDataRejectsManifestMismatch(t *testing.T) {
 		}
 		prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
 		defer device.SetUUIDFunc(prev)
-		err := tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+		err := tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 		if err == nil || !strings.Contains(err.Error(), "size") {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/transfer/run_apply.go
+++ b/transfer/run_apply.go
@@ -53,9 +53,9 @@ func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string
 				}
 			}
 		}()
-		return t.ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)
+		return t.ProcessDumpDataWithDeduplication(context.Background(), cfg, in, destDevice, dedup)
 	}
-	return t.ProcessDumpData(cfg, in, destDevice)
+	return t.ProcessDumpData(context.Background(), cfg, in, destDevice)
 }
 
 // RunApply reads a dump file or stdin and writes the data to destDevice.

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -218,13 +218,16 @@ func readManifestHeader(path string) (*manifestpkg.Header, error) {
 	return &hdr, nil
 }
 
-func (t *Transfer) verifyDestination(cfg *config.Config, destPath string) error {
+func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, destPath string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if cfg.ManifestPath != "" {
 		hdr, err := readManifestHeader(cfg.ManifestPath)
 		if err != nil {
 			return err
 		}
-		id, err := device.GetDeviceID(context.Background(), destPath)
+		id, err := device.GetDeviceID(ctx, destPath)
 		if err != nil {
 			return fmt.Errorf("read destination id: %w", err)
 		}
@@ -233,7 +236,7 @@ func (t *Transfer) verifyDestination(cfg *config.Config, destPath string) error 
 			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", manID), zap.String("resource_id", id))
 			return fmt.Errorf("destination device id %s does not match manifest %s", id, manID)
 		}
-		size, err := device.SizeBytes(context.Background(), destPath)
+		size, err := device.SizeBytes(ctx, destPath)
 		if err != nil {
 			return fmt.Errorf("read destination size: %w", err)
 		}
@@ -243,7 +246,7 @@ func (t *Transfer) verifyDestination(cfg *config.Config, destPath string) error 
 		}
 		t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
 	} else if cfg.DeviceUUID != "" {
-		id, err := device.GetDeviceID(context.Background(), destPath)
+		id, err := device.GetDeviceID(ctx, destPath)
 		if err != nil {
 			return fmt.Errorf("read destination uuid: %w", err)
 		}


### PR DESCRIPTION
## Summary
- propagate caller contexts into destination verification
- allow ProcessDumpData to accept contexts
- test cancellation on destination verification

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake: client negotiate: read handshake: EOF)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a089ee98ec8323b56e92fcf27569fc