### PR TITLE
transfer: defer log sync and test early error

### DIFF
--- a/transfer/sync_logger_error_test.go
+++ b/transfer/sync_logger_error_test.go
@@ -43,3 +43,23 @@ func TestDumpChangesLogsSyncError(t *testing.T) {
 		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), logs[0].ContextMap()["error"])
 	}
 }
+
+func TestDumpChangesLogsSyncErrorOnEarlyFailure(t *testing.T) {
+	syncErr := errors.New("sync fail")
+	core, observed := observer.New(zap.InfoLevel)
+	logger := zap.New(&failingSyncCore{Core: core, err: syncErr})
+	tr := NewTransfer(logger, &sync.WaitGroup{})
+
+	cfg := &config.Config{BlockSize: 0, Compress: "none", MaxRetries: 1}
+	var buf bytes.Buffer
+	if err := tr.DumpChangesSequential(cfg, "snapshot", "/nonexistent", &buf); err == nil {
+		t.Fatalf("expected DumpChangesSequential error")
+	}
+	logs := observed.FilterMessage("Logger sync error").All()
+	if len(logs) != 1 {
+		t.Fatalf("expected sync error log, got %d", len(logs))
+	}
+	if errStr, ok := logs[0].ContextMap()["error"].(string); !ok || errStr != syncErr.Error() {
+		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), logs[0].ContextMap()["error"])
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -101,6 +101,8 @@ func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger
 
 // dumpChangesCore handles core transfer logic; logger must be non-nil.
 func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
+	defer rootcmd.SyncLogger(t.Logger)
+
 	ranges, err := prepareRanges(cfg, snapshot, source, t.Logger)
 	if err != nil {
 		return err
@@ -145,7 +147,6 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	if len(finalDigest) > 0 {
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}
-	rootcmd.SyncLogger(t.Logger)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- ensure `dumpChangesCore` flushes logs via deferred `rootcmd.SyncLogger`
- add test covering sync errors even on early dump failures

## Testing
- `go build ./... && echo build-ok`
- `go test ./transfer -run TestDumpChangesLogsSyncError`
- `golangci-lint run`
- `go test -cover ./...` *(fails: interrupt in lvmsync_go/grpc/server)*

------
https://chatgpt.com/codex/tasks/task_e_68a1297d79208323be8c9871d923e690