### PR TITLE
rsynkwire: enforce frame size limit

### DIFF
--- a/internal/rsynkserver/server_test.go
+++ b/internal/rsynkserver/server_test.go
@@ -10,6 +10,8 @@ import (
 	"lvmsync_go/internal/rsynkwire"
 )
 
+const maxFrame = 1 << 20
+
 type memDevice struct {
 	buf  []byte
 	sync bool
@@ -41,9 +43,9 @@ func TestHandleApplyDelta(t *testing.T) {
 	srv := New(dev)
 	ctx := context.Background()
 	errCh := make(chan error)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
 
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1))
+	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
 	if err := cl.SendDelta(0, []byte("hello")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
@@ -71,7 +73,7 @@ func TestHandleCRCError(t *testing.T) {
 	srv := New(dev)
 	ctx := context.Background()
 	errCh := make(chan error)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
 
 	// craft invalid CRC frame
 	payload := make([]byte, 1+8) // 'D' + offset 0
@@ -100,9 +102,9 @@ func TestHandleWriteError(t *testing.T) {
 	srv := New(dev)
 	ctx := context.Background()
 	errCh := make(chan error)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
 
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1))
+	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
 	if err := cl.SendDelta(0, []byte("data")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}

--- a/internal/rsynkwire/client_test.go
+++ b/internal/rsynkwire/client_test.go
@@ -11,13 +11,15 @@ import (
 	"github.com/gokrazy/rsync"
 )
 
+const maxFrame = 1 << 20
+
 func TestClientSendSignatures(t *testing.T) {
 	c1, c2 := net.Pipe()
 	defer c1.Close()
 	defer c2.Close()
 
-	client := NewClient(NewStream(c1))
-	srv := NewStream(c2)
+	client := NewClient(NewStream(c1, maxFrame))
+	srv := NewStream(c2, maxFrame)
 
 	data := []byte("testdata")
 	headExpect := sumSizesSqroot(int64(len(data)))
@@ -91,7 +93,7 @@ func TestStreamBadCRC(t *testing.T) {
 	defer c1.Close()
 	defer c2.Close()
 
-	s := NewStream(c2)
+	s := NewStream(c2, maxFrame)
 	payload := []byte("bad")
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(payload)))

--- a/internal/rsynkwire/stream_test.go
+++ b/internal/rsynkwire/stream_test.go
@@ -1,0 +1,55 @@
+package rsynkwire
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestStreamRecvWithinLimit(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	const max = 4
+	sender := NewStream(c1, max)
+	recv := NewStream(c2, max)
+
+	payload := []byte("test")
+	go func() {
+		if err := sender.Send(payload); err != nil {
+			t.Errorf("Send: %v", err)
+		}
+	}()
+
+	frame, err := recv.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if string(frame) != string(payload) {
+		t.Fatalf("unexpected payload %q", string(frame))
+	}
+}
+
+func TestStreamRecvTooLarge(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	const max = 4
+	recv := NewStream(c2, max)
+
+	payload := []byte("hello")
+	var hdr [8]byte
+	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(payload)))
+	binary.BigEndian.PutUint32(hdr[4:8], crc32.Checksum(payload, crcTable))
+	go func() {
+		c1.Write(hdr[:])
+	}()
+
+	if _, err := recv.Recv(); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("expected size limit error, got %v", err)
+	}
+}

--- a/internal/rsynkwire/wire.go
+++ b/internal/rsynkwire/wire.go
@@ -18,11 +18,13 @@ var crcTable = crc32.MakeTable(crc32.Castagnoli)
 // with a prepended CRC32C. Each Write becomes a single frame and Recv
 // yields fully validated frames to callers.
 type Stream struct {
-	rw io.ReadWriter
+	rw  io.ReadWriter
+	max uint32
 }
 
 // NewStream wraps the provided io.ReadWriter with CRC32C framing.
-func NewStream(rw io.ReadWriter) *Stream { return &Stream{rw: rw} }
+// max specifies the maximum accepted frame size.
+func NewStream(rw io.ReadWriter, max uint32) *Stream { return &Stream{rw: rw, max: max} }
 
 // Send writes a single frame to the underlying stream, prefixing the
 // payload with its length and CRC32C checksum.
@@ -49,6 +51,9 @@ func (s *Stream) Recv() ([]byte, error) {
 		return nil, err
 	}
 	n := binary.BigEndian.Uint32(hdr[0:4])
+	if n > s.max {
+		return nil, fmt.Errorf("frame %d exceeds max %d", n, s.max)
+	}
 	expected := binary.BigEndian.Uint32(hdr[4:8])
 	buf := make([]byte, n)
 	if _, err := io.ReadFull(s.rw, buf); err != nil {


### PR DESCRIPTION
## Summary
- add max frame size tracking to rsynkwire.Stream
- reject frames exceeding configured limit
- test accepted and oversized frames

## Testing
- `go build ./...` *(fails: internal/logging/logging.go:41:1: syntax error: non-declaration statement outside function body)*
- `go test -cover ./...` *(fails: internal/logging/logging.go:41:1: syntax error: non-declaration statement outside function body)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4a000648323ba4ed4ce7602e0e5