### PR TITLE
Add QUIC serve subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,23 @@ SSH transport negotiation also derives read and write deadlines from the caller'
   lvmsync run --mode throughput /dev/vg0/source /dev/vg1/target
   ```
 
+## Serve Subcommand
+
+Run a standalone QUIC listener:
+
+```sh
+lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
+```
+
+| Flag | Environment | Description |
+|------|-------------|-------------|
+| `--transport` | `LVMSYNC_SERVE_TRANSPORT` | Transport to serve |
+| `--quic-listen` | `LVMSYNC_SERVE_QUIC_LISTEN` | QUIC listen address |
+| `--tls-cert` | `LVMSYNC_SERVE_TLS_CERT` | TLS certificate file |
+| `--tls-key` | `LVMSYNC_SERVE_TLS_KEY` | TLS key file |
+| `--ca-cert` | `LVMSYNC_SERVE_CA_CERT` | CA certificate file |
+| `--allow-insecure` | `LVMSYNC_SERVE_ALLOW_INSECURE` | Permit insecure (no TLS) connections |
+
 ## gRPC Control Plane
 
 The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel. Plaintext connections are rejected unless `--allow-insecure` is explicitly set.

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zeebo/xxh3"
 	"go.uber.org/zap"
 
+	servecmd "lvmsync_go/cmd/serve"
 	verifycmd "lvmsync_go/cmd/verify"
 	"lvmsync_go/config"
 	"lvmsync_go/manifest"
@@ -34,6 +35,7 @@ var (
 	runCommand      = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil }
 	manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error { return nil }
 	verifyRun       = func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) }
+	serveRun        = func(args []string, logger *zap.Logger) error { return servecmd.Run(args, logger) }
 )
 
 // NewRootCmd creates the root cobra command with all subcommands wired.
@@ -129,7 +131,16 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 		},
 	}
 
-	rootCmd.AddCommand(runCmd, manifestCmd, verifyCmd)
+	serveCmd := &cobra.Command{
+		Use:                "serve [flags]",
+		Short:              "Run a transport listener",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return serveRun(args, logger)
+		},
+	}
+
+	rootCmd.AddCommand(runCmd, manifestCmd, verifyCmd, serveCmd)
 	return rootCmd
 }
 

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -1,0 +1,123 @@
+package serve
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/transport"
+	_ "lvmsync_go/transport/quic"
+)
+
+// Options holds configuration for the serve command.
+type Options struct {
+	Transport     string
+	QUICListen    string
+	TLSCert       string
+	TLSKey        string
+	CACert        string
+	AllowInsecure bool
+}
+
+// Run executes the serve command with provided arguments and logger.
+// Args should exclude the "serve" subcommand itself.
+func Run(args []string, logger *zap.Logger) error {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	defer rootcmd.SyncLogger(logger)
+
+	v := viper.New()
+	cmd := &cobra.Command{
+		Use:   "serve [flags]",
+		Short: "Run a transport listener",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts := Options{
+				Transport:     v.GetString("transport"),
+				QUICListen:    v.GetString("quic-listen"),
+				TLSCert:       v.GetString("tls-cert"),
+				TLSKey:        v.GetString("tls-key"),
+				CACert:        v.GetString("ca-cert"),
+				AllowInsecure: v.GetBool("allow-insecure"),
+			}
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+			defer stop()
+			return startServer(ctx, opts, logger)
+		},
+	}
+	bindFlags(cmd, v)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+	fs := pflag.NewFlagSet("serve", pflag.ExitOnError)
+	fs.String("transport", "quic", "transport to use")
+	fs.String("quic-listen", ":12000", "QUIC listen address")
+	fs.String("tls-cert", "", "TLS certificate file")
+	fs.String("tls-key", "", "TLS key file")
+	fs.String("ca-cert", "", "CA certificate file")
+	fs.Bool("allow-insecure", false, "allow insecure (no TLS)")
+	cmd.Flags().AddFlagSet(fs)
+	v.BindPFlags(fs)
+	v.SetEnvPrefix("LVMSYNC_SERVE")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+}
+
+func startServer(ctx context.Context, opts Options, logger *zap.Logger) error {
+	cfg := transport.Config{Logger: logger, AllowInsecure: opts.AllowInsecure}
+	if !opts.AllowInsecure {
+		if opts.TLSCert == "" || opts.TLSKey == "" || opts.CACert == "" {
+			return fmt.Errorf("tls-cert, tls-key, and ca-cert are required unless --allow-insecure is set")
+		}
+	}
+	if opts.TLSCert != "" && opts.TLSKey != "" {
+		cert, err := tls.LoadX509KeyPair(opts.TLSCert, opts.TLSKey)
+		if err != nil {
+			return fmt.Errorf("load TLS key pair: %w", err)
+		}
+		cfg.ClientCert = cert
+	}
+	if opts.CACert != "" {
+		pem, err := os.ReadFile(opts.CACert)
+		if err != nil {
+			return fmt.Errorf("read CA cert: %w", err)
+		}
+		roots := x509.NewCertPool()
+		if !roots.AppendCertsFromPEM(pem) {
+			return fmt.Errorf("invalid CA cert")
+		}
+		cfg.Roots = roots
+	}
+	tr, err := transport.Get(opts.Transport, cfg)
+	if err != nil {
+		return fmt.Errorf("get transport: %w", err)
+	}
+	ln, err := tr.Listen(ctx, opts.QUICListen)
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	<-ctx.Done()
+	return nil
+}

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -1,0 +1,72 @@
+package serve
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+func TestFlagParsing(t *testing.T) {
+	v := viper.New()
+	cmd := &cobra.Command{Use: "serve"}
+	bindFlags(cmd, v)
+	args := []string{
+		"--transport", "quic",
+		"--quic-listen", "127.0.0.1:1234",
+		"--tls-cert", "cert.pem",
+		"--tls-key", "key.pem",
+		"--ca-cert", "ca.pem",
+		"--allow-insecure",
+	}
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	got := Options{
+		Transport:     v.GetString("transport"),
+		QUICListen:    v.GetString("quic-listen"),
+		TLSCert:       v.GetString("tls-cert"),
+		TLSKey:        v.GetString("tls-key"),
+		CACert:        v.GetString("ca-cert"),
+		AllowInsecure: v.GetBool("allow-insecure"),
+	}
+	want := Options{
+		Transport:     "quic",
+		QUICListen:    "127.0.0.1:1234",
+		TLSCert:       "cert.pem",
+		TLSKey:        "key.pem",
+		CACert:        "ca.pem",
+		AllowInsecure: true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v want %+v", got, want)
+	}
+}
+
+func TestStartServer(t *testing.T) {
+	logger := zap.NewNop()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opts := Options{Transport: "quic", QUICListen: "127.0.0.1:0", AllowInsecure: true}
+	errCh := make(chan error, 1)
+	go func() { errCh <- startServer(ctx, opts, logger) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("startServer: %v", err)
+	}
+}
+
+func TestStartServerRequiresCerts(t *testing.T) {
+	logger := zap.NewNop()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opts := Options{Transport: "quic", QUICListen: "127.0.0.1:0"}
+	if err := startServer(ctx, opts, logger); err == nil {
+		t.Fatalf("expected error for missing certs")
+	}
+}

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -81,6 +81,12 @@ Example:
 lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
 ```
 
+Run a listener with the `serve` subcommand:
+
+```sh
+lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
+```
+
 ## HTTP/2 (h2)
 
 - Runs over TLS 1.3 with mutual authentication


### PR DESCRIPTION
## Summary
- add `serve` subcommand implementing a minimal QUIC listener with TLS options
- expose the subcommand from the root CLI and document usage
- cover flag parsing and server initialization with unit tests

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: client negotiate: read handshake: Application error; test timed out; see logs)*
- `go test -cover ./cmd/serve`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a093a42f088323a8efc11eef71e7e3