### PR TITLE
Add setupPipe tests covering zero-copy and failure paths

### DIFF
--- a/transfer/setup_pipe_test.go
+++ b/transfer/setup_pipe_test.go
@@ -1,0 +1,91 @@
+package transfer
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/internal/config"
+)
+
+func TestSetupPipeZeroCopyEnabled(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{ZeroCopy: true}
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	pipeFds, cleanup, err := setupPipe(cfg, logger)
+	if err != nil {
+		t.Fatalf("setupPipe returned error: %v", err)
+	}
+	if pipeFds[0] < 0 || pipeFds[1] < 0 {
+		t.Fatalf("invalid pipe fds: %v", pipeFds)
+	}
+
+	// ensure cleanup closes descriptors
+	cleanup()
+	if err := syscall.Close(pipeFds[0]); !errors.Is(err, syscall.EBADF) {
+		t.Fatalf("expected fd0 closed, got %v", err)
+	}
+	if err := syscall.Close(pipeFds[1]); !errors.Is(err, syscall.EBADF) {
+		t.Fatalf("expected fd1 closed, got %v", err)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("expected no warnings, got %d", logs.Len())
+	}
+}
+
+func TestSetupPipePipeFailure(t *testing.T) {
+	cfg := &config.Config{ZeroCopy: true}
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	var orig syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &orig); err != nil {
+		t.Fatalf("getrlimit: %v", err)
+	}
+	// restrict the soft limit to the current number of open descriptors
+	fds, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	lim := orig
+	lim.Cur = uint64(len(fds))
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &lim); err != nil {
+		t.Fatalf("setrlimit: %v", err)
+	}
+	defer syscall.Setrlimit(syscall.RLIMIT_NOFILE, &orig)
+
+	_, cleanup, err := setupPipe(cfg, logger)
+	if err == nil {
+		t.Fatalf("expected error but got nil")
+	}
+	// cleanup should be safe and produce no warnings
+	cleanup()
+	if logs.Len() != 0 {
+		t.Fatalf("expected no warnings, got %d", logs.Len())
+	}
+}
+
+func TestSetupPipeZeroCopyDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{ZeroCopy: false}
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	pipeFds, cleanup, err := setupPipe(cfg, logger)
+	if err != nil {
+		t.Fatalf("setupPipe returned error: %v", err)
+	}
+	if pipeFds[0] != -1 || pipeFds[1] != -1 {
+		t.Fatalf("expected pipe fds to be -1, got %v", pipeFds)
+	}
+	cleanup()
+	if logs.Len() != 0 {
+		t.Fatalf("expected no warnings, got %d", logs.Len())
+	}
+}


### PR DESCRIPTION
## Summary
- test setupPipe success with zero copy
- test setupPipe failure when pipe creation fails
- test setupPipe no-op when zero copy disabled

## Testing
- `go test ./transport/tcp_tls -run TestTCPTLSTransportSelectBestHandshake -count=1` (fails: client negotiate: read handshake: EOF)
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a11b89feac83239173bc62dfa669e0