### PR TITLE
transfer: default to zap.NewNop logger

### DIFF
--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -27,7 +27,7 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 		return fmt.Errorf("failed to create decompression reader: %w", err)
 	}
 	defer func() {
-		if closeErr := decReader.Close(); closeErr != nil && t.Logger != nil {
+		if closeErr := decReader.Close(); closeErr != nil {
 			t.Logger.Warn("Failed to close decompression reader", zap.Error(closeErr))
 		}
 	}()
@@ -70,12 +70,10 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 	}
 
 	elapsed := time.Since(startTime)
-	if t.Logger != nil {
-		t.Logger.Info("applied_changes",
-			zap.Int64("size_bytes", totalBytes),
-			zap.Int64("duration_ms", elapsed.Milliseconds()),
-			zap.Float64("mb_per_s", float64(totalBytes)/elapsed.Seconds()/1048576.0))
-	}
+	t.Logger.Info("applied_changes",
+		zap.Int64("size_bytes", totalBytes),
+		zap.Int64("duration_ms", elapsed.Milliseconds()),
+		zap.Float64("mb_per_s", float64(totalBytes)/elapsed.Seconds()/1048576.0))
 	return nil
 }
 

--- a/transfer/run_apply.go
+++ b/transfer/run_apply.go
@@ -43,14 +43,10 @@ func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string
 	}
 	dedup := NewDeduplicationStrategy(cfg, t.Logger)
 	if dedup != nil {
-		if t.Logger != nil {
-			t.Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
-		}
+		t.Logger.Info("Applying deduplication during restore", zap.String("strategy", cfg.DedupStrategy))
 		defer func() {
 			if err := dedup.SaveState(); err != nil {
-				if t.Logger != nil {
-					t.Logger.Error("Failed to save dedup state", zap.Error(err))
-				}
+				t.Logger.Error("Failed to save dedup state", zap.Error(err))
 			}
 		}()
 		return t.ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -29,8 +29,12 @@ type Transfer struct {
 }
 
 // NewTransfer creates a Transfer with the provided logger and wait group.
-// When wg is nil, a new instance is allocated. logger must be non-nil.
+// When wg is nil, a new instance is allocated. A nil logger is replaced with
+// zap.NewNop().
 func NewTransfer(logger *zap.Logger, wg *sync.WaitGroup) *Transfer {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	if wg == nil {
 		wg = &sync.WaitGroup{}
 	}

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bits-and-blooms/bloom/v3"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"lvmsync_go/config"
 )
@@ -69,5 +70,15 @@ func TestNewDeduplicationStrategyInvalidBloomEntries(t *testing.T) {
 	cfg := &config.Config{DedupStrategy: "bloom", BloomEntries: -1, BloomFpRate: 0.05}
 	if NewDeduplicationStrategy(cfg, zap.NewNop()) != nil {
 		t.Fatal("expected nil strategy for invalid bloom entries")
+	}
+}
+
+func TestNewTransferNilLogger(t *testing.T) {
+	tr := NewTransfer(nil, nil)
+	if tr.Logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+	if tr.Logger.Core().Enabled(zapcore.InfoLevel) {
+		t.Fatal("expected nop logger")
 	}
 }


### PR DESCRIPTION
## Summary
- ensure transfer.NewTransfer always provides a logger via zap.NewNop
- drop redundant nil logger checks in apply and run_apply
- add regression test for nil logger behavior

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake, TestQUICTransportSelectBestHandshake, TestSSHTransportSelectBestHandshake, TestTCPTLSTransportSelectBestHandshake)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a089d7dd1483238c4084b911bdc27e