### PR TITLE
feat: add digest verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,8 @@ LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
 | `--block_size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
 | `--verbose` | `LVMSYNC_VERBOSE` | `verbose` | Verbosity level |
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
-| `--checksum_algorithm` | `LVMSYNC_CHECKSUM_ALGORITHM` | `checksum_algorithm` | Checksum algorithm: `auto`, `sha256`, `blake3`, or `blake3-512` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
+| `--verify` | `LVMSYNC_VERIFY` | `verify` | Verification level: `full`, `sampled`, or `none` |
+| `--checksum_algorithm`, `--digest` | `LVMSYNC_CHECKSUM_ALGORITHM`, `LVMSYNC_DIGEST` | `checksum_algorithm`, `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
 | `--manifest_path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
 | `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -10,6 +11,8 @@ import (
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	cpufeatures "lvmsync_go/internal/cpufeatures"
+	digestpkg "lvmsync_go/internal/digest"
 	"lvmsync_go/transfer"
 )
 
@@ -60,5 +63,36 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 	if cleanupErr != nil {
 		return cleanupErr
 	}
-	return closeErr
+	if closeErr != nil {
+		return closeErr
+	}
+	if strings.ToLower(cfg.VerifyLevel) == "none" {
+		return nil
+	}
+	alg := strings.ToLower(cfg.ChecksumAlgorithm)
+	if alg == "" || alg == "auto" {
+		alg = digestpkg.Select()
+	}
+	logger.Info("cpu_features",
+		zap.Bool("avx2", cpufeatures.HasAVX2()),
+		zap.Bool("avx512", cpufeatures.HasAVX512()),
+		zap.Bool("neon", cpufeatures.HasNEON()),
+	)
+	sampled := strings.ToLower(cfg.VerifyLevel) == "sampled"
+	match, srcSum, dstSum, err := digestpkg.VerifyFiles(applyFile, dev.Path(), alg, sampled)
+	if err != nil {
+		return err
+	}
+	if !match {
+		logger.Error("digest_mismatch",
+			zap.String("source_digest", fmt.Sprintf("%x", srcSum[:])),
+			zap.String("dest_digest", fmt.Sprintf("%x", dstSum[:])),
+		)
+		return fmt.Errorf("digest mismatch")
+	}
+	logger.Info("verification_success",
+		zap.String("digest_algorithm", alg),
+		zap.String("verify_level", cfg.VerifyLevel),
+	)
+	return nil
 }

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -16,6 +16,8 @@ import (
 
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/internal/config"
+	cpufeatures "lvmsync_go/internal/cpufeatures"
+	digestpkg "lvmsync_go/internal/digest"
 	manifestpkg "lvmsync_go/manifest"
 	"lvmsync_go/transfer"
 )
@@ -118,7 +120,38 @@ func (r *Runner) verifyDevices(cfg *config.Config, src, dst, manifestPath string
 			return fmt.Errorf("stat manifest: %w", err)
 		}
 	}
-	return verifyWithManifest(cfg, dst, manifestPath, logger)
+	if err := verifyWithManifest(cfg, dst, manifestPath, logger); err != nil {
+		return err
+	}
+	if strings.ToLower(cfg.VerifyLevel) == "none" {
+		return nil
+	}
+	alg := strings.ToLower(cfg.ChecksumAlgorithm)
+	if alg == "" || alg == "auto" {
+		alg = digestpkg.Select()
+	}
+	logger.Info("cpu_features",
+		zap.Bool("avx2", cpufeatures.HasAVX2()),
+		zap.Bool("avx512", cpufeatures.HasAVX512()),
+		zap.Bool("neon", cpufeatures.HasNEON()),
+	)
+	sampled := strings.ToLower(cfg.VerifyLevel) == "sampled"
+	match, srcSum, dstSum, err := digestpkg.VerifyFiles(src, dst, alg, sampled)
+	if err != nil {
+		return err
+	}
+	if !match {
+		logger.Error("digest_mismatch",
+			zap.String("source_digest", fmt.Sprintf("%x", srcSum[:])),
+			zap.String("dest_digest", fmt.Sprintf("%x", dstSum[:])),
+		)
+		return fmt.Errorf("digest mismatch")
+	}
+	logger.Info("verification_success",
+		zap.String("digest_algorithm", alg),
+		zap.String("verify_level", cfg.VerifyLevel),
+	)
+	return nil
 }
 
 // Run executes using a default Runner.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -72,6 +72,7 @@ type Config struct {
 	Speed                    string        `mapstructure:"speed"`
 	SpeedLimit               int           `mapstructure:"-"`
 	VerifyChecksum           bool          `mapstructure:"verify_checksum"`
+	VerifyLevel              string        `mapstructure:"verify"`
 	ChecksumAlgorithm        string        `mapstructure:"checksum_algorithm"`
 	Verbose                  int           `mapstructure:"verbose"`
 	SkipSnapshotCreation     bool          `mapstructure:"skip_snapshot_creation"`
@@ -204,6 +205,7 @@ func DefaultConfig() (*Config, error) {
 		CompressThreshold:        0.9,
 		Speed:                    "100MB",
 		VerifyChecksum:           false,
+		VerifyLevel:              "none",
 		ChecksumAlgorithm:        Auto,
 		Verbose:                  0,
 		SkipSnapshotCreation:     false,

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -80,7 +80,9 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("block_size", cfg.BlockSizeRaw, "Block size for data transfer; specify 'auto' or 0 for automatic detection")
 	fs.CountP("verbose", "v", "Verbosity level")
 	fs.Bool("verify_checksum", cfg.VerifyChecksum, "Enable checksum verification")
+	fs.String("verify", cfg.VerifyLevel, "Verification level: full, sampled, or none")
 	fs.String("checksum_algorithm", cfg.ChecksumAlgorithm, fmt.Sprintf("Checksum algorithm: %v", SupportedChecksumAlgorithms))
+	fs.String("digest", cfg.ChecksumAlgorithm, fmt.Sprintf("Digest algorithm: %v", SupportedChecksumAlgorithms))
 	fs.Bool("progress", cfg.Progress, "Show progress during transfer")
 	return fs
 }

