### PR TITLE
blockio: add ReadFrom and WriteTo

### DIFF
--- a/internal/blockio/blockio.go
+++ b/internal/blockio/blockio.go
@@ -3,6 +3,7 @@ package blockio
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -93,6 +94,64 @@ func (f *File) Read(p []byte) (int, error) {
 	return n, err
 }
 
+func (f *File) WriteTo(w io.Writer) (int64, error) {
+	block := lcm(f.logical, f.physical)
+	size := 1 << 20
+	if size%block != 0 {
+		size = block*(size/block) + block
+	}
+	buf := make([]byte, size)
+	var n int64
+	for {
+		nr, er := f.Read(buf)
+		if nr > 0 {
+			nw, ew := w.Write(buf[:nr])
+			n += int64(nw)
+			if ew != nil {
+				return n, ew
+			}
+			if nw != nr {
+				return n, io.ErrShortWrite
+			}
+		}
+		if er != nil {
+			if er == io.EOF {
+				return n, nil
+			}
+			return n, er
+		}
+	}
+}
+
+func (f *File) ReadFrom(r io.Reader) (int64, error) {
+	block := lcm(f.logical, f.physical)
+	size := 1 << 20
+	if size%block != 0 {
+		size = block*(size/block) + block
+	}
+	buf := make([]byte, size)
+	var n int64
+	for {
+		nr, er := r.Read(buf)
+		if nr > 0 {
+			nw, ew := f.Write(buf[:nr])
+			n += int64(nw)
+			if ew != nil {
+				return n, ew
+			}
+			if nw != nr {
+				return n, io.ErrShortWrite
+			}
+		}
+		if er != nil {
+			if er == io.EOF {
+				return n, nil
+			}
+			return n, er
+		}
+	}
+}
+
 func (f *File) Seek(offset int64, whence int) (int64, error) { return f.f.Seek(offset, whence) }
 
 func (f *File) Sync() error {
@@ -149,4 +208,22 @@ func readInt(dir, name string) int {
 		return 0
 	}
 	return v
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func lcm(a, b int) int {
+	g := gcd(a, b)
+	if g == 0 {
+		return 0
+	}
+	return a / g * b
 }

--- a/internal/blockio/blockio_test.go
+++ b/internal/blockio/blockio_test.go
@@ -2,6 +2,7 @@ package blockio
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -126,4 +127,105 @@ func TestOpenBlockDevice(t *testing.T) {
 		t.Fatalf("open block device %s: %v", dev, err)
 	}
 	f.Close()
+}
+
+type countingReader struct {
+	data  []byte
+	off   int
+	calls int
+}
+
+func newCountingReader(size int) *countingReader {
+	return &countingReader{data: bytes.Repeat([]byte{0x5}, size)}
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	r.calls++
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}
+
+type countingWriter struct {
+	w     io.Writer
+	calls int
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.calls++
+	return w.w.Write(p)
+}
+
+func TestReadFromSyscallReduction(t *testing.T) {
+	const size = 1 << 20
+	base := newCountingReader(size)
+	if _, err := io.Copy(io.Discard, base); err != nil {
+		t.Fatalf("baseline copy: %v", err)
+	}
+	if base.calls <= 1 {
+		t.Fatalf("expected baseline reads >1, got %d", base.calls)
+	}
+
+	cr := newCountingReader(size)
+	tmp, err := os.CreateTemp(t.TempDir(), "blk")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	f, err := Open(tmp.Name(), false, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	n, err := io.Copy(f, cr)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != size {
+		t.Fatalf("copied %d want %d", n, size)
+	}
+	if cr.calls >= base.calls {
+		t.Fatalf("expected fewer reads: %d >= %d", cr.calls, base.calls)
+	}
+}
+
+func TestWriteToSyscallReduction(t *testing.T) {
+	const size = 1 << 20
+	data := bytes.Repeat([]byte{0x6}, size)
+	tmp, err := os.CreateTemp(t.TempDir(), "blk")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	if err := os.WriteFile(tmp.Name(), data, 0600); err != nil {
+		t.Fatalf("writefile: %v", err)
+	}
+
+	fBase, err := Open(tmp.Name(), false, false)
+	if err != nil {
+		t.Fatalf("open baseline: %v", err)
+	}
+	cwBase := &countingWriter{w: io.Discard}
+	type noWriteTo struct{ io.Reader }
+	if _, err := io.Copy(cwBase, noWriteTo{fBase}); err != nil {
+		t.Fatalf("baseline copy: %v", err)
+	}
+	if cwBase.calls <= 1 {
+		t.Fatalf("expected baseline writes >1, got %d", cwBase.calls)
+	}
+	fBase.Close()
+
+	f, err := Open(tmp.Name(), false, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	cw := &countingWriter{w: io.Discard}
+	if _, err := io.Copy(cw, f); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if cw.calls >= cwBase.calls {
+		t.Fatalf("expected fewer writes: %d >= %d", cw.calls, cwBase.calls)
+	}
 }


### PR DESCRIPTION
## Summary
- add `ReadFrom` and `WriteTo` methods with block-size alignment handling
- track fewer syscalls via new blockio benchmarks/tests

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: internal/rsynkserver/server_test.go:45:6: expected '(')*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0f99b6ba883238764b6b0427f8d6f