### PR TITLE
feat: add automatic digest selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
 | `--block_size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
 | `--verbose` | `LVMSYNC_VERBOSE` | `verbose` | Verbosity level |
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
-| `--checksum_algorithm` | `LVMSYNC_CHECKSUM_ALGORITHM` | `checksum_algorithm` | Checksum algorithm: `auto`, `sha256`, `blake3`, or `blake3-512` |
+| `--checksum_algorithm` | `LVMSYNC_CHECKSUM_ALGORITHM` | `checksum_algorithm` | Checksum algorithm: `auto`, `sha256`, `blake3`, or `blake3-512` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
 | `--manifest_path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
 | `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 
 	compressiondetect "lvmsync_go/internal/compressiondetect"
+	digest "lvmsync_go/internal/digest"
 	"lvmsync_go/lvm"
 )
 
@@ -340,7 +341,7 @@ func TestConfigValidate(t *testing.T) {
 		cfg := &Config{
 			Mode:                 "default",
 			VolumeGroup:          "vg0",
-                       LVMEscalation:        "sudo -n",
+			LVMEscalation:        "sudo -n",
 			SSHKeepAliveInterval: time.Second,
 			LVMTimeout:           time.Second,
 			GRPCDialTimeout:      time.Second,
@@ -363,49 +364,49 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-               cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidKeepalive", func(t *testing.T) {
-               cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatInterval", func(t *testing.T) {
-               cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatSendTimeout", func(t *testing.T) {
-               cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidGRPCSetupTimeout", func(t *testing.T) {
-               cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: 0, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: 0, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPParallel", func(t *testing.T) {
-               cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 5, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 5, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPLowat", func(t *testing.T) {
-               cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, TCPNotSentLowAt: -1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, TCPNotSentLowAt: -1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -416,7 +417,7 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-               cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Millisecond, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Millisecond, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected timeout error")
 		}
@@ -424,23 +425,23 @@ func TestConfigValidate(t *testing.T) {
 }
 
 func TestConfigValidateCDC(t *testing.T) {
-       base := Config{
-               Mode:                 "default",
-               SSHKeepAliveInterval: time.Second,
-               GRPCDialTimeout:      time.Second,
-               GRPCSetupTimeout:     time.Second,
-               HeartbeatInterval:    time.Second,
-               HeartbeatSendTimeout: time.Second,
-               TCPParallel:          1,
-               LVMEscalation:        "sudo -n",
-       }
+	base := Config{
+		Mode:                 "default",
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+		LVMEscalation:        "sudo -n",
+	}
 
 	t.Run("valid", func(t *testing.T) {
 		cfg := base
-               cfg.CDCMin = 1
-               cfg.CDCAvg = 1
-               cfg.CDCMax = 1
-               cfg.LVMEscalation = "sudo -n"
+		cfg.CDCMin = 1
+		cfg.CDCAvg = 1
+		cfg.CDCMax = 1
+		cfg.LVMEscalation = "sudo -n"
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -549,19 +550,19 @@ func TestValidateEscalationCommand(t *testing.T) {
 }
 
 func TestValidateMode(t *testing.T) {
-        geteuid := func() int { return 0 }
-        base := Config{
-                SSHKeepAliveInterval: time.Second,
-                GRPCDialTimeout:      time.Second,
-                GRPCSetupTimeout:     time.Second,
-                HeartbeatInterval:    time.Second,
-                HeartbeatSendTimeout: time.Second,
-                TCPParallel:          1,
-                CDCMin:               64,
-                CDCAvg:               128,
-                CDCMax:               256,
-               LVMEscalation:        "sudo -n",
-        }
+	geteuid := func() int { return 0 }
+	base := Config{
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+		CDCMin:               64,
+		CDCAvg:               128,
+		CDCMax:               256,
+		LVMEscalation:        "sudo -n",
+	}
 
 	cases := []struct {
 		name    string
@@ -585,18 +586,61 @@ func TestValidateMode(t *testing.T) {
 	}
 }
 
+func TestValidateChecksumAuto(t *testing.T) {
+	geteuid := func() int { return 0 }
+	base := Config{
+		Mode:                 "default",
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+		CDCMin:               64,
+		CDCAvg:               128,
+		CDCMax:               256,
+		ChecksumAlgorithm:    Auto,
+	}
+
+	t.Run("simd", func(t *testing.T) {
+		cfg := base
+		orig := digest.Select
+		digest.Select = func() string { return digest.BLAKE3 }
+		defer func() { digest.Select = orig }()
+		if err := cfg.ValidateWith(geteuid); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.ChecksumAlgorithm != digest.BLAKE3 {
+			t.Fatalf("expected %s, got %s", digest.BLAKE3, cfg.ChecksumAlgorithm)
+		}
+	})
+
+	t.Run("fallback", func(t *testing.T) {
+		cfg := base
+		orig := digest.Select
+		digest.Select = func() string { return digest.SHA256 }
+		defer func() { digest.Select = orig }()
+		if err := cfg.ValidateWith(geteuid); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.ChecksumAlgorithm != digest.SHA256 {
+			t.Fatalf("expected %s, got %s", digest.SHA256, cfg.ChecksumAlgorithm)
+		}
+	})
+}
+
 func TestValidateCDCOrdering(t *testing.T) {
-        geteuid := func() int { return 0 }
-        base := Config{
-                Mode:                 "default",
-                SSHKeepAliveInterval: time.Second,
-                GRPCDialTimeout:      time.Second,
-                GRPCSetupTimeout:     time.Second,
-                HeartbeatInterval:    time.Second,
-                HeartbeatSendTimeout: time.Second,
-                TCPParallel:          1,
-               LVMEscalation:        "sudo -n",
-        }
+	geteuid := func() int { return 0 }
+	base := Config{
+		Mode:                 "default",
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+		LVMEscalation:        "sudo -n",
+	}
 
 	cases := []struct {
 		name    string

--- a/config/validation.go
+++ b/config/validation.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	digest "lvmsync_go/internal/digest"
 	"lvmsync_go/lvm"
 )
 
@@ -14,6 +15,9 @@ import (
 func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.Mode != "default" && c.Mode != "throughput" {
 		return fmt.Errorf("invalid mode %q: must be \"default\" or \"throughput\"", c.Mode)
+	}
+	if strings.ToLower(c.ChecksumAlgorithm) == "" || strings.ToLower(c.ChecksumAlgorithm) == Auto {
+		c.ChecksumAlgorithm = digest.Select()
 	}
 	if c.SourceType != "" && c.SourceType != "auto" && c.SourceType != "file" && c.SourceType != "raw" && c.SourceType != "lvm" {
 		return fmt.Errorf("invalid source type %q", c.SourceType)

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,0 +1,29 @@
+package digest
+
+import cpufeatures "lvmsync_go/internal/cpufeatures"
+
+const (
+	// SHA256 represents the SHA-256 digest algorithm.
+	SHA256 = "sha256"
+	// BLAKE3 represents the BLAKE3 digest algorithm.
+	BLAKE3 = "blake3"
+)
+
+var (
+	hasAVX2   = cpufeatures.HasAVX2
+	hasAVX512 = cpufeatures.HasAVX512
+	hasNEON   = cpufeatures.HasNEON
+)
+
+func detect() string {
+	if hasAVX512() || hasAVX2() || hasNEON() {
+		return BLAKE3
+	}
+	return SHA256
+}
+
+// Select returns the preferred digest algorithm based on CPU capabilities.
+// It chooses BLAKE3 when AVX2, AVX-512, or NEON are available, falling back
+// to SHA-256 otherwise. The function variable allows tests to override the
+// detection logic.
+var Select = detect

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -1,0 +1,29 @@
+package digest
+
+import "testing"
+
+func TestDetect(t *testing.T) {
+	origAVX2, origAVX512, origNEON := hasAVX2, hasAVX512, hasNEON
+	t.Cleanup(func() { hasAVX2, hasAVX512, hasNEON = origAVX2, origAVX512, origNEON })
+
+	tests := []struct {
+		name               string
+		avx2, avx512, neon bool
+		want               string
+	}{
+		{name: "avx2", avx2: true, want: BLAKE3},
+		{name: "avx512", avx512: true, want: BLAKE3},
+		{name: "neon", neon: true, want: BLAKE3},
+		{name: "none", want: SHA256},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasAVX2 = func() bool { return tt.avx2 }
+			hasAVX512 = func() bool { return tt.avx512 }
+			hasNEON = func() bool { return tt.neon }
+			if got := detect(); got != tt.want {
+				t.Fatalf("detect() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -35,7 +35,7 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 	defer device.SetMountFunc(prevMount)
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
-	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected", DedupStrategy: "none", VerifyChecksum: true}
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected", DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
 
 	dest := filepath.Join(t.TempDir(), "dest")
 	f, err := os.Create(dest)
@@ -87,7 +87,7 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 	defer device.SetMountFunc(prevMount)
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
-	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true}
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
 
 	dest := filepath.Join(t.TempDir(), "dest")
 	f, err := os.Create(dest)
@@ -258,7 +258,7 @@ func TestProcessDumpDataCanceledContext(t *testing.T) {
 	defer device.SetMountFunc(prevMount)
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
-	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true}
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
 
 	dest := filepath.Join(t.TempDir(), "dest")
 	f, err := os.Create(dest)

--- a/transfer/block_stream.go
+++ b/transfer/block_stream.go
@@ -17,6 +17,7 @@ import (
 
 	"lvmsync_go/config"
 	hashutil "lvmsync_go/hash"
+	digest "lvmsync_go/internal/digest"
 	manifestpkg "lvmsync_go/manifest"
 )
 
@@ -31,7 +32,11 @@ func validateOffsetAndSize(offset uint64, size int) (int64, uint32, error) {
 }
 
 func newDigestHasher(algo string) hash.Hash {
-	switch strings.ToLower(algo) {
+	a := strings.ToLower(algo)
+	if a == "" || a == config.Auto {
+		a = digest.Select()
+	}
+	switch a {
 	case "blake3", "blake3-256":
 		return blake3.New()
 	default:

--- a/transfer/block_stream_test.go
+++ b/transfer/block_stream_test.go
@@ -1,12 +1,15 @@
 package transfer
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"math"
 	"testing"
 
 	"github.com/zeebo/blake3"
 
 	"lvmsync_go/config"
+	digest "lvmsync_go/internal/digest"
 )
 
 func TestValidateOffsetAndSizeFunc(t *testing.T) {
@@ -31,4 +34,23 @@ func TestPrepareResultHeader(t *testing.T) {
 	if n != len(header) {
 		t.Fatalf("expected header length %d, got %d", len(header), n)
 	}
+}
+
+func TestNewDigestHasherAuto(t *testing.T) {
+	data := []byte("data")
+	orig := digest.Select
+	digest.Select = func() string { return digest.BLAKE3 }
+	h := newDigestHasher(config.Auto)
+	if _, ok := h.(*blake3.Hasher); !ok {
+		t.Fatalf("expected BLAKE3 hasher")
+	}
+	digest.Select = func() string { return digest.SHA256 }
+	h = newDigestHasher(config.Auto)
+	h.Write(data)
+	sum := h.Sum(nil)
+	exp := sha256.Sum256(data)
+	if !bytes.Equal(sum, exp[:]) {
+		t.Fatalf("expected SHA-256 sum, got %x", sum)
+	}
+	digest.Select = orig
 }

--- a/transfer/checksum.go
+++ b/transfer/checksum.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/zeebo/blake3"
 
-	cpufeatures "lvmsync_go/internal/cpufeatures"
+	digest "lvmsync_go/internal/digest"
 )
 
 // ChecksumStrategy defines an interface for computing checksums with a
@@ -45,12 +45,7 @@ var (
 	initOnce   sync.Once
 )
 
-var detectChecksumAlgorithm = func() string {
-	if cpufeatures.HasAESNI() || cpufeatures.HasSIMD() {
-		return "blake3"
-	}
-	return "sha256"
-}
+var detectChecksumAlgorithm = digest.Select
 
 func initChecksumStrategies() {
 	strategies = map[string]ChecksumStrategy{

--- a/transfer/digest_verification_test.go
+++ b/transfer/digest_verification_test.go
@@ -18,7 +18,7 @@ func TestIterateBlocksFinalSHA(t *testing.T) {
 	blockSize := int64(1024)
 	snapshot := "vg-lv"
 	_, src := createVolumeFiles(t, snapshot, blockSize, []int{0})
-	cfg := &config.Config{BlockSize: int(blockSize), Compress: "zstd", ZstdLevel: 1, CompressLevel: 1, MaxRetries: 1}
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "zstd", ZstdLevel: 1, CompressLevel: 1, MaxRetries: 1, ChecksumAlgorithm: "sha256"}
 	ranges, err := gatherChangedRanges(snapshot, blockSize, logger)
 	if err != nil {
 		t.Fatalf("gather ranges: %v", err)

--- a/transfer/handshake.go
+++ b/transfer/handshake.go
@@ -10,6 +10,7 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/config"
+	digest "lvmsync_go/internal/digest"
 )
 
 func composeHandshake(cfg *config.Config, mode string) common.Handshake {
@@ -91,12 +92,13 @@ func readAndValidateHandshake(cfg *config.Config, bufReader *bufio.Reader, dedup
 	cfg.Compress = compress
 	hs.Compress = compress
 	hs.Compressors = []string{compress}
-	digest, err := negotiate(splitDigests(cfg.ChecksumAlgorithm), hs.Digests)
+	digestAlg, err := negotiate(splitDigests(cfg.ChecksumAlgorithm), hs.Digests)
 	if err != nil {
 		return hs, fmt.Errorf("no common digest algorithm")
 	}
-	cfg.ChecksumAlgorithm = digest
-	hs.Digests = []string{digest}
+	cfg.ChecksumAlgorithm = digestAlg
+	hs.Digests = []string{digestAlg}
+	hs.Digest = digestAlg
 
 	if hs.Endianness != "" && hs.Endianness != common.NativeEndianness() {
 		return hs, fmt.Errorf("endianness mismatch: %s", hs.Endianness)
@@ -158,10 +160,11 @@ func splitCompression(s string) []string {
 }
 
 func splitDigests(s string) []string {
-	if s == "" {
-		return []string{"blake3", "sha256"}
+	a := strings.TrimSpace(strings.ToLower(s))
+	if a == "" || a == config.Auto {
+		return []string{digest.Select()}
 	}
-	return commonSplit(s)
+	return commonSplit(a)
 }
 
 func commonSplit(s string) []string {

--- a/transfer/handshake_test.go
+++ b/transfer/handshake_test.go
@@ -36,6 +36,9 @@ func TestReadAndValidateHandshake(t *testing.T) {
 	if cfg.CDCMin != 64 || cfg.CDCAvg != 128 || cfg.CDCMax != 256 || cfg.ResumeToken != "tok" || cfg.Concurrency != 8 {
 		t.Fatalf("values not propagated: %+v", cfg)
 	}
+	if hs.Digest != "sha256" {
+		t.Fatalf("expected digest sha256, got %s", hs.Digest)
+	}
 }
 
 func TestReadAndValidateHandshakeError(t *testing.T) {

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -91,7 +91,7 @@ func TestProcessDumpDataRejectsManifestMismatch(t *testing.T) {
 	}
 
 	tr := NewTransfer(zap.NewNop(), nil)
-	cfg := &config.Config{BlockSize: 4096, ManifestPath: manPath, MaxRetries: 1, Compress: "none"}
+	cfg := &config.Config{BlockSize: 4096, ManifestPath: manPath, MaxRetries: 1, Compress: "none", ChecksumAlgorithm: "sha256"}
 
 	t.Run("id mismatch", func(t *testing.T) {
 		dest := filepath.Join(dir, "dest-id")

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -289,6 +289,7 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 
 	srvHS := common.Handshake{
 		DedupMode:   expDedup,
+		Compress:    expCompress,
 		Compressors: srvCompress,
 		Digests:     srvDigest,
 		ResumeToken: "tok",
@@ -300,6 +301,7 @@ func TestH2TransportSelectBestHandshake(t *testing.T) {
 	}
 	cliHS := common.Handshake{
 		DedupMode:   expDedup,
+		Compress:    expCompress,
 		Compressors: cliCompress,
 		Digests:     cliDigest,
 		ResumeToken: "tok",


### PR DESCRIPTION
## Summary
- detect AVX2/AVX-512/NEON and select BLAKE3 or SHA-256 accordingly
- honor auto digest selection in block streaming and handshakes
- document and test automatic checksum algorithm resolution

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0c04aabc48323b79402c31138db5d