### PR TITLE
blockio: use pooled page-aligned buffers

### DIFF
--- a/internal/blockio/blockio.go
+++ b/internal/blockio/blockio.go
@@ -100,7 +100,8 @@ func (f *File) WriteTo(w io.Writer) (int64, error) {
 	if size%block != 0 {
 		size = block*(size/block) + block
 	}
-	buf := make([]byte, size)
+	buf := getAlignedBlockBuffer(size)
+	defer putAlignedBlockBuffer(buf)
 	var n int64
 	for {
 		nr, er := f.Read(buf)
@@ -129,7 +130,8 @@ func (f *File) ReadFrom(r io.Reader) (int64, error) {
 	if size%block != 0 {
 		size = block*(size/block) + block
 	}
-	buf := make([]byte, size)
+	buf := getAlignedBlockBuffer(size)
+	defer putAlignedBlockBuffer(buf)
 	var n int64
 	for {
 		nr, er := r.Read(buf)
@@ -182,20 +184,20 @@ func (f *File) WriteAt(p []byte, off int64) (int, error) {
 
 // Size returns the current size of the underlying file.
 func (f *File) Size() int64 {
-       if fi, err := f.f.Stat(); err == nil {
-               return fi.Size()
-       }
-       cur, err := f.f.Seek(0, io.SeekCurrent)
-       if err != nil {
-               return 0
-       }
-       end, err := f.f.Seek(0, io.SeekEnd)
-       if err != nil {
-               _, _ = f.f.Seek(cur, io.SeekStart)
-               return 0
-       }
-       _, _ = f.f.Seek(cur, io.SeekStart)
-       return end
+	if fi, err := f.f.Stat(); err == nil {
+		return fi.Size()
+	}
+	cur, err := f.f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0
+	}
+	end, err := f.f.Seek(0, io.SeekEnd)
+	if err != nil {
+		_, _ = f.f.Seek(cur, io.SeekStart)
+		return 0
+	}
+	_, _ = f.f.Seek(cur, io.SeekStart)
+	return end
 }
 
 func (f *File) Sync() error {

--- a/internal/blockio/blockio_test.go
+++ b/internal/blockio/blockio_test.go
@@ -255,3 +255,55 @@ func TestWriteToSyscallReduction(t *testing.T) {
 		t.Fatalf("expected fewer writes: %d >= %d", cw.calls, cwBase.calls)
 	}
 }
+
+func BenchmarkReadFromPool(b *testing.B) {
+	tmp, err := os.CreateTemp(b.TempDir(), "blk")
+	if err != nil {
+		b.Fatalf("tempfile: %v", err)
+	}
+	f, err := Open(tmp.Name(), false, false)
+	if err != nil {
+		b.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	data := bytes.Repeat([]byte{0x7}, 1<<20)
+	r := bytes.NewReader(data)
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		r.Reset(data)
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			b.Fatalf("seek: %v", err)
+		}
+		if _, err := f.ReadFrom(r); err != nil {
+			b.Fatalf("readfrom: %v", err)
+		}
+	}
+}
+
+func BenchmarkWriteToPool(b *testing.B) {
+	data := bytes.Repeat([]byte{0x8}, 1<<20)
+	tmp, err := os.CreateTemp(b.TempDir(), "blk")
+	if err != nil {
+		b.Fatalf("tempfile: %v", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		b.Fatalf("write: %v", err)
+	}
+	tmp.Close()
+	f, err := Open(tmp.Name(), false, false)
+	if err != nil {
+		b.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			b.Fatalf("seek: %v", err)
+		}
+		if _, err := f.WriteTo(io.Discard); err != nil {
+			b.Fatalf("writeto: %v", err)
+		}
+	}
+}

--- a/internal/blockio/buffer_pool.go
+++ b/internal/blockio/buffer_pool.go
@@ -1,0 +1,47 @@
+package blockio
+
+import (
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+var bufferPools sync.Map
+
+func getAlignedBlockBuffer(size int) []byte {
+	if p, ok := bufferPools.Load(size); ok {
+		if pool, ok := p.(*sync.Pool); ok {
+			if bufAny := pool.Get(); bufAny != nil {
+				if bp, ok := bufAny.(*[]byte); ok {
+					return *bp
+				}
+			}
+		}
+	}
+	pool := &sync.Pool{New: func() any {
+		b, err := unix.Mmap(-1, 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANON)
+		if err != nil {
+			buf := make([]byte, size)
+			return &buf
+		}
+		return &b
+	}}
+	actual, _ := bufferPools.LoadOrStore(size, pool)
+	bufAny := actual.(*sync.Pool).Get()
+	if bp, ok := bufAny.(*[]byte); ok {
+		return *bp
+	}
+	if b, ok := bufAny.([]byte); ok {
+		return b
+	}
+	buf := make([]byte, size)
+	return buf
+}
+
+func putAlignedBlockBuffer(buf []byte) {
+	if p, ok := bufferPools.Load(len(buf)); ok {
+		if pool, ok := p.(*sync.Pool); ok {
+			pool.Put(&buf)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add sync.Pool of page-aligned buffers for block I/O
- reuse pooled buffers in WriteTo and ReadFrom
- add benchmarks exercising pooled path

## Testing
- `go build ./...` *(fails: internal/rsynkserver/server.go: imports not used)*
- `go test -cover ./...` *(fails: internal/rsynkserver/server_test.go: expected ';', found int64; interrupted at internal/rsynkwire)*
- `go test -bench=. -benchmem ./internal/blockio`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a101fee67c8323a439daedc5e28679