### PR TITLE
fix(lock): validate VG/LV identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- lock: reject VG/LV names with invalid characters via regex validation
 - tests: flush H2 handshake data by buffering server errors, closing connections before sending, and applying context timeouts
 - manifest: return error when block size is zero
 - device: Detect, OpenFile, and OpenRaw return error when logger is nil

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,14 +1,20 @@
+// Package lock provides lightweight file locking for volume group and logical
+// volume operations. VG and LV identifiers must match the regular expression
+// `^[A-Za-z0-9_.-]+$` to avoid path traversal and other unsafe names.
 package lock
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"golang.org/x/sys/unix"
 )
 
 var baseDir = "/run/lvmsync"
+
+var identRe = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 
 // SetBaseDir overrides the default lock directory for tests.
 func SetBaseDir(dir string) func() {
@@ -25,7 +31,7 @@ type Lock struct {
 // Acquire obtains an exclusive lock for the given volume group and logical volume.
 // The lock file is placed at /run/lvmsync/<vg>.<lv>.lock.
 func Acquire(vg, lv string) (*Lock, error) {
-	if vg == "" || lv == "" {
+	if !identRe.MatchString(vg) || !identRe.MatchString(lv) {
 		return nil, fmt.Errorf("invalid vg/lv")
 	}
 	if err := os.MkdirAll(baseDir, 0o755); err != nil {

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -25,3 +25,42 @@ func TestAcquireRelease(t *testing.T) {
 		t.Fatalf("lock file not removed")
 	}
 }
+
+func TestAcquireValidIdentifiers(t *testing.T) {
+	dir := t.TempDir()
+	restore := SetBaseDir(dir)
+	defer restore()
+	cases := []struct{ vg, lv string }{
+		{"vg-1", "lv_1"},
+		{"vg.name", "lv.name"},
+	}
+	for _, c := range cases {
+		t.Run(c.vg+"/"+c.lv, func(t *testing.T) {
+			l, err := Acquire(c.vg, c.lv)
+			if err != nil {
+				t.Fatalf("Acquire: %v", err)
+			}
+			if err := l.Release(); err != nil {
+				t.Fatalf("Release: %v", err)
+			}
+		})
+	}
+}
+
+func TestAcquireInvalidIdentifiers(t *testing.T) {
+	dir := t.TempDir()
+	restore := SetBaseDir(dir)
+	defer restore()
+	cases := []struct{ vg, lv string }{
+		{"", "lv"},
+		{"vg", ""},
+		{"vg/1", "lv"},
+		{"vg", "lv/1"},
+		{"vg!", "lv"},
+	}
+	for _, c := range cases {
+		if _, err := Acquire(c.vg, c.lv); err == nil {
+			t.Fatalf("Acquire(%q,%q) succeeded; want error", c.vg, c.lv)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- validate VG/LV identifiers in lock acquisition using `^[A-Za-z0-9_.-]+$`
- cover valid and invalid lock identifiers in tests
- document allowed identifier characters

## Testing
- `go build ./...` *(fails: internal/rsynkserver/server.go: context imported and not used)*
- `go test -coverprofile=coverage.out ./...` *(fails: internal/rsynkserver/server_test.go: expected ';', found int64)*
- `go tool cover -func=coverage.out`
- `golangci-lint run`
- `go test ./internal/lock -cover`


------
https://chatgpt.com/codex/tasks/task_e_68a1022920e88323902f5c82125931e1