### PR TITLE
device: add locking and discard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,6 +1040,7 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--progress`        | Show progress percentage during the transfer                                                            | `true`    |
 | `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
 | `--dry-run`         | Print actions without executing | `false`   |
+| `--discard`         | Issue BLKDISCARD before writing blocks | `false`   |
 | `--offline`         | Assume source raw device is offline | `false`   |
 | `--fs-freeze-command` | Command to freeze filesystem before reading raw source; path must be absolute and arguments use shell-style quoting | `""` |
 | `--fs-thaw-command`  | Command to thaw filesystem after reading raw source; path must be absolute and arguments use shell-style quoting | `""` |

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -33,6 +33,7 @@ type Config struct {
 	StdoutMode               bool          `mapstructure:"stdout"`
 	DryRun                   bool          `mapstructure:"dry-run"`
 	Force                    bool          `mapstructure:"force"`
+	Discard                  bool          `mapstructure:"discard"`
 	Offline                  bool          `mapstructure:"offline"`
 	FSFreezeCommand          string        `mapstructure:"fs-freeze-command"`
 	FSThawCommand            string        `mapstructure:"fs-thaw-command"`

--- a/config/flagsets.go
+++ b/config/flagsets.go
@@ -58,6 +58,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("stdout", cfg.StdoutMode, "Write change dump to STDOUT")
 	fs.Bool("dry-run", cfg.DryRun, "Print actions without executing")
 	fs.Bool("force", cfg.Force, "Override safety checks and proceed on mounted destination")
+	fs.Bool("discard", cfg.Discard, "Issue BLKDISCARD before writing blocks")
 	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")
 	fs.String("fs-freeze-command", cfg.FSFreezeCommand, "Command to freeze filesystem before reading raw source")
 	fs.String("fs-thaw-command", cfg.FSThawCommand, "Command to thaw filesystem after reading raw source")

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -20,6 +20,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"stdout", strconv.FormatBool(cfg.StdoutMode)},
 		{"dry-run", strconv.FormatBool(cfg.DryRun)},
 		{"force", strconv.FormatBool(cfg.Force)},
+		{"discard", strconv.FormatBool(cfg.Discard)},
 		{"offline", strconv.FormatBool(cfg.Offline)},
 		{"fs-freeze-command", cfg.FSFreezeCommand},
 		{"fs-thaw-command", cfg.FSThawCommand},

--- a/device/discard_linux.go
+++ b/device/discard_linux.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package device
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func blkdiscard(f *os.File, offset, length uint64) error {
+	data := [2]uint64{offset, length}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.BLKDISCARD, uintptr(unsafe.Pointer(&data)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+var discardImpl = blkdiscard
+
+// SetDiscardFunc overrides the discard implementation. It returns a restore function.
+func SetDiscardFunc(fn func(*os.File, uint64, uint64) error) func() {
+	orig := discardImpl
+	if fn == nil {
+		discardImpl = blkdiscard
+	} else {
+		discardImpl = fn
+	}
+	return func() { discardImpl = orig }
+}
+
+// DiscardRange issues BLKDISCARD for the specified range on f.
+func DiscardRange(f *os.File, offset, length uint64) error {
+	return discardImpl(f, offset, length)
+}

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
+	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
 )
 
@@ -24,26 +25,38 @@ type LVMDevice struct {
 	cleanupPath string
 	escalation  string
 	logger      *zap.Logger
+	lock        *lock.Lock
 }
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
 // Size information is obtained through the lvm package helpers.
 func OpenLVM(path string, cache *lvm.FDCache, escalation string, logger *zap.Logger) (*LVMDevice, error) {
+	vg, lv, err := lvm.ParseLVPath(path)
+	if err != nil {
+		return nil, err
+	}
+	lk, err := lockAcquire(vg, lv)
+	if err != nil {
+		return nil, err
+	}
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
+		_ = lk.Release()
 		return nil, err
 	}
 	bs, err := unix.IoctlGetInt(int(f.Fd()), unix.BLKSSZGET)
 	if err != nil {
 		f.Close()
+		_ = lk.Release()
 		return nil, err
 	}
 	size, err := lvm.GetVolumeSize(path, cache, logger)
 	if err != nil {
 		f.Close()
+		_ = lk.Release()
 		return nil, err
 	}
-	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs), escalation: escalation, logger: logger}, nil
+	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs), escalation: escalation, logger: logger, lock: lk}, nil
 }
 
 // Path returns the underlying device path.
