### PR TITLE
Use SyncLogger helper for transfers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,13 @@ command-line use, environment variables, and `config.yaml` files.
 
 - Use [zap](https://github.com/uber-go/zap) for structured logging.
 - Zap is the sole logging backend; avoid `log` or `fmt.Print*` for progress output.
-- Always call `Sync()` (e.g., `defer logger.Sync()`) before program exit to flush buffers.
+- Always flush logs using the `SyncLogger` helper (e.g., `defer rootcmd.SyncLogger(logger)`) so `logger.Sync()` errors are recorded.
 - Transport constructors must accept a `*zap.Logger`; avoid package-level loggers.
 - Pass loggers explicitly to commands and helpers; do not use `zap.L()` or other globals.
 - Use `zap.NewNop()` instead of `nil` when no logging is needed.
 - Log connection lifecycle events and errors with `snake_case` fields including units (e.g., `bytes_transferred`, `duration_ms`).
 - Do not log secrets or authentication tokens; scrub sensitive values before emitting them.
-- Callers using transports should `defer logger.Sync()` to ensure logs are flushed.
+- Callers using transports should `defer rootcmd.SyncLogger(logger)` to ensure logs are flushed.
 
 ### Logging utilities
 
@@ -250,7 +250,7 @@ Run these commands locally before opening a pull request:
 
 ## Production Readiness Checklist
 
-- Use `zap` for all structured logging and call `logger.Sync()` on shutdown.
+- Use `zap` for all structured logging and call `rootcmd.SyncLogger(logger)` on shutdown.
 - Parse configuration with `pflag` and `viper`; expose every option via CLI flags, `LVMSYNC_*` environment variables, and the
   `config.yaml` file.
 - Group related CLI options into dedicated `FlagSet`s with clear descriptions.
@@ -265,14 +265,14 @@ Run these commands locally before opening a pull request:
 
 ## TODO
 
-- [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `logger.Sync()` before exit (block size logs now use `size_bytes`).
+- [ ] Audit logging: ensure `zap` is used with `snake_case` fields, include units, and call `rootcmd.SyncLogger(logger)` before exit (block size logs now use `size_bytes`).
 - [ ] Remove package-wide loggers; transport constructors such as `ssh.New(cfg, logger)` now require an explicit `*zap.Logger` parameter.
 - [ ] Remove stray `fmt.Print*` calls in favor of structured logs.
 - [ ] Monitor elimination of `fmt.Print*` calls to keep progress logging fully structured.
 - [ ] device: expand mountinfo parsing to handle bind mounts and multiple entries.
 - [ ] Review QUIC constructor refactor and expand tests for sender/receiver coverage.
 - [ ] LVM device support: plumb snapshot creation through the device abstraction, allow raw device fallbacks, and unit test LVM vs. file paths.
- - [x] Transport logging: emit connection handshake and teardown events with `snake_case` fields and ensure callers `defer logger.Sync()`.
+ - [x] Transport logging: emit connection handshake and teardown events with `snake_case` fields and ensure callers `defer rootcmd.SyncLogger(logger)`.
 - [ ] Manifest rebuild: add a subcommand to regenerate chunk digests when manifests are missing or out of date, exercising rebuild logic in tests.
 - [ ] Verify command: compare source and destination devices against manifest entries and surface mismatched digests with structured logs.
 - [x] Manifest: return error when block size is 0 during creation.
@@ -360,4 +360,4 @@ golangci-lint run
 
 ### Logging Rules
 - [ ] Use zap for structured logging with snake_case fields.
-- [ ] Call `logger.Sync()` on shutdown and avoid `fmt.Print*` for progress output.
+ - [ ] Call `rootcmd.SyncLogger(logger)` on shutdown and avoid `fmt.Print*` for progress output.

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -10,12 +10,13 @@ import (
 
 	"go.uber.org/zap"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/config"
 )
 
 func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, in io.Reader, destPath string, dedup DeduplicationStrategy, verify bool) (err error) {
-	defer func() { _ = t.Logger.Sync() }()
+	defer rootcmd.SyncLogger(t.Logger)
 	bufReader := bufio.NewReader(in)
 	var hs common.Handshake
 	hs, err = readAndValidateHandshake(cfg, bufReader, dedup, verify)

--- a/transfer/sync_logger_error_test.go
+++ b/transfer/sync_logger_error_test.go
@@ -1,0 +1,45 @@
+package transfer
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/config"
+)
+
+// failingSyncCore wraps a zapcore.Core and returns a fixed error from Sync.
+type failingSyncCore struct {
+	zapcore.Core
+	err error
+}
+
+func (c *failingSyncCore) Sync() error { return c.err }
+
+func TestDumpChangesLogsSyncError(t *testing.T) {
+	syncErr := errors.New("sync fail")
+	core, observed := observer.New(zap.InfoLevel)
+	logger := zap.New(&failingSyncCore{Core: core, err: syncErr})
+	tr := NewTransfer(logger, &sync.WaitGroup{})
+
+	blockSize := int64(1024)
+	changed := []int{0}
+	src, snapshot := createDumpTestFiles(t, blockSize, changed)
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
+	var buf bytes.Buffer
+	if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("DumpChangesSequential failed: %v", err)
+	}
+	logs := observed.FilterMessage("Logger sync error").All()
+	if len(logs) != 1 {
+		t.Fatalf("expected sync error log, got %d", len(logs))
+	}
+	if errStr, ok := logs[0].ContextMap()["error"].(string); !ok || errStr != syncErr.Error() {
+		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), logs[0].ContextMap()["error"])
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/config"
 	"lvmsync_go/device"
@@ -140,7 +141,7 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	if len(finalDigest) > 0 {
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}
-	_ = t.Logger.Sync()
+	rootcmd.SyncLogger(t.Logger)
 	return nil
 }
 

--- a/transfer/worker.go
+++ b/transfer/worker.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/config"
 	"lvmsync_go/internal/blocksize"
@@ -175,6 +176,6 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 	if len(finalDigest) > 0 {
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}
-	_ = t.Logger.Sync()
+	rootcmd.SyncLogger(t.Logger)
 	return nil
 }


### PR DESCRIPTION
## Summary
- ensure transfer code uses SyncLogger helper to log logger sync errors
- test logging when logger sync fails
- document SyncLogger usage in contributor guidelines

## Testing
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake: client negotiate: read handshake: EOF; TestQUICTransportSelectBestHandshake: read handshake: Application error 0x0; TestSSHTransportSelectBestHandshake: read handshake: EOF)*
- `go build ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a08e0e6acc8323a4271f089b623bb7