### PR TITLE
Use timeouts for network operations in tests

### DIFF
--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -254,7 +254,9 @@ func TestDialFailure(t *testing.T) {
 	failDialer := func(ctx context.Context, s string) (net.Conn, error) {
 		return nil, errors.New("fail")
 	}
-	_, err := Dial(context.Background(), "fail", Config{AllowInsecure: true, DialTimeout: time.Second}, zap.NewNop(), grpc.WithContextDialer(failDialer))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, "fail", Config{AllowInsecure: true, DialTimeout: time.Second}, zap.NewNop(), grpc.WithContextDialer(failDialer))
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -265,7 +267,9 @@ func TestDialTimeoutExceeded(t *testing.T) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	_, err := Dial(context.Background(), "slow", Config{AllowInsecure: true, DialTimeout: 10 * time.Millisecond}, zap.NewNop(), grpc.WithContextDialer(slowDialer))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, "slow", Config{AllowInsecure: true, DialTimeout: 10 * time.Millisecond}, zap.NewNop(), grpc.WithContextDialer(slowDialer))
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/transport/negotiation_integration_test.go
+++ b/transport/negotiation_integration_test.go
@@ -24,30 +24,36 @@ import (
 )
 
 func handshakeRoundTrip(t transport.Interface, tname string) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ln, err := t.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		return err
 	}
 	defer ln.Close()
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
+		send := func(err error) {
+			select {
+			case done <- err:
+			case <-ctx.Done():
+			}
+		}
 		conn, err := ln.Accept()
 		if err != nil {
-			done <- err
+			send(err)
 			return
 		}
 		req, err := common.ReadHandshake(bufio.NewReader(conn))
 		if err != nil {
 			conn.Close()
-			done <- err
+			send(err)
 			return
 		}
 		if req.ALPN != "h2" || req.TLSVersion != "1.3" {
-			// Expect ALPN "h2" and TLS version "1.3" from the client handshake
 			conn.Close()
-			done <- fmt.Errorf("unexpected request: %+v", req)
+			send(fmt.Errorf("unexpected request: %+v", req))
 			return
 		}
 		resp := common.Handshake{Version: common.ProtocolVersion, ALPN: req.ALPN, TLSVersion: req.TLSVersion}
@@ -56,11 +62,11 @@ func handshakeRoundTrip(t transport.Interface, tname string) error {
 		resp.Digest = common.SelectBest([]string{"blake3", "sha256"}, req.Digests)
 		if err := common.WriteHandshake(conn, resp); err != nil {
 			conn.Close()
-			done <- err
+			send(err)
 			return
 		}
 		conn.Close()
-		done <- nil
+		send(nil)
 	}()
 
 	conn, err := t.Dial(ctx, ln.Addr().String())

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -187,17 +187,17 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 		srvErr <- err
 	}()
 
-	dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+	dialCtx, dialCancel := context.WithTimeout(ctx, time.Second)
 	conn, err := tr.Dial(dialCtx, ln.Addr().String())
 	if err != nil {
-		cancel()
+		dialCancel()
 		t.Fatalf("dial: %v", err)
 	}
-	defer cancel()
+	defer dialCancel()
 	qconn := conn.(*Conn)
-	negCtx, cancel := context.WithTimeout(ctx, time.Second)
+	negCtx, negCancel := context.WithTimeout(ctx, time.Second)
 	peer, err := tr.Negotiate(negCtx, qconn, transport.Client, cliHS)
-	cancel()
+	negCancel()
 	if err != nil {
 		qconn.Close()
 		t.Fatalf("client negotiate: %v", err)
@@ -220,7 +220,8 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 		t.Fatalf("new transport: %v", err)
 	}
 	tr := trIface.(*Transport)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -267,7 +268,8 @@ func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
 		t.Fatalf("new transport: %v", err)
 	}
 	tr := trIface.(*Transport)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -355,7 +357,8 @@ func TestConnDatagramReadDeadline(t *testing.T) {
 		t.Fatalf("new transport: %v", err)
 	}
 	tr := trIface.(*Transport)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -414,7 +417,8 @@ func TestConnDatagramContextDeadline(t *testing.T) {
 		t.Fatalf("new transport: %v", err)
 	}
 	tr := trIface.(*Transport)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -457,7 +461,8 @@ func TestConnStreamDeadlines(t *testing.T) {
 		t.Fatalf("new transport: %v", err)
 	}
 	tr := trIface.(*Transport)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)

--- a/transport/registry_fallback_test.go
+++ b/transport/registry_fallback_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -60,7 +61,9 @@ func TestRegistryDialFallbackSequence(t *testing.T) {
 	logger := zap.New(core)
 	defer logger.Sync()
 
-	tr, conn, err := DialWithFallback(context.Background(), "127.0.0.1:0", []string{"quic", "h2", "tcp+tls", "ssh"}, Config{Logger: logger})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	tr, conn, err := DialWithFallback(ctx, "127.0.0.1:0", []string{"quic", "h2", "tcp+tls", "ssh"}, Config{Logger: logger})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add context deadlines when dialing transports
- time out ReceiveDatagram calls to avoid hanging goroutines
- cancel negotiation goroutines when context expires

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestQUICTransportSelectBestHandshake, TestH2TransportSelectBestHandshake)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a0b1359f6883238d87af73479aa0c4