### PR TITLE
Add LVM device writer with alignment and O_DIRECT fallback

### DIFF
--- a/internal/blockio/blockio.go
+++ b/internal/blockio/blockio.go
@@ -2,7 +2,6 @@ package blockio
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -24,12 +23,23 @@ type File struct {
 // Open opens path with O_DIRECT when possible and records queue block sizes.
 // When strict is false and a later write is not block aligned, the file
 // reopens without O_DIRECT to allow buffered I/O.
-func Open(path string, strict bool) (*File, error) {
+func Open(path string, direct, strict bool) (*File, error) {
 	logical, physical := detectBlockSizes(path)
-	fd, err := unix.Open(path, unix.O_RDWR|unix.O_CREAT|unix.O_DIRECT, 0)
-	direct := err == nil
-	var f *os.File
+	var (
+		fd  int
+		err error
+	)
 	if direct {
+		fd, err = unix.Open(path, unix.O_RDWR|unix.O_CREAT|unix.O_DIRECT, 0)
+		if err != nil {
+			if strict {
+				return nil, err
+			}
+			direct = false
+		}
+	}
+	var f *os.File
+	if direct && err == nil {
 		f = os.NewFile(uintptr(fd), path)
 	} else {
 		f, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0)
@@ -57,78 +67,36 @@ func (f *File) Physical() int { return f.physical }
 // Direct reports whether O_DIRECT is currently enabled.
 func (f *File) Direct() bool { return f.direct }
 
-// ReaderFrom copies from r into the file, enforcing block alignment.
-// If the read size is not aligned and strict mode is disabled, the file falls
-// back to buffered I/O and the write proceeds.
-func (f *File) ReaderFrom(r io.Reader) (int64, error) {
-	bufSize := f.physical
-	if bufSize < f.logical {
-		bufSize = f.logical
-	}
-	buf := make([]byte, bufSize)
-	var total int64
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			if n%f.logical != 0 {
-				if f.strict {
-					return total, fmt.Errorf("write size %d not multiple of %d", n, f.logical)
-				}
-				if f.direct {
-					if err := f.reopen(); err != nil {
-						return total, err
-					}
-				}
-			}
-			w, err := f.f.Write(buf[:n])
-			total += int64(w)
-			if err != nil {
-				return total, err
+func (f *File) Write(p []byte) (int, error) {
+	n := len(p)
+	if n%f.logical != 0 || n%f.physical != 0 {
+		if f.strict {
+			return 0, fmt.Errorf("write size %d not multiple of %d or %d", n, f.logical, f.physical)
+		}
+		if f.direct {
+			if err := f.reopen(); err != nil {
+				return 0, err
 			}
 		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return total, err
-		}
 	}
-	if f.syncFunc != nil {
-		if err := f.syncFunc(); err != nil {
-			return total, err
-		}
-	}
-	return total, nil
+	return f.f.Write(p)
 }
 
-// WriterTo copies from the file to w enforcing block alignment.
-func (f *File) WriterTo(w io.Writer) (int64, error) {
-	bufSize := f.physical
-	if bufSize < f.logical {
-		bufSize = f.logical
+func (f *File) Read(p []byte) (int, error) {
+	n, err := f.f.Read(p)
+	if n%f.logical != 0 && f.strict {
+		return n, fmt.Errorf("read size %d not multiple of %d", n, f.logical)
 	}
-	buf := make([]byte, bufSize)
-	var total int64
-	for {
-		n, err := f.f.Read(buf)
-		if n > 0 {
-			if n%f.logical != 0 && f.strict {
-				return total, fmt.Errorf("read size %d not multiple of %d", n, f.logical)
-			}
-			wn, err := w.Write(buf[:n])
-			total += int64(wn)
-			if err != nil {
-				return total, err
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return total, err
-		}
+	return n, err
+}
+
+func (f *File) Seek(offset int64, whence int) (int64, error) { return f.f.Seek(offset, whence) }
+
+func (f *File) Sync() error {
+	if f.syncFunc != nil {
+		return f.syncFunc()
 	}
-	return total, nil
+	return nil
 }
 
 func (f *File) reopen() error {

--- a/internal/blockio/blockio_test.go
+++ b/internal/blockio/blockio_test.go
@@ -6,23 +6,19 @@ import (
 	"testing"
 )
 
-func TestReaderFromAligned(t *testing.T) {
+func TestWriteAligned(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "blk")
 	if err != nil {
 		t.Fatalf("tempfile: %v", err)
 	}
-	f, err := Open(tmp.Name(), false)
+	f, err := Open(tmp.Name(), false, false)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	defer f.Close()
 	data := bytes.Repeat([]byte{0x1}, f.Logical()*2)
-	n, err := f.ReaderFrom(bytes.NewReader(data))
-	if err != nil {
-		t.Fatalf("readerfrom: %v", err)
-	}
-	if int(n) != len(data) {
-		t.Fatalf("wrote %d want %d", n, len(data))
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
 	}
 	fi, _ := tmp.Stat()
 	if int(fi.Size()) != len(data) {
@@ -30,20 +26,20 @@ func TestReaderFromAligned(t *testing.T) {
 	}
 }
 
-func TestReaderFromMisalignedFallback(t *testing.T) {
+func TestWriteMisalignedFallback(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "blk")
 	if err != nil {
 		t.Fatalf("tempfile: %v", err)
 	}
-	f, err := Open(tmp.Name(), false)
+	f, err := Open(tmp.Name(), true, false)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	defer f.Close()
 	f.direct = true // simulate O_DIRECT
 	data := bytes.Repeat([]byte{0x2}, f.Logical()-1)
-	if _, err := f.ReaderFrom(bytes.NewReader(data)); err != nil {
-		t.Fatalf("readerfrom: %v", err)
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
 	}
 	if f.Direct() {
 		t.Fatalf("expected fallback to buffered IO")
@@ -54,19 +50,19 @@ func TestReaderFromMisalignedFallback(t *testing.T) {
 	}
 }
 
-func TestReaderFromMisalignedStrict(t *testing.T) {
+func TestWriteMisalignedStrict(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "blk")
 	if err != nil {
 		t.Fatalf("tempfile: %v", err)
 	}
-	f, err := Open(tmp.Name(), true)
+	f, err := Open(tmp.Name(), true, true)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	defer f.Close()
 	f.direct = true
 	data := bytes.Repeat([]byte{0x3}, f.Logical()-1)
-	if _, err := f.ReaderFrom(bytes.NewReader(data)); err == nil {
+	if _, err := f.Write(data); err == nil {
 		t.Fatalf("expected error for misaligned write")
 	}
 	fi, _ := tmp.Stat()
@@ -75,53 +71,23 @@ func TestReaderFromMisalignedStrict(t *testing.T) {
 	}
 }
 
-func TestReaderFromSync(t *testing.T) {
+func TestWritePhysicalMisaligned(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "blk")
 	if err != nil {
 		t.Fatalf("tempfile: %v", err)
 	}
-	f, err := Open(tmp.Name(), false)
+	f, err := Open(tmp.Name(), true, false)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	defer f.Close()
-	called := false
-	f.syncFunc = func() error { called = true; return nil }
+	f.direct = true
+	f.physical = f.logical * 2
 	data := bytes.Repeat([]byte{0x4}, f.Logical())
-	if _, err := f.ReaderFrom(bytes.NewReader(data)); err != nil {
-		t.Fatalf("readerfrom: %v", err)
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
 	}
-	if !called {
-		t.Fatalf("expected syncFunc to be called")
-	}
-}
-
-func TestWriterTo(t *testing.T) {
-	tmp, err := os.CreateTemp(t.TempDir(), "blk")
-	if err != nil {
-		t.Fatalf("tempfile: %v", err)
-	}
-	f, err := Open(tmp.Name(), false)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	defer f.Close()
-	data := bytes.Repeat([]byte{0x5}, f.Logical()*2)
-	if _, err := f.ReaderFrom(bytes.NewReader(data)); err != nil {
-		t.Fatalf("prep write: %v", err)
-	}
-	var buf bytes.Buffer
-	if _, err := f.f.Seek(0, 0); err != nil {
-		t.Fatalf("seek: %v", err)
-	}
-	n, err := f.WriterTo(&buf)
-	if err != nil {
-		t.Fatalf("writerto: %v", err)
-	}
-	if int(n) != len(data) {
-		t.Fatalf("read %d want %d", n, len(data))
-	}
-	if !bytes.Equal(buf.Bytes(), data) {
-		t.Fatalf("data mismatch")
+	if f.Direct() {
+		t.Fatalf("expected fallback for physical misalignment")
 	}
 }

--- a/internal/blockio/devicewriter.go
+++ b/internal/blockio/devicewriter.go
@@ -1,0 +1,37 @@
+package blockio
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+
+	"lvmsync_go/internal/lvm"
+)
+
+// DeviceWriter opens LVM logical volumes for writing.
+// When strict is true, misaligned writes or failed O_DIRECT opens error.
+type DeviceWriter struct {
+	Checker lvm.Checker
+	Strict  bool
+}
+
+// Open prepares the logical volume and returns a writer with a close callback.
+func (d DeviceWriter) Open(ctx context.Context, vg, lv string, direct bool) (io.ReadWriteSeeker, func() error, error) {
+	path, err := d.Checker.PreOpen(ctx, vg, lv)
+	if err != nil {
+		return nil, nil, err
+	}
+	f, err := Open(path, direct, d.Strict)
+	if err != nil {
+		_ = d.Checker.Agent.Unlock(ctx, filepath.Join(vg, lv), d.Checker.Requester)
+		return nil, nil, err
+	}
+	closeFn := func() error {
+		if err := d.Checker.PostCommit(ctx, vg, lv, f); err != nil {
+			_ = f.Close()
+			return err
+		}
+		return f.Close()
+	}
+	return f, closeFn, nil
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"lvmsync_go/config"
+	"lvmsync_go/internal/config"
 )
 
 // NewLogger builds a production logger with sampling enabled and

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"lvmsync_go/config"
+	"lvmsync_go/internal/config"
 )
 
 func TestNewLoggerSamplingDefaults(t *testing.T) {

--- a/internal/lvm/device.go
+++ b/internal/lvm/device.go
@@ -1,0 +1,55 @@
+package lvm
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+)
+
+// Checker validates LVM volumes before use and releases locks after writes.
+// Requester identifies the lock holder.
+type Checker struct {
+	Agent     Agent
+	Requester string
+}
+
+// PreOpen ensures the logical volume exists and is ready for writes.
+// It locks the volume and returns the device path.
+func (c Checker) PreOpen(ctx context.Context, vg, lv string) (string, error) {
+	vol := filepath.Join(vg, lv)
+	ok, err := c.Agent.VolumeExists(ctx, vol)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("volume %s not found", vol)
+	}
+	if ok, err := c.Agent.AutoExtendEnabled(ctx, vol); err != nil {
+		return "", err
+	} else if !ok {
+		return "", fmt.Errorf("auto-extend disabled")
+	}
+	if ok, err := c.Agent.DiscardEnabled(ctx, vol); err != nil {
+		return "", err
+	} else if !ok {
+		return "", fmt.Errorf("discard disabled")
+	}
+	if mounted, err := c.Agent.IsMounted(ctx, vol); err != nil {
+		return "", err
+	} else if mounted {
+		return "", fmt.Errorf("volume %s mounted", vol)
+	}
+	if err := c.Agent.Lock(ctx, vol, c.Requester); err != nil {
+		return "", err
+	}
+	return filepath.Join("/dev", vg, lv), nil
+}
+
+// PostCommit fsyncs the device and releases the lock.
+func (c Checker) PostCommit(ctx context.Context, vg, lv string, f interface{ Sync() error }) error {
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	vol := filepath.Join(vg, lv)
+	return c.Agent.Unlock(ctx, vol, c.Requester)
+}

--- a/internal/lvm/device_test.go
+++ b/internal/lvm/device_test.go
@@ -1,0 +1,64 @@
+package lvm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeFile struct {
+	synced bool
+	err    error
+}
+
+func (f *fakeFile) Sync() error {
+	f.synced = true
+	return f.err
+}
+
+type preMock struct {
+	Agent
+	exists, auto, discard, mounted bool
+	lockErr                        error
+}
+
+func (m *preMock) VolumeExists(context.Context, string) (bool, error)      { return m.exists, nil }
+func (m *preMock) AutoExtendEnabled(context.Context, string) (bool, error) { return m.auto, nil }
+func (m *preMock) DiscardEnabled(context.Context, string) (bool, error)    { return m.discard, nil }
+func (m *preMock) IsMounted(context.Context, string) (bool, error)         { return m.mounted, nil }
+func (m *preMock) Lock(context.Context, string, string) error              { return m.lockErr }
+func (m *preMock) Unlock(context.Context, string, string) error            { return nil }
+
+func TestCheckerPreOpen(t *testing.T) {
+	ctx := context.Background()
+	mock := &preMock{exists: true, auto: true, discard: true}
+	c := Checker{Agent: mock, Requester: "req"}
+	path, err := c.PreOpen(ctx, "vg", "lv")
+	if err != nil {
+		t.Fatalf("preopen: %v", err)
+	}
+	if path != "/dev/vg/lv" {
+		t.Fatalf("path %s", path)
+	}
+	mock.exists = false
+	if _, err := c.PreOpen(ctx, "vg", "lv"); err == nil {
+		t.Fatalf("expected error for missing volume")
+	}
+}
+
+func TestCheckerPostCommit(t *testing.T) {
+	ctx := context.Background()
+	f := &fakeFile{}
+	mock := &preMock{exists: true, auto: true, discard: true}
+	c := Checker{Agent: mock, Requester: "req"}
+	if err := c.PostCommit(ctx, "vg", "lv", f); err != nil {
+		t.Fatalf("postcommit: %v", err)
+	}
+	if !f.synced {
+		t.Fatalf("expected sync")
+	}
+	f.err = errors.New("boom")
+	if err := c.PostCommit(ctx, "vg", "lv", f); err == nil {
+		t.Fatalf("expected sync error")
+	}
+}


### PR DESCRIPTION
## Summary
- add DeviceWriter.Open with LVM pre-checks and fsync/unlock on close
- enforce logical/physical block alignment with optional strict-direct
- cover misalignment errors and O_DIRECT fallback in tests

## Testing
- `go build ./...`
- `go test -cover ./internal/blockio ./internal/lvm ./internal/logging`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0d9068e548323868a457457c35b0f