### PR TITLE
Add context-aware file opening

### DIFF
--- a/common/open.go
+++ b/common/open.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"context"
+	"os"
+)
+
+// OpenWithContext opens the file at path respecting ctx cancellation.
+// It returns context error if ctx is done before the open completes.
+func OpenWithContext(ctx context.Context, path string) (*os.File, error) {
+	if ctx == nil {
+		return os.Open(path)
+	}
+	type result struct {
+		f   *os.File
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		f, err := os.OpenFile(path, os.O_RDONLY, 0)
+		ch <- result{f: f, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		go func() {
+			r := <-ch
+			if r.err == nil {
+				_ = r.f.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	case r := <-ch:
+		return r.f, r.err
+	}
+}

--- a/common/open_test.go
+++ b/common/open_test.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestOpenWithContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := OpenWithContext(ctx, "nonexistent")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestOpenWithContextSuccess(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "file")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmp.Close()
+	f, err := OpenWithContext(context.Background(), tmp.Name())
+	if err != nil {
+		t.Fatalf("OpenWithContext: %v", err)
+	}
+	f.Close()
+}

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +14,7 @@ import (
 	"lvmsync_go/config"
 )
 
-func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
+func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
 	defer func() { _ = t.Logger.Sync() }()
 	bufReader := bufio.NewReader(in)
 	var hs common.Handshake
@@ -34,7 +35,7 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 
 	reader := bufio.NewReader(decReader)
 
-	if err := t.verifyDestination(cfg, destPath); err != nil {
+	if err := t.verifyDestination(ctx, cfg, destPath); err != nil {
 		return err
 	}
 
@@ -80,11 +81,11 @@ func (t *Transfer) processDumpDataCore(cfg *config.Config, in io.Reader, destPat
 }
 
 // ProcessDumpDataWithDeduplication applies a dump stream to destPath using the given dedup strategy without checksum verification, updating the strategy's state.
-func (t *Transfer) ProcessDumpDataWithDeduplication(cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy) error {
-	return t.processDumpDataCore(cfg, in, destPath, dedup, false)
+func (t *Transfer) ProcessDumpDataWithDeduplication(ctx context.Context, cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy) error {
+	return t.processDumpDataCore(ctx, cfg, in, destPath, dedup, false)
 }
 
 // ProcessDumpData applies a dump stream to destPath with checksum verification for each block before writing.
-func (t *Transfer) ProcessDumpData(cfg *config.Config, in io.Reader, destPath string) error {
-	return t.processDumpDataCore(cfg, in, destPath, nil, true)
+func (t *Transfer) ProcessDumpData(ctx context.Context, cfg *config.Config, in io.Reader, destPath string) error {
+	return t.processDumpDataCore(ctx, cfg, in, destPath, nil, true)
 }

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -54,7 +54,7 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 		t.Fatalf("stat before: %v", err)
 	}
 
-	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for uuid mismatch")
 	}
@@ -106,7 +106,7 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 		t.Fatalf("stat before: %v", err)
 	}
 
-	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err == nil {
 		t.Fatalf("expected error for mounted device")
 	}
@@ -129,7 +129,7 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 	}
 
 	cfg.Force = true
-	err = tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 	if err != nil {
 		t.Fatalf("unexpected error with force: %v", err)
 	}

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"os"
@@ -164,7 +165,7 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 	destFile.Close()
 
 	cfgProcess := &config.Config{BlockSize: int(blockSize), Compress: "zstd,lz4", MaxRetries: 1}
-	if err = tr.ProcessDumpData(cfgProcess, bytes.NewReader(data), dest); err != nil {
+	if err = tr.ProcessDumpData(context.Background(), cfgProcess, bytes.NewReader(data), dest); err != nil {
 		t.Fatalf("ProcessDumpData failed: %v", err)
 	}
 

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -127,7 +127,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 			SyncIntervalBytes: 512,
 		}
 		tt := NewTransfer(zap.NewNop(), nil)
-		done <- tt.ProcessDumpData(applyCfg, conn, destLoop)
+		done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, destLoop)
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -240,7 +240,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 			SyncIntervalBytes: 512,
 		}
 		tt := NewTransfer(zap.NewNop(), nil)
-		done <- tt.ProcessDumpData(applyCfg, conn, dstLoop)
+		done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, dstLoop)
 	}()
 
 	conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -385,7 +385,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 					SyncIntervalBytes: 512,
 				}
 				tt := NewTransfer(zap.NewNop(), nil)
-				done <- tt.ProcessDumpData(applyCfg, conn, destLoop)
+				done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, destLoop)
 			}()
 
 			conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -510,7 +510,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 					SyncIntervalBytes: 512,
 				}
 				tt := NewTransfer(zap.NewNop(), nil)
-				done <- tt.ProcessDumpData(applyCfg, conn, dstLoop)
+				done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, dstLoop)
 			}()
 
 			conn, err := tr.Dial(ctx, ln.Addr().String())
@@ -684,7 +684,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 					SyncIntervalBytes: 512,
 				}
 				tt := NewTransfer(zap.NewNop(), nil)
