### PR TITLE
Use context-aware SSH agent dialer

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -50,7 +50,7 @@ func NewSSHClient(
 		logger = zap.NewNop()
 	}
 
-	authMethods, err := selectAuthMethods(logger, keyPath)
+	authMethods, err := selectAuthMethods(ctx, logger, keyPath, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func NewSSHClient(
 }
 
 //revive:disable-next-line:cognitive-complexity
-func selectAuthMethods(logger *zap.Logger, keyPath string) ([]ssh.AuthMethod, error) {
+func selectAuthMethods(ctx context.Context, logger *zap.Logger, keyPath string, timeout time.Duration) ([]ssh.AuthMethod, error) {
 	var authMethods []ssh.AuthMethod
 	if keyPath != "" {
 		key, err := os.ReadFile(keyPath)
@@ -93,8 +93,12 @@ func selectAuthMethods(logger *zap.Logger, keyPath string) ([]ssh.AuthMethod, er
 	} else {
 		sshAgentSock := os.Getenv("SSH_AUTH_SOCK")
 		if sshAgentSock != "" {
-			conn, err := net.DialTimeout("unix", sshAgentSock, 5*time.Second)
+			dialer := net.Dialer{Timeout: timeout}
+			conn, err := dialer.DialContext(ctx, "unix", sshAgentSock)
 			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return nil, ctxErr
+				}
 				logger.Warn("ssh agent dial failed", zap.String("sock", sshAgentSock), zap.Error(err))
 			} else {
 				agentClient := agent.NewClient(conn)

--- a/remote/select_auth_methods_test.go
+++ b/remote/select_auth_methods_test.go
@@ -1,0 +1,70 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// helper to start a stub ssh agent listening on a unix socket
+func startAgent(t *testing.T) (string, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "agent.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		agent.ServeAgent(agent.NewKeyring(), conn)
+	}()
+	cleanup := func() { ln.Close() }
+	return sock, cleanup
+}
+
+func TestSelectAuthMethodsSuccess(t *testing.T) {
+	sock, cleanup := startAgent(t)
+	defer cleanup()
+	t.Setenv("SSH_AUTH_SOCK", sock)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	methods, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
+	if err != nil {
+		t.Fatalf("selectAuthMethods error: %v", err)
+	}
+	if len(methods) == 0 {
+		t.Fatal("expected auth methods")
+	}
+}
+
+func TestSelectAuthMethodsTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+	defer cancel()
+	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "missing.sock"))
+	_, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+}
+
+func TestSelectAuthMethodsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "missing.sock"))
+	_, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+


### PR DESCRIPTION
## Summary
- Allow `selectAuthMethods` to take a context and timeout
- Use `net.Dialer.DialContext` for SSH agent with proper cancellation/timeout
- Add tests for successful, timeout, and canceled SSH agent connections

## Testing
- `go build ./...` *(fails: go: No such file or directory)*
- `go test -cover ./...` *(fails: go: No such file or directory)*
- `golangci-lint run` *(fails: golangci-lint: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1203c1a2c8323a2c6b9d9ab3ba07d