### PR TITLE
feat: add runner for lvmsync commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ tooling to track transfer completion.
 
 - Use `zap` for all logging and avoid `fmt.Print*` or `log.*` calls.
 - Pass loggers explicitly to commands and helpers; `cmd/lvmsync.Execute` requires a
-  `*zap.Logger` argument instead of relying on `zap.L()`.
+  `*zap.Logger` and accepts a `*lvmsync.Runner` for dependency injection instead of
+  relying on `zap.L()`.
 - All commands receive an explicit `*zap.Logger` and default to `zap.NewNop()` when no logger is supplied.
 - Device constructors return an error when the logger is `nil`; use `zap.NewNop()` to disable logging.
 - Log field keys in `snake_case` and include units where relevant (for example, `duration_ms`).

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -31,16 +31,72 @@ type RunOptions struct {
 	ChunkSeed uint64
 }
 
-var (
-	// These function variables allow tests to stub command behavior.
-	runCommand      = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil }
-	manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error { return nil }
-	verifyRun       = func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) }
-	serveRun        = func(args []string, logger *zap.Logger) error { return servecmd.Run(args, logger) }
-)
+// Runner holds command behaviors to allow dependency injection in tests.
+type Runner struct {
+	run             func(src, dst string, opts RunOptions, logger *zap.Logger) error
+	manifestRebuild func(device string, dryRun bool, logger *zap.Logger) error
+	verify          func(args []string, logger *zap.Logger) error
+	serve           func(args []string, logger *zap.Logger) error
+}
+
+// Run executes the main synchronization command.
+func (r *Runner) Run(src, dst string, opts RunOptions, logger *zap.Logger) error {
+	return r.run(src, dst, opts, logger)
+}
+
+// ManifestRebuild regenerates a manifest for the specified device.
+func (r *Runner) ManifestRebuild(device string, dryRun bool, logger *zap.Logger) error {
+	return r.manifestRebuild(device, dryRun, logger)
+}
+
+// Verify compares source and destination devices against a manifest.
+func (r *Runner) Verify(args []string, logger *zap.Logger) error {
+	return r.verify(args, logger)
+}
+
+// Serve launches a transport listener.
+func (r *Runner) Serve(args []string, logger *zap.Logger) error {
+	return r.serve(args, logger)
+}
+
+// NewRunner constructs a Runner with default no-op behaviors.
+func NewRunner() *Runner {
+	return &Runner{
+		run:             func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil },
+		manifestRebuild: func(device string, dryRun bool, logger *zap.Logger) error { return nil },
+		verify:          func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) },
+		serve:           func(args []string, logger *zap.Logger) error { return servecmd.Run(args, logger) },
+	}
+}
+
+// NewRunnerWithDeps constructs a Runner with custom behaviors, useful for tests.
+func NewRunnerWithDeps(
+	run func(src, dst string, opts RunOptions, logger *zap.Logger) error,
+	rebuild func(device string, dryRun bool, logger *zap.Logger) error,
+	verify func(args []string, logger *zap.Logger) error,
+	serve func(args []string, logger *zap.Logger) error,
+) *Runner {
+	r := NewRunner()
+	if run != nil {
+		r.run = run
+	}
+	if rebuild != nil {
+		r.manifestRebuild = rebuild
+	}
+	if verify != nil {
+		r.verify = verify
+	}
+	if serve != nil {
+		r.serve = serve
+	}
+	return r
+}
 
 // NewRootCmd creates the root cobra command with all subcommands wired.
-func NewRootCmd(logger *zap.Logger) *cobra.Command {
+func NewRootCmd(logger *zap.Logger, r *Runner) *cobra.Command {
+	if r == nil {
+		r = NewRunner()
+	}
 	rootCmd := &cobra.Command{
 		Use:   "lvmsync",
 		Short: "LVMSync command line tool",
@@ -84,7 +140,7 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 				CDCMax:    cfg.CDCMax,
 				ChunkSeed: cfg.ChunkSeed,
 			}
-			return runCommand(remaining[0], remaining[1], opts, logger)
+			return r.Run(remaining[0], remaining[1], opts, logger)
 		},
 	}
 
@@ -121,7 +177,7 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 				fs.Usage()
 				return fmt.Errorf("usage: lvmsync manifest rebuild [flags] <device>")
 			}
-			return manifestRebuild(remaining[0], cfg.DryRun, logger)
+			return r.ManifestRebuild(remaining[0], cfg.DryRun, logger)
 		},
 	}
 	manifestCmd.AddCommand(rebuildCmd)
@@ -131,7 +187,7 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 		Short:              "Verify that source and destination match",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return verifyRun(args, logger)
+			return r.Verify(args, logger)
 		},
 	}
 
@@ -140,7 +196,7 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 		Short:              "Run a transport listener",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return serveRun(args, logger)
+			return r.Serve(args, logger)
 		},
 	}
 
@@ -151,11 +207,17 @@ func NewRootCmd(logger *zap.Logger) *cobra.Command {
 // Execute runs the command tree with provided arguments.
 // If args is nil, the global os.Args are used by cobra.
 func Execute(args []string, logger *zap.Logger) error {
+	return ExecuteWithRunner(args, logger, nil)
+}
+
+// ExecuteWithRunner runs the command tree using the provided Runner.
+// If args is nil, the global os.Args are used by cobra.
+func ExecuteWithRunner(args []string, logger *zap.Logger, r *Runner) error {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 	defer rootcmd.SyncLogger(logger)
-	cmd := NewRootCmd(logger)
+	cmd := NewRootCmd(logger, r)
 	if args != nil {
 		cmd.SetArgs(args)
 	}

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	verifycmd "lvmsync_go/cmd/verify"
 	"lvmsync_go/internal/config"
 	"lvmsync_go/manifest"
 
@@ -29,13 +28,11 @@ func TestRunCommandExecutes(t *testing.T) {
 	t.Setenv("LVMSYNC_TRANSPORT_TRANSPORT", "ssh")
 	var gotSrc, gotDst string
 	var gotOpts RunOptions
-	runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(func(src, dst string, opts RunOptions, logger *zap.Logger) error {
 		gotSrc, gotDst, gotOpts = src, dst, opts
 		return nil
-	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
-
-	if err := Execute([]string{"run", "src", "dst"}, zap.NewNop()); err != nil {
+	}, nil, nil, nil)
+	if err := ExecuteWithRunner([]string{"run", "src", "dst"}, zap.NewNop(), r); err != nil {
 		t.Fatalf("execute run: %v", err)
 	}
 	if gotSrc != "src" || gotDst != "dst" {
@@ -55,13 +52,11 @@ func TestRunCommandDryRun(t *testing.T) {
 		t.Fatalf("write src: %v", err)
 	}
 	called := false
-	runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(func(src, dst string, opts RunOptions, logger *zap.Logger) error {
 		called = true
 		return nil
-	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
-
-	if err := Execute([]string{"run", "--dry-run", src, "dst"}, zap.NewNop()); err != nil {
+	}, nil, nil, nil)
+	if err := ExecuteWithRunner([]string{"run", "--dry-run", src, "dst"}, zap.NewNop(), r); err != nil {
 		t.Fatalf("execute run dry-run: %v", err)
 	}
 	if called {
@@ -76,13 +71,11 @@ func TestRunCommandDryRunEnv(t *testing.T) {
 	}
 	t.Setenv("LVMSYNC_DRY_RUN", "true")
 	called := false
-	runCommand = func(src, dst string, o RunOptions, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(func(src, dst string, o RunOptions, logger *zap.Logger) error {
 		called = true
 		return nil
-	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
-
-	if err := Execute([]string{"run", src, "dst"}, zap.NewNop()); err != nil {
+	}, nil, nil, nil)
+	if err := ExecuteWithRunner([]string{"run", src, "dst"}, zap.NewNop(), r); err != nil {
 		t.Fatalf("execute run with env: %v", err)
 	}
 	if called {
@@ -92,13 +85,11 @@ func TestRunCommandDryRunEnv(t *testing.T) {
 
 func TestRunCommandInvalidConfig(t *testing.T) {
 	called := false
-	runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(func(src, dst string, opts RunOptions, logger *zap.Logger) error {
 		called = true
 		return nil
-	}
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
-
-	if err := Execute([]string{"run", "--cdc-min=65536", "--cdc-avg=1024", "src", "dst"}, zap.NewNop()); err == nil {
+	}, nil, nil, nil)
+	if err := ExecuteWithRunner([]string{"run", "--cdc-min=65536", "--cdc-avg=1024", "src", "dst"}, zap.NewNop(), r); err == nil {
 		t.Fatalf("expected error for invalid config")
 	}
 	if called {
@@ -109,13 +100,11 @@ func TestRunCommandInvalidConfig(t *testing.T) {
 func TestManifestRebuildRoutes(t *testing.T) {
 	var gotDevice string
 	var dry bool
-	manifestRebuild = func(device string, d bool, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(nil, func(device string, d bool, logger *zap.Logger) error {
 		gotDevice, dry = device, d
 		return nil
-	}
-	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error { return nil } })
-
-	if err := Execute([]string{"manifest", "rebuild", "--dry-run", "/dev/vg0"}, zap.NewNop()); err != nil {
+	}, nil, nil)
+	if err := ExecuteWithRunner([]string{"manifest", "rebuild", "--dry-run", "/dev/vg0"}, zap.NewNop(), r); err != nil {
 		t.Fatalf("execute rebuild: %v", err)
 	}
 	if gotDevice != "/dev/vg0" {
@@ -128,13 +117,11 @@ func TestManifestRebuildRoutes(t *testing.T) {
 
 func TestManifestRebuildInvalidConfig(t *testing.T) {
 	called := false
-	manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(nil, func(device string, dryRun bool, logger *zap.Logger) error {
 		called = true
 		return nil
-	}
-	t.Cleanup(func() { manifestRebuild = func(device string, dryRun bool, logger *zap.Logger) error { return nil } })
-
-	if err := Execute([]string{"manifest", "rebuild", "--ssh_keepalive=0s", "/dev/vg0"}, zap.NewNop()); err == nil {
+	}, nil, nil)
+	if err := ExecuteWithRunner([]string{"manifest", "rebuild", "--ssh_keepalive=0s", "/dev/vg0"}, zap.NewNop(), r); err == nil {
 		t.Fatalf("expected error for invalid config")
 	}
 	if called {
@@ -144,15 +131,11 @@ func TestManifestRebuildInvalidConfig(t *testing.T) {
 
 func TestVerifyRoutes(t *testing.T) {
 	var got []string
-	verifyRun = func(a []string, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(nil, nil, func(a []string, logger *zap.Logger) error {
 		got = append([]string{}, a...)
 		return nil
-	}
-	t.Cleanup(func() {
-		verifyRun = func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) }
-	})
-
-	if err := Execute([]string{"verify", "a", "b"}, zap.NewNop()); err != nil {
+	}, nil)
+	if err := ExecuteWithRunner([]string{"verify", "a", "b"}, zap.NewNop(), r); err != nil {
 		t.Fatalf("execute verify: %v", err)
 	}
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
@@ -166,12 +149,11 @@ func TestExecuteSyncsLogger(t *testing.T) {
 	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write src: %v", err)
 	}
-	runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil }
-	t.Cleanup(func() { runCommand = func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil } })
+	r := NewRunnerWithDeps(func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil }, nil, nil, nil)
 	var syncs int
 	core, _ := observer.New(zap.InfoLevel)
 	logger := zap.New(syncTrackerCore{Core: core, syncs: &syncs})
-	if err := Execute([]string{"run", src, "dst"}, logger); err != nil {
+	if err := ExecuteWithRunner([]string{"run", src, "dst"}, logger, r); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if syncs != 1 {


### PR DESCRIPTION
## Summary
- add Runner struct to inject lvmsync command behaviors
- allow NewRootCmd and Execute to accept a Runner instance
- document Runner injection in README

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a11b806a248323bf1623ee9ddde4f3