### PR TITLE
Use signature cache in rsynkserver

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -932,7 +932,7 @@ func TestUnsupportedChecksumAlgorithm(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	v := viper.New()
-	v.Set("checksum_algorithm", "blake3-512")
+	v.Set("digest", "blake3-512")
 	b := &builder{v: v, defaults: defaults}
 	if _, err := b.Build(); err == nil {
 		t.Fatalf("expected error for unsupported checksum algorithm")

--- a/internal/rsynkserver/server.go
+++ b/internal/rsynkserver/server.go
@@ -13,6 +13,7 @@ import (
 
 	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsynkwire"
+	"lvmsync_go/internal/signaturecache"
 )
 
 // Device represents a writable block device supporting random writes and sync.
@@ -41,16 +42,19 @@ type Server struct {
 	expect  [32]byte
 	logger  *zap.Logger
 	sigHead *rsync.SumHead
+	cache   *signaturecache.Cache
+	vg      string
+	lv      string
 }
 
 // New constructs a Server using the provided Device and logger. The digest
 // algorithm and expected sum are supplied via a later digest frame. A nil
 // logger is replaced with zap.NewNop().
-func New(dev Device, logger *zap.Logger) *Server {
+func New(dev Device, logger *zap.Logger, cache *signaturecache.Cache, vg, lv string) *Server {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	return &Server{dev: dev, logger: logger}
+	return &Server{dev: dev, logger: logger, cache: cache, vg: vg, lv: lv}
 }
 
 // Handle consumes frames from the Stream until EOF, applying any delta frames to
@@ -123,6 +127,9 @@ func (s *Server) Handle(ctx context.Context, stream *rsynkwire.Stream) error {
 			}
 			s.alg = string(frame[2 : 2+algLen])
 			copy(s.expect[:], frame[2+algLen:])
+			if s.cache != nil && s.cache.Check(s.vg, s.lv, s.dev.Size(), s.expect[:]) {
+				return nil
+			}
 			continue
 		default:
 			return fmt.Errorf("unknown frame type %q", frame[0])
@@ -203,6 +210,11 @@ func (s *Server) verifyDigest() error {
 			zap.String("expected_digest", fmt.Sprintf("%x", s.expect)),
 			zap.String("actual_digest", fmt.Sprintf("%x", got)))
 		return fmt.Errorf("digest mismatch")
+	}
+	if s.cache != nil {
+		if err := s.cache.Put(s.vg, s.lv, s.dev.Size(), got[:]); err != nil {
+			s.logger.Warn("cache_put_failed", zap.Error(err))
+		}
 	}
 	return nil
 }

--- a/internal/rsynkserver/server_test.go
+++ b/internal/rsynkserver/server_test.go
@@ -6,13 +6,17 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
 	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsynkwire"
+	"lvmsync_go/internal/signaturecache"
 )
 
 const maxFrame = 1 << 20
@@ -55,7 +59,7 @@ func (m *memDevice) Sync() error { m.sync = true; return nil }
 
 func newServer(t *testing.T, dev *memDevice, data []byte) *Server {
 	t.Helper()
-	srv := New(dev, zap.NewNop())
+	srv := New(dev, zap.NewNop(), nil, "", "")
 	exp, err := digest.SumReader(bytes.NewReader(data), digest.SHA256)
 	if err != nil {
 		t.Fatalf("digest: %v", err)
@@ -121,7 +125,7 @@ func TestHandleRejectsOversizedSignatures(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{buf: make([]byte, 1)}
-	srv := New(dev, zap.NewNop())
+	srv := New(dev, zap.NewNop(), nil, "", "")
 	ctx := context.Background()
 	errCh := make(chan error, 1)
 	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
@@ -143,5 +147,162 @@ func TestHandleRejectsOversizedSignatures(t *testing.T) {
 	err := <-errCh
 	if err == nil || !strings.Contains(err.Error(), "checksum count") {
 		t.Fatalf("expected checksum count error, got %v", err)
+	}
+}
+
+func TestHandleCacheHit(t *testing.T) {
+	dir := t.TempDir()
+	cache := signaturecache.New(dir, time.Hour, 10)
+	data := []byte("hello")
+	dev := &memDevice{buf: append([]byte{}, data...)}
+	dgst, err := digest.SumReader(bytes.NewReader(data), digest.SHA256)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if err := cache.Put("vg", "lv", int64(len(data)), dgst[:]); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	srv := New(dev, zap.NewNop(), cache, "vg", "lv")
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+
+	var buf bytes.Buffer
+	buf.WriteByte('G')
+	buf.WriteByte(byte(len(digest.SHA256)))
+	buf.WriteString(digest.SHA256)
+	buf.Write(dgst[:])
+	if err := rsynkwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if dev.sync {
+		t.Fatalf("expected no sync on cache hit")
+	}
+}
+
+func TestHandleCacheMissUpdates(t *testing.T) {
+	dir := t.TempDir()
+	cache := signaturecache.New(dir, time.Hour, 10)
+	data := []byte("hi")
+	dev := &memDevice{buf: make([]byte, len(data))}
+	srv := New(dev, zap.NewNop(), cache, "vg", "lv")
+	dgst, err := digest.SumReader(bytes.NewReader(data), digest.SHA256)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+	stream := rsynkwire.NewStream(c1, maxFrame)
+
+	var gbuf bytes.Buffer
+	gbuf.WriteByte('G')
+	gbuf.WriteByte(byte(len(digest.SHA256)))
+	gbuf.WriteString(digest.SHA256)
+	gbuf.Write(dgst[:])
+	if err := stream.Send(gbuf.Bytes()); err != nil {
+		t.Fatalf("Send digest: %v", err)
+	}
+	if err := rsynkwire.NewClient(stream).SendDelta(0, data); err != nil {
+		t.Fatalf("SendDelta: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if string(dev.buf) != string(data) {
+		t.Fatalf("device %q want %q", dev.buf, data)
+	}
+	if !dev.sync {
+		t.Fatalf("expected sync")
+	}
+	if _, ok := cache.Get("vg", "lv", int64(len(data))); !ok {
+		t.Fatalf("expected cache populated")
+	}
+}
+
+func TestHandleCacheTTLExpiry(t *testing.T) {
+	dir := t.TempDir()
+	cache := signaturecache.New(dir, 10*time.Millisecond, 10)
+	data := []byte("hello")
+	dgst, err := digest.SumReader(bytes.NewReader(data), digest.SHA256)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if err := cache.Put("vg", "lv", int64(len(data)), dgst[:]); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	dev := &memDevice{buf: append([]byte{}, data...)}
+	srv := New(dev, zap.NewNop(), cache, "vg", "lv")
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+	var buf bytes.Buffer
+	buf.WriteByte('G')
+	buf.WriteByte(byte(len(digest.SHA256)))
+	buf.WriteString(digest.SHA256)
+	buf.Write(dgst[:])
+	if err := rsynkwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !dev.sync {
+		t.Fatalf("expected sync after TTL expiry")
+	}
+}
+
+func TestHandleCacheLRUEviction(t *testing.T) {
+	dir := t.TempDir()
+	cache := signaturecache.New(dir, time.Hour, 1)
+
+	run := func(vg, lv, content string) {
+		dev := &memDevice{buf: []byte(content)}
+		dgst, err := digest.SumReader(bytes.NewReader([]byte(content)), digest.SHA256)
+		if err != nil {
+			t.Fatalf("digest: %v", err)
+		}
+		srv := New(dev, zap.NewNop(), cache, vg, lv)
+		c1, c2 := net.Pipe()
+		ctx := context.Background()
+		errCh := make(chan error, 1)
+		go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+		var buf bytes.Buffer
+		buf.WriteByte('G')
+		buf.WriteByte(byte(len(digest.SHA256)))
+		buf.WriteString(digest.SHA256)
+		buf.Write(dgst[:])
+		if err := rsynkwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		c1.Close()
+		if err := <-errCh; err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+	}
+
+	run("vg", "a", "a")
+	if _, err := os.Stat(filepath.Join(dir, "vg", "a.sig")); err != nil {
+		t.Fatalf("expected a.sig present: %v", err)
+	}
+	run("vg", "b", "b")
+	if _, err := os.Stat(filepath.Join(dir, "vg", "a.sig")); !os.IsNotExist(err) {
+		t.Fatalf("expected a.sig evicted, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- integrate signaturecache into rsynkserver to persist signatures and skip work when cached
- add server tests covering cache hits, misses, TTL expiry, and LRU eviction
- fix config test to use correct checksum key

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a10f0e8fbc8323a013cdaf4cd2a3a8