### PR TITLE
rsynkwire: reject oversized frames

### DIFF
--- a/internal/rsynkwire/stream_test.go
+++ b/internal/rsynkwire/stream_test.go
@@ -1,6 +1,7 @@
 package rsynkwire
 
 import (
+	"bytes"
 	"encoding/binary"
 	"hash/crc32"
 	"net"
@@ -51,5 +52,18 @@ func TestStreamRecvTooLarge(t *testing.T) {
 
 	if _, err := recv.Recv(); err == nil || !strings.Contains(err.Error(), "exceeds max") {
 		t.Fatalf("expected size limit error, got %v", err)
+	}
+}
+
+func TestStreamSendTooLarge(t *testing.T) {
+	var buf bytes.Buffer
+	const max = 4
+	s := NewStream(&buf, max)
+	payload := []byte("hello")
+	if err := s.Send(payload); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("expected size limit error, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no data written, got %d bytes", buf.Len())
 	}
 }

--- a/internal/rsynkwire/wire.go
+++ b/internal/rsynkwire/wire.go
@@ -1,3 +1,6 @@
+// Package rsynkwire implements a length-prefixed framing protocol with CRC32C
+// for streaming rsync data. Frames larger than the configured maximum cause
+// Send and Recv to return an error.
 package rsynkwire
 
 import (
@@ -29,6 +32,9 @@ func NewStream(rw io.ReadWriter, max uint32) *Stream { return &Stream{rw: rw, ma
 // Send writes a single frame to the underlying stream, prefixing the
 // payload with its length and CRC32C checksum.
 func (s *Stream) Send(p []byte) error {
+	if uint32(len(p)) > s.max {
+		return fmt.Errorf("frame %d exceeds max %d", len(p), s.max)
+	}
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(p)))
 	binary.BigEndian.PutUint32(hdr[4:8], crc32.Checksum(p, crcTable))


### PR DESCRIPTION
## Summary
- guard against sending frames larger than the configured max
- add tests for oversized send
- document size limit failure in rsynkwire package docs

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: internal/rsynkserver/server_test.go:45:6: expected '(' found TestHandleApplyDelta)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0efebdf30832387a1efd678b22d6d