### PR TITLE
Define exit code constants and update CLI exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1442,15 +1442,18 @@ Invalid configurations will cause the tool to abort with a clear error message.
 
 ## Exit Codes
 
-LVMSync commands such as `lvmsync` and `lvmsync-grpcd` return conventional exit codes to indicate overall status:
+LVMSync commands such as `lvmsync` and `lvmsync-grpcd` return specific exit codes:
 
 | Code | Meaning |
 |------|---------|
 | `0`  | Success |
-| `1`  | Configuration or runtime failure |
-| other | Subcommand-specific codes (see individual command docs) |
+| `10` | Privilege or capability check failed |
+| `20` | Device error |
+| `30` | Unsupported platform |
+| `40` | Configuration error |
+| `50` | Runtime failure |
 
-Exit code handling lives in [main.go](main.go#L21-L37), with configuration errors bubbling up from [cmd/root/root.go](cmd/root/root.go#L42-L52) and runtime errors from [cmd/root/root.go](cmd/root/root.go#L121-L186). Subcommands may return additional exit codes to communicate their own failure modes.
+Exit code definitions live in [internal/exitcode](internal/exitcode/exitcode.go), and handling resides in [main.go](main.go).
 
 Shell scripts can rely on `set -e` to abort on non-zero exit codes:
 

--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -4,21 +4,27 @@ import (
 	"os"
 
 	"go.uber.org/zap"
+
+	"lvmsync_go/internal/exitcode"
 )
 
-func main() {
-	logger, err := zap.NewProduction()
+func run(newLogger func() (*zap.Logger, error), runner *Runner) int {
+	logger, err := newLogger()
 	if err != nil {
-		os.Exit(1)
+		return exitcode.ErrConfig
 	}
 	defer func() {
 		if err := logger.Sync(); err != nil {
 			logger.Error("logger sync error", zap.Error(err))
 		}
 	}()
-	runner := NewRunner()
 	if err := runner.Execute(nil, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
-		os.Exit(1)
+		return exitcode.ErrRuntime
 	}
+	return exitcode.OK
+}
+
+func main() {
+	os.Exit(run(func() (*zap.Logger, error) { return zap.NewProduction() }, NewRunner()))
 }

--- a/cmd/grpcd/main_test.go
+++ b/cmd/grpcd/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/exitcode"
+)
+
+func TestRunLoggerError(t *testing.T) {
+	code := run(func() (*zap.Logger, error) { return nil, errors.New("logger fail") }, NewRunner())
+	if code != exitcode.ErrConfig {
+		t.Fatalf("expected %d, got %d", exitcode.ErrConfig, code)
+	}
+}
+
+func TestRunExecuteError(t *testing.T) {
+	r := NewRunnerWithDeps(func(_ context.Context, _ Options, _ *zap.Logger) error {
+		return errors.New("boom")
+	})
+	code := run(func() (*zap.Logger, error) { return zap.NewNop(), nil }, r)
+	if code != exitcode.ErrRuntime {
+		t.Fatalf("expected %d, got %d", exitcode.ErrRuntime, code)
+	}
+}

--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -1,0 +1,16 @@
+package exitcode
+
+// Exit codes for lvmsync binaries.
+const (
+	OK = 0
+	// ErrCapability indicates missing privileges or capabilities.
+	ErrCapability = 10
+	// ErrDevice indicates a device-related failure.
+	ErrDevice = 20
+	// ErrPlatform is returned when the operating system is unsupported.
+	ErrPlatform = 30
+	// ErrConfig represents configuration or validation failures.
+	ErrConfig = 40
+	// ErrRuntime represents errors during command execution.
+	ErrRuntime = 50
+)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"runtime"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -10,6 +11,7 @@ import (
 	_ "lvmsync_go/cmd/dump"
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/config"
+	"lvmsync_go/internal/exitcode"
 )
 
 // Runner executes the application with injected dependencies.
@@ -67,7 +69,7 @@ func (r *Runner) Run() {
 		if err := tmpLogger.Sync(); err != nil {
 			tmpLogger.Error("Logger sync error", zap.Error(err))
 		}
-		r.Exit(1)
+		r.Exit(exitcode.ErrPlatform)
 		return
 	}
 
@@ -78,13 +80,21 @@ func (r *Runner) Run() {
 		if err := tmpLogger.Sync(); err != nil {
 			tmpLogger.Error("Logger sync error", zap.Error(err))
 		}
-		r.Exit(1)
+		if strings.Contains(err.Error(), "privilege check failed") {
+			r.Exit(exitcode.ErrCapability)
+		} else {
+			r.Exit(exitcode.ErrConfig)
+		}
 		return
 	}
 	if err := r.RunFunc(cfg, args, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
 		r.SyncLogger(logger)
-		r.Exit(1)
+		if strings.Contains(err.Error(), "device") {
+			r.Exit(exitcode.ErrDevice)
+		} else {
+			r.Exit(exitcode.ErrRuntime)
+		}
 		return
 	}
 	r.SyncLogger(logger)

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -10,6 +10,7 @@ import (
 
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/config"
+	"lvmsync_go/internal/exitcode"
 )
 
 type syncCheckCore struct {
@@ -43,8 +44,8 @@ func TestMainLogsStructuredError(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
+	if code != exitcode.ErrRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrRuntime, code)
 	}
 
 	entries := logs.FilterMessage("run failed").All()
@@ -83,8 +84,8 @@ func TestMainLogsConfigError(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
+	if code != exitcode.ErrConfig {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrConfig, code)
 	}
 
 	entries := logs.FilterMessage("configuration failed").All()
@@ -123,8 +124,8 @@ func TestMainErrorsOnNonLinux(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
+	if code != exitcode.ErrPlatform {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrPlatform, code)
 	}
 
 	entries := logs.FilterMessage("unsupported platform").All()
@@ -143,5 +144,40 @@ func TestMainErrorsOnNonLinux(t *testing.T) {
 
 	if !synced {
 		t.Fatalf("logger was not synced")
+	}
+}
+
+func TestMainCapabilityErrorExitCode(t *testing.T) {
+	var code int
+	runner := NewRunnerWithDeps(
+		func() (*config.Config, []string, *zap.Logger, error) {
+			return nil, nil, nil, errors.New("privilege check failed: caps")
+		},
+		rootcmd.Run,
+		rootcmd.SyncLogger,
+		func(c int) { code = c },
+		func() *zap.Logger { return zap.NewNop() },
+		"linux",
+	)
+	runner.Run()
+	if code != exitcode.ErrCapability {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrCapability, code)
+	}
+}
+
+func TestMainDeviceErrorExitCode(t *testing.T) {
+	var code int
+	logger := zap.NewNop()
+	runner := NewRunnerWithDeps(
+		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("device lost") },
+		rootcmd.SyncLogger,
+		func(c int) { code = c },
+		func() *zap.Logger { return zap.NewNop() },
+		"linux",
+	)
+	runner.Run()
+	if code != exitcode.ErrDevice {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrDevice, code)
 	}
 }


### PR DESCRIPTION
## Summary
- add internal/exitcode package defining standardized exit codes
- map main and grpcd binaries to use exit codes and document them
- test exit codes for config, runtime, platform, capability, and device errors

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake: client negotiate: read handshake: EOF)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0c0512d788323a54d4d484f335088