### PR TITLE
Remove checksum alias for digest flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
 | `--verbose` | `LVMSYNC_VERBOSE` | `verbose` | Verbosity level |
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
 | `--verify` | `LVMSYNC_VERIFY` | `verify` | Verification level: `full`, `sampled`, or `none` |
-| `--checksum_algorithm`, `--digest` | `LVMSYNC_CHECKSUM_ALGORITHM`, `LVMSYNC_DIGEST` | `checksum_algorithm`, `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
+| `--digest` | `LVMSYNC_DIGEST` | `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
 | `--manifest_path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
 | `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |

--- a/cmd/verify/verify_mismatch_test.go
+++ b/cmd/verify/verify_mismatch_test.go
@@ -69,7 +69,7 @@ func TestRunLogsMismatchBlockSHA256(t *testing.T) {
 		}
 		return idx.Close()
 	})
-	err := r.Run([]string{"--checksum_algorithm", "sha256", src, dst}, logger)
+	err := r.Run([]string{"--digest", "sha256", src, dst}, logger)
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -64,8 +64,8 @@ compress_threshold: 0.9
 speed: "100MB"  # Speed limit (e.g. "100MB")
 # Enable checksum verification for data integrity
 verify_checksum: false
-# Checksum algorithm (options: auto, sha256, blake3, blake3-512)
-checksum_algorithm: auto
+# Digest algorithm (options: auto, sha256, blake3, blake3-512)
+digest: auto
 verbose: 0  # Verbosity level (0 = silent, higher numbers = more verbose)
 
 # LVM Options:

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -125,6 +125,7 @@ lvmsync verify /dev/vg0/snap0 /dev/null
 |------|----------------------|------------|-------------|
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file |
 | `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
+| `--digest` | `LVMSYNC_DIGEST` | `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` |
 
 ### Freeze and Thaw Live Filesystems
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -73,7 +73,7 @@ type Config struct {
 	SpeedLimit               int           `mapstructure:"-"`
 	VerifyChecksum           bool          `mapstructure:"verify_checksum"`
 	VerifyLevel              string        `mapstructure:"verify"`
-	ChecksumAlgorithm        string        `mapstructure:"checksum_algorithm"`
+	ChecksumAlgorithm        string        `mapstructure:"digest"`
 	Verbose                  int           `mapstructure:"verbose"`
 	SkipSnapshotCreation     bool          `mapstructure:"skip_snapshot_creation"`
 	SkipDiskCheck            bool          `mapstructure:"skip_disk_check"`

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -81,7 +81,6 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.CountP("verbose", "v", "Verbosity level")
 	fs.Bool("verify_checksum", cfg.VerifyChecksum, "Enable checksum verification")
 	fs.String("verify", cfg.VerifyLevel, "Verification level: full, sampled, or none")
-	fs.String("checksum_algorithm", cfg.ChecksumAlgorithm, fmt.Sprintf("Checksum algorithm: %v", SupportedChecksumAlgorithms))
 	fs.String("digest", cfg.ChecksumAlgorithm, fmt.Sprintf("Digest algorithm: %v", SupportedChecksumAlgorithms))
 	fs.Bool("progress", cfg.Progress, "Show progress during transfer")
 	return fs

--- a/internal/config/flagsets_test.go
+++ b/internal/config/flagsets_test.go
@@ -42,7 +42,6 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"verbose", "0"},
 		{"verify_checksum", strconv.FormatBool(cfg.VerifyChecksum)},
 		{"verify", cfg.VerifyLevel},
-		{"checksum_algorithm", cfg.ChecksumAlgorithm},
 		{"digest", cfg.ChecksumAlgorithm},
 		{"progress", strconv.FormatBool(cfg.Progress)},
 	}
@@ -54,6 +53,31 @@ func TestInitGeneralFlags(t *testing.T) {
 		if f.DefValue != tt.want {
 			t.Fatalf("%s default %s want %s", tt.name, f.DefValue, tt.want)
 		}
+	}
+	if f := fs.Lookup("checksum_algorithm"); f != nil {
+		t.Fatalf("unexpected checksum_algorithm flag")
+	}
+}
+
+func TestDigestFlagBindsToConfig(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := initGeneralFlags(cfg)
+	if err := fs.Parse([]string{"--digest", "sha256"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v := viper.New()
+	if err := v.BindPFlags(fs); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	var c Config
+	if err := v.Unmarshal(&c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.ChecksumAlgorithm != "sha256" {
+		t.Fatalf("got %s want sha256", c.ChecksumAlgorithm)
 	}
 }
 

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -317,7 +317,6 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 	v.RegisterAlias("lz4_level", "lz4-level")
 	v.RegisterAlias("compress_threshold", "compress-threshold")
 	v.RegisterAlias("lvm_escalation", "lvm-escalation")
-	v.RegisterAlias("checksum_algorithm", "digest")
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary
- drop `--checksum_algorithm` flag in favor of a single `--digest` option
- update configuration parsing and documentation for the new flag
- test `--digest` binding and ensure removed alias is absent

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1088135188323b32015d49d536d06