### PR TITLE
transfer: add CRC32C validation

### DIFF
--- a/common/handshake.go
+++ b/common/handshake.go
@@ -25,6 +25,7 @@ type Handshake struct {
 
 	Checksum      bool
 	ChecksumDedup bool
+	CRC32C        bool
 	Endianness    string
 	BlockSize     int
 	DedupMode     string
@@ -109,6 +110,9 @@ func WriteHandshake(w io.Writer, h Handshake) error {
 		tokens = append(tokens, "digests:"+strings.Join(h.Digests, ","))
 	}
 
+	if h.CRC32C {
+		tokens = append(tokens, "crc32c")
+	}
 	if h.ChecksumDedup {
 		tokens = append(tokens, "checksum-dedup")
 	} else if h.Checksum {
@@ -211,6 +215,8 @@ func ReadHandshake(r *bufio.Reader) (Handshake, error) {
 			h.ALPN = strings.TrimPrefix(t, "alpn:")
 		case strings.HasPrefix(t, "tls:"):
 			h.TLSVersion = strings.TrimPrefix(t, "tls:")
+		case t == "crc32c":
+			h.CRC32C = true
 		case t == "checksum":
 			h.Checksum = true
 		case t == "checksum-dedup":

--- a/common/handshake_validate.go
+++ b/common/handshake_validate.go
@@ -41,6 +41,9 @@ func ValidateHandshake(local, peer Handshake) error {
 	if peer.Digest != "" && local.Digest != "" && peer.Digest != local.Digest {
 		return fmt.Errorf("digest mismatch: %s", peer.Digest)
 	}
+	if peer.CRC32C != local.CRC32C {
+		return fmt.Errorf("crc32c support mismatch: %v", peer.CRC32C)
+	}
 	if peer.ODirect != local.ODirect {
 		return fmt.Errorf("o_direct mismatch: %v", peer.ODirect)
 	}

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -20,7 +20,7 @@ import (
 
 func minimalStream(t *testing.T) []byte {
 	var buf bytes.Buffer
-	if err := common.WriteHandshake(&buf, common.Handshake{Compress: "none", Checksum: true, Digests: []string{"sha256"}, Digest: "sha256"}); err != nil {
+	if err := common.WriteHandshake(&buf, common.Handshake{Compress: "none", Checksum: true, CRC32C: true, Digests: []string{"sha256"}, Digest: "sha256"}); err != nil {
 		t.Fatalf("handshake: %v", err)
 	}
 	return buf.Bytes()

--- a/transfer/block_stream.go
+++ b/transfer/block_stream.go
@@ -51,7 +51,7 @@ func iterateBlocks(
 ) (int64, int, []byte, error) {
 	var totalBytes int64
 	skippedBlocks := 0
-	var header [12]byte
+	var header [16]byte
 	h := newDigestHasher(cfg.ChecksumAlgorithm)
 	var idx *manifestpkg.Index
 	if cfg.ManifestPath != "" {
@@ -98,7 +98,8 @@ func iterateBlocks(
 		binary.BigEndian.PutUint64(header[0:8], r.Start)
 		if isAllZero(data) {
 			binary.BigEndian.PutUint32(header[8:12], 0)
-			if _, err := bufOut.Write(header[:]); err != nil {
+			binary.BigEndian.PutUint32(header[12:16], 0)
+			if _, err := bufOut.Write(header[:16]); err != nil {
 				putBlockBuffer(data)
 				return totalBytes, skippedBlocks, nil, fmt.Errorf("failed to write header: %w", err)
 			}
@@ -116,7 +117,8 @@ func iterateBlocks(
 		}
 		sum = sumFn()
 		binary.BigEndian.PutUint32(header[8:12], blockSize)
-		if _, err := bufOut.Write(header[:]); err != nil {
+		binary.BigEndian.PutUint32(header[12:16], crc32c(data))
+		if _, err := bufOut.Write(header[:16]); err != nil {
 			putBlockBuffer(data)
 			return totalBytes, skippedBlocks, nil, fmt.Errorf("failed to write header: %w", err)
 		}
@@ -144,10 +146,11 @@ func iterateBlocks(
 func prepareResultHeader(cfg *config.Config, checksum ChecksumStrategy, res *BlockResult, header []byte) int {
 	binary.BigEndian.PutUint64(header[0:8], res.Offset)
 	binary.BigEndian.PutUint32(header[8:12], res.Size)
-	n := 12
+	binary.BigEndian.PutUint32(header[12:16], crc32c(res.Data))
+	n := 16
 	if cfg.VerifyChecksum {
 		sum := checksum.Compute(res.Data)
-		copy(header[12:], sum)
+		copy(header[16:], sum)
 		n += checksum.Size()
 	}
 	return n
@@ -173,7 +176,7 @@ func processParallelResults(
 	logger *zap.Logger,
 	rt *resumeTracker,
 ) (int64, []byte, error) {
-	headerSize := 12
+	headerSize := 16
 	if cfg.VerifyChecksum {
 		headerSize += checksum.Size()
 	}

--- a/transfer/block_stream_test.go
+++ b/transfer/block_stream_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
 
@@ -26,9 +27,12 @@ func TestPrepareResultHeader(t *testing.T) {
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	sum := blake3.Sum256([]byte("test"))
 	res := &BlockResult{Offset: 5, Size: 4, Data: []byte("test"), ChunkID: sum}
-	header := make([]byte, 12+checksum.Size())
+	header := make([]byte, 16+checksum.Size())
 	n := prepareResultHeader(cfg, checksum, res, header)
 	if n != len(header) {
 		t.Fatalf("expected header length %d, got %d", len(header), n)
+	}
+	if binary.BigEndian.Uint32(header[12:16]) != crc32c(res.Data) {
+		t.Fatalf("unexpected crc32c")
 	}
 }

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -62,14 +62,14 @@ func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrate
 // checksum verification, and issues fdatasync calls after each configured
 // interval. It returns the total number of bytes written.
 func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
-	headerLen := 12
+	headerLen := 16
 	if bw.verify {
 		headerLen += bw.checksum.Size()
 	}
 	headerBuf := make([]byte, headerLen)
 	var total int64
 	for {
-		offset, chunkSize, transmitted, err := readBlockHeader(reader, headerBuf, bw.verify, bw.checksum)
+		offset, chunkSize, crc, transmitted, err := readBlockHeader(reader, headerBuf, bw.verify, bw.checksum)
 		if err == io.EOF {
 			break
 		}
@@ -89,7 +89,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		} else {
 			chunkID = zeroHash(int(chunkSize))
 		}
-		written, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.verify, bw.checksum, offset, transmitted, data, chunkSize, bw.logger)
+		written, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.verify, bw.checksum, offset, crc, transmitted, data, chunkSize, bw.logger)
 		if bw.cfg.ODirect {
 			if data != nil {
 				putAlignedBlockBuffer(data)

--- a/transfer/block_writer_apply_test.go
+++ b/transfer/block_writer_apply_test.go
@@ -20,6 +20,7 @@ func buildBlockStream(t *testing.T, verify bool, checksum ChecksumStrategy, bloc
 		offset := uint64(i * len(data))
 		binary.Write(w, binary.BigEndian, offset)
 		binary.Write(w, binary.BigEndian, uint32(len(data)))
+		binary.Write(w, binary.BigEndian, crc32c(data))
 		if verify {
 			sum := checksum.Compute(data)
 			w.Write(sum)
@@ -94,6 +95,7 @@ func TestBlockWriterMACVerification(t *testing.T) {
 	w := bufio.NewWriter(buf)
 	binary.Write(w, binary.BigEndian, uint64(0))
 	binary.Write(w, binary.BigEndian, uint32(len(data)))
+	binary.Write(w, binary.BigEndian, crc32c(data))
 	sum := checksum.Compute(data)
 	sum[0] ^= 0xff
 	w.Write(sum)
@@ -102,5 +104,38 @@ func TestBlockWriterMACVerification(t *testing.T) {
 	badReader := bufio.NewReader(bytes.NewReader(buf.Bytes()))
 	if _, err := bw.write(badReader); err == nil {
 		t.Fatalf("expected checksum mismatch")
+	}
+}
+
+func TestBlockWriterCRCValidation(t *testing.T) {
+	cfg := &config.Config{BlockSize: 4}
+	tmp := t.TempDir()
+	f, err := os.CreateTemp(tmp, "dest")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	defer f.Close()
+
+	bw, err := newBlockWriter(cfg, f, nil, false, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newBlockWriter: %v", err)
+	}
+	data := []byte{1, 2, 3, 4}
+	reader := buildBlockStream(t, false, nil, [][]byte{data})
+	if _, err := bw.write(reader); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	w := bufio.NewWriter(buf)
+	binary.Write(w, binary.BigEndian, uint64(0))
+	binary.Write(w, binary.BigEndian, uint32(len(data)))
+	badCRC := crc32c(data) ^ 0xff
+	binary.Write(w, binary.BigEndian, badCRC)
+	w.Write(data)
+	w.Flush()
+	badReader := bufio.NewReader(bytes.NewReader(buf.Bytes()))
+	if _, err := bw.write(badReader); err == nil {
+		t.Fatalf("expected crc mismatch")
 	}
 }

--- a/transfer/block_writer_test.go
+++ b/transfer/block_writer_test.go
@@ -26,14 +26,19 @@ func TestBlockWriterSyncIntervalTriggers(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	hdr := make([]byte, 12)
+	hdr := make([]byte, 16)
+	data1 := []byte{1, 2, 3, 4}
 	binary.BigEndian.PutUint64(hdr[0:8], 0)
 	binary.BigEndian.PutUint32(hdr[8:12], 4)
+	binary.BigEndian.PutUint32(hdr[12:16], crc32c(data1))
 	buf.Write(hdr)
-	buf.Write([]byte{1, 2, 3, 4})
+	buf.Write(data1)
+	data2 := []byte{5, 6, 7, 8}
 	binary.BigEndian.PutUint64(hdr[0:8], 4)
+	binary.BigEndian.PutUint32(hdr[8:12], 4)
+	binary.BigEndian.PutUint32(hdr[12:16], crc32c(data2))
 	buf.Write(hdr)
-	buf.Write([]byte{5, 6, 7, 8})
+	buf.Write(data2)
 
 	calls := 0
 	orig := fdatasyncFile

--- a/transfer/crc32c.go
+++ b/transfer/crc32c.go
@@ -1,0 +1,9 @@
+package transfer
+
+import "hash/crc32"
+
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+func crc32c(data []byte) uint32 {
+	return crc32.Checksum(data, crc32cTable)
+}

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -32,7 +32,7 @@ func parseOffsetsNoHandshake(t *testing.T, r io.Reader) []int64 {
 	reader := bufio.NewReader(r)
 	var offsets []int64
 	for {
-		header := make([]byte, 12)
+		header := make([]byte, 16)
 		if _, err := io.ReadFull(reader, header); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				break

--- a/transfer/handshake.go
+++ b/transfer/handshake.go
@@ -24,6 +24,7 @@ func composeHandshake(cfg *config.Config, mode string) common.Handshake {
 		CDCMax:      cfg.CDCMax,
 		ResumeToken: cfg.ResumeToken,
 		MaxInFlight: cfg.Concurrency,
+		CRC32C:      true,
 	}
 	switch mode {
 	case StrategyChecksum:
@@ -74,6 +75,9 @@ func readAndValidateHandshake(cfg *config.Config, bufReader *bufio.Reader, dedup
 	}
 	if dedup != nil && !hs.ChecksumDedup {
 		return hs, fmt.Errorf("unexpected protocol handshake: %s", hs.String())
+	}
+	if !hs.CRC32C {
+		return hs, fmt.Errorf("remote lacks CRC32C support")
 	}
 	transport, err := negotiate(splitList(cfg.Transport), hs.Transports)
 	if err == nil && transport != "" {

--- a/transfer/handshake_test.go
+++ b/transfer/handshake_test.go
@@ -12,7 +12,7 @@ import (
 func TestComposeHandshake(t *testing.T) {
 	cfg := &config.Config{Compress: "zstd", Transport: "ssh", ChecksumAlgorithm: "sha256"}
 	hs := composeHandshake(cfg, "")
-	if hs.Compress != "zstd" || len(hs.Transports) != 1 || hs.Transports[0] != "ssh" {
+	if hs.Compress != "zstd" || len(hs.Transports) != 1 || hs.Transports[0] != "ssh" || !hs.CRC32C {
 		t.Fatalf("unexpected handshake: %+v", hs)
 	}
 	hs = composeHandshake(cfg, StrategyChecksum)
@@ -27,7 +27,7 @@ func TestComposeHandshake(t *testing.T) {
 
 func TestReadAndValidateHandshake(t *testing.T) {
 	buf := &bytes.Buffer{}
-	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, Checksum: true, CDCMin: 64, CDCAvg: 128, CDCMax: 256, ResumeToken: "tok", MaxInFlight: 8})
+	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, Checksum: true, CRC32C: true, CDCMin: 64, CDCAvg: 128, CDCMax: 256, ResumeToken: "tok", MaxInFlight: 8})
 	cfg := &config.Config{Transport: "ssh", Compress: "zstd", ChecksumAlgorithm: "sha256"}
 	hs, err := readAndValidateHandshake(cfg, bufio.NewReader(buf), nil, true)
 	if err != nil || !hs.Checksum {
@@ -40,7 +40,7 @@ func TestReadAndValidateHandshake(t *testing.T) {
 
 func TestReadAndValidateHandshakeError(t *testing.T) {
 	buf := &bytes.Buffer{}
-	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, Checksum: false})
+	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, Checksum: false, CRC32C: true})
 	cfg := &config.Config{Transport: "ssh", Compress: "zstd", ChecksumAlgorithm: "sha256"}
 	_, err := readAndValidateHandshake(cfg, bufio.NewReader(buf), nil, true)
 	if err == nil {
@@ -50,7 +50,7 @@ func TestReadAndValidateHandshakeError(t *testing.T) {
 
 func TestReadAndValidateResumeTokenMismatch(t *testing.T) {
 	buf := &bytes.Buffer{}
-	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, ResumeToken: "remote"})
+	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, ResumeToken: "remote", CRC32C: true})
 	cfg := &config.Config{Transport: "ssh", Compress: "zstd", ChecksumAlgorithm: "sha256", ResumeToken: "local"}
 	if _, err := readAndValidateHandshake(cfg, bufio.NewReader(buf), nil, false); err == nil {
 		t.Fatal("expected resume token mismatch error")
@@ -59,7 +59,7 @@ func TestReadAndValidateResumeTokenMismatch(t *testing.T) {
 
 func TestReadAndValidateMaxInFlightMismatch(t *testing.T) {
 	buf := &bytes.Buffer{}
-	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, MaxInFlight: 4})
+	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compress: "zstd", Compressors: []string{"zstd"}, Digests: []string{"sha256"}, MaxInFlight: 4, CRC32C: true})
 	cfg := &config.Config{Transport: "ssh", Compress: "zstd", ChecksumAlgorithm: "sha256", Concurrency: 8}
 	if _, err := readAndValidateHandshake(cfg, bufio.NewReader(buf), nil, false); err == nil {
 		t.Fatal("expected max in-flight mismatch error")
@@ -69,7 +69,7 @@ func TestReadAndValidateMaxInFlightMismatch(t *testing.T) {
 func TestHandshakeNegotiation(t *testing.T) {
 	buf := &bytes.Buffer{}
 	// remote supports ssh and tcp+tls, prefers ssh
-	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh", "tcp+tls"}, Compressors: []string{"lz4", "zstd"}, Digests: []string{"sha256", "blake3"}, Checksum: true})
+	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh", "tcp+tls"}, Compressors: []string{"lz4", "zstd"}, Digests: []string{"sha256", "blake3"}, Checksum: true, CRC32C: true})
 	cfg := &config.Config{Transport: "tcp+tls,ssh", Compress: "zstd,lz4", ChecksumAlgorithm: "blake3,sha256"}
 	hs, err := readAndValidateHandshake(cfg, bufio.NewReader(buf), nil, true)
 	if err != nil {
@@ -85,7 +85,7 @@ func TestHandshakeNegotiation(t *testing.T) {
 
 func TestHandshakeDigestMismatch(t *testing.T) {
 	buf := &bytes.Buffer{}
-	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compressors: []string{"zstd"}, Digests: []string{"sha256"}, Checksum: true})
+	common.WriteHandshake(buf, common.Handshake{Transports: []string{"ssh"}, Compressors: []string{"zstd"}, Digests: []string{"sha256"}, Checksum: true, CRC32C: true})
 	cfg := &config.Config{Transport: "ssh", Compress: "zstd", ChecksumAlgorithm: "blake3"}
 	if _, err := readAndValidateHandshake(cfg, bufio.NewReader(buf), nil, true); err == nil {
 		t.Fatal("expected digest mismatch error")

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -55,7 +55,7 @@ func parseOffsets(t *testing.T, data []byte, blockSize int64) []int64 {
 	}
 	var offsets []int64
 	for {
-		header := make([]byte, 12)
+		header := make([]byte, 16)
 		if _, err = io.ReadFull(reader, header); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				break

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -56,12 +56,13 @@ func TestSaveResumeStatePermissions(t *testing.T) {
 }
 
 func TestReadBlockHeaderOffsetBoundary(t *testing.T) {
-	header := make([]byte, 12)
+	header := make([]byte, 16)
 	offset := uint64(math.MaxInt64)
 	binary.BigEndian.PutUint64(header[0:8], offset)
 	binary.BigEndian.PutUint32(header[8:12], 1)
+	binary.BigEndian.PutUint32(header[12:16], 0)
 	reader := bufio.NewReader(bytes.NewReader(header))
-	gotOffset, gotSize, _, err := readBlockHeader(reader, make([]byte, 12), false, nil)
+	gotOffset, gotSize, _, _, err := readBlockHeader(reader, make([]byte, 16), false, nil)
 	if err != nil {
 		t.Fatalf("readBlockHeader returned error: %v", err)
 	}
@@ -71,12 +72,13 @@ func TestReadBlockHeaderOffsetBoundary(t *testing.T) {
 }
 
 func TestReadBlockHeaderOffsetOverflow(t *testing.T) {
-	header := make([]byte, 12)
+	header := make([]byte, 16)
 	offset := uint64(math.MaxUint64)
 	binary.BigEndian.PutUint64(header[0:8], offset)
 	binary.BigEndian.PutUint32(header[8:12], 1)
+	binary.BigEndian.PutUint32(header[12:16], 0)
 	reader := bufio.NewReader(bytes.NewReader(header))
-	if _, _, _, err := readBlockHeader(reader, make([]byte, 12), false, nil); err == nil {
+	if _, _, _, _, err := readBlockHeader(reader, make([]byte, 16), false, nil); err == nil {
 		t.Fatalf("expected overflow error")
 	}
 }

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -35,28 +35,29 @@ func cleanupOutput(buf *bufio.Writer, w io.WriteCloser, logger *zap.Logger) {
 	}
 }
 
-func readBlockHeader(reader *bufio.Reader, headerBuf []byte, verify bool, checksum ChecksumStrategy) (uint64, uint32, []byte, error) {
+func readBlockHeader(reader *bufio.Reader, headerBuf []byte, verify bool, checksum ChecksumStrategy) (uint64, uint32, uint32, []byte, error) {
 	_, err := io.ReadFull(reader, headerBuf)
 	if err == io.EOF || err == io.ErrUnexpectedEOF {
-		return 0, 0, nil, io.EOF
+		return 0, 0, 0, nil, io.EOF
 	}
 	if err != nil {
-		return 0, 0, nil, fmt.Errorf("failed to read chunk header: %w", err)
+		return 0, 0, 0, nil, fmt.Errorf("failed to read chunk header: %w", err)
 	}
 
 	offset := binary.BigEndian.Uint64(headerBuf[0:8])
 	if offset > math.MaxInt64 {
-		return 0, 0, nil, fmt.Errorf("offset %d overflows int64", offset)
+		return 0, 0, 0, nil, fmt.Errorf("offset %d overflows int64", offset)
 	}
 	chunkSize := binary.BigEndian.Uint32(headerBuf[8:12])
+	crc := binary.BigEndian.Uint32(headerBuf[12:16])
 
 	var transmittedSum []byte
 	if verify {
 		transmittedSum = make([]byte, checksum.Size())
-		copy(transmittedSum, headerBuf[12:])
+		copy(transmittedSum, headerBuf[16:])
 	}
 
-	return offset, chunkSize, transmittedSum, nil
+	return offset, chunkSize, crc, transmittedSum, nil
 }
 
 func readBlockData(cfg *config.Config, reader io.Reader, chunkSize uint32) ([]byte, error) {
@@ -82,6 +83,13 @@ func readBlockData(cfg *config.Config, reader io.Reader, chunkSize uint32) ([]by
 		return nil, fmt.Errorf("failed to read chunk data: %w", err)
 	}
 	return data, nil
+}
+
+func verifyCRC(expected uint32, data []byte, offset uint64) error {
+	if crc32c(data) != expected {
+		return fmt.Errorf("crc32c mismatch at offset %d", offset)
+	}
+	return nil
 }
 
 func verifyChecksum(verify bool, checksum ChecksumStrategy, data, transmitted []byte, offset uint64) error {
@@ -122,12 +130,16 @@ func processBlock(
 	verify bool,
 	checksum ChecksumStrategy,
 	offset uint64,
+	crc uint32,
 	transmitted, data []byte,
 	chunkSize uint32,
 	logger *zap.Logger,
 ) (bool, error) {
 	if offset > math.MaxInt64 {
 		return false, fmt.Errorf("offset %d overflows int64", offset)
+	}
+	if err := verifyCRC(crc, data, offset); err != nil {
+		return false, err
 	}
 	if err := verifyChecksum(verify, checksum, data, transmitted, offset); err != nil {
 		return false, err

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -208,7 +208,7 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	}
 	defer ln.Close()
 
-	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -297,6 +297,7 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 	cliHS := common.Handshake{
 		DedupMode:   expDedup,
@@ -308,6 +309,7 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 
 	srvErr := make(chan error, 1)
@@ -395,7 +397,7 @@ func TestH2TransportTLSCDCMismatch(t *testing.T) {
 			close(done)
 			return
 		}
-		if _, err := tr.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+		if _, err := tr.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 			t.Errorf("expected server negotiate error")
 		}
 		conn.Close()
@@ -406,7 +408,7 @@ func TestH2TransportTLSCDCMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected client negotiate error")
 	}
 	conn.Close()
@@ -537,7 +539,7 @@ func TestH2NegotiateContextCancel(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected negotiate error")
 	} else {
 		var ne net.Error

--- a/transport/logging_test.go
+++ b/transport/logging_test.go
@@ -28,6 +28,7 @@ func TestHandshakeFields(t *testing.T) {
 		Transport:     "quic",
 		ALPN:          "lvmsync",
 		TLSVersion:    "1.3",
+		CRC32C:        true,
 	}
 
 	core, logs := observer.New(zap.InfoLevel)

--- a/transport/negotiation_params_test.go
+++ b/transport/negotiation_params_test.go
@@ -129,6 +129,7 @@ func TestTransportNegotiationMatrix(t *testing.T) {
 				Endianness:    common.NativeEndianness(),
 				ALPN:          "lvmsync",
 				TLSVersion:    "1.3",
+				CRC32C:        true,
 			}
 			if name == "h2" {
 				base.ALPN = "h2"

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -75,7 +75,7 @@ func TestQUICTransportHandshake(t *testing.T) {
 	}
 	defer ln.Close()
 
-	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -157,6 +157,7 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 	cliHS := common.Handshake{
 		DedupMode:   expDedup,
@@ -168,6 +169,7 @@ func TestQUICTransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 
 	srvErr := make(chan error, 1)
@@ -246,7 +248,7 @@ func TestQUICTransportHandshakeError(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	qconn := conn.(*Conn)
-	if _, err := tr.Negotiate(ctx, qconn, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, qconn, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected negotiate error")
 	}
 	qconn.Close()
@@ -285,7 +287,7 @@ func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
 			return
 		}
 		qconn := conn.(*Conn)
-		if _, err := tr.Negotiate(ctx, qconn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+		if _, err := tr.Negotiate(ctx, qconn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 			t.Errorf("expected server negotiate error")
 		}
 		qconn.Close()
@@ -297,7 +299,7 @@ func TestQUICTransportHandshakeCDCMismatch(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	qconn := conn.(*Conn)
-	if _, err := tr.Negotiate(ctx, qconn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, qconn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected client negotiate error")
 	}
 	qconn.Close()
@@ -479,7 +481,7 @@ func TestConnStreamDeadlines(t *testing.T) {
 		}
 		qconn := conn.(*Conn)
 		defer qconn.Close()
-		hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
 		if _, err := tr.Negotiate(ctx, qconn, transport.Server, hs); err != nil {
 			done <- fmt.Errorf("server negotiate: %w", err)
 			return
@@ -516,7 +518,7 @@ func TestConnStreamDeadlines(t *testing.T) {
 	}
 	qconn := conn.(*Conn)
 	defer qconn.Close()
-	hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
 	if _, err := tr.Negotiate(ctx, qconn, transport.Client, hs); err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
@@ -539,7 +541,7 @@ func TestQUICNegotiateContextCancel(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected negotiate error")
 	} else {
 		var ne net.Error

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -249,7 +249,7 @@ func TestSSHTransportAuthSuccess(t *testing.T) {
 	}
 	client := clientIface.(*Transport)
 
-	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -344,7 +344,7 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		peerHS, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		peerHS, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true})
 		if err != nil {
 			t.Errorf("server negotiate: %v", err)
 			return
@@ -363,7 +363,7 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peerHS, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	peerHS, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true})
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
@@ -430,6 +430,7 @@ func TestSSHTransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 	cliHS := common.Handshake{
 		DedupMode:   expDedup,
@@ -441,6 +442,7 @@ func TestSSHTransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 
 	srvErr := make(chan error, 1)
@@ -504,7 +506,7 @@ func TestSSHTransportAgentFallback(t *testing.T) {
 			t.Errorf("accept: %v", err)
 			return
 		}
-		peerHS, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+		peerHS, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true})
 		if err != nil {
 			t.Errorf("server negotiate: %v", err)
 			return
@@ -523,7 +525,7 @@ func TestSSHTransportAgentFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	peerHS, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256})
+	peerHS, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true})
 	if err != nil {
 		t.Fatalf("client negotiate: %v", err)
 	}
@@ -620,7 +622,7 @@ func TestSSHTransportCDCMismatch(t *testing.T) {
 			close(done)
 			return
 		}
-		if _, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+		if _, err := server.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 			t.Errorf("expected server negotiate error")
 		}
 		conn.Close()
@@ -631,7 +633,7 @@ func TestSSHTransportCDCMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	if _, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256}); err == nil {
+	if _, err := client.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected client negotiate error")
 	}
 	conn.Close()
@@ -682,7 +684,7 @@ func TestSSHTransportNegotiateTimeoutClient(t *testing.T) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 	time.Sleep(60 * time.Millisecond)
 	start := time.Now()
-	if _, err := client.Negotiate(timeoutCtx, conn, transport.Client, common.Handshake{}); err == nil {
+	if _, err := client.Negotiate(timeoutCtx, conn, transport.Client, common.Handshake{CRC32C: true}); err == nil {
 		t.Fatalf("expected client negotiate error")
 	}
 	if time.Since(start) > 200*time.Millisecond {
@@ -722,7 +724,7 @@ func TestSSHTransportNegotiateTimeoutServer(t *testing.T) {
 		}
 		timeoutCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 		time.Sleep(60 * time.Millisecond)
-		_, err = server.Negotiate(timeoutCtx, conn, transport.Server, common.Handshake{})
+		_, err = server.Negotiate(timeoutCtx, conn, transport.Server, common.Handshake{CRC32C: true})
 		conn.Close()
 		errCh <- err
 		cancel()

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -74,7 +74,7 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	}
 	defer ln.Close()
 
-	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
 	done := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
@@ -162,6 +162,7 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 	cliHS := common.Handshake{
 		DedupMode:   expDedup,
@@ -173,6 +174,7 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 		CDCMin:      64,
 		CDCAvg:      128,
 		CDCMax:      256,
+		CRC32C:      true,
 	}
 
 	srvErr := make(chan error, 1)
@@ -241,7 +243,7 @@ func TestTCPTLSTransportHandshakeError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected negotiate error")
 	}
 	conn.Close()
@@ -278,7 +280,7 @@ func TestTCPTLSTransportCDCMismatch(t *testing.T) {
 			close(done)
 			return
 		}
-		if _, err := tr.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+		if _, err := tr.Negotiate(ctx, conn, transport.Server, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 			t.Errorf("expected server negotiate error")
 		}
 		conn.Close()
@@ -289,7 +291,7 @@ func TestTCPTLSTransportCDCMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{ResumeToken: "tok", MaxInFlight: 8, CDCMin: 64, CDCAvg: 256, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected client negotiate error")
 	}
 	conn.Close()
@@ -373,7 +375,7 @@ func TestTCPTLSNegotiateInvalidRole(t *testing.T) {
 	c1, c2 := net.Pipe()
 	defer c1.Close()
 	defer c2.Close()
-	if _, err := tr.Negotiate(ctx, c1, transport.Role(99), common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, c1, transport.Role(99), common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected error for invalid role")
 	}
 }
@@ -445,7 +447,7 @@ func TestTCPTLSNegotiateContextCancel(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256}); err == nil {
+	if _, err := tr.Negotiate(ctx, c1, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err == nil {
 		t.Fatalf("expected negotiate error")
 	} else {
 		var ne net.Error


### PR DESCRIPTION
## Summary
- append CRC32C to block headers and verify on read
- advertise CRC32C capability in handshake and reject peers without it
- test successful and mismatched CRC paths

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0c0413d88832394d59b68eea3d1b5