### PR TITLE
Ensure complete frame writes in Stream.Send

### DIFF
--- a/internal/rsynkwire/stream_test.go
+++ b/internal/rsynkwire/stream_test.go
@@ -67,3 +67,46 @@ func TestStreamSendTooLarge(t *testing.T) {
 		t.Fatalf("expected no data written, got %d bytes", buf.Len())
 	}
 }
+
+type shortReadWriter struct {
+	bytes.Buffer
+	max   int
+	calls int
+}
+
+func (s *shortReadWriter) Write(p []byte) (int, error) {
+	s.calls++
+	if len(p) > s.max {
+		p = p[:s.max]
+	}
+	return s.Buffer.Write(p)
+}
+
+// TestStreamSendShortWrites ensures Send retries until all bytes are written.
+func TestStreamSendShortWrites(t *testing.T) {
+	const limit = 3
+	srw := &shortReadWriter{max: limit}
+	s := NewStream(srw, 1<<20)
+	payload := []byte("hello world")
+	if err := s.Send(payload); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	expectedLen := 8 + len(payload)
+	if srw.Len() != expectedLen {
+		t.Fatalf("wrote %d bytes, want %d", srw.Len(), expectedLen)
+	}
+	data := srw.Bytes()
+	n := binary.BigEndian.Uint32(data[0:4])
+	if int(n) != len(payload) {
+		t.Fatalf("header length %d != payload length %d", n, len(payload))
+	}
+	crc := binary.BigEndian.Uint32(data[4:8])
+	if crc != crc32.Checksum(payload, crcTable) {
+		t.Fatalf("crc mismatch")
+	}
+	// Expect multiple writes due to short writer.
+	expectedCalls := (expectedLen + limit - 1) / limit
+	if srw.calls != expectedCalls {
+		t.Fatalf("expected %d writes, got %d", expectedCalls, srw.calls)
+	}
+}

--- a/internal/rsynkwire/wire.go
+++ b/internal/rsynkwire/wire.go
@@ -30,7 +30,8 @@ type Stream struct {
 func NewStream(rw io.ReadWriter, max uint32) *Stream { return &Stream{rw: rw, max: max} }
 
 // Send writes a single frame to the underlying stream, prefixing the
-// payload with its length and CRC32C checksum.
+// payload with its length and CRC32C checksum. It retries short writes so the
+// header and payload are fully written unless an error occurs.
 func (s *Stream) Send(p []byte) error {
 	if uint32(len(p)) > s.max {
 		return fmt.Errorf("frame %d exceeds max %d", len(p), s.max)
@@ -38,12 +39,28 @@ func (s *Stream) Send(p []byte) error {
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(p)))
 	binary.BigEndian.PutUint32(hdr[4:8], crc32.Checksum(p, crcTable))
-	if _, err := s.rw.Write(hdr[:]); err != nil {
+	if err := writeFull(s.rw, hdr[:]); err != nil {
 		return err
 	}
 	if len(p) > 0 {
-		if _, err := s.rw.Write(p); err != nil {
+		if err := writeFull(s.rw, p); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func writeFull(w io.Writer, buf []byte) error {
+	for len(buf) > 0 {
+		n, err := w.Write(buf)
+		if n > 0 {
+			buf = buf[n:]
+		}
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Retry short writes in rsynkwire Stream.Send so headers and payloads fully flush
- Test Stream.Send against short writes to confirm retry logic
- Clarify Send's guaranteed write semantics

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: expected '(' found newServer)*
- `go test -run TestStreamSendShortWrites -v ./internal/rsynkwire`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1003dded08323bc784202f8ceb168