### PR TITLE
refactor(device): inject lvm helpers via runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Override detection with `--source-type` and `--dest-type` when necessary.
 Internally, `device.Detect` delegates to dedicated helpers:
 
 ```go
-dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, logger)
+dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, logger, device.NewRunner())
 // detectFileDevice, detectLVMDevice, or detectRawDevice is selected based on the path.
 ```
 

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -39,7 +39,19 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 		return fmt.Errorf("no destination device specified for apply mode")
 	}
 	destPath := args[0]
-	dev, err := detectDevice(context.Background(), destPath, cfg.Offline, cfg.DestType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
+	dev, err := detectDevice(
+		context.Background(),
+		destPath,
+		cfg.Offline,
+		cfg.DestType,
+		cfg.FSFreezeCommand,
+		cfg.FSThawCommand,
+		cfg.LVMEscalation,
+		cfg.FreezeTimeout,
+		cfg.ThawTimeout,
+		logger,
+		device.NewRunner(),
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -37,7 +37,7 @@ func TestRun(t *testing.T) {
 		}
 		return nil
 	}
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: dest}, nil
 	}
 	defer func() { applyFunc = origApply; detectDevice = origDetect }()
@@ -72,7 +72,7 @@ func TestRunSyncsLogger(t *testing.T) {
 	origApply := applyFunc
 	origDetect := detectDevice
 	applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: dest}, nil
 	}
 	defer func() { applyFunc = origApply; detectDevice = origDetect }()
@@ -144,7 +144,7 @@ func TestRunVerifyModes(t *testing.T) {
 			origApply := applyFunc
 			origDetect := detectDevice
 			applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
-			detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+			detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 				return &fakeDevice{path: destFile}, nil
 			}
 			defer func() { applyFunc = origApply; detectDevice = origDetect }()

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -144,7 +144,7 @@ func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io
 // Run executes client mode transferring data to dest and returns the destination type.
 func Run(ctx context.Context, cfg *config.Config, source, dest string, logger *zap.Logger) (string, error) {
 	defer rootcmd.SyncLogger(logger)
-	dev, err := detectDevice(ctx, source, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger)
+	dev, err := detectDevice(ctx, source, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner())
 	if err != nil {
 		return cfg.DestType, err
 	}
@@ -191,7 +191,7 @@ func Run(ctx context.Context, cfg *config.Config, source, dest string, logger *z
 func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
 	destType := cfg.DestType
 	if destType == "auto" {
-		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger); err == nil {
+		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner()); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -56,7 +56,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()
@@ -110,7 +110,7 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()
@@ -169,7 +169,7 @@ func TestRemotePostScriptContextError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -38,7 +38,7 @@ func TestRunLogsSaveStateError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -43,7 +43,7 @@ func TestRunStdout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()

--- a/device/detect.go
+++ b/device/detect.go
@@ -29,14 +29,14 @@ func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
 }
 
 // detectLVMDevice opens an LVM logical volume.
-func detectLVMDevice(path, lvmEscalation string, logger *zap.Logger) (Device, error) {
+func detectLVMDevice(path, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
 	if err := lvm.VerifyEscalationCommand(lvmEscalation); err != nil {
 		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
 	}
 	cache := lvm.NewDeviceFDCache(logger)
 	defer cache.Close()
-	dev, err := openLVMFunc(path, cache, lvmEscalation, logger)
+	dev, err := runner.OpenLVM(path, cache, lvmEscalation, logger)
 	if err != nil {
 		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
@@ -88,9 +88,20 @@ func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd
 // set via --source-type or --dest-type and is not TypeAuto, Detect will attempt
 // to open the device using the explicit type without auto detection. logger
 // must be non-nil.
-func Detect(ctx context.Context, path string, offline bool, explicitType, fsFreezeCmd, fsThawCmd, lvmEscalation string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
+func Detect(
+	ctx context.Context,
+	path string,
+	offline bool,
+	explicitType, fsFreezeCmd, fsThawCmd, lvmEscalation string,
+	freezeTimeout, thawTimeout time.Duration,
+	logger *zap.Logger,
+	runner *Runner,
+) (Device, error) {
 	if logger == nil {
 		return nil, fmt.Errorf("logger is nil")
+	}
+	if runner == nil {
+		runner = NewRunner()
 	}
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
@@ -113,7 +124,7 @@ func Detect(ctx context.Context, path string, offline bool, explicitType, fsFree
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type lvm: %s", resolved)
 			}
-			return detectLVMDevice(resolved, lvmEscalation, logger)
+			return detectLVMDevice(resolved, lvmEscalation, runner, logger)
 		case TypeRaw:
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
@@ -130,7 +141,7 @@ func Detect(ctx context.Context, path string, offline bool, explicitType, fsFree
 		out, err := execCommand(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
 		fsType := strings.TrimSpace(string(out))
 		if err == nil && fsType == "LVM2_member" {
-			return detectLVMDevice(resolved, lvmEscalation, logger)
+			return detectLVMDevice(resolved, lvmEscalation, runner, logger)
 		}
 		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger)
 	}

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -50,14 +50,13 @@ func TestDetectFileDeviceError(t *testing.T) {
 }
 
 func TestDetectLVMDeviceSuccess(t *testing.T) {
-	orig := openLVMFunc
-	openLVMFunc = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
-		return &LVMDevice{path: p, logger: zap.NewNop()}, nil
-	}
-	defer func() { openLVMFunc = orig }()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := detectLVMDevice("/dev/test", "", logger)
+	runner := NewRunner()
+	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
+	}
+	dev, err := detectLVMDevice("/dev/test", "", runner, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -78,12 +77,11 @@ func TestDetectLVMDeviceSuccess(t *testing.T) {
 }
 
 func TestDetectLVMDeviceError(t *testing.T) {
-	orig := openLVMFunc
-	openLVMFunc = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+	runner := NewRunner()
+	runner.openLVMOverride = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 		return nil, errors.New("fail")
 	}
-	defer func() { openLVMFunc = orig }()
-	if _, err := detectLVMDevice("/dev/test", "", zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice("/dev/test", "", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -91,18 +89,17 @@ func TestDetectLVMDeviceError(t *testing.T) {
 func TestDetectLVMDeviceEscalationError(t *testing.T) {
 	restore := lvm.SetEscalationChecker(func(string) error { return errors.New("escalate fail") })
 	defer restore()
-	orig := openLVMFunc
+	runner := NewRunner()
 	called := false
-	openLVMFunc = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 		called = true
-		return &LVMDevice{path: "/dev/test", logger: zap.NewNop()}, nil
+		return &LVMDevice{path: "/dev/test", logger: zap.NewNop(), runner: runner}, nil
 	}
-	defer func() { openLVMFunc = orig }()
-	if _, err := detectLVMDevice("/dev/test", "sudo -n", zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice("/dev/test", "sudo -n", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 	if called {
-		t.Fatalf("openLVMFunc should not be called on escalation failure")
+		t.Fatalf("openLVM should not be called on escalation failure")
 	}
 }
 

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -44,7 +44,7 @@ func TestDetectFile(t *testing.T) {
 	f.Close()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), f.Name(), true, "", "", "", "", 0, 0, logger)
+	dev, err := Detect(context.Background(), f.Name(), true, "", "", "", "", 0, 0, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestDetectFile(t *testing.T) {
 }
 
 func TestDetectNilLogger(t *testing.T) {
-	if _, err := Detect(context.Background(), "", true, "", "", "", "", 0, 0, nil); err == nil {
+	if _, err := Detect(context.Background(), "", true, "", "", "", "", 0, 0, nil, NewRunner()); err == nil {
 		t.Fatalf("expected error when logger is nil")
 	}
 }
@@ -81,7 +81,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop())
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestDetectRaw(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, logger)
+	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop())
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(context.Background(), lvPath, true, "", "", "", "", 0, 0, zap.NewNop())
+	dev, err := Detect(context.Background(), lvPath, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -185,12 +185,11 @@ func TestDetectLVM(t *testing.T) {
 		return exec.CommandContext(ctx, name, args...)
 	}
 	defer func() { execCommand = origExec }()
-	origOpen := openLVMFunc
-	openLVMFunc = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
-		return &LVMDevice{path: p, logger: zap.NewNop()}, nil
+	runner := NewRunner()
+	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
-	defer func() { openLVMFunc = origOpen }()
-	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, zap.NewNop())
+	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, zap.NewNop(), runner)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -221,7 +220,7 @@ func TestDetectRawCommandQuoting(t *testing.T) {
 	defer func() { execCommand = origExec }()
 	freeze := "/bin/echo 'freeze path with spaces'"
 	thaw := "/bin/echo 'thaw path with spaces'"
-	dev, err := Detect(context.Background(), loop, false, "raw", freeze, thaw, "", 0, 0, zap.NewNop())
+	dev, err := Detect(context.Background(), loop, false, "raw", freeze, thaw, "", 0, 0, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/info.go
+++ b/device/info.go
@@ -141,7 +141,7 @@ func SizeBytes(ctx context.Context, path string) (uint64, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	dev, err := Detect(ctx, path, true, "", "", "", "", 0, 0, zap.NewNop())
+	dev, err := Detect(ctx, path, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
 	if err != nil {
 		return 0, err
 	}

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -16,6 +16,44 @@ import (
 	"lvmsync_go/lvm"
 )
 
+// Runner coordinates interactions with LVM helpers.
+type Runner struct {
+	volumeExists      func(context.Context, string) (bool, error)
+	autoExtendEnabled func(context.Context, string) (bool, error)
+	discardEnabled    func(context.Context, string) (bool, error)
+	isMountedRW       func(string) (bool, error)
+	lockAcquire       func(string, string) (*lock.Lock, error)
+	openLVMOverride   func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error)
+}
+
+// NewRunner returns a Runner using real LVM helpers.
+func NewRunner() *Runner {
+	return &Runner{
+		volumeExists:      lvm.VolumeExists,
+		autoExtendEnabled: lvm.AutoExtendEnabled,
+		discardEnabled:    lvm.DiscardEnabled,
+		isMountedRW:       IsMountedRW,
+		lockAcquire:       lock.Acquire,
+	}
+}
+
+// NewRunnerWithDeps constructs a Runner with custom dependencies.
+func NewRunnerWithDeps(
+	volumeExists func(context.Context, string) (bool, error),
+	autoExtendEnabled func(context.Context, string) (bool, error),
+	discardEnabled func(context.Context, string) (bool, error),
+	isMountedRW func(string) (bool, error),
+	lockAcquire func(string, string) (*lock.Lock, error),
+) *Runner {
+	return &Runner{
+		volumeExists:      volumeExists,
+		autoExtendEnabled: autoExtendEnabled,
+		discardEnabled:    discardEnabled,
+		isMountedRW:       isMountedRW,
+		lockAcquire:       lockAcquire,
+	}
+}
+
 // LVMDevice represents a logical volume managed by LVM.
 type LVMDevice struct {
 	f           *os.File
@@ -26,34 +64,38 @@ type LVMDevice struct {
 	escalation  string
 	logger      *zap.Logger
 	lock        *lock.Lock
+	runner      *Runner
 }
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
 // Size information is obtained through the lvm package helpers.
-func OpenLVM(path string, cache *lvm.FDCache, escalation string, logger *zap.Logger) (*LVMDevice, error) {
+func (r *Runner) OpenLVM(path string, cache *lvm.FDCache, escalation string, logger *zap.Logger) (*LVMDevice, error) {
+	if r.openLVMOverride != nil {
+		return r.openLVMOverride(path, cache, escalation, logger)
+	}
 	ctx := context.Background()
-	exists, err := volumeExistsFunc(ctx, path)
+	exists, err := r.volumeExists(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
 		return nil, fmt.Errorf("volume %s does not exist", path)
 	}
-	auto, err := autoExtendEnabledFunc(ctx, path)
+	auto, err := r.autoExtendEnabled(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 	if auto {
 		return nil, fmt.Errorf("auto-extend enabled for %s", path)
 	}
-	discard, err := discardEnabledFunc(ctx, path)
+	discard, err := r.discardEnabled(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 	if !discard {
 		return nil, fmt.Errorf("discard disabled for %s", path)
 	}
-	mounted, err := isMountedRWFunc(path)
+	mounted, err := r.isMountedRW(path)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +106,7 @@ func OpenLVM(path string, cache *lvm.FDCache, escalation string, logger *zap.Log
 	if err != nil {
 		return nil, err
 	}
-	lk, err := lockAcquire(vg, lv)
+	lk, err := r.lockAcquire(vg, lv)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +127,7 @@ func OpenLVM(path string, cache *lvm.FDCache, escalation string, logger *zap.Log
 		_ = lk.Release()
 		return nil, err
 	}
-	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs), escalation: escalation, logger: logger, lock: lk}, nil
+	return &LVMDevice{f: f, path: path, size: size, blockSize: uint64(bs), escalation: escalation, logger: logger, lock: lk, runner: r}, nil
 }
 
 // Path returns the underlying device path.
@@ -106,14 +148,8 @@ func (d *LVMDevice) Close() error {
 }
 
 var (
-	generateSnapshot      = func() string { return fmt.Sprintf("lvmsync_%d", time.Now().UnixNano()) }
-	geteuid               = os.Geteuid
-	openLVMFunc           = OpenLVM
-	volumeExistsFunc      = lvm.VolumeExists
-	autoExtendEnabledFunc = lvm.AutoExtendEnabled
-	discardEnabledFunc    = lvm.DiscardEnabled
-	isMountedRWFunc       = IsMountedRW
-	lockAcquire           = lock.Acquire
+	generateSnapshot = func() string { return fmt.Sprintf("lvmsync_%d", time.Now().UnixNano()) }
+	geteuid          = os.Geteuid
 )
 
 func runLVM(ctx context.Context, escalation, cmdName string, args ...string) error {
@@ -154,7 +190,7 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 	}
 	cache := lvm.NewDeviceFDCache(d.logger)
 	defer cache.Close()
-	snapDev, err := openLVMFunc(snapPath, cache, d.escalation, d.logger)
+	snapDev, err := d.runner.OpenLVM(snapPath, cache, d.escalation, d.logger)
 	if err != nil {
 		_ = runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -8,14 +8,26 @@ import (
 
 	"go.uber.org/zap"
 
+	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
 )
+
+// Runner is a stub on non-Linux platforms.
+type Runner struct{}
+
+// NewRunner returns a stub runner.
+func NewRunner() *Runner { return &Runner{} }
+
+// NewRunnerWithDeps returns a stub runner with custom deps.
+func NewRunnerWithDeps(func(context.Context, string) (bool, error), func(context.Context, string) (bool, error), func(context.Context, string) (bool, error), func(string) (bool, error), func(string, string) (*lock.Lock, error)) *Runner {
+	return &Runner{}
+}
 
 // LVMDevice is unsupported on non-Linux platforms.
 type LVMDevice struct{}
 
 // OpenLVM returns an error on non-Linux systems.
-func OpenLVM(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+func (r *Runner) OpenLVM(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 	return nil, fmt.Errorf("LVM devices are only supported on Linux")
 }
 

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -25,7 +25,8 @@ func TestOpenLVM(t *testing.T) {
 	defer cleanup()
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
-	dev, err := OpenLVM(loop, cache, "", zap.NewNop())
+	runner := NewRunner()
+	dev, err := runner.OpenLVM(loop, cache, "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -46,18 +47,17 @@ func TestOpenLVMNonBlockDevice(t *testing.T) {
 	f.Close()
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
-	if _, err := OpenLVM(f.Name(), cache, "", zap.NewNop()); err == nil {
+	runner := NewRunner()
+	if _, err := runner.OpenLVM(f.Name(), cache, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error for non-block device")
 	}
 }
 
 func TestOpenLVMChecks(t *testing.T) {
-	orig := volumeExistsFunc
-	volumeExistsFunc = func(ctx context.Context, path string) (bool, error) { return false, nil }
-	t.Cleanup(func() { volumeExistsFunc = orig })
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
-	if _, err := OpenLVM("/dev/missing", cache, "", zap.NewNop()); err == nil {
+	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, IsMountedRW, lock.Acquire)
+	if _, err := runner.OpenLVM("/dev/missing", cache, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error when volume missing")
 	}
 }

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -66,17 +66,16 @@ func TestSnapshotLifecycle(t *testing.T) {
 	generateSnapshot = func() string { return "snap" }
 	defer func() { generateSnapshot = origName }()
 
-	origOpen := openLVMFunc
-	openLVMFunc = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
-		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop()}, nil
+	runner := NewRunner()
+	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop(), runner: runner}, nil
 	}
-	defer func() { openLVMFunc = origOpen }()
 
 	origEuid := geteuid
 	geteuid = func() int { return 1 }
 	defer func() { geteuid = origEuid }()
 
-	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop()}
+	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop(), runner: runner}
 	snap, err := lvd.Snapshot(ctx, "2G")
 	if err != nil {
 		t.Fatalf("lvm snapshot: %v", err)
@@ -118,7 +117,7 @@ func TestSnapshotLVCreateFailure(t *testing.T) {
 	geteuid = func() int { return 1 }
 	defer func() { geteuid = origEuid }()
 
-	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop()}
+	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop(), runner: NewRunner()}
 	if _, err := lvd.Snapshot(ctx, "1G"); err == nil {
 		t.Fatalf("expected error from lvcreate failure")
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -66,7 +66,7 @@ type IndexOption func(*indexOptions)
 func defaultIndexOptions() indexOptions {
 	return indexOptions{
 		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger)
+			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger, device.NewRunner())
 		},
 		closeHook: func() error { return nil },
 	}


### PR DESCRIPTION
## Summary
- add Runner struct for LVM helpers with constructors for dependency injection
- refactor detection and LVM device to use Runner methods
- update tests and docs for new Runner usage

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a11b75aa948323b012703c62db3dc3