### PR TITLE
blockio: handle WriteAt offset alignment

### DIFF
--- a/internal/blockio/blockio.go
+++ b/internal/blockio/blockio.go
@@ -179,6 +179,16 @@ func (f *File) WriteAt(p []byte, off int64) (int, error) {
 			}
 		}
 	}
+	if off%int64(f.logical) != 0 || off%int64(f.physical) != 0 {
+		if f.strict {
+			return 0, fmt.Errorf("write offset %d not multiple of %d or %d", off, f.logical, f.physical)
+		}
+		if f.direct {
+			if err := f.reopen(); err != nil {
+				return 0, err
+			}
+		}
+	}
 	return f.f.WriteAt(p, off)
 }
 

--- a/internal/blockio/blockio_test.go
+++ b/internal/blockio/blockio_test.go
@@ -94,6 +94,84 @@ func TestWritePhysicalMisaligned(t *testing.T) {
 	}
 }
 
+func TestWriteAtAlignedOffset(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "blk")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	f, err := Open(tmp.Name(), true, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	f.direct = true
+	data := bytes.Repeat([]byte{0x6}, f.Logical())
+	off := int64(f.Logical())
+	if _, err := f.WriteAt(data, off); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if !f.Direct() {
+		t.Fatalf("expected direct IO to remain enabled")
+	}
+	buf := make([]byte, len(data))
+	if _, err := f.ReadAt(buf, off); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("data mismatch at aligned offset")
+	}
+}
+
+func TestWriteAtMisalignedOffsetFallback(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "blk")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	f, err := Open(tmp.Name(), true, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	f.direct = true
+	data := bytes.Repeat([]byte{0x7}, f.Logical())
+	off := int64(f.Logical() / 2)
+	if _, err := f.WriteAt(data, off); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if f.Direct() {
+		t.Fatalf("expected fallback to buffered IO for misaligned offset")
+	}
+	buf := make([]byte, len(data))
+	if _, err := f.ReadAt(buf, off); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("data mismatch after misaligned offset write")
+	}
+}
+
+func TestWriteAtMisalignedOffsetStrict(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "blk")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	f, err := Open(tmp.Name(), true, true)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	f.direct = true
+	data := bytes.Repeat([]byte{0x8}, f.Logical())
+	off := int64(f.Logical() / 2)
+	if _, err := f.WriteAt(data, off); err == nil {
+		t.Fatalf("expected error for misaligned offset in strict mode")
+	}
+	fi, _ := tmp.Stat()
+	if fi.Size() != 0 {
+		t.Fatalf("expected no data written")
+	}
+}
+
 func TestReadWriteAtAndSize(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "blk")
 	if err != nil {


### PR DESCRIPTION
## Summary
- check WriteAt offset alignment against logical/physical blocks
- reopen file without O_DIRECT on misalignment unless strict
- add tests for aligned and misaligned WriteAt offsets

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a108734c6c83238718c01b0f3662d2