### PR TITLE
Include AES-NI in digest detection

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -13,10 +13,11 @@ var (
 	hasAVX2   = cpufeatures.HasAVX2
 	hasAVX512 = cpufeatures.HasAVX512
 	hasNEON   = cpufeatures.HasNEON
+	hasAESNI  = cpufeatures.HasAESNI
 )
 
 func detect() string {
-	if hasAVX512() || hasAVX2() || hasNEON() {
+	if hasAVX512() || hasAVX2() || hasNEON() || hasAESNI() {
 		return BLAKE3
 	}
 	return SHA256

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -3,17 +3,18 @@ package digest
 import "testing"
 
 func TestDetect(t *testing.T) {
-	origAVX2, origAVX512, origNEON := hasAVX2, hasAVX512, hasNEON
-	t.Cleanup(func() { hasAVX2, hasAVX512, hasNEON = origAVX2, origAVX512, origNEON })
+	origAVX2, origAVX512, origNEON, origAESNI := hasAVX2, hasAVX512, hasNEON, hasAESNI
+	t.Cleanup(func() { hasAVX2, hasAVX512, hasNEON, hasAESNI = origAVX2, origAVX512, origNEON, origAESNI })
 
 	tests := []struct {
-		name               string
-		avx2, avx512, neon bool
-		want               string
+		name                      string
+		avx2, avx512, neon, aesni bool
+		want                      string
 	}{
 		{name: "avx2", avx2: true, want: BLAKE3},
 		{name: "avx512", avx512: true, want: BLAKE3},
 		{name: "neon", neon: true, want: BLAKE3},
+		{name: "aesni", aesni: true, want: BLAKE3},
 		{name: "none", want: SHA256},
 	}
 	for _, tt := range tests {
@@ -21,6 +22,7 @@ func TestDetect(t *testing.T) {
 			hasAVX2 = func() bool { return tt.avx2 }
 			hasAVX512 = func() bool { return tt.avx512 }
 			hasNEON = func() bool { return tt.neon }
+			hasAESNI = func() bool { return tt.aesni }
 			if got := detect(); got != tt.want {
 				t.Fatalf("detect() = %s, want %s", got, tt.want)
 			}


### PR DESCRIPTION
## Summary
- detect AES-NI in digest detection to prefer BLAKE3
- cover AES-NI detection in digest tests

## Testing
- `go build ./...` *(fails: syntax error in internal/logging/logging.go)*
- `go test -cover ./...` *(fails: syntax error in internal/logging/logging.go)*
- `go test ./internal/digest`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1c464048323aebd5e4c88c975f6