@@ -67,6 +80,7 @@ var (
 	generateSnapshot = func() string { return fmt.Sprintf("lvmsync_%d", time.Now().UnixNano()) }
 	geteuid          = os.Geteuid
 	openLVMFunc      = OpenLVM
+	lockAcquire      = lock.Acquire
 )
 
 func runLVM(ctx context.Context, escalation, cmdName string, args ...string) error {
@@ -118,6 +132,10 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 
 // Cleanup removes the snapshot if one was created.
 func (d *LVMDevice) Cleanup(ctx context.Context) error {
+	if d.lock != nil {
+		_ = d.lock.Release()
+		d.lock = nil
+	}
 	if d.cleanupPath == "" {
 		return nil
 	}

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
 )
 
@@ -18,6 +19,8 @@ func TestOpenLVM(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root")
 	}
+	restoreDir := lock.SetBaseDir(t.TempDir())
+	t.Cleanup(restoreDir)
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
 	cache := lvm.NewDeviceFDCache(zap.NewNop())

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,61 @@
+package lock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+var baseDir = "/run/lvmsync"
+
+// SetBaseDir overrides the default lock directory for tests.
+func SetBaseDir(dir string) func() {
+	orig := baseDir
+	baseDir = dir
+	return func() { baseDir = orig }
+}
+
+// Lock represents an acquired lock file.
+type Lock struct {
+	f *os.File
+}
+
+// Acquire obtains an exclusive lock for the given volume group and logical volume.
+// The lock file is placed at /run/lvmsync/<vg>.<lv>.lock.
+func Acquire(vg, lv string) (*Lock, error) {
+	if vg == "" || lv == "" {
+		return nil, fmt.Errorf("invalid vg/lv")
+	}
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(baseDir, fmt.Sprintf("%s.%s.lock", vg, lv))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &Lock{f: f}, nil
+}
+
+// Release unlocks and removes the underlying lock file.
+func (l *Lock) Release() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	defer func() { l.f = nil }()
+	if err := unix.Flock(int(l.f.Fd()), unix.LOCK_UN); err != nil {
+		_ = l.f.Close()
+		return err
+	}
+	path := l.f.Name()
+	if err := l.f.Close(); err != nil {
+		return err
+	}
+	return os.Remove(path)
+}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,27 @@
+package lock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+	restore := SetBaseDir(dir)
+	defer restore()
+	l, err := Acquire("vg0", "lv0")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	path := filepath.Join(dir, "vg0.lv0.lock")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock file missing: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("lock file not removed")
+	}
+}

--- a/lvm/backend_test.go
+++ b/lvm/backend_test.go
@@ -109,12 +109,12 @@ func TestParseLVPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		vg, lv, err := parseLVPath(tt.path)
+		vg, lv, err := ParseLVPath(tt.path)
 		if err != nil {
-			t.Fatalf("parseLVPath(%s) error: %v", tt.path, err)
+			t.Fatalf("ParseLVPath(%s) error: %v", tt.path, err)
 		}
 		if vg != tt.vg || lv != tt.lv {
-			t.Fatalf("parseLVPath(%s) = %s/%s, want %s/%s", tt.path, vg, lv, tt.vg, tt.lv)
+			t.Fatalf("ParseLVPath(%s) = %s/%s, want %s/%s", tt.path, vg, lv, tt.vg, tt.lv)
 		}
 	}
 }

--- a/lvm/path.go
+++ b/lvm/path.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 )
 
-// parseLVPath splits a logical volume path into its volume group and logical volume names.
+// ParseLVPath splits a logical volume path into its volume group and logical volume names.
 // It resolves symlinks before parsing and understands both /dev/<vg>/<lv> and
 // /dev/mapper/<vg>-<lv> style paths.
-func parseLVPath(p string) (string, string, error) {
+func ParseLVPath(p string) (string, string, error) {
 	if p == "" {
 		return "", "", fmt.Errorf("empty logical volume path")
 	}

--- a/transfer/discard_test.go
+++ b/transfer/discard_test.go
@@ -1,0 +1,58 @@
+package transfer
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/config"
+	"lvmsync_go/device"
+)
+
+func TestProcessBlockDiscard(t *testing.T) {
+	cfg := &config.Config{BlockSize: 4, Discard: true}
+	f, err := os.CreateTemp(t.TempDir(), "dest")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer f.Close()
+	called := false
+	restore := device.SetDiscardFunc(func(_ *os.File, off, length uint64) error {
+		called = true
+		if off != 0 || length != 4 {
+			t.Errorf("unexpected params: off=%d len=%d", off, length)
+		}
+		return nil
+	})
+	defer restore()
+	data := []byte("abcd")
+	if written, err := processBlock(cfg, f, nil, false, nil, 0, nil, data, 4, zap.NewNop()); err != nil || !written {
+		t.Fatalf("processBlock: %v written=%v", err, written)
+	}
+	if !called {
+		t.Fatalf("discard not called")
+	}
+}
+
+func TestProcessBlockDiscardDisabled(t *testing.T) {
+	cfg := &config.Config{BlockSize: 4, Discard: false}
+	f, err := os.CreateTemp(t.TempDir(), "dest")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer f.Close()
+	called := false
+	restore := device.SetDiscardFunc(func(_ *os.File, off, length uint64) error {
+		called = true
+		return nil
+	})
+	defer restore()
+	data := []byte("abcd")
+	if _, err := processBlock(cfg, f, nil, false, nil, 0, nil, data, 4, zap.NewNop()); err != nil {
+		t.Fatalf("processBlock: %v", err)
+	}
+	if called {
+		t.Fatalf("discard called when disabled")
+	}
+}

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/config"
+	"lvmsync_go/device"
 )
 
 func prepareOutputWriter(out io.Writer, cfg *config.Config, logger *zap.Logger) (io.WriteCloser, *bufio.Writer, error) {
@@ -144,6 +145,11 @@ func processBlock(
 			return false, nil
 		}
 		dedup.RecordTransfer(intOffset, data)
+	}
+	if cfg.Discard {
+		if err := device.DiscardRange(destFile, offset, uint64(chunkSize)); err != nil {
+			logger.Debug("discard failed", zap.Error(err))
+		}
 	}
 	if err := writeData(destFile, offset, data, logger); err != nil {
 		return false, err


### PR DESCRIPTION
## Summary
- guard LVM device access with flocked lockfiles under `/run/lvmsync`
- add optional BLKDISCARD before writes and expose `--discard` flag
- document discard flag and cover lock/discard logic with tests

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestH2TransportSelectBestHandshake)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0c088662083238d4b447262cd1cbe