--- a/internal/config/flagsets_test.go
+++ b/internal/config/flagsets_test.go
@@ -40,7 +40,9 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"block_size", cfg.BlockSizeRaw},
 		{"verbose", "0"},
 		{"verify_checksum", strconv.FormatBool(cfg.VerifyChecksum)},
+		{"verify", cfg.VerifyLevel},
 		{"checksum_algorithm", cfg.ChecksumAlgorithm},
+		{"digest", cfg.ChecksumAlgorithm},
 		{"progress", strconv.FormatBool(cfg.Progress)},
 	}
 	for _, tt := range cases {

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -317,6 +317,7 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 	v.RegisterAlias("lz4_level", "lz4-level")
 	v.RegisterAlias("compress_threshold", "compress-threshold")
 	v.RegisterAlias("lvm_escalation", "lvm-escalation")
+	v.RegisterAlias("checksum_algorithm", "digest")
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
 		return nil, nil, err
 	}

--- a/internal/digest/hash.go
+++ b/internal/digest/hash.go
@@ -1,0 +1,117 @@
+package digest
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+
+	"github.com/zeebo/blake3"
+)
+
+// newHasher returns a hash.Hash for the given algorithm.
+func newHasher(alg string) (hash.Hash, error) {
+	switch alg {
+	case SHA256:
+		return sha256.New(), nil
+	case BLAKE3:
+		return blake3.New(), nil
+	default:
+		return nil, fmt.Errorf("unsupported digest algorithm: %s", alg)
+	}
+}
+
+// SumReader computes the digest of data from r using the specified algorithm.
+func SumReader(r io.Reader, alg string) ([32]byte, error) {
+	h, err := newHasher(alg)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	if _, err := io.Copy(h, r); err != nil {
+		return [32]byte{}, err
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// SumFile computes the digest of the file at path using the specified algorithm.
+func SumFile(path, alg string) ([32]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer f.Close()
+	return SumReader(f, alg)
+}
+
+// sampleSize is the number of bytes read from the start and end of a file when
+// performing sampled verification.
+const sampleSize int64 = 1 << 20 // 1MiB
+
+// sampledSumFile computes a digest of the first and last sampleSize bytes of
+// the file at path using the specified algorithm. If the file is smaller than
+// 2*sampleSize, the entire file is hashed.
+func sampledSumFile(path, alg string) ([32]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	h, err := newHasher(alg)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	buf := make([]byte, sampleSize)
+	n, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		return [32]byte{}, err
+	}
+	h.Write(buf[:n])
+	if info.Size() > sampleSize*2 {
+		if _, err := f.Seek(-sampleSize, io.SeekEnd); err != nil {
+			return [32]byte{}, err
+		}
+		n, err = f.Read(buf)
+		if err != nil && err != io.EOF {
+			return [32]byte{}, err
+		}
+		h.Write(buf[:n])
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// VerifyFiles compares digests of src and dst using the specified algorithm.
+// If sampled is true, only the first and last sampleSize bytes are hashed.
+// It returns whether the digests match along with the individual digests.
+func VerifyFiles(src, dst, alg string, sampled bool) (bool, [32]byte, [32]byte, error) {
+	var s1, s2 [32]byte
+	var err error
+	if sampled {
+		s1, err = sampledSumFile(src, alg)
+		if err != nil {
+			return false, s1, s2, err
+		}
+		s2, err = sampledSumFile(dst, alg)
+		if err != nil {
+			return false, s1, s2, err
+		}
+	} else {
+		s1, err = SumFile(src, alg)
+		if err != nil {
+			return false, s1, s2, err
+		}
+		s2, err = SumFile(dst, alg)
+		if err != nil {
+			return false, s1, s2, err
+		}
+	}
+	return s1 == s2, s1, s2, nil
+}

--- a/internal/digest/verify_file_test.go
+++ b/internal/digest/verify_file_test.go
@@ -1,0 +1,45 @@
+package digest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTemp(t *testing.T, dir, name, data string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(data), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	return p
+}
+
+func TestVerifyFilesMatch(t *testing.T) {
+	dir := t.TempDir()
+	a := writeTemp(t, dir, "a", "same data")
+	b := writeTemp(t, dir, "b", "same data")
+	match, _, _, err := VerifyFiles(a, b, SHA256, false)
+	if err != nil {
+		t.Fatalf("VerifyFiles: %v", err)
+	}
+	if !match {
+		t.Fatalf("expected digests to match")
+	}
+}
+
+func TestVerifyFilesMismatch(t *testing.T) {
+	dir := t.TempDir()
+	a := writeTemp(t, dir, "a", "foo")
+	b := writeTemp(t, dir, "b", "bar")
+	match, d1, d2, err := VerifyFiles(a, b, BLAKE3, false)
+	if err != nil {
+		t.Fatalf("VerifyFiles: %v", err)
+	}
+	if match {
+		t.Fatalf("expected mismatch")
+	}
+	if d1 == d2 {
+		t.Fatalf("expected different digests")
+	}
+}


### PR DESCRIPTION
## Summary
- verify apply and verify commands with configurable digest algorithms
- expose `--verify` and `--digest` flags
- add digest utilities and tests for matching and mismatched files

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfbe282483238db1aed0434cbf14