### PR TITLE
manifest: add header MAC mismatch test

### DIFF
--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -93,6 +93,25 @@ func TestCreateZeroBlockSize(t *testing.T) {
 	}
 }
 
+func TestReadHeaderMACMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mac.man")
+	idx, err := Create(path, "dev", 4096, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	idx.data[104] ^= 0xff
+	if err := idx.readHeader(); err == nil || !strings.Contains(err.Error(), "header MAC mismatch") {
+		t.Fatalf("expected header MAC mismatch, got %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := Open(path); err == nil || !strings.Contains(err.Error(), "header MAC mismatch") {
+		t.Fatalf("expected Open to propagate mismatch, got %v", err)
+	}
+}
+
 func TestUpgrade(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "old.man")


### PR DESCRIPTION
## Summary
- add unit test verifying header MAC mismatch detection and error propagation

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake: client negotiate: read handshake: EOF)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a0ad20483883239d1b6343e0c1ab68