-				done <- tt.ProcessDumpData(applyCfg, conn, dstLoop)
+				done <- tt.ProcessDumpData(context.Background(), applyCfg, conn, dstLoop)
 			}()
 
 			conn, err := tr.Dial(ctx, ln.Addr().String())

--- a/transfer/manifest_ctx_test.go
+++ b/transfer/manifest_ctx_test.go
@@ -1,0 +1,65 @@
+//go:build unix
+
+package transfer
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	manifestpkg "lvmsync_go/manifest"
+)
+
+func writeHeader(t *testing.T, path string) {
+	var hdr manifestpkg.Header
+	hdr.Version = manifestpkg.Version
+	copy(hdr.DeviceID[:], []byte("dev"))
+	hdr.MAC = manifestHeaderMAC(&hdr)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create header: %v", err)
+	}
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	f.Close()
+}
+
+func TestReadManifestHeaderCanceled(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "man")
+	writeHeader(t, p)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := readManifestHeader(ctx, p, 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestReadManifestHeaderTimeout(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "fifo")
+	if err := syscall.Mkfifo(fifo, 0600); err != nil {
+		t.Skipf("mkfifo: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		w, _ := os.OpenFile(fifo, os.O_WRONLY, 0600)
+		if w != nil {
+			w.Close()
+		}
+		close(done)
+	}()
+	if _, err := readManifestHeader(ctx, fifo, 0); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	<-done
+}

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -100,7 +100,7 @@ func TestProcessDumpDataRejectsManifestMismatch(t *testing.T) {
 		}
 		prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "wrong", nil })
 		defer device.SetUUIDFunc(prev)
-		err := tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+		err := tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 		if err == nil || !strings.Contains(err.Error(), "does not match manifest") {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -113,7 +113,7 @@ func TestProcessDumpDataRejectsManifestMismatch(t *testing.T) {
 		}
 		prev := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
 		defer device.SetUUIDFunc(prev)
-		err := tr.ProcessDumpData(cfg, bytes.NewReader(minimalStream(t)), dest)
+		err := tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
 		if err == nil || !strings.Contains(err.Error(), "size") {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/transfer/run_apply.go
+++ b/transfer/run_apply.go
@@ -53,9 +53,9 @@ func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string
 				}
 			}
 		}()
-		return t.ProcessDumpDataWithDeduplication(cfg, in, destDevice, dedup)
+		return t.ProcessDumpDataWithDeduplication(context.Background(), cfg, in, destDevice, dedup)
 	}
-	return t.ProcessDumpData(cfg, in, destDevice)
+	return t.ProcessDumpData(context.Background(), cfg, in, destDevice)
 }
 
 // RunApply reads a dump file or stdin and writes the data to destDevice.

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -199,8 +199,16 @@ func manifestHeaderMAC(h *manifestpkg.Header) [32]byte {
 	return blake3.Sum256(buf[:])
 }
 
-func readManifestHeader(path string) (*manifestpkg.Header, error) {
-	f, err := os.Open(path)
+func readManifestHeader(ctx context.Context, path string, timeout time.Duration) (*manifestpkg.Header, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	f, err := common.OpenWithContext(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -218,13 +226,13 @@ func readManifestHeader(path string) (*manifestpkg.Header, error) {
 	return &hdr, nil
 }
 
-func (t *Transfer) verifyDestination(cfg *config.Config, destPath string) error {
+func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, destPath string) error {
 	if cfg.ManifestPath != "" {
-		hdr, err := readManifestHeader(cfg.ManifestPath)
+		hdr, err := readManifestHeader(ctx, cfg.ManifestPath, 0)
 		if err != nil {
 			return err
 		}
-		id, err := device.GetDeviceID(context.Background(), destPath)
+		id, err := device.GetDeviceID(ctx, destPath)
 		if err != nil {
 			return fmt.Errorf("read destination id: %w", err)
 		}
@@ -233,7 +241,7 @@ func (t *Transfer) verifyDestination(cfg *config.Config, destPath string) error 
 			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", manID), zap.String("resource_id", id))
 			return fmt.Errorf("destination device id %s does not match manifest %s", id, manID)
 		}
-		size, err := device.SizeBytes(context.Background(), destPath)
+		size, err := device.SizeBytes(ctx, destPath)
 		if err != nil {
 			return fmt.Errorf("read destination size: %w", err)
 		}
@@ -243,7 +251,7 @@ func (t *Transfer) verifyDestination(cfg *config.Config, destPath string) error 
 		}
 		t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
 	} else if cfg.DeviceUUID != "" {
-		id, err := device.GetDeviceID(context.Background(), destPath)
+		id, err := device.GetDeviceID(ctx, destPath)
 		if err != nil {
 			return fmt.Errorf("read destination uuid: %w", err)
 		}


### PR DESCRIPTION
## Summary
- add `OpenWithContext` to allow cancelling file open operations
- plumb contexts through manifest header reading and destination verification
- test manifest header timeouts and cancellation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: read handshake EOF; QUIC negotiate error)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a08cf9a0008323b2f0ca219e93852e