### PR TITLE
h2: add handshake deadlines

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -135,6 +135,9 @@ func dialTLS(ctx context.Context, address string, conf *tls.Config, logger *zap.
 }
 
 func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger) (*http2.Framer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	role := "client"
 	address := conn.RemoteAddr().String()
 	logger.Info("h2_handshake_start",
@@ -144,7 +147,22 @@ func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger)
 	)
 	start := time.Now()
 	fr := http2.NewFramer(conn, conn)
-	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
+
+	do := func(op func() error) error {
+		if err := setDeadline(ctx, conn); err != nil {
+			return err
+		}
+		defer clearDeadline(conn)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return op()
+	}
+
+	if err := do(func() error {
+		_, err := conn.Write([]byte(http2.ClientPreface))
+		return err
+	}); err != nil {
 		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", role),
@@ -154,7 +172,7 @@ func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger)
 		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	}
-	if err := fr.WriteSettings(); err != nil {
+	if err := do(func() error { return fr.WriteSettings() }); err != nil {
 		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", role),
@@ -164,7 +182,12 @@ func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger)
 		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	}
-	if f, err := fr.ReadFrame(); err != nil {
+	var f http2.Frame
+	if err := do(func() error {
+		var err error
+		f, err = fr.ReadFrame()
+		return err
+	}); err != nil {
 		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", role),
@@ -184,7 +207,7 @@ func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger)
 		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	}
-	if err := fr.WriteSettingsAck(); err != nil {
+	if err := do(func() error { return fr.WriteSettingsAck() }); err != nil {
 		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", role),
@@ -194,7 +217,11 @@ func performH2Handshake(ctx context.Context, conn *tls.Conn, logger *zap.Logger)
 		logger.Error("h2_handshake_end", fields...)
 		return nil, err
 	}
-	if f, err := fr.ReadFrame(); err != nil {
+	if err := do(func() error {
+		var err error
+		f, err = fr.ReadFrame()
+		return err
+	}); err != nil {
 		fields := []zap.Field{
 			zap.String("address", address),
 			zap.String("role", role),

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -181,6 +181,90 @@ func TestPerformH2Handshake(t *testing.T) {
 	}
 }
 
+func TestPerformH2HandshakeTimeout(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	serverConf := &tls.Config{Certificates: []tls.Certificate{cert}, NextProtos: []string{"h2"}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverConf)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		tlsConn := conn.(*tls.Conn)
+		fr := http2.NewFramer(tlsConn, tlsConn)
+		preface := make([]byte, len(http2.ClientPreface))
+		if _, err := io.ReadFull(tlsConn, preface); err != nil {
+			return
+		}
+		if _, err := fr.ReadFrame(); err != nil {
+			return
+		}
+		select {}
+	}()
+
+	clientConf := &tls.Config{RootCAs: pool, NextProtos: []string{"h2"}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, zap.NewNop())
+	if err != nil {
+		t.Fatalf("dialTLS: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := performH2Handshake(ctx, conn, zap.NewNop()); err == nil {
+		t.Fatalf("expected timeout error")
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPerformH2HandshakeCanceled(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	serverConf := &tls.Config{Certificates: []tls.Certificate{cert}, NextProtos: []string{"h2"}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverConf)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		tlsConn := conn.(*tls.Conn)
+		fr := http2.NewFramer(tlsConn, tlsConn)
+		preface := make([]byte, len(http2.ClientPreface))
+		if _, err := io.ReadFull(tlsConn, preface); err != nil {
+			return
+		}
+		if _, err := fr.ReadFrame(); err != nil {
+			return
+		}
+		select {}
+	}()
+
+	clientConf := &tls.Config{RootCAs: pool, NextProtos: []string{"h2"}, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13}
+	conn, err := dialTLS(context.Background(), ln.Addr().String(), clientConf, zap.NewNop())
+	if err != nil {
+		t.Fatalf("dialTLS: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := performH2Handshake(ctx, conn, zap.NewNop()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
 func TestLogDialResult(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)


### PR DESCRIPTION
## Summary
- set/clear deadlines for every frame in HTTP/2 handshake
- return early when context is canceled
- cover handshake timeouts and cancellations in tests

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a12043a9c48323bf2890a65038a116