### PR TITLE
blockio: add random access helpers

### DIFF
--- a/internal/blockio/blockio.go
+++ b/internal/blockio/blockio.go
@@ -124,11 +124,20 @@ func (f *File) WriteAt(p []byte, off int64) (int, error) {
 
 // Size returns the current size of the underlying file.
 func (f *File) Size() int64 {
-	if fi, err := f.f.Stat(); err == nil {
-		return fi.Size()
-	}
-	off, _ := f.f.Seek(0, io.SeekEnd)
-	return off
+       if fi, err := f.f.Stat(); err == nil {
+               return fi.Size()
+       }
+       cur, err := f.f.Seek(0, io.SeekCurrent)
+       if err != nil {
+               return 0
+       }
+       end, err := f.f.Seek(0, io.SeekEnd)
+       if err != nil {
+               _, _ = f.f.Seek(cur, io.SeekStart)
+               return 0
+       }
+       _, _ = f.f.Seek(cur, io.SeekStart)
+       return end
 }
 
 func (f *File) Sync() error {

--- a/internal/blockio/blockio.go
+++ b/internal/blockio/blockio.go
@@ -3,6 +3,7 @@ package blockio
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -94,6 +95,41 @@ func (f *File) Read(p []byte) (int, error) {
 }
 
 func (f *File) Seek(offset int64, whence int) (int64, error) { return f.f.Seek(offset, whence) }
+
+// ReadAt reads from the file at a specific offset.
+func (f *File) ReadAt(p []byte, off int64) (int, error) {
+	n, err := f.f.ReadAt(p, off)
+	if n%f.logical != 0 && f.strict {
+		return n, fmt.Errorf("read size %d not multiple of %d", n, f.logical)
+	}
+	return n, err
+}
+
+// WriteAt writes to the file at a specific offset, falling back to buffered
+// I/O when misaligned and strict mode is disabled.
+func (f *File) WriteAt(p []byte, off int64) (int, error) {
+	n := len(p)
+	if n%f.logical != 0 || n%f.physical != 0 {
+		if f.strict {
+			return 0, fmt.Errorf("write size %d not multiple of %d or %d", n, f.logical, f.physical)
+		}
+		if f.direct {
+			if err := f.reopen(); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return f.f.WriteAt(p, off)
+}
+
+// Size returns the current size of the underlying file.
+func (f *File) Size() int64 {
+	if fi, err := f.f.Stat(); err == nil {
+		return fi.Size()
+	}
+	off, _ := f.f.Seek(0, io.SeekEnd)
+	return off
+}
 
 func (f *File) Sync() error {
 	if f.syncFunc != nil {

--- a/internal/blockio/blockio_test.go
+++ b/internal/blockio/blockio_test.go
@@ -93,6 +93,32 @@ func TestWritePhysicalMisaligned(t *testing.T) {
 	}
 }
 
+func TestReadWriteAtAndSize(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "blk")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	f, err := Open(tmp.Name(), false, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	data := bytes.Repeat([]byte{0x5}, f.Logical()*2)
+	if _, err := f.WriteAt(data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	buf := make([]byte, len(data))
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("ReadAt data mismatch")
+	}
+	if size := f.Size(); size != int64(len(data)) {
+		t.Fatalf("size %d want %d", size, len(data))
+	}
+}
+
 func TestOpenNonexistentPath(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing")
 	if _, err := Open(path, false, false); err == nil {

--- a/internal/blockio/devicewriter.go
+++ b/internal/blockio/devicewriter.go
@@ -2,7 +2,6 @@ package blockio
 
 import (
 	"context"
-	"io"
 	"path/filepath"
 
 	"lvmsync_go/internal/lvm"
@@ -15,8 +14,8 @@ type DeviceWriter struct {
 	Strict  bool
 }
 
-// Open prepares the logical volume and returns a writer with a close callback.
-func (d DeviceWriter) Open(ctx context.Context, vg, lv string, direct bool) (io.ReadWriteSeeker, func() error, error) {
+// Open prepares the logical volume and returns a file with a close callback.
+func (d DeviceWriter) Open(ctx context.Context, vg, lv string, direct bool) (*File, func() error, error) {
 	path, err := d.Checker.PreOpen(ctx, vg, lv)
 	if err != nil {
 		return nil, nil, err

--- a/internal/rsynkserver/server_test.go
+++ b/internal/rsynkserver/server_test.go
@@ -41,21 +41,6 @@ func (m *memDevice) WriteAt(p []byte, off int64) (int, error) {
 func (m *memDevice) ReadAt(p []byte, off int64) (int, error) {
 	if off >= int64(len(m.buf)) {
 		return 0, io.EOF
-
-func TestHandleApplyDelta(t *testing.T) {
-	c1, c2 := net.Pipe()
-	defer c1.Close()
-	defer c2.Close()
-
-	dev := &memDevice{}
-	srv := New(dev)
-	ctx := context.Background()
-	errCh := make(chan error)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
-
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
-	if err := cl.SendDelta(0, []byte("hello")); err != nil {
-		t.Fatalf("SendDelta: %v", err)
 	}
 	n := copy(p, m.buf[off:])
 	if n < len(p) {
@@ -68,6 +53,44 @@ func (m *memDevice) Size() int64 { return int64(len(m.buf)) }
 
 func (m *memDevice) Sync() error { m.sync = true; return nil }
 
+func TestHandleApplyDelta(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	dev := &memDevice{}
+	expect, err := digest.SumReader(bytes.NewReader([]byte("hello")), digest.SHA256)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	srv := New(dev, digest.SHA256, expect, zap.NewNop())
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+
+	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
+	if err := cl.SendDelta(0, []byte("hello")); err != nil {
+		t.Fatalf("SendDelta: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	buf := make([]byte, 5)
+	if _, err := dev.ReadAt(buf, 0); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Fatalf("data %q want %q", string(buf), "hello")
+	}
+	if dev.Size() != 5 {
+		t.Fatalf("size %d want 5", dev.Size())
+	}
+	if !dev.sync {
+		t.Fatalf("expected sync called")
+	}
+}
+
 func TestHandleCRCError(t *testing.T) {
 	c1, c2 := net.Pipe()
 	defer c1.Close()
@@ -76,15 +99,14 @@ func TestHandleCRCError(t *testing.T) {
 	dev := &memDevice{}
 	srv := New(dev, digest.SHA256, [32]byte{}, zap.NewNop())
 	ctx := context.Background()
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
 
-	// craft invalid CRC frame
-	payload := make([]byte, 1+8) // 'D' + offset 0
+	payload := make([]byte, 1+8)
 	payload[0] = 'D'
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(payload)))
-	binary.BigEndian.PutUint32(hdr[4:8], 0) // wrong CRC
+	binary.BigEndian.PutUint32(hdr[4:8], 0)
 	if _, err := c1.Write(hdr[:]); err != nil {
 		t.Fatalf("write hdr: %v", err)
 	}
@@ -105,7 +127,7 @@ func TestHandleWriteError(t *testing.T) {
 	dev := &memDevice{fail: true}
 	srv := New(dev, digest.SHA256, [32]byte{}, zap.NewNop())
 	ctx := context.Background()
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
@@ -127,10 +149,10 @@ func TestHandleDigestMismatch(t *testing.T) {
 	wrong := [32]byte{}
 	srv := New(dev, digest.SHA256, wrong, zap.NewNop())
 	ctx := context.Background()
-	errCh := make(chan error)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2)) }()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
 
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1))
+	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
 	data := []byte("mismatch")
 	if _, err := cl.SendSignatures(bytes.NewReader(data)); err != nil {
 		t.Fatalf("SendSignatures: %v", err)


### PR DESCRIPTION
## Summary
- extend blockio.File with ReadAt, WriteAt, and Size
- expose *blockio.File from DeviceWriter.Open
- add tests for random access and size in blockio and rsynkserver

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0f856f8f083238bbc2056554caa3c