### PR TITLE
Remove unsupported BLAKE3-512 checksum option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -64,7 +64,7 @@ compress_threshold: 0.9
 speed: "100MB"  # Speed limit (e.g. "100MB")
 # Enable checksum verification for data integrity
 verify_checksum: false
-# Checksum algorithm (options: auto, sha256, blake3, blake3-512)
+# Checksum algorithm (options: auto, sha256, blake3)
 checksum_algorithm: auto
 verbose: 0  # Verbosity level (0 = silent, higher numbers = more verbose)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -925,3 +925,16 @@ func TestLoadConfigInvalidPath(t *testing.T) {
 		t.Fatalf("expected config file error, got %v", err)
 	}
 }
+
+func TestUnsupportedChecksumAlgorithm(t *testing.T) {
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	v := viper.New()
+	v.Set("checksum_algorithm", "blake3-512")
+	b := &builder{v: v, defaults: defaults}
+	if _, err := b.Build(); err == nil {
+		t.Fatalf("expected error for unsupported checksum algorithm")
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -22,7 +22,7 @@ var (
 	SupportedCompression        = []string{"none", "lz4", Zstd, Auto}
 	SupportedDedupStrategies    = []string{"none", Auto, "checksum", "rolling_hash", "bloom"}
 	SupportedDedupModes         = []string{"fixed", "cdc", "hybrid"}
-	SupportedChecksumAlgorithms = []string{"sha256", "blake3", "blake3-512", Auto}
+	SupportedChecksumAlgorithms = []string{"sha256", "blake3", Auto}
 )
 
 type Config struct {

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -227,7 +227,7 @@ func (b *builder) validateCompression(conf *Config) error {
 func (b *builder) finalizeConfig(conf *Config) error {
 	algo := strings.ToLower(conf.ChecksumAlgorithm)
 	switch algo {
-	case "sha256", "blake3", "blake3-512", Auto:
+	case "sha256", "blake3", Auto:
 		conf.ChecksumAlgorithm = algo
 	default:
 		return fmt.Errorf("unsupported checksum algorithm: %s", conf.ChecksumAlgorithm)

--- a/transfer/checksum.go
+++ b/transfer/checksum.go
@@ -27,18 +27,14 @@ func (s *SHA256Checksum) Compute(data []byte) []byte {
 
 func (s *SHA256Checksum) Size() int { return sha256.Size }
 
-type BLAKE3Checksum struct{ size int }
+type BLAKE3Checksum struct{}
 
 func (b *BLAKE3Checksum) Compute(data []byte) []byte {
-	if b.size > 32 {
-		sum := blake3.Sum512(data)
-		return sum[:]
-	}
 	sum := blake3.Sum256(data)
 	return sum[:]
 }
 
-func (b *BLAKE3Checksum) Size() int { return b.size }
+func (b *BLAKE3Checksum) Size() int { return 32 }
 
 var (
 	strategies map[string]ChecksumStrategy
@@ -50,9 +46,8 @@ var detectChecksumAlgorithm = digest.Select
 func initChecksumStrategies() {
 	strategies = map[string]ChecksumStrategy{
 		"sha256":     &SHA256Checksum{},
-		"blake3":     &BLAKE3Checksum{size: 32},
-		"blake3-256": &BLAKE3Checksum{size: 32},
-		"blake3-512": &BLAKE3Checksum{size: 64},
+		"blake3":     &BLAKE3Checksum{},
+		"blake3-256": &BLAKE3Checksum{},
 	}
 }
 

--- a/transfer/checksum_test.go
+++ b/transfer/checksum_test.go
@@ -26,21 +26,15 @@ func TestBLAKE3Checksum(t *testing.T) {
 	}
 }
 
-func TestBLAKE3_512Checksum(t *testing.T) {
-	data := []byte("verify blake3 512")
-	want := blake3.Sum512(data)
-	got := GetChecksumStrategy("blake3-512").Compute(data)
-	if !bytes.Equal(got, want[:]) {
-		t.Fatalf("blake3-512 checksum mismatch: got %x, want %x", got, want)
-	}
-}
-
 func TestUnsupportedAlgorithmDefaultsToSHA256(t *testing.T) {
 	data := []byte("verify default")
 	want := sha256.Sum256(data)
-	got := GetChecksumStrategy("unsupported").Compute(data)
-	if !bytes.Equal(got, want[:]) {
-		t.Fatalf("default checksum mismatch: got %x, want %x", got, want)
+	cases := []string{"unsupported", "blake3-512"}
+	for _, alg := range cases {
+		got := GetChecksumStrategy(alg).Compute(data)
+		if !bytes.Equal(got, want[:]) {
+			t.Fatalf("%s checksum mismatch: got %x, want %x", alg, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- drop BLAKE3-512 from supported checksum algorithms
- reject blake3-512 in config validation and default to SHA-256 when requested
- document available checksum options

## Testing
- `go build ./...`
- `go test -run TestUnsupportedChecksumAlgorithm ./internal/config -cover`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1089acb1c8323bfbf266857ebe03a