### PR TITLE
Ensure SSH dialer respects context deadlines

### DIFF
--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -21,6 +21,8 @@ import (
 	"lvmsync_go/transport"
 )
 
+const defaultDialTimeout = 5 * time.Second
+
 // Transport implements the transport.Interface over SSH.
 type Transport struct {
 	serverConf *ssh.ServerConfig
@@ -179,7 +181,26 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
+	dl, ok := ctx.Deadline()
+	if !ok {
+		dl = time.Now().Add(defaultDialTimeout)
+	}
+	if err := raw.SetDeadline(dl); err != nil {
+		raw.Close()
+		fields = append(fields, zap.Error(err))
+		t.logger.Error("dial_end", fields...)
+		return nil, err
+	}
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			raw.SetDeadline(time.Now())
+		case <-done:
+		}
+	}()
 	cc, chans, reqs, err := ssh.NewClientConn(raw, address, t.clientConf)
+	close(done)
 	fields = []zap.Field{
 		zap.String("address", address),
 		zap.String("role", role),
@@ -187,6 +208,16 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 	}
 	if err != nil {
 		raw.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
+		fields = append(fields, zap.Error(err))
+		t.logger.Error("dial_end", fields...)
+		return nil, err
+	}
+	if err := raw.SetDeadline(time.Time{}); err != nil {
+		raw.Close()
+		cc.Close()
 		fields = append(fields, zap.Error(err))
 		t.logger.Error("dial_end", fields...)
 		return nil, err

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -781,3 +781,34 @@ func TestSSHTransportRejectsUnknownHost(t *testing.T) {
 	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
 }
+
+func TestSSHTransportDialContextCancel(t *testing.T) {
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), SSHUser: "u", SSHPassword: "p", AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		io.Copy(io.Discard, conn)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := tr.Dial(ctx, ln.Addr().String()); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- set a deadline on SSH connections during handshake and clear it after
- add test verifying Dial respects canceled contexts

## Testing
- `go build -v ./...` *(fails: internal/rsynkserver/server.go:5:2: "context" imported and not used)*
- `go test -cover ./...` *(fails: internal/rsynkserver/server_test.go:94:28: expected ';', found int64)*
- `go test -cover -tags ssh ./transport/ssh` *(fails: transport/ssh/ssh_test.go:342:2: declared and not used: client)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1021a38d483239d752302a156372f