### PR TITLE
transport: add insecure flags and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ no additional coordination.
 
 LVMSync negotiates transports in the order provided by `--transport` (default
 `quic,h2,tcp+tls,ssh`). All transports require TLS 1.3 with mutual
-authentication unless `--allow-insecure` is set or the SSH transport is used.
+authentication unless `--allow-insecure` (or `--insecure`) is set or the SSH transport is used.
 See [docs/transports.md](docs/transports.md) for details.
 
 | Transport | Security defaults | Notes |
@@ -117,7 +117,7 @@ Transfers rely on a manifest that tracks chunk offsets and digests:
 LVMSync ships a gRPC daemon for remote control. The daemon listens on the port
 specified by `--grpc-port` (default `9443`) and requires TLS 1.3 with mutual
 authentication. Provide certificate files with `--tls-cert`, `--tls-key`, and
-`--ca-cert`. Insecure mode can be enabled with `--allow-insecure`, but it is
+`--ca-cert`. Insecure mode can be enabled with `--allow-insecure` (or `--insecure`), but it is
 disabled by default and should only be used for testing.
 
 Configuration can be supplied via flags, environment variables prefixed with
@@ -165,7 +165,7 @@ transfer. See [docs/manifest.md](docs/manifest.md) for manifest and verification
 
 - Run `manifest rebuild` and `verify` against quiescent devices.
 - Use `--offline` or freeze/thaw hooks when scanning live filesystems to keep manifests consistent.
-- Network transports default to TLS 1.3; `--allow-insecure` should only be used for testing.
+- Network transports default to TLS 1.3; `--allow-insecure` (or `--insecure`) should only be used for testing.
 - Apply refuses to write when the destination's identity or size differs from the manifest or when the device is mounted read-write; use `--force` to override the mount check.
 - Back up destination data before running apply; writes are destructive.
 ## Supported Platforms
@@ -611,7 +611,7 @@ LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
 | `--tls_cert` | `LVMSYNC_TLS_CERT` | `tls_cert` | TLS certificate file |
 | `--tls_key` | `LVMSYNC_TLS_KEY` | `tls_key` | TLS key file |
 | `--ca_cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
-| `--allow_insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
+| `--allow-insecure`, `--insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
 
 If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh_timeout` as its deadline.
 SSH transport negotiation also derives read and write deadlines from the caller's context; when the context expires, the handshake fails quickly and deadlines are cleared afterward.
@@ -657,11 +657,11 @@ lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-ke
 | `--tls-cert` | `LVMSYNC_SERVE_TLS_CERT` | TLS certificate file |
 | `--tls-key` | `LVMSYNC_SERVE_TLS_KEY` | TLS key file |
 | `--ca-cert` | `LVMSYNC_SERVE_CA_CERT` | CA certificate file |
-| `--allow-insecure` | `LVMSYNC_SERVE_ALLOW_INSECURE` | Permit insecure (no TLS) connections |
+| `--allow-insecure`, `--insecure` | `LVMSYNC_SERVE_ALLOW_INSECURE` | Permit insecure (no TLS) connections |
 
 ## gRPC Control Plane
 
-The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel. Plaintext connections are rejected unless `--allow-insecure` is explicitly set.
+The optional gRPC daemon exposes snapshot management and replication over a mutually authenticated channel. Plaintext connections are rejected unless `--allow-insecure` (or `--insecure`) is explicitly set.
 
 TLS mode requires explicit certificates. Provide `--tls-cert`, `--tls-key`, and `--ca-cert`; the daemon fails to start if any are missing and does not generate self-signed certificates.
 
@@ -686,7 +686,7 @@ Run the daemon with TLS:
 lvmsync-grpcd --grpc-port 9443 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
 
-Disabling TLS with `--allow-insecure` is supported for development but is unsafe for production deployments.
+Disabling TLS with `--allow-insecure` (or `--insecure`) is supported for development but is unsafe for production deployments.
 
 On failure, `lvmsync-grpcd` logs the error and exits with status `1` so calling scripts can inspect `$?`.
 
@@ -775,7 +775,7 @@ transports to attempt (for example `quic,h2,tcp+tls,ssh`). The `quic` transport 
 authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional streams and datagrams. The `h2`
 transport also requires TLS 1.3 with client certificates and negotiates the `h2` ALPN. Provide certificates via
 `--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and will refuse
-connections when no roots are provided unless `--allow_insecure` (or the `AllowInsecure` configuration flag) is
+connections when no roots are provided unless `--allow-insecure` (or `--insecure`, or the `AllowInsecure` configuration flag) is
 set. Enabling this option logs a warning. Client certificates must be supplied explicitly; transports no longer generate self-signed certificates
 automatically. The [transport documentation](docs/transports.md) covers each option in depth. The flags below
 configure transport behavior.
@@ -1172,7 +1172,7 @@ The client aborts dialing if a connection cannot be established within
 | `--tls_cert`       | TLS certificate file         | `""`            |
 | `--tls_key`        | TLS key file                 | `""`            |
 | `--ca_cert`        | CA certificate file          | `""`            |
-| `--allow_insecure` | Allow insecure (disable TLS) | `false`         |
+| `--allow-insecure`, `--insecure` | Allow insecure (disable TLS) | `false`         |
 
 ### Examples
 
@@ -1423,7 +1423,7 @@ volume_group: vg_data
 | `--tls-cert` | `LVMSYNC_GRPC_TLS_CERT` | `tls-cert` | TLS certificate file |
 | `--tls-key` | `LVMSYNC_GRPC_TLS_KEY` | `tls-key` | TLS key file |
 | `--ca-cert` | `LVMSYNC_GRPC_CA_CERT` | `ca-cert` | CA certificate file |
-| `--allow-insecure` | `LVMSYNC_GRPC_ALLOW_INSECURE` | `allow-insecure` | Allow insecure (no TLS) |
+| `--allow-insecure`, `--insecure` | `LVMSYNC_GRPC_ALLOW_INSECURE` | `allow-insecure` | Allow insecure (no TLS) |
 | `--config` | `LVMSYNC_GRPC_CONFIG` | `config` | Path to config YAML file |
 
 Precedence example:

--- a/cmd/grpcd/cobra.go
+++ b/cmd/grpcd/cobra.go
@@ -82,6 +82,7 @@ func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
 	grpc.String("tls-key", "", "TLS key file")
 	grpc.String("ca-cert", "", "CA certificate file")
 	grpc.Bool("allow-insecure", false, "allow plaintext gRPC")
+	grpc.Bool("insecure", false, "allow plaintext gRPC")
 	grpc.Duration("keepalive-time", 2*time.Minute, "interval between server pings")
 	grpc.Duration("keepalive-timeout", 20*time.Second, "timeout waiting for keepalive ack")
 	grpc.Duration("request-timeout", 15*time.Second, "deadline for unary RPCs")
@@ -114,7 +115,7 @@ func loadConfig(v *viper.Viper) (Options, error) {
 		TLSCert:          v.GetString("tls-cert"),
 		TLSKey:           v.GetString("tls-key"),
 		CACert:           v.GetString("ca-cert"),
-		AllowInsecure:    v.GetBool("allow-insecure"),
+		AllowInsecure:    v.GetBool("allow-insecure") || v.GetBool("insecure"),
 		KeepaliveTime:    v.GetDuration("keepalive-time"),
 		KeepaliveTimeout: v.GetDuration("keepalive-timeout"),
 		RequestTimeout:   v.GetDuration("request-timeout"),

--- a/cmd/grpcd/cobra_test.go
+++ b/cmd/grpcd/cobra_test.go
@@ -36,6 +36,22 @@ func TestFlagParsing(t *testing.T) {
 	}
 }
 
+func TestFlagParsingInsecureAlias(t *testing.T) {
+	logger := zap.NewNop()
+	var got Options
+	runner := NewRunnerWithDeps(func(ctx context.Context, opts Options, _ *zap.Logger) error {
+		got = opts
+		return nil
+	})
+	args := []string{"--insecure"}
+	if err := runner.Execute(args, logger); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !got.AllowInsecure {
+		t.Fatalf("expected AllowInsecure true")
+	}
+}
+
 func TestGRPCPortPrecedence(t *testing.T) {
 	logger := zap.NewNop()
 	cfgPath := writeTempConfig(t, "grpc-port: 1111\n")

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -48,7 +48,7 @@ func Run(args []string, logger *zap.Logger) error {
 				TLSCert:       v.GetString("tls-cert"),
 				TLSKey:        v.GetString("tls-key"),
 				CACert:        v.GetString("ca-cert"),
-				AllowInsecure: v.GetBool("allow-insecure"),
+				AllowInsecure: v.GetBool("allow-insecure") || v.GetBool("insecure"),
 			}
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 			defer stop()
@@ -68,6 +68,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	fs.String("tls-key", "", "TLS key file")
 	fs.String("ca-cert", "", "CA certificate file")
 	fs.Bool("allow-insecure", false, "allow insecure (no TLS)")
+	fs.Bool("insecure", false, "allow insecure (no TLS)")
 	cmd.Flags().AddFlagSet(fs)
 	v.BindPFlags(fs)
 	v.SetEnvPrefix("LVMSYNC_SERVE")

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -47,6 +47,19 @@ func TestFlagParsing(t *testing.T) {
 	}
 }
 
+func TestFlagParsingInsecureAlias(t *testing.T) {
+	v := viper.New()
+	cmd := &cobra.Command{Use: "serve"}
+	bindFlags(cmd, v)
+	args := []string{"--insecure"}
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if !(v.GetBool("allow-insecure") || v.GetBool("insecure")) {
+		t.Fatalf("expected allow-insecure to be true")
+	}
+}
+
 func TestStartServer(t *testing.T) {
 	logger := zap.NewNop()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/config/flagsets.go
+++ b/config/flagsets.go
@@ -168,6 +168,8 @@ func initGRPCFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("tls_key", cfg.TLSKey, "Path to TLS private key")
 	fs.String("ca_cert", cfg.CACert, "Path to CA certificate")
 	fs.Bool("allow_insecure", cfg.AllowInsecure, "Allow insecure connections")
+	fs.Bool("allow-insecure", cfg.AllowInsecure, "Allow insecure connections")
+	fs.Bool("insecure", cfg.AllowInsecure, "Allow insecure connections")
 	return fs
 }
 

--- a/config/flagsets_test.go
+++ b/config/flagsets_test.go
@@ -202,6 +202,8 @@ func TestInitGRPCFlags(t *testing.T) {
 		{"tls_key", cfg.TLSKey},
 		{"ca_cert", cfg.CACert},
 		{"allow_insecure", strconv.FormatBool(cfg.AllowInsecure)},
+		{"allow-insecure", strconv.FormatBool(cfg.AllowInsecure)},
+		{"insecure", strconv.FormatBool(cfg.AllowInsecure)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)

--- a/config/viper_builder.go
+++ b/config/viper_builder.go
@@ -335,5 +335,11 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, error) {
 			return nil, fmt.Errorf("error reading config file %q: %w", cfgFile, err)
 		}
 	}
+	if v.IsSet("allow-insecure") {
+		v.Set("allow_insecure", v.Get("allow-insecure"))
+	}
+	if v.IsSet("insecure") {
+		v.Set("allow_insecure", v.Get("insecure"))
+	}
 	return v, nil
 }

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -73,7 +73,7 @@ clients. Defaults:
 - ALPN negotiation using `lvmsync`
 - Bidirectional streams and datagram support
 - BBR congestion control
-- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`
+ - Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow-insecure`/`--insecure`
 
 Example:
 
@@ -92,14 +92,14 @@ lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-ke
 - Runs over TLS 1.3 with mutual authentication
 - Provides stream-level back-pressure
 - Enforces context deadlines during connection and HTTP/2 handshakes
-- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`, `--tcp_port`
+ - Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow-insecure`/`--insecure`, `--tcp_port`
 
 ## TCP+TLS
 
 - Plain TCP encapsulated in TLS 1.3
 - Requires mutual TLS authentication
 - Logs a warning if listener shutdown encounters an error
-- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`, `--tcp_port`
+ - Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow-insecure`/`--insecure`, `--tcp_port`
 
 ## SSH
 
@@ -109,4 +109,4 @@ lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-ke
 - Verifies server host keys using `known_hosts` or an explicit `--ssh_host_key`; unknown hosts are rejected
 - Key authentication via `--ssh_key`/`LVMSYNC_SSH_KEY`
 - Optional agent auth with `--ssh_agent`/`LVMSYNC_SSH_AGENT` using `SSH_AUTH_SOCK`
-- Flags: `--ssh_user`, `--ssh_password`, `--ssh_key`, `--ssh_host_key`, `--ssh_host_key_path`, `--ssh_agent`, `--allow_insecure`
+ - Flags: `--ssh_user`, `--ssh_password`, `--ssh_key`, `--ssh_host_key`, `--ssh_host_key_path`, `--ssh_agent`, `--allow-insecure`/`--insecure`

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -54,25 +54,31 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
 		return nil, fmt.Errorf("logger is required")
 	}
-	if cfg.Roots == nil {
-		return nil, fmt.Errorf("tls roots are required")
+	if cfg.Roots == nil && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")
 	}
 	if len(cfg.ServerCert.Certificate) == 0 {
 		return nil, fmt.Errorf("server certificate is required")
 	}
 	clientConf := &tls.Config{
-		RootCAs:    cfg.Roots,
-		NextProtos: []string{"h2"},
-		MinVersion: tls.VersionTLS13,
-		MaxVersion: tls.VersionTLS13,
+		RootCAs:            cfg.Roots,
+		InsecureSkipVerify: cfg.AllowInsecure,
+		NextProtos:         []string{"h2"},
+		MinVersion:         tls.VersionTLS13,
+		MaxVersion:         tls.VersionTLS13,
 	}
 	if len(cfg.ClientCert.Certificate) != 0 {
 		clientConf.Certificates = []tls.Certificate{cfg.ClientCert}
 	}
+	clientAuth := tls.RequireAndVerifyClientCert
+	if cfg.AllowInsecure {
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "h2"))
+		clientAuth = tls.RequireAnyClientCert
+	}
 	serverConf := &tls.Config{
 		Certificates: []tls.Certificate{cfg.ServerCert},
 		ClientCAs:    cfg.Roots,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientAuth:   clientAuth,
 		MinVersion:   tls.VersionTLS13,
 		MaxVersion:   tls.VersionTLS13,
 		NextProtos:   []string{"h2"},

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -581,6 +581,31 @@ func TestTLSVersionString(t *testing.T) {
 	}
 }
 
+func TestH2TransportAllowInsecureWarn(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
+	core, obs := observer.New(zap.WarnLevel)
+	if _, err := New(transport.Config{Logger: zap.New(core), ServerCert: cert, AllowInsecure: true}); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	entries := obs.FilterMessage("allow_insecure_enabled").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if tr := entries[0].ContextMap()["transport"]; tr != "h2" {
+		t.Fatalf("unexpected transport %v", tr)
+	}
+}
+
+func TestH2TransportRequiresRootsOrAllowInsecure(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
+	if _, err := New(transport.Config{Logger: zap.NewNop(), ServerCert: cert}); err == nil {
+		t.Fatalf("expected error when roots are nil without AllowInsecure")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), ServerCert: cert, AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing roots: %v", err)
+	}
+}
+
 func TestRoleString(t *testing.T) {
 	tests := []struct {
 		role transport.Role


### PR DESCRIPTION
## Summary
- add `--allow-insecure`/`--insecure` flags for TLS-based transports and ssh
- warn loudly when insecure mode is enabled
- support skipping TLS roots for HTTP/2 transport

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0cda966a88323b24421b44f4b41b6