### PR TITLE
Log TLS version during h2 handshake

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -130,6 +130,7 @@ func dialTLS(ctx context.Context, address string, conf *tls.Config, logger *zap.
 		logger.Error("tls_handshake_end", fields...)
 		return nil, err
 	}
+	fields = append(fields, zap.String("tls_version", logging.TLSVersionString(conn.ConnectionState().Version)))
 	logger.Info("tls_handshake_end", fields...)
 	return conn, nil
 }

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -47,6 +47,23 @@ func checkLogFields(t *testing.T, logs *observer.ObservedLogs, msg string, expec
 	}
 }
 
+func checkTLSVersionField(t *testing.T, logs *observer.ObservedLogs, msg string, expected int, version string) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != expected {
+		t.Fatalf("expected %d %s logs, got %d", expected, msg, len(entries))
+	}
+	for _, e := range entries {
+		ctx := e.ContextMap()
+		v, ok := ctx["tls_version"]
+		if !ok {
+			t.Fatalf("expected field %q in %s log", "tls_version", msg)
+		}
+		if v != version {
+			t.Fatalf("expected tls_version %q in %s log, got %v", version, msg, v)
+		}
+	}
+}
+
 func checkHandshakeFields(t *testing.T, logs *observer.ObservedLogs, msg string, expected int) {
 	entries := logs.FilterMessage(msg).All()
 	if len(entries) != expected {
@@ -114,6 +131,7 @@ func TestDialTLS(t *testing.T) {
 	}
 	checkLogFields(t, logs, "tls_handshake_start", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "tls_handshake_end", 1, false, zapcore.InfoLevel)
+	checkTLSVersionField(t, logs, "tls_handshake_end", 1, "1.3")
 
 	badConf := &tls.Config{RootCAs: x509.NewCertPool(), MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
 	core2, logs2 := observer.New(zapcore.InfoLevel)
@@ -261,6 +279,9 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	<-done
 
 	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "tls_handshake_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "tls_handshake_end", 1, false, zapcore.InfoLevel)
+	checkTLSVersionField(t, logs, "tls_handshake_end", 1, "1.3")
 	checkLogFields(t, logs, "dial_end", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "listen_start", 1, false, zapcore.InfoLevel)
 	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)


### PR DESCRIPTION
## Summary
- log the TLS protocol version after a successful h2 TLS handshake
- verify `tls_version` is logged in h2 transport tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestTCPTLSTransportSelectBestHandshake, TestTCPTLSDialUnreachable)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a12040d7c48323bb29ac1af813ba20