### PR TITLE
transport: honor AllowInsecure for h2

### DIFF
--- a/transport/config.go
+++ b/transport/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	ClientCert    tls.Certificate
 	ServerCert    tls.Certificate
 	Logger        *zap.Logger
-	AllowInsecure bool
+	AllowInsecure bool // Skip certificate verification (development only)
 	SSHUser       string
 	SSHPassword   string
 	SSHKnownHosts string

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -55,28 +55,39 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
 		return nil, fmt.Errorf("logger is required")
 	}
-	if cfg.Roots == nil {
-		return nil, fmt.Errorf("tls roots are required")
+	if cfg.Roots == nil && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")
 	}
-	if len(cfg.ServerCert.Certificate) == 0 {
-		return nil, fmt.Errorf("server certificate is required")
+	if len(cfg.ServerCert.Certificate) == 0 && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("server certificate is required unless AllowInsecure is set")
+	}
+	if len(cfg.ClientCert.Certificate) == 0 && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("client certificate is required unless AllowInsecure is set")
+	}
+	clientAuth := tls.RequireAndVerifyClientCert
+	if cfg.AllowInsecure {
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "h2"))
+		clientAuth = tls.RequireAnyClientCert
 	}
 	clientConf := &tls.Config{
-		RootCAs:    cfg.Roots,
-		NextProtos: []string{"h2"},
-		MinVersion: tls.VersionTLS13,
-		MaxVersion: tls.VersionTLS13,
+		RootCAs:            cfg.Roots,
+		NextProtos:         []string{"h2"},
+		MinVersion:         tls.VersionTLS13,
+		MaxVersion:         tls.VersionTLS13,
+		InsecureSkipVerify: cfg.AllowInsecure,
 	}
 	if len(cfg.ClientCert.Certificate) != 0 {
 		clientConf.Certificates = []tls.Certificate{cfg.ClientCert}
 	}
 	serverConf := &tls.Config{
-		Certificates: []tls.Certificate{cfg.ServerCert},
-		ClientCAs:    cfg.Roots,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS13,
-		MaxVersion:   tls.VersionTLS13,
-		NextProtos:   []string{"h2"},
+		ClientCAs:  cfg.Roots,
+		ClientAuth: clientAuth,
+		MinVersion: tls.VersionTLS13,
+		MaxVersion: tls.VersionTLS13,
+		NextProtos: []string{"h2"},
+	}
+	if len(cfg.ServerCert.Certificate) != 0 {
+		serverConf.Certificates = []tls.Certificate{cfg.ServerCert}
 	}
 	return &Transport{clientConf: clientConf, serverConf: serverConf, logger: cfg.Logger}, nil
 }

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -465,6 +465,50 @@ func TestH2TransportRequiresLogger(t *testing.T) {
 	}
 }
 
+func TestH2TransportAllowInsecureWarn(t *testing.T) {
+	core, obs := observer.New(zap.WarnLevel)
+	if _, err := New(transport.Config{Logger: zap.New(core), AllowInsecure: true}); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	entries := obs.FilterMessage("allow_insecure_enabled").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if tr := entries[0].ContextMap()["transport"]; tr != "h2" {
+		t.Fatalf("unexpected transport %v", tr)
+	}
+}
+
+func TestH2TransportRequiresRootsOrAllowInsecure(t *testing.T) {
+	cert, _ := generateSelfSignedCert(t)
+	if _, err := New(transport.Config{Logger: zap.NewNop(), ClientCert: cert, ServerCert: cert}); err == nil {
+		t.Fatalf("expected error when roots are nil without AllowInsecure")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing roots: %v", err)
+	}
+}
+
+func TestH2TransportRequiresServerCert(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ClientCert: cert}); err == nil {
+		t.Fatalf("expected error when server cert is nil")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ClientCert: cert, AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing server cert: %v", err)
+	}
+}
+
+func TestH2TransportRequiresClientCert(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ServerCert: cert}); err == nil {
+		t.Fatalf("expected error when client cert is nil")
+	}
+	if _, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ServerCert: cert, AllowInsecure: true}); err != nil {
+		t.Fatalf("allow insecure should permit missing client cert: %v", err)
+	}
+}
+
 func TestH2DialTimeout(t *testing.T) {
 	cert, pool := generateSelfSignedCert(t)
 	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ClientCert: cert, ServerCert: cert})


### PR DESCRIPTION
## Summary
- skip TLS verification when AllowInsecure is set for h2 transport
- warn when AllowInsecure is enabled
- add tests covering secure and insecure h2 configurations

## Testing
- `go build ./...`
- `go test -cover ./transport/h2`
- `go test -cover ./...` *(fails: internal/rsynkserver/server_test.go:45:6: expected '(')*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a0f98a8ff08323925368bd5b06b881