### PR TITLE
manifest: structure config warning logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- manifest: log configuration warnings with structured fields
 - lock: reject VG/LV names with invalid characters via regex validation
 - tests: flush H2 handshake data by buffering server errors, closing connections before sending, and applying context timeouts
 - manifest: return error when block size is zero

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -57,7 +57,7 @@ func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) erro
 		return err
 	}
 	for _, w := range warns {
-		logger.Warn(w)
+		logger.Warn("config_warning", zap.String("detail", w))
 	}
 	if len(remaining) != 1 {
 		fs.Usage()

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,6 +111,42 @@ func TestRunManifestPathFlag(t *testing.T) {
 	completeLogs := logs.FilterMessage("rebuild complete").All()
 	if len(completeLogs) != 1 {
 		t.Fatalf("expected 1 complete log, got %d", len(completeLogs))
+	}
+}
+
+func TestRunLogsConfigWarnings(t *testing.T) {
+	dir := t.TempDir()
+	devicePath := filepath.Join(dir, "dev.img")
+	if err := os.WriteFile(devicePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.DryRun = true
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("bogus: 1\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	args := []string{"rebuild", "--config", cfgPath, devicePath}
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	if err := Run(cfg, args, logger); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	warnLogs := logs.FilterMessage("config_warning").All()
+	if len(warnLogs) != 1 {
+		t.Fatalf("expected 1 config warning, got %d", len(warnLogs))
+	}
+	ctx := warnLogs[0].ContextMap()
+	detail, ok := ctx["detail"].(string)
+	if !ok || !strings.Contains(detail, "bogus") {
+		t.Fatalf("unexpected detail field: %v", ctx["detail"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- structure config warnings in manifest rebuild command
- test structured config warning logging
- document structured config warning logging

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestStreamBadCRC timeout; TestTCPTLSTransportSelectBestHandshake EOF)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a1203e46c08323832ddef25cb03523