### PR TITLE
rsynkserver: verify target digest

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -37,14 +37,3 @@ func TLSVersionString(v uint16) string {
 		return strconv.FormatUint(uint64(v), 10)
 	}
 }
-
-package logging
-
-import (
-	"crypto/tls"
-	"strconv"
-
-	"go.uber.org/zap"
-
-	"lvmsync_go/internal/config"
-)

--- a/internal/rsynkserver/server.go
+++ b/internal/rsynkserver/server.go
@@ -1,11 +1,16 @@
 package rsynkserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 
+	"github.com/gokrazy/rsync"
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsynkwire"
 )
 
@@ -14,8 +19,10 @@ import (
 // Implementations must write the provided data at the given offset and ensure
 // persistence when Sync is called.
 type Device interface {
+	io.ReaderAt
 	io.WriterAt
 	Sync() error
+	Size() int64
 }
 
 // Server applies incoming deltas to the Device.
@@ -23,16 +30,26 @@ type Device interface {
 // Frames are expected to be sent using rsynkwire.Stream and consist of a leading
 // byte indicating the frame type:
 //
-//	'S' - signature frame (currently ignored)
+//	'S' - signature frame used to reconstruct source signatures
 //	'D' - delta frame containing an 8 byte big endian offset followed by data
 //
 // CRC32C integrity of each frame is verified by rsynkwire.Stream.
 type Server struct {
-	dev Device
+	dev     Device
+	alg     string
+	expect  [32]byte
+	logger  *zap.Logger
+	sigHead *rsync.SumHead
 }
 
-// New constructs a Server using the provided Device.
-func New(dev Device) *Server { return &Server{dev: dev} }
+// New constructs a Server using the provided Device, digest algorithm, expected
+// manifest digest, and logger. A nil logger is replaced with zap.NewNop().
+func New(dev Device, alg string, expect [32]byte, logger *zap.Logger) *Server {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Server{dev: dev, alg: alg, expect: expect, logger: logger}
+}
 
 // Handle consumes frames from the Stream until EOF, applying any delta frames to
 // the Device. On graceful EOF the Device is fsynced.
@@ -43,7 +60,10 @@ func (s *Server) Handle(ctx context.Context, stream *rsynkwire.Stream) error {
 		}
 		frame, err := stream.Recv()
 		if err == io.EOF {
-			return s.dev.Sync()
+			if err := s.dev.Sync(); err != nil {
+				return err
+			}
+			return s.verifyDigest()
 		}
 		if err != nil {
 			return err
@@ -53,7 +73,11 @@ func (s *Server) Handle(ctx context.Context, stream *rsynkwire.Stream) error {
 		}
 		switch frame[0] {
 		case 'S':
-			// Signature frame; currently ignored.
+			head, err := parseSignatures(frame[1:])
+			if err != nil {
+				return err
+			}
+			s.sigHead = &head
 			continue
 		case 'D':
 			if len(frame) < 9 {
@@ -68,4 +92,63 @@ func (s *Server) Handle(ctx context.Context, stream *rsynkwire.Stream) error {
 			return fmt.Errorf("unknown frame type %q", frame[0])
 		}
 	}
+}
+
+func parseSignatures(p []byte) (rsync.SumHead, error) {
+	var head rsync.SumHead
+	buf := bytes.NewReader(p)
+	if err := binary.Read(buf, binary.LittleEndian, &head.ChecksumCount); err != nil {
+		return head, err
+	}
+	if err := binary.Read(buf, binary.LittleEndian, &head.BlockLength); err != nil {
+		return head, err
+	}
+	if err := binary.Read(buf, binary.LittleEndian, &head.ChecksumLength); err != nil {
+		return head, err
+	}
+	if err := binary.Read(buf, binary.LittleEndian, &head.RemainderLength); err != nil {
+		return head, err
+	}
+	head.Sums = make([]rsync.SumBuf, head.ChecksumCount)
+	for i := int32(0); i < head.ChecksumCount; i++ {
+		var short int32
+		if err := binary.Read(buf, binary.LittleEndian, &short); err != nil {
+			return head, err
+		}
+		strong := make([]byte, head.ChecksumLength)
+		if _, err := io.ReadFull(buf, strong); err != nil {
+			return head, err
+		}
+		blockLen := int64(head.BlockLength)
+		if i == head.ChecksumCount-1 && head.RemainderLength != 0 {
+			blockLen = int64(head.RemainderLength)
+		}
+		var strongArr [16]byte
+		copy(strongArr[:], strong)
+		head.Sums[i] = rsync.SumBuf{
+			Offset: int64(i) * int64(head.BlockLength),
+			Len:    blockLen,
+			Index:  i,
+			Sum1:   uint32(short),
+			Sum2:   strongArr,
+		}
+	}
+	return head, nil
+}
+
+func (s *Server) verifyDigest() error {
+	r := io.NewSectionReader(s.dev, 0, s.dev.Size())
+	got, err := digest.SumReader(r, s.alg)
+	if err != nil {
+		s.logger.Error("digest_compute_failed", zap.Error(err))
+		return err
+	}
+	if got != s.expect {
+		s.logger.Error("digest_mismatch",
+			zap.String("algorithm", s.alg),
+			zap.String("expected_digest", fmt.Sprintf("%x", s.expect)),
+			zap.String("actual_digest", fmt.Sprintf("%x", got)))
+		return fmt.Errorf("digest mismatch")
+	}
+	return nil
 }

--- a/internal/rsynkserver/server_test.go
+++ b/internal/rsynkserver/server_test.go
@@ -1,12 +1,18 @@
 package rsynkserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
+	"io"
 	"net"
+	"strings"
 	"testing"
 
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsynkwire"
 )
 
@@ -30,35 +36,71 @@ func (m *memDevice) WriteAt(p []byte, off int64) (int, error) {
 	return len(p), nil
 }
 
+func (m *memDevice) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(m.buf)) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.buf[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (m *memDevice) Size() int64 { return int64(len(m.buf)) }
+
 func (m *memDevice) Sync() error { m.sync = true; return nil }
 
 func TestHandleApplyDelta(t *testing.T) {
-	c1, c2 := net.Pipe()
-	defer c1.Close()
-	defer c2.Close()
+	data := []byte("hello world")
+	algs := []string{digest.BLAKE3, digest.SHA256}
+	for _, alg := range algs {
+		t.Run(alg, func(t *testing.T) {
+			c1, c2 := net.Pipe()
+			defer c1.Close()
+			defer c2.Close()
 
-	dev := &memDevice{}
-	srv := New(dev)
-	ctx := context.Background()
-	errCh := make(chan error)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
+			dev := &memDevice{}
+			expect, err := digest.SumReader(bytes.NewReader(data), alg)
+			if err != nil {
+				t.Fatalf("SumReader: %v", err)
+			}
+			srv := New(dev, alg, expect, zap.NewNop())
+			ctx := context.Background()
+			errCh := make(chan error)
+			go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
 
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1))
-	if err := cl.SendDelta(0, []byte("hello")); err != nil {
-		t.Fatalf("SendDelta: %v", err)
-	}
-	if err := cl.SendDelta(5, []byte(" world")); err != nil {
-		t.Fatalf("SendDelta: %v", err)
-	}
-	c1.Close()
-	if err := <-errCh; err != nil {
-		t.Fatalf("Handle: %v", err)
-	}
-	if string(dev.buf) != "hello world" {
-		t.Fatalf("unexpected buffer %q", string(dev.buf))
-	}
-	if !dev.sync {
-		t.Fatalf("Sync not called")
+			cl := rsynkwire.NewClient(rsynkwire.NewStream(c1))
+			head, err := cl.SendSignatures(bytes.NewReader(data))
+			if err != nil {
+				t.Fatalf("SendSignatures: %v", err)
+			}
+			if err := cl.SendDelta(0, []byte("hello")); err != nil {
+				t.Fatalf("SendDelta: %v", err)
+			}
+			if err := cl.SendDelta(5, []byte(" world")); err != nil {
+				t.Fatalf("SendDelta: %v", err)
+			}
+			c1.Close()
+			if err := <-errCh; err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+			if string(dev.buf) != string(data) {
+				t.Fatalf("unexpected buffer %q", string(dev.buf))
+			}
+			if !dev.sync {
+				t.Fatalf("Sync not called")
+			}
+			if srv.sigHead == nil {
+				t.Fatalf("signatures not parsed")
+			}
+			if srv.sigHead.ChecksumCount != head.ChecksumCount || srv.sigHead.BlockLength != head.BlockLength {
+				t.Fatalf("unexpected signature head %+v want %+v", srv.sigHead, head)
+			}
+			if len(srv.sigHead.Sums) != len(head.Sums) || srv.sigHead.Sums[0].Sum1 != head.Sums[0].Sum1 {
+				t.Fatalf("signature sums mismatch")
+			}
+		})
 	}
 }
 
@@ -68,7 +110,7 @@ func TestHandleCRCError(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{}
-	srv := New(dev)
+	srv := New(dev, digest.SHA256, [32]byte{}, zap.NewNop())
 	ctx := context.Background()
 	errCh := make(chan error)
 	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
@@ -97,7 +139,7 @@ func TestHandleWriteError(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{fail: true}
-	srv := New(dev)
+	srv := New(dev, digest.SHA256, [32]byte{}, zap.NewNop())
 	ctx := context.Background()
 	errCh := make(chan error)
 	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
@@ -109,5 +151,32 @@ func TestHandleWriteError(t *testing.T) {
 	c1.Close()
 	if err := <-errCh; err == nil {
 		t.Fatalf("expected write error")
+	}
+}
+
+func TestHandleDigestMismatch(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	dev := &memDevice{}
+	wrong := [32]byte{}
+	srv := New(dev, digest.SHA256, wrong, zap.NewNop())
+	ctx := context.Background()
+	errCh := make(chan error)
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
+
+	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1))
+	data := []byte("mismatch")
+	if _, err := cl.SendSignatures(bytes.NewReader(data)); err != nil {
+		t.Fatalf("SendSignatures: %v", err)
+	}
+	if err := cl.SendDelta(0, data); err != nil {
+		t.Fatalf("SendDelta: %v", err)
+	}
+	c1.Close()
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("expected digest mismatch, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- parse `S` frames to rebuild source signatures
- verify device contents against transmitted digest using configurable BLAKE3 or SHA-256
- add tests for both digest algorithms and mismatch handling

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4b476c48323b00729849dcd51b0