### PR TITLE
refactor: introduce runner structs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,14 @@ practical. Break down large functions into focused helpers and test each helper 
 Logging and configuration are fully structured to keep behavior predictable across
 command-line use, environment variables, and `config.yaml` files.
 
+## Dependency Injection
+
+- Avoid package-level function variables for stubbing dependencies.
+- Use a `Runner` struct to hold external interactions and provide `NewRunner` and
+  `NewRunnerWithDeps` constructors so tests can inject mocks.
+- Callers and subcommands should invoke methods on a `Runner` instance rather than
+  modifying global variables.
+
 ## Device Detection
 
 - `Detect` orchestrates `detectFileDevice`, `detectLVMDevice`, and `detectRawDevice`.

--- a/app/app.go
+++ b/app/app.go
@@ -35,9 +35,9 @@ var (
 	ackStream     = func(ctx context.Context, c proto.ReplicationClient, id string) (ackStreamClient, error) {
 		return grpcclient.AckStream(ctx, c, id)
 	}
-	handleSignals   = signalspkg.Handle
-	prepareSnapshot = clientpkg.PrepareSnapshot
-	newTicker       = time.NewTicker
+	signalsHandler  signalspkg.Handler = signalspkg.NewRunner()
+	prepareSnapshot                    = clientpkg.PrepareSnapshot
+	newTicker                          = time.NewTicker
 )
 
 type grpcServer interface {
@@ -181,7 +181,7 @@ func SetupSignalHandling(ctx context.Context, cfg *config.Config, snapshotPath *
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	sigErrCh := make(chan error, 1)
-	go handleSignals(ctx, cfg, logger, signals, snapshotPath, sigErrCh)
+	go signalsHandler.Handle(ctx, cfg, logger, signals, snapshotPath, sigErrCh)
 	return signals, sigErrCh
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	signalspkg "lvmsync_go/cmd/lvmsync/signals"
 	"lvmsync_go/config"
 	grpcclient "lvmsync_go/grpc/client"
 	grpcserver "lvmsync_go/grpc/server"
@@ -282,13 +283,13 @@ func TestSetupSignalHandling(t *testing.T) {
 	cfg := &config.Config{}
 	var path string
 	called := make(chan struct{})
-	origHandle := handleSignals
-	defer func() { handleSignals = origHandle }()
-	handleSignals = func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	origHandle := signalsHandler
+	defer func() { signalsHandler = origHandle }()
+	signalsHandler = signalspkg.HandlerFunc(func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		<-sigs
 		*p = "set"
 		close(called)
-	}
+	})
 	logger := zap.NewNop()
 	signals, sigErrCh := SetupSignalHandling(context.Background(), cfg, &path, logger)
 	signals <- os.Interrupt
@@ -313,11 +314,11 @@ func TestSetupSignalHandling(t *testing.T) {
 func TestSetupSignalHandlingError(t *testing.T) {
 	cfg := &config.Config{}
 	var path string
-	origHandle := handleSignals
-	defer func() { handleSignals = origHandle }()
-	handleSignals = func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	origHandle := signalsHandler
+	defer func() { signalsHandler = origHandle }()
+	signalsHandler = signalspkg.HandlerFunc(func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		errCh <- errors.New("boom")
-	}
+	})
 	logger := zap.NewNop()
 	_, sigErrCh := SetupSignalHandling(context.Background(), cfg, &path, logger)
 	if err := <-sigErrCh; err == nil {

--- a/cmd/grpcd/cobra.go
+++ b/cmd/grpcd/cobra.go
@@ -27,8 +27,7 @@ type Options struct {
 	RequestTimeout   time.Duration
 }
 
-// startFunc allows tests to stub server startup.
-var startFunc = func(ctx context.Context, opts Options, logger *zap.Logger) error {
+func startServer(ctx context.Context, opts Options, logger *zap.Logger) error {
 	addr := fmt.Sprintf(":%d", opts.GRPCPort)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -58,6 +57,19 @@ var startFunc = func(ctx context.Context, opts Options, logger *zap.Logger) erro
 	ln.Close()
 	cleanup()
 	return nil
+}
+
+// Runner holds dependencies for gRPC server execution.
+type Runner struct {
+	Start func(ctx context.Context, opts Options, logger *zap.Logger) error
+}
+
+// NewRunner returns a Runner with production dependencies.
+func NewRunner() *Runner { return &Runner{Start: startServer} }
+
+// NewRunnerWithDeps creates a Runner with custom start function for tests.
+func NewRunnerWithDeps(start func(ctx context.Context, opts Options, logger *zap.Logger) error) *Runner {
+	return &Runner{Start: start}
 }
 
 func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
@@ -110,7 +122,7 @@ func loadConfig(v *viper.Viper) (Options, error) {
 }
 
 // NewCmd creates the root cobra command.
-func NewCmd(logger *zap.Logger) *cobra.Command {
+func (r *Runner) NewCmd(logger *zap.Logger) *cobra.Command {
 	v := viper.New()
 	cmd := &cobra.Command{
 		Use:   "lvmsync-grpcd",
@@ -124,7 +136,7 @@ func NewCmd(logger *zap.Logger) *cobra.Command {
 			if ctx == nil {
 				ctx = context.Background()
 			}
-			return startFunc(ctx, opts, logger)
+			return r.Start(ctx, opts, logger)
 		},
 	}
 	bindFlagSets(cmd, v)
@@ -132,8 +144,8 @@ func NewCmd(logger *zap.Logger) *cobra.Command {
 }
 
 // Execute runs the command with provided args.
-func Execute(args []string, logger *zap.Logger) error {
-	cmd := NewCmd(logger)
+func (r *Runner) Execute(args []string, logger *zap.Logger) error {
+	cmd := r.NewCmd(logger)
 	if args != nil {
 		cmd.SetArgs(args)
 	}

--- a/cmd/grpcd/cobra_test.go
+++ b/cmd/grpcd/cobra_test.go
@@ -13,12 +13,10 @@ import (
 func TestFlagParsing(t *testing.T) {
 	logger := zap.NewNop()
 	var got Options
-	orig := startFunc
-	startFunc = func(ctx context.Context, opts Options, _ *zap.Logger) error {
+	runner := NewRunnerWithDeps(func(ctx context.Context, opts Options, _ *zap.Logger) error {
 		got = opts
 		return nil
-	}
-	defer func() { startFunc = orig }()
+	})
 	args := []string{
 		"--grpc-port", "1234",
 		"--tls-cert", "cert",
@@ -29,7 +27,7 @@ func TestFlagParsing(t *testing.T) {
 		"--keepalive-timeout", "5s",
 		"--request-timeout", "1m",
 	}
-	if err := Execute(args, logger); err != nil {
+	if err := runner.Execute(args, logger); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	want := Options{GRPCPort: 1234, TLSCert: "cert", TLSKey: "key", CACert: "ca", AllowInsecure: true, KeepaliveTime: 30 * time.Second, KeepaliveTimeout: 5 * time.Second, RequestTimeout: time.Minute}
@@ -44,15 +42,13 @@ func TestGRPCPortPrecedence(t *testing.T) {
 	t.Setenv("LVMSYNC_GRPC_GRPC_PORT", "2222")
 
 	var got Options
-	orig := startFunc
-	startFunc = func(ctx context.Context, opts Options, _ *zap.Logger) error {
+	runner := NewRunnerWithDeps(func(ctx context.Context, opts Options, _ *zap.Logger) error {
 		got = opts
 		return nil
-	}
-	defer func() { startFunc = orig }()
+	})
 
 	args := []string{"--config", cfgPath, "--grpc-port", "3333"}
-	if err := Execute(args, logger); err != nil {
+	if err := runner.Execute(args, logger); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if got.GRPCPort != 3333 {
@@ -60,7 +56,7 @@ func TestGRPCPortPrecedence(t *testing.T) {
 	}
 
 	got = Options{}
-	if err := Execute([]string{"--config", cfgPath}, logger); err != nil {
+	if err := runner.Execute([]string{"--config", cfgPath}, logger); err != nil {
 		t.Fatalf("Execute env: %v", err)
 	}
 	if got.GRPCPort != 2222 {

--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -16,7 +16,8 @@ func main() {
 			logger.Error("logger sync error", zap.Error(err))
 		}
 	}()
-	if err := Execute(nil, logger); err != nil {
+	runner := NewRunner()
+	if err := runner.Execute(nil, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
 		os.Exit(1)
 	}

--- a/cmd/lvmsync/signals/signals.go
+++ b/cmd/lvmsync/signals/signals.go
@@ -13,17 +13,41 @@ import (
 	"lvmsync_go/lvm"
 )
 
-var removeSnapshot = lvm.RemoveSnapshot
+// Handler processes OS signals and performs cleanup.
+type Handler interface {
+	Handle(ctx context.Context, cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error)
+}
+
+// HandlerFunc adapts a function to the Handler interface.
+type HandlerFunc func(ctx context.Context, cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error)
+
+// Handle calls f(ctx, cfg, logger, signals, snapshotPath, errCh).
+func (f HandlerFunc) Handle(ctx context.Context, cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error) {
+	f(ctx, cfg, logger, signals, snapshotPath, errCh)
+}
+
+// Runner holds signal handling dependencies.
+type Runner struct {
+	RemoveSnapshot func(context.Context, string, *zap.Logger) error
+}
+
+// NewRunner constructs a Runner with production dependencies.
+func NewRunner() *Runner { return &Runner{RemoveSnapshot: lvm.RemoveSnapshot} }
+
+// NewRunnerWithDeps constructs a Runner with custom dependencies.
+func NewRunnerWithDeps(remove func(context.Context, string, *zap.Logger) error) *Runner {
+	return &Runner{RemoveSnapshot: remove}
+}
 
 // Handle waits for an OS signal, logs it, and removes the snapshot when
 // necessary.
-func Handle(ctx context.Context, cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error) {
+func (r *Runner) Handle(ctx context.Context, cfg *config.Config, logger *zap.Logger, signals <-chan os.Signal, snapshotPath *string, errCh chan<- error) {
 	sig := <-signals
 	logger.Info("received signal, aborting", zap.String("signal", sig.String()))
 	if !cfg.SkipSnapshotCreation && *snapshotPath != "" && *snapshotPath != pflag.Arg(0) {
 		rmCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		if err := removeSnapshot(rmCtx, *snapshotPath, logger); err != nil {
+		if err := r.RemoveSnapshot(rmCtx, *snapshotPath, logger); err != nil {
 			logger.Warn("failed to remove snapshot on shutdown", zap.Error(err))
 		} else {
 			logger.Info("snapshot removed on shutdown", zap.String("snapshot", *snapshotPath))

--- a/cmd/lvmsync/signals/signals_test.go
+++ b/cmd/lvmsync/signals/signals_test.go
@@ -17,7 +17,8 @@ func TestHandle(t *testing.T) {
 	errCh := make(chan error, 1)
 	var snap string
 	logger := zap.NewNop()
-	go Handle(context.Background(), cfg, logger, sigCh, &snap, errCh)
+	runner := NewRunner()
+	go runner.Handle(context.Background(), cfg, logger, sigCh, &snap, errCh)
 	sigCh <- os.Interrupt
 	err := <-errCh
 	if err == nil || !strings.Contains(err.Error(), "received signal") {

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -12,14 +13,28 @@ import (
 	manifestpkg "lvmsync_go/manifest"
 )
 
-var rebuildFn = manifestpkg.Rebuild
+// Runner holds dependencies for manifest operations.
+type Runner struct {
+	Rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error
+}
+
+// NewRunner returns a Runner with production dependencies.
+func NewRunner() *Runner { return &Runner{Rebuild: manifestpkg.Rebuild} }
+
+// NewRunnerWithDeps creates a Runner with custom rebuild function.
+func NewRunnerWithDeps(
+	rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error,
+) *Runner {
+	return &Runner{Rebuild: rebuild}
+}
 
 func init() {
-	rootcmd.RunManifest = Run
+	r := NewRunner()
+	rootcmd.RunManifest = r.Run
 }
 
 // Run executes manifest subcommands. Currently only "rebuild" is supported.
-func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
+func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -65,10 +80,15 @@ func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if conf.DedupMode == "hybrid" {
 		hybridFixed = uint32(conf.BlockSize)
 	}
-	if err := rebuildFn(ctx, device, path, logger, conf.ManifestProgressInterval, conf.ManifestAllowMounted, uint32(conf.CDCMin), uint32(conf.CDCAvg), uint32(conf.CDCMax), hybridFixed); err != nil {
+	if err := r.Rebuild(ctx, device, path, logger, conf.ManifestProgressInterval, conf.ManifestAllowMounted, uint32(conf.CDCMin), uint32(conf.CDCAvg), uint32(conf.CDCMax), hybridFixed); err != nil {
 		logger.Error("rebuild failed", zap.Error(err))
 		return err
 	}
 	logger.Info("rebuild complete")
 	return nil
+}
+
+// Run executes using a default Runner.
+func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
+	return NewRunner().Run(cfg, args, logger)
 }

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -150,13 +150,11 @@ func TestRunAppliesManifestTimeout(t *testing.T) {
 	}
 	cfg.ManifestTimeout = 2 * time.Second
 	var captured context.Context
-	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
-	}
-	defer func() { rebuildFn = orig }()
-	if err := Run(cfg, []string{"rebuild", "/dev/test"}, nil); err != nil {
+	})
+	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if _, ok := captured.Deadline(); !ok {
@@ -171,13 +169,11 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	}
 	cfg.ManifestTimeout = 0
 	var captured context.Context
-	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
-	}
-	defer func() { rebuildFn = orig }()
-	if err := Run(cfg, []string{"rebuild", "/dev/test"}, nil); err != nil {
+	})
+	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if _, ok := captured.Deadline(); ok {
@@ -198,13 +194,11 @@ func TestRunContextNoDeadline(t *testing.T) {
 	}
 	cfg.ManifestTimeout = 0
 	var captured context.Context
-	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
-	}
-	defer func() { rebuildFn = orig }()
-	if err := Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
+	})
+	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if _, ok := captured.Deadline(); ok {

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -20,15 +20,29 @@ import (
 	"lvmsync_go/transfer"
 )
 
-func init() {
-	rootcmd.RunVerify = Run
+// Runner holds dependencies for verify operations.
+type Runner struct {
+	Rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error
 }
 
-var rebuildFn = manifestpkg.Rebuild
+// NewRunner returns a Runner with production dependencies.
+func NewRunner() *Runner { return &Runner{Rebuild: manifestpkg.Rebuild} }
+
+// NewRunnerWithDeps creates a Runner with custom rebuild function.
+func NewRunnerWithDeps(
+	rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error,
+) *Runner {
+	return &Runner{Rebuild: rebuild}
+}
+
+func init() {
+	r := NewRunner()
+	rootcmd.RunVerify = r.Run
+}
 
 // Run executes the verify command with the provided arguments and logger.
 // Args should exclude the "verify" subcommand itself.
-func Run(args []string, logger *zap.Logger) error {
+func (r *Runner) Run(args []string, logger *zap.Logger) error {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -71,14 +85,14 @@ func Run(args []string, logger *zap.Logger) error {
 				logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
 				return nil
 			}
-			return verifyDevices(cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)
+			return r.verifyDevices(cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)
 		},
 	}
 	cmd.SetArgs(args)
 	return cmd.Execute()
 }
 
-func verifyDevices(cfg *config.Config, src, dst, manifestPath string, logger *zap.Logger) error {
+func (r *Runner) verifyDevices(cfg *config.Config, src, dst, manifestPath string, logger *zap.Logger) error {
 	if manifestPath == "" {
 		manifestPath = src + ".manifest"
 	}
@@ -94,7 +108,7 @@ func verifyDevices(cfg *config.Config, src, dst, manifestPath string, logger *za
 			if cfg.DedupMode == "hybrid" {
 				hybridFixed = uint32(cfg.BlockSize)
 			}
-			if err := rebuildFn(ctx, src, manifestPath, logger, cfg.ManifestProgressInterval, cfg.ManifestAllowMounted, uint32(cfg.CDCMin), uint32(cfg.CDCAvg), uint32(cfg.CDCMax), hybridFixed); err != nil {
+			if err := r.Rebuild(ctx, src, manifestPath, logger, cfg.ManifestProgressInterval, cfg.ManifestAllowMounted, uint32(cfg.CDCMin), uint32(cfg.CDCAvg), uint32(cfg.CDCMax), hybridFixed); err != nil {
 				return fmt.Errorf("rebuild manifest: %w", err)
 			}
 		} else {
@@ -102,6 +116,11 @@ func verifyDevices(cfg *config.Config, src, dst, manifestPath string, logger *za
 		}
 	}
 	return verifyWithManifest(cfg, dst, manifestPath, logger)
+}
+
+// Run executes using a default Runner.
+func Run(args []string, logger *zap.Logger) error {
+	return NewRunner().Run(args, logger)
 }
 
 func digestFunc(cfg *config.Config) func([]byte) [32]byte {

--- a/cmd/verify/verify_mismatch_test.go
+++ b/cmd/verify/verify_mismatch_test.go
@@ -26,8 +26,7 @@ func TestRunLogsMismatchBlock(t *testing.T) {
 	}
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
-	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		idx, err := manifestpkg.Create(output, "dev", 3, 4096, 0, 0, 0, 0)
 		if err != nil {
 			return err
@@ -37,9 +36,8 @@ func TestRunLogsMismatchBlock(t *testing.T) {
 			return err
 		}
 		return idx.Close()
-	}
-	defer func() { rebuildFn = orig }()
-	err := Run([]string{src, dst}, logger)
+	})
+	err := r.Run([]string{src, dst}, logger)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -60,8 +58,7 @@ func TestRunLogsMismatchBlockSHA256(t *testing.T) {
 	}
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
-	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		idx, err := manifestpkg.Create(output, "dev", 3, 4096, 0, 0, 0, 0)
 		if err != nil {
 			return err
@@ -71,9 +68,8 @@ func TestRunLogsMismatchBlockSHA256(t *testing.T) {
 			return err
 		}
 		return idx.Close()
-	}
-	defer func() { rebuildFn = orig }()
-	err := Run([]string{"--checksum_algorithm", "sha256", src, dst}, logger)
+	})
+	err := r.Run([]string{"--checksum_algorithm", "sha256", src, dst}, logger)
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -139,8 +139,7 @@ func TestVerifyDevicesRebuildsManifest(t *testing.T) {
 		t.Fatalf("write dst: %v", err)
 	}
 	called := false
-	orig := rebuildFn
-	rebuildFn = func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		called = true
 		idx, err := manifestpkg.Create(output, "dev", uint64(len("foo")), 4096, 0, 0, 0, 0)
 		if err != nil {
@@ -151,10 +150,9 @@ func TestVerifyDevicesRebuildsManifest(t *testing.T) {
 			return err
 		}
 		return idx.Close()
-	}
-	defer func() { rebuildFn = orig }()
+	})
 	cfg := &config.Config{}
-	if err := verifyDevices(cfg, src, dst, "", zap.NewNop()); err != nil {
+	if err := r.verifyDevices(cfg, src, dst, "", zap.NewNop()); err != nil {
 		t.Fatalf("verifyDevices: %v", err)
 	}
 	if !called {

--- a/error_handling_test.go
+++ b/error_handling_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	dumpcmd "lvmsync_go/cmd/dump"
+	rootcmd "lvmsync_go/cmd/root"
 )
 
 type failingSyncCore struct {
@@ -36,7 +37,7 @@ func TestSyncLoggerLogsError(t *testing.T) {
 	syncErr := errors.New("sync fail")
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(&failingSyncCore{Core: core, err: syncErr})
-	syncLogger(logger)
+	rootcmd.SyncLogger(logger)
 	logs := observed.All()
 	if len(logs) != 1 {
 		t.Fatalf("expected one log entry, got %d", len(logs))

--- a/main.go
+++ b/main.go
@@ -9,51 +9,87 @@ import (
 	_ "lvmsync_go/cmd/apply"
 	_ "lvmsync_go/cmd/dump"
 	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/config"
 )
 
-var (
-	configureFunc     = rootcmd.Configure
-	runFunc           = rootcmd.Run
-	syncLoggerFunc    = rootcmd.SyncLogger
-	exitFunc          = os.Exit
-	exampleLoggerFunc = func() *zap.Logger {
-		logger, err := zap.NewProduction()
-		if err != nil {
-			return zap.NewNop()
-		}
-		return logger
+// Runner executes the application with injected dependencies.
+type Runner struct {
+	Configure     func() (*config.Config, []string, *zap.Logger, error)
+	RunFunc       func(*config.Config, []string, *zap.Logger) error
+	SyncLogger    func(*zap.Logger)
+	Exit          func(int)
+	ExampleLogger func() *zap.Logger
+	GOOS          string
+}
+
+// NewRunner constructs a Runner with production dependencies.
+func NewRunner() *Runner {
+	return &Runner{
+		Configure:  rootcmd.Configure,
+		RunFunc:    rootcmd.Run,
+		SyncLogger: rootcmd.SyncLogger,
+		Exit:       os.Exit,
+		ExampleLogger: func() *zap.Logger {
+			logger, err := zap.NewProduction()
+			if err != nil {
+				return zap.NewNop()
+			}
+			return logger
+		},
+		GOOS: runtime.GOOS,
 	}
-	runtimeGOOS = runtime.GOOS
-)
+}
 
-func syncLogger(logger *zap.Logger) { syncLoggerFunc(logger) }
+// NewRunnerWithDeps constructs a Runner with custom dependencies, useful for tests.
+func NewRunnerWithDeps(
+	configure func() (*config.Config, []string, *zap.Logger, error),
+	run func(*config.Config, []string, *zap.Logger) error,
+	syncLogger func(*zap.Logger),
+	exit func(int),
+	exampleLogger func() *zap.Logger,
+	goos string,
+) *Runner {
+	return &Runner{
+		Configure:     configure,
+		RunFunc:       run,
+		SyncLogger:    syncLogger,
+		Exit:          exit,
+		ExampleLogger: exampleLogger,
+		GOOS:          goos,
+	}
+}
 
-func main() {
-	if runtimeGOOS != "linux" {
-		tmpLogger := exampleLoggerFunc()
-		tmpLogger.Error("unsupported platform", zap.String("goos", runtimeGOOS))
+// Run executes the configured application flow.
+func (r *Runner) Run() {
+	if r.GOOS != "linux" {
+		tmpLogger := r.ExampleLogger()
+		tmpLogger.Error("unsupported platform", zap.String("goos", r.GOOS))
 		if err := tmpLogger.Sync(); err != nil {
 			tmpLogger.Error("Logger sync error", zap.Error(err))
 		}
-		exitFunc(1)
+		r.Exit(1)
 		return
 	}
 
-	cfg, args, logger, err := configureFunc()
+	cfg, args, logger, err := r.Configure()
 	if err != nil {
-		tmpLogger := exampleLoggerFunc()
+		tmpLogger := r.ExampleLogger()
 		tmpLogger.Error("configuration failed", zap.Error(err))
 		if err := tmpLogger.Sync(); err != nil {
 			tmpLogger.Error("Logger sync error", zap.Error(err))
 		}
-		exitFunc(1)
+		r.Exit(1)
 		return
 	}
-	if err := runFunc(cfg, args, logger); err != nil {
+	if err := r.RunFunc(cfg, args, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
-		syncLogger(logger)
-		exitFunc(1)
+		r.SyncLogger(logger)
+		r.Exit(1)
 		return
 	}
-	syncLogger(logger)
+	r.SyncLogger(logger)
+}
+
+func main() {
+	NewRunner().Run()
 }

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/config"
 )
 
@@ -26,27 +27,21 @@ func (c *syncCheckCore) Sync() error {
 }
 
 func TestMainLogsStructuredError(t *testing.T) {
-	// stub run to force an error
-	oldRun := runFunc
-	runFunc = func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("boom") }
-	defer func() { runFunc = oldRun }()
-
-	// capture exit code
-	oldExit := exitFunc
-	var code int
-	exitFunc = func(c int) { code = c }
-	defer func() { exitFunc = oldExit }()
-
 	syncErr := errors.New("sync fail")
 	core, logs := observer.New(zap.ErrorLevel)
 	synced := false
 	logger := zap.New(&syncCheckCore{Core: core, synced: &synced, err: syncErr})
 
-	oldConfigure := configureFunc
-	configureFunc = func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil }
-	defer func() { configureFunc = oldConfigure }()
-
-	main()
+	var code int
+	runner := NewRunnerWithDeps(
+		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("boom") },
+		rootcmd.SyncLogger,
+		func(c int) { code = c },
+		func() *zap.Logger { return zap.NewNop() },
+		"linux",
+	)
+	runner.Run()
 
 	if code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
@@ -72,27 +67,21 @@ func TestMainLogsStructuredError(t *testing.T) {
 }
 
 func TestMainLogsConfigError(t *testing.T) {
-	// stub configure to return an error
-	oldConfigure := configureFunc
-	configureFunc = func() (*config.Config, []string, *zap.Logger, error) { return nil, nil, nil, errors.New("cfg fail") }
-	defer func() { configureFunc = oldConfigure }()
-
-	// capture exit code
-	oldExit := exitFunc
-	var code int
-	exitFunc = func(c int) { code = c }
-	defer func() { exitFunc = oldExit }()
-
 	syncErr := errors.New("sync fail")
 	core, logs := observer.New(zap.ErrorLevel)
 	synced := false
 	tmpLogger := zap.New(&syncCheckCore{Core: core, synced: &synced, err: syncErr})
 
-	oldExample := exampleLoggerFunc
-	exampleLoggerFunc = func() *zap.Logger { return tmpLogger }
-	defer func() { exampleLoggerFunc = oldExample }()
-
-	main()
+	var code int
+	runner := NewRunnerWithDeps(
+		func() (*config.Config, []string, *zap.Logger, error) { return nil, nil, nil, errors.New("cfg fail") },
+		rootcmd.Run,
+		rootcmd.SyncLogger,
+		func(c int) { code = c },
+		func() *zap.Logger { return tmpLogger },
+		"linux",
+	)
+	runner.Run()
 
 	if code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
@@ -118,25 +107,21 @@ func TestMainLogsConfigError(t *testing.T) {
 }
 
 func TestMainErrorsOnNonLinux(t *testing.T) {
-	oldGOOS := runtimeGOOS
-	runtimeGOOS = "darwin"
-	defer func() { runtimeGOOS = oldGOOS }()
-
-	oldExit := exitFunc
-	var code int
-	exitFunc = func(c int) { code = c }
-	defer func() { exitFunc = oldExit }()
-
 	syncErr := errors.New("sync fail")
 	core, logs := observer.New(zap.ErrorLevel)
 	synced := false
 	tmpLogger := zap.New(&syncCheckCore{Core: core, synced: &synced, err: syncErr})
 
-	oldExample := exampleLoggerFunc
-	exampleLoggerFunc = func() *zap.Logger { return tmpLogger }
-	defer func() { exampleLoggerFunc = oldExample }()
-
-	main()
+	var code int
+	runner := NewRunnerWithDeps(
+		rootcmd.Configure,
+		rootcmd.Run,
+		rootcmd.SyncLogger,
+		func(c int) { code = c },
+		func() *zap.Logger { return tmpLogger },
+		"darwin",
+	)
+	runner.Run()
 
 	if code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)


### PR DESCRIPTION
## Summary
- encapsulate main entrypoint dependencies in a new Runner struct
- switch subcommands to Runner-based dependency injection with test hooks
- document Runner pattern in AGENTS.md

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake: client negotiate: read handshake: EOF)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a08b54e18483238d593e0d29e40ad6