### PR TITLE
Add context cancellation support to dump operations

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -34,14 +34,14 @@ var ErrRemoteCommand = errors.New("remote command error")
 const maxFrame = 1 << 20
 
 var (
-	dumpChangesSequential = func(t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
-		return t.DumpChangesSequential(cfg, snap, origin, out)
+	dumpChangesSequential = func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
+		return t.DumpChangesSequential(ctx, cfg, snap, origin, out)
 	}
-	dumpChangesParallel = func(t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
-		return t.DumpChangesParallel(cfg, snap, origin, out)
+	dumpChangesParallel = func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
+		return t.DumpChangesParallel(ctx, cfg, snap, origin, out)
 	}
-	dumpChangesWithDeduplication = func(t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
-		return t.DumpChangesWithDeduplication(cfg, snap, origin, out, d)
+	dumpChangesWithDeduplication = func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
+		return t.DumpChangesWithDeduplication(ctx, cfg, snap, origin, out, d)
 	}
 	newSSHClient   = remote.NewSSHClient
 	openFile       = os.OpenFile
@@ -124,7 +124,7 @@ func init() {
 }
 
 // ExecuteDump selects the appropriate dump implementation based on configuration.
-func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io.Writer, logger *zap.Logger) error {
+func ExecuteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice string, out io.Writer, logger *zap.Logger) error {
 	t := transfer.NewTransfer(logger, &sync.WaitGroup{})
 	dedup := transfer.NewDeduplicationStrategy(cfg, logger)
 	if dedup != nil {
@@ -133,12 +133,12 @@ func ExecuteDump(cfg *config.Config, snapshotDevice, originDevice string, out io
 				logger.Error("Failed to save dedup state", zap.Error(err))
 			}
 		}()
-		return dumpChangesWithDeduplication(t, cfg, snapshotDevice, originDevice, out, dedup)
+		return dumpChangesWithDeduplication(ctx, t, cfg, snapshotDevice, originDevice, out, dedup)
 	}
 	if cfg.Parallel <= 1 {
-		return dumpChangesSequential(t, cfg, snapshotDevice, originDevice, out)
+		return dumpChangesSequential(ctx, t, cfg, snapshotDevice, originDevice, out)
 	}
-	return dumpChangesParallel(t, cfg, snapshotDevice, originDevice, out)
+	return dumpChangesParallel(ctx, t, cfg, snapshotDevice, originDevice, out)
 }
 
 // Run executes client mode transferring data to dest and returns the destination type.
@@ -179,16 +179,16 @@ func Run(ctx context.Context, cfg *config.Config, source, dest string, logger *z
 	}()
 	if cfg.StdoutMode {
 		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)
-		return cfg.DestType, ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
+		return cfg.DestType, ExecuteDump(ctx, cfg, snapshotDevice, originDevice, limitedOut, logger)
 	}
 	if strings.Contains(dest, ":") {
 		return cfg.DestType, RunRemoteDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
 	}
-	return RunLocalDump(cfg, snapshotDevice, originDevice, dest, logger)
+	return RunLocalDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
 }
 
 // RunLocalDump dumps changes to a local destination device and returns the detected destination type.
-func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
+func RunLocalDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
 	destType := cfg.DestType
 	if destType == "auto" {
 		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner()); err == nil {
@@ -213,7 +213,7 @@ func RunLocalDump(cfg *config.Config, snapshotDevice, originDevice, dest string,
 	}
 	defer common.CloseWithErr(destFile, &err, "close destination device")
 	limitedOut := transfer.WrapRateLimitedWriter(destFile, cfg.SpeedLimit)
-	return destType, ExecuteDump(cfg, snapshotDevice, originDevice, limitedOut, logger)
+	return destType, ExecuteDump(ctx, cfg, snapshotDevice, originDevice, limitedOut, logger)
 }
 
 // SetupSSHClient creates an SSH client for remote operations.
@@ -266,8 +266,8 @@ func SetupSessionStreams(ctx context.Context, session pipeSession) (io.WriteClos
 
 // StreamToRemote dumps snapshot data to the remote stdin, then computes and
 // transmits the digest before closing the stream.
-func StreamToRemote(cfg *config.Config, remoteStdin io.WriteCloser, snapshotDevice, originDevice, alg string, logger *zap.Logger) error {
-	streamErr := ExecuteDump(cfg, snapshotDevice, originDevice, remoteStdin, logger)
+func StreamToRemote(ctx context.Context, cfg *config.Config, remoteStdin io.WriteCloser, snapshotDevice, originDevice, alg string, logger *zap.Logger) error {
+	streamErr := ExecuteDump(ctx, cfg, snapshotDevice, originDevice, remoteStdin, logger)
 	if streamErr != nil {
 		if err := remoteStdin.Close(); err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("%v; failed to close remote stdin: %w", streamErr, err)
@@ -340,7 +340,7 @@ func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remot
 		return fmt.Errorf("failed to start remote command: %w", err)
 	}
 
-	if err = streamToRemote(cfg, remoteStdin, snapshotDevice, originDevice, alg, logger); err != nil {
+	if err = streamToRemote(ctx, cfg, remoteStdin, snapshotDevice, originDevice, alg, logger); err != nil {
 		return err
 	}
 

--- a/cmd/dump/client_test.go
+++ b/cmd/dump/client_test.go
@@ -84,7 +84,7 @@ func TestRunSyncsLogger(t *testing.T) {
 	core := &countingSyncCore{Core: zapcore.NewNopCore()}
 	logger := zap.New(core)
 	origSeq := dumpChangesSequential
-	dumpChangesSequential = func(*transfer.Transfer, *config.Config, string, string, io.Writer) error { return nil }
+	dumpChangesSequential = func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error { return nil }
 	defer func() { dumpChangesSequential = origSeq }()
 	snap := filepath.Join(t.TempDir(), "snap")
 	if err := os.WriteFile(snap, []byte("data"), 0o600); err != nil {

--- a/cmd/dump/dump_test.go
+++ b/cmd/dump/dump_test.go
@@ -1,6 +1,7 @@
 package dump
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -20,13 +21,13 @@ func TestExecuteDumpSequential(t *testing.T) {
 
 	called := false
 	original := dumpChangesSequential
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		called = true
 		return nil
 	}
 	defer func() { dumpChangesSequential = original }()
 
-	if execErr := ExecuteDump(cfg2, "snap", "orig", io.Discard, zap.NewNop()); execErr != nil {
+	if execErr := ExecuteDump(context.Background(), cfg2, "snap", "orig", io.Discard, zap.NewNop()); execErr != nil {
 		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {
@@ -43,13 +44,13 @@ func TestExecuteDumpParallel(t *testing.T) {
 
 	called := false
 	original := dumpChangesParallel
-	dumpChangesParallel = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesParallel = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		called = true
 		return nil
 	}
 	defer func() { dumpChangesParallel = original }()
 
-	if execErr := ExecuteDump(cfg2, "snap", "orig", io.Discard, zap.NewNop()); execErr != nil {
+	if execErr := ExecuteDump(context.Background(), cfg2, "snap", "orig", io.Discard, zap.NewNop()); execErr != nil {
 		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {
@@ -66,7 +67,7 @@ func TestExecuteDumpWithDedup(t *testing.T) {
 
 	called := false
 	original := dumpChangesWithDeduplication
-	dumpChangesWithDeduplication = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
+	dumpChangesWithDeduplication = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
 		if d == nil {
 			t.Fatalf("deduplication strategy was nil")
 		}
@@ -75,7 +76,7 @@ func TestExecuteDumpWithDedup(t *testing.T) {
 	}
 	defer func() { dumpChangesWithDeduplication = original }()
 
-	if execErr := ExecuteDump(cfg2, "snap", "orig", io.Discard, zap.NewNop()); execErr != nil {
+	if execErr := ExecuteDump(context.Background(), cfg2, "snap", "orig", io.Discard, zap.NewNop()); execErr != nil {
 		t.Fatalf("executeDump returned error: %v", execErr)
 	}
 	if !called {

--- a/cmd/dump/local_dump_test.go
+++ b/cmd/dump/local_dump_test.go
@@ -1,6 +1,7 @@
 package dump
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -34,7 +35,7 @@ func TestRunLocalDumpSuccess(t *testing.T) {
 
 	originalDump := dumpChangesSequential
 	var dumpCalled bool
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		dumpCalled = true
 		if snap != "snap" || origin != "orig" {
 			t.Fatalf("unexpected devices: %s %s", snap, origin)
@@ -44,7 +45,7 @@ func TestRunLocalDumpSuccess(t *testing.T) {
 	defer func() { dumpChangesSequential = originalDump }()
 
 	originalDestType := cfg.DestType
-	destType, err := RunLocalDump(cfg, "snap", "orig", "/fake/dest", zap.NewNop())
+	destType, err := RunLocalDump(context.Background(), cfg, "snap", "orig", "/fake/dest", zap.NewNop())
 	if err != nil {
 		t.Fatalf("runLocalDump returned error: %v", err)
 	}
@@ -75,14 +76,14 @@ func TestRunLocalDumpOpenError(t *testing.T) {
 	defer func() { openFile = originalOpen }()
 
 	originalDump := dumpChangesSequential
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		t.Fatalf("dumpChangesSequential should not be called on open error")
 		return nil
 	}
 	defer func() { dumpChangesSequential = originalDump }()
 
 	originalDestType := cfg.DestType
-	if destType, err := RunLocalDump(cfg, "snap", "orig", "/fake/dest", zap.NewNop()); err == nil {
+	if destType, err := RunLocalDump(context.Background(), cfg, "snap", "orig", "/fake/dest", zap.NewNop()); err == nil {
 		t.Fatalf("expected error, got nil")
 	} else if destType != originalDestType {
 		t.Fatalf("expected dest type %q, got %q", originalDestType, destType)

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -61,13 +61,13 @@ func TestRunRemoteDump(t *testing.T) {
 	origStream := streamToRemote
 	digestpkg.Select = func() string { return digestpkg.SHA256 }
 	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
 		if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
 			t.Fatalf("unexpected params: %s %s %s", snap, origin, alg)
 		}
 		return nil
 	}
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		if snap != "snap" || origin != "origin" {
 			t.Fatalf("unexpected devices: %s %s", snap, origin)
 		}
@@ -136,13 +136,13 @@ func TestRunRemoteDumpError(t *testing.T) {
 	origStream := streamToRemote
 	digestpkg.Select = func() string { return digestpkg.SHA256 }
 	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
 		if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
 			t.Fatalf("unexpected params: %s %s %s", snap, origin, alg)
 		}
 		return nil
 	}
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		return nil
 	}
 	defer func() {
@@ -205,10 +205,10 @@ func TestRunRemoteDumpTimeout(t *testing.T) {
 	origSum := sumFile
 	origStream := streamToRemote
 	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
 		return nil
 	}
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		return nil
 	}
 	defer func() {
@@ -291,10 +291,10 @@ func TestRunRemoteDumpLogsDigestSelection(t *testing.T) {
 	origSum := sumFile
 	origStream := streamToRemote
 	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
 		return nil
 	}
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
 		return nil
 	}
 	defer func() {

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -171,11 +171,11 @@ func TestStreamToRemote(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snapshot, origin string, out io.Writer) error {
+			dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, origin string, out io.Writer) error {
 				return tc.dumpErr
 			}
 			remoteStdin := &mockWriteCloser{Writer: io.Discard, closeErr: tc.closeErr}
-			err := StreamToRemote(cfg, remoteStdin, snapFile, "origin", digestpkg.SHA256, zap.NewNop())
+			err := StreamToRemote(context.Background(), cfg, remoteStdin, snapFile, "origin", digestpkg.SHA256, zap.NewNop())
 			if tc.dumpErr == nil && tc.closeErr == nil {
 				if err != nil {
 					t.Fatalf("expected nil error, got %v", err)

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -45,7 +45,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 
 	original := dumpChangesSequential
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
 		return io.ErrUnexpectedEOF
 	}
 	origSum := sumFile

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -27,7 +27,7 @@ func TestRunLogsSaveStateError(t *testing.T) {
 	cfg.MaxRetries = 1
 
 	original := dumpChangesWithDeduplication
-	dumpChangesWithDeduplication = func(_ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
+	dumpChangesWithDeduplication = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
 		return nil
 	}
 	defer func() { dumpChangesWithDeduplication = original }()

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -27,7 +27,7 @@ func TestRunStdout(t *testing.T) {
 	expected := "test output"
 
 	originalFunc := dumpChangesSequential
-	dumpChangesSequential = func(_ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
+	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
 		_, writeErr := out.Write([]byte(expected))
 		return writeErr
 	}

--- a/transfer/block_stream.go
+++ b/transfer/block_stream.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -45,6 +46,7 @@ func newDigestHasher(algo string) hash.Hash {
 }
 
 func iterateBlocks(
+	ctx context.Context,
 	cfg *config.Config,
 	ranges []Range,
 	srcFile *os.File,
@@ -72,6 +74,9 @@ func iterateBlocks(
 		intra = newChunkCache(intraCacheCapacity)
 	}
 	for _, r := range ranges {
+		if err := ctx.Err(); err != nil {
+			return totalBytes, skippedBlocks, nil, err
+		}
 		offset, blockSize, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
 		if err != nil {
 			return totalBytes, skippedBlocks, nil, err
@@ -181,6 +186,7 @@ func writeResult(bufOut *bufio.Writer, header, data []byte) error {
 }
 
 func processParallelResults(
+	ctx context.Context,
 	cfg *config.Config,
 	results <-chan *BlockResult,
 	bufOut *bufio.Writer,
@@ -206,83 +212,98 @@ func processParallelResults(
 		}
 		defer idx.Close()
 	}
-	for res := range results {
-		if res.Err != nil {
-			return totalBytesTransferred, nil, fmt.Errorf("error in block %d: %w", res.Index, res.Err)
-		}
-		if idx != nil && res.Data != nil {
-			xx := hashutil.SumXXH3(res.Data)
-			if idx.Match(res.Offset, res.Size, 0, xx, func() [32]byte { return res.ChunkID }) {
-				putBlockBuffer(res.Data)
-				continue
+	for {
+		select {
+		case <-ctx.Done():
+			return totalBytesTransferred, nil, ctx.Err()
+		case res, ok := <-results:
+			if !ok {
+				return totalBytesTransferred, h.Sum(nil), nil
 			}
-		}
-
-		n := prepareResultHeader(cfg, checksum, res, header)
-		if err := writeResult(bufOut, header[:n], res.Data); err != nil {
-			if res.Data != nil {
-				putBlockBuffer(res.Data)
+			if res.Err != nil {
+				return totalBytesTransferred, nil, fmt.Errorf("error in block %d: %w", res.Index, res.Err)
 			}
-			return totalBytesTransferred, nil, err
-		}
-		if res.Data != nil {
-			h.Write(res.Data)
-			if idx != nil {
+			if idx != nil && res.Data != nil {
 				xx := hashutil.SumXXH3(res.Data)
-				if err := idx.Set(res.Offset, res.Size, 0, xx, res.ChunkID); err != nil {
+				if idx.Match(res.Offset, res.Size, 0, xx, func() [32]byte { return res.ChunkID }) {
 					putBlockBuffer(res.Data)
-					return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
+					continue
 				}
 			}
-			saveResumeState(cfg, rt, res.Offset, res.ChunkID, int64(res.Size), logger)
-			putBlockBuffer(res.Data)
-		} else {
-			if idx != nil {
-				xx := hashutil.SumXXH3(nil)
-				if err := idx.Set(res.Offset, res.Size, 0, xx, res.ChunkID); err != nil {
-					return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
-				}
-			}
-			saveResumeState(cfg, rt, res.Offset, res.ChunkID, 0, logger)
-		}
 
-		totalBytesTransferred += int64(res.Size)
-		reportProgress(cfg, totalBytesTransferred, totalDataSize, res.Index, startTime, logger)
+			n := prepareResultHeader(cfg, checksum, res, header)
+			if err := writeResult(bufOut, header[:n], res.Data); err != nil {
+				if res.Data != nil {
+					putBlockBuffer(res.Data)
+				}
+				return totalBytesTransferred, nil, err
+			}
+			if res.Data != nil {
+				h.Write(res.Data)
+				if idx != nil {
+					xx := hashutil.SumXXH3(res.Data)
+					if err := idx.Set(res.Offset, res.Size, 0, xx, res.ChunkID); err != nil {
+						putBlockBuffer(res.Data)
+						return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
+					}
+				}
+				saveResumeState(cfg, rt, res.Offset, res.ChunkID, int64(res.Size), logger)
+				putBlockBuffer(res.Data)
+			} else {
+				if idx != nil {
+					xx := hashutil.SumXXH3(nil)
+					if err := idx.Set(res.Offset, res.Size, 0, xx, res.ChunkID); err != nil {
+						return totalBytesTransferred, nil, fmt.Errorf("manifest set: %w", err)
+					}
+				}
+				saveResumeState(cfg, rt, res.Offset, res.ChunkID, 0, logger)
+			}
+
+			totalBytesTransferred += int64(res.Size)
+			reportProgress(cfg, totalBytesTransferred, totalDataSize, res.Index, startTime, logger)
+		}
 	}
-	return totalBytesTransferred, h.Sum(nil), nil
 }
 
-func worker(cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult, wg *sync.WaitGroup, logger *zap.Logger) {
+func worker(ctx context.Context, cfg *config.Config, srcFile *os.File, tasks <-chan BlockTask, results chan<- *BlockResult, wg *sync.WaitGroup, logger *zap.Logger) {
 	defer wg.Done()
 	unlock := pinWorkerToDevice(cfg, srcFile, logger)
 	defer unlock()
-	for task := range tasks {
-		offset, blockSize, err := validateOffsetAndSize(task.R.Start, cfg.BlockSize)
-		if err != nil {
-			results <- &BlockResult{Index: task.Index, Err: err}
-			continue
-		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, false, [2]int{-1, -1}, logger)
-		zero := err == nil && isAllZero(data)
-		var resData []byte
-		size := blockSize
-		var chunkID [32]byte
-		if zero {
-			putBlockBuffer(data)
-			resData = nil
-			size = 0
-			chunkID = zeroHash(int(blockSize))
-		} else {
-			resData = data
-			chunkID = blake3.Sum256(data)
-		}
-		results <- &BlockResult{
-			Index:   task.Index,
-			Offset:  task.R.Start,
-			Size:    size,
-			Data:    resData,
-			ChunkID: chunkID,
-			Err:     err,
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case task, ok := <-tasks:
+			if !ok {
+				return
+			}
+			offset, blockSize, err := validateOffsetAndSize(task.R.Start, cfg.BlockSize)
+			if err != nil {
+				results <- &BlockResult{Index: task.Index, Err: err}
+				continue
+			}
+			data, err := ReadBlockWithRetries(cfg, srcFile, offset, false, [2]int{-1, -1}, logger)
+			zero := err == nil && isAllZero(data)
+			var resData []byte
+			size := blockSize
+			var chunkID [32]byte
+			if zero {
+				putBlockBuffer(data)
+				resData = nil
+				size = 0
+				chunkID = zeroHash(int(blockSize))
+			} else {
+				resData = data
+				chunkID = blake3.Sum256(data)
+			}
+			results <- &BlockResult{
+				Index:   task.Index,
+				Offset:  task.R.Start,
+				Size:    size,
+				Data:    resData,
+				ChunkID: chunkID,
+				Err:     err,
+			}
 		}
 	}
 }

--- a/transfer/digest_verification_test.go
+++ b/transfer/digest_verification_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"io"
 	"os"
@@ -19,7 +20,7 @@ func TestIterateBlocksFinalSHA(t *testing.T) {
 	snapshot := "vg-lv"
 	_, src := createVolumeFiles(t, snapshot, blockSize, []int{0})
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "zstd", ZstdLevel: 1, CompressLevel: 1, MaxRetries: 1, ChecksumAlgorithm: "sha256"}
-	ranges, err := gatherChangedRanges(snapshot, blockSize, logger)
+	ranges, err := gatherChangedRanges(context.Background(), snapshot, blockSize, logger)
 	if err != nil {
 		t.Fatalf("gather ranges: %v", err)
 	}
@@ -33,7 +34,7 @@ func TestIterateBlocksFinalSHA(t *testing.T) {
 		t.Fatalf("compression writer: %v", err)
 	}
 	bufOut := bufio.NewWriter(w)
-	_, _, digest, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, logger, nil)
+	_, _, digest, err := iterateBlocks(context.Background(), cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, logger, nil)
 	if err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}

--- a/transfer/dumpchanges_benchmark_test.go
+++ b/transfer/dumpchanges_benchmark_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"sync"
 	"testing"
 
@@ -20,7 +21,7 @@ func BenchmarkDumpChangesSequential(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+		if err := tr.DumpChangesSequential(context.Background(), cfg, snapshot, src, &buf); err != nil {
 			b.Fatalf("DumpChangesSequential failed: %v", err)
 		}
 	}
@@ -36,7 +37,7 @@ func BenchmarkDumpChangesParallel(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+		if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
 			b.Fatalf("DumpChangesParallel failed: %v", err)
 		}
 	}

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -57,7 +58,7 @@ func TestDumpChangesSequential(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", DedupStateFile: filepath.Join(t.TempDir(), "state"), DedupStrategy: "checksum", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesSequential(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesSequential failed: %v", err)
 	}
 	reader := bufio.NewReader(bytes.NewReader(buf.Bytes()))
@@ -91,7 +92,7 @@ func TestDumpChangesWithDeduplication(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
 	dedup := &dummyDedup{}
-	if err := tr.DumpChangesWithDeduplication(cfg, snapshot, src, &buf, dedup); err != nil {
+	if err := tr.DumpChangesWithDeduplication(context.Background(), cfg, snapshot, src, &buf, dedup); err != nil {
 		t.Fatalf("DumpChangesWithDeduplication failed: %v", err)
 	}
 	reader := bufio.NewReader(bytes.NewReader(buf.Bytes()))
@@ -120,7 +121,7 @@ func TestDumpChangesParallelProgress(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, MaxRetries: 1, Progress: true}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	if logs.FilterMessage("transfer progress").Len() == 0 {
@@ -136,7 +137,7 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 
 	cfgDump := &config.Config{BlockSize: int(blockSize), Compress: "zstd", ZstdLevel: 1, CompressLevel: 1, VerifyChecksum: true, Parallel: 1, MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesParallel(cfgDump, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(context.Background(), cfgDump, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 
@@ -181,5 +182,31 @@ func TestProcessDumpDataAutoDecompression(t *testing.T) {
 	want := bytes.Repeat([]byte{1}, int(blockSize))
 	if !bytes.Equal(got, want) {
 		t.Fatalf("unexpected data %v, want %v", got[:4], want[:4])
+	}
+}
+
+func TestDumpChangesSequentialCanceled(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	blockSize := int64(1024)
+	changed := []int{0, 1}
+	src, snapshot := createDumpTestFiles(t, blockSize, changed)
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := tr.DumpChangesSequential(ctx, cfg, snapshot, src, io.Discard); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
+func TestDumpChangesParallelCanceled(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	blockSize := int64(1024)
+	changed := []int{0, 1}
+	src, snapshot := createDumpTestFiles(t, blockSize, changed)
+	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, MaxRetries: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := tr.DumpChangesParallel(ctx, cfg, snapshot, src, io.Discard); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
 	}
 }

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"path/filepath"
 	"sync"
@@ -24,7 +25,7 @@ func TestDumpChangesSequentialLogFields(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesSequential(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesSequential failed: %v", err)
 	}
 

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -135,7 +135,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	tt := NewTransfer(zap.NewNop(), nil)
-	if err := tt.DumpChangesParallel(cfg, snapshot, srcLoop, conn); err != nil {
+	if err := tt.DumpChangesParallel(ctx, cfg, snapshot, srcLoop, conn); err != nil {
 		t.Fatalf("DumpChangesParallel: %v", err)
 	}
 	conn.Close()
@@ -263,7 +263,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 	if startIdx > 0 {
 		ranges = ranges[startIdx:]
 	}
-	if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
+	if _, _, _, err := iterateBlocks(context.Background(), cfg, ranges, srcFile, bufOut, nil, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}
 	finalizeProgress(cfg, tt.Logger)
@@ -393,7 +393,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 				t.Fatalf("dial: %v", err)
 			}
 			tt := NewTransfer(zap.NewNop(), nil)
-			if err := tt.DumpChangesParallel(cfg, snapshot, srcLoop, conn); err != nil {
+			if err := tt.DumpChangesParallel(ctx, cfg, snapshot, srcLoop, conn); err != nil {
 				t.Fatalf("DumpChangesParallel: %v", err)
 			}
 			conn.Close()
@@ -534,7 +534,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 				ranges = ranges[startIdx:]
 			}
 			dedup, cleanup := tt.setupDedup(cfg)
-			if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
+			if _, _, _, err := iterateBlocks(context.Background(), cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
 				t.Fatalf("iterateBlocks: %v", err)
 			}
 			cleanup()
@@ -708,7 +708,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 				ranges = ranges[startIdx:]
 			}
 			dedup, cleanup := tt.setupDedup(cfg)
-			if _, _, _, err := iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
+			if _, _, _, err := iterateBlocks(context.Background(), cfg, ranges, srcFile, bufOut, dedup, [2]int{-1, -1}, tt.Logger, tt.Tracker); err != nil {
 				t.Fatalf("iterateBlocks: %v", err)
 			}
 			cleanup()

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -55,7 +55,7 @@ func TestIterateBlocksUsesManifest(t *testing.T) {
 	cfg := &config.Config{BlockSize: 4096, ChecksumAlgorithm: "sha256", ManifestPath: manPath, MaxRetries: 1}
 	ranges := []Range{{Start: 0, End: 4096}, {Start: 4096, End: 8192}}
 	buf := bufio.NewWriter(bytes.NewBuffer(nil))
-	total, skipped, _, err := iterateBlocks(cfg, ranges, src, buf, nil, [2]int{-1, -1}, zap.NewNop(), nil)
+	total, skipped, _, err := iterateBlocks(context.Background(), cfg, ranges, src, buf, nil, [2]int{-1, -1}, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -46,7 +47,7 @@ func TestResumeCDCSequential(t *testing.T) {
 	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
 
 	var buf bytes.Buffer
-	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
@@ -73,7 +74,7 @@ func TestResumeCDCIdempotent(t *testing.T) {
 		if i == 1 {
 			buf = &second
 		}
-		if err := tr.DumpChangesParallel(cfg, snapshot, src, buf); err != nil {
+		if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, buf); err != nil {
 			t.Fatalf("DumpChangesParallel failed: %v", err)
 		}
 		finalizeResumeState(cfg, tr.Tracker, zap.NewNop())

--- a/transfer/resume_checksum_test.go
+++ b/transfer/resume_checksum_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"io"
 	"os"
@@ -18,7 +19,7 @@ func TestResumeFinalChecksum(t *testing.T) {
 	blockSize := int64(1024)
 	src, snapshot, resume := createTestFiles(t, blockSize, 4, "sha256")
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "sha256", Transport: "ssh", DedupMode: "fixed"}
-	ranges, err := gatherChangedRanges(snapshot, blockSize, logger)
+	ranges, err := gatherChangedRanges(context.Background(), snapshot, blockSize, logger)
 	if err != nil {
 		t.Fatalf("gather ranges: %v", err)
 	}
@@ -30,7 +31,7 @@ func TestResumeFinalChecksum(t *testing.T) {
 	checkpoint := readResumeState(cfg, logger)
 	start := findResumeIndex(cfg, srcFile, ranges, checkpoint, logger)
 	w := bufio.NewWriter(io.Discard)
-	_, _, digest, err := iterateBlocks(cfg, ranges[start:], srcFile, w, nil, [2]int{-1, -1}, logger, nil)
+	_, _, digest, err := iterateBlocks(context.Background(), cfg, ranges[start:], srcFile, w, nil, [2]int{-1, -1}, logger, nil)
 	if err != nil {
 		t.Fatalf("iterateBlocks: %v", err)
 	}

--- a/transfer/resume_fixed_test.go
+++ b/transfer/resume_fixed_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"sync"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestResumeFixedIdempotent(t *testing.T) {
 		if i == 1 {
 			buf = &second
 		}
-		if err := tr.DumpChangesParallel(cfg, snapshot, src, buf); err != nil {
+		if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, buf); err != nil {
 			t.Fatalf("DumpChangesParallel failed: %v", err)
 		}
 		finalizeResumeState(cfg, tr.Tracker, zap.NewNop())

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -46,7 +47,7 @@ func TestResumeHybridSequential(t *testing.T) {
 	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
 
 	var buf bytes.Buffer
-	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
@@ -73,7 +74,7 @@ func TestResumeHybridIdempotent(t *testing.T) {
 		if i == 1 {
 			buf = &second
 		}
-		if err := tr.DumpChangesParallel(cfg, snapshot, src, buf); err != nil {
+		if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, buf); err != nil {
 			t.Fatalf("DumpChangesParallel failed: %v", err)
 		}
 		finalizeResumeState(cfg, tr.Tracker, zap.NewNop())

--- a/transfer/resume_interrupted_test.go
+++ b/transfer/resume_interrupted_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
 	"path/filepath"
 	"reflect"
@@ -47,7 +48,7 @@ func runInterrupted(t *testing.T, mode string) {
 	close(results)
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	bufOut := bufio.NewWriter(io.Discard)
-	if _, _, err := processParallelResults(cfg, results, bufOut, checksum, 0, time.Now(), zap.NewNop(), tr.Tracker); err == nil {
+	if _, _, err := processParallelResults(context.Background(), cfg, results, bufOut, checksum, 0, time.Now(), zap.NewNop(), tr.Tracker); err == nil {
 		t.Fatalf("expected error")
 	}
 
@@ -57,7 +58,7 @@ func runInterrupted(t *testing.T, mode string) {
 	}
 
 	var buf bytes.Buffer
-	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"path/filepath"
@@ -81,7 +82,7 @@ func TestResumeSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "fixed"}
 
 	var buf bytes.Buffer
-	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
@@ -106,7 +107,7 @@ func TestResumeParallel(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 2, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "fixed"}
 
 	var buf bytes.Buffer
-	if err := tr.DumpChangesParallel(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesParallel failed: %v", err)
 	}
 	finalizeResumeState(cfg, tr.Tracker, zap.NewNop())
@@ -155,7 +156,7 @@ func TestResumeModeTransitions(t *testing.T) {
 			cfgResume := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.to}
 
 			var buf bytes.Buffer
-			if err := tr.DumpChangesParallel(cfgResume, snapshot, src, &buf); err != nil {
+			if err := tr.DumpChangesParallel(context.Background(), cfgResume, snapshot, src, &buf); err != nil {
 				t.Fatalf("DumpChangesParallel failed: %v", err)
 			}
 			finalizeResumeState(cfgResume, tr.Tracker, zap.NewNop())

--- a/transfer/save_state_error_test.go
+++ b/transfer/save_state_error_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -23,7 +24,7 @@ func TestDumpChangesLogsSaveStateError(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", DedupStrategy: "checksum", DedupStateFile: filepath.Join(t.TempDir(), "missing", "state"), MaxRetries: 1}
 	var buf bytes.Buffer
-	if dumpErr := tr.DumpChanges(cfg, snapshot, src, &buf); dumpErr != nil {
+	if dumpErr := tr.DumpChanges(context.Background(), cfg, snapshot, src, &buf); dumpErr != nil {
 		t.Fatalf("DumpChanges failed: %v", dumpErr)
 	}
 	logs := observed.FilterMessage("Failed to save dedup state").All()

--- a/transfer/sync_logger_error_test.go
+++ b/transfer/sync_logger_error_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -32,7 +33,7 @@ func TestDumpChangesLogsSyncError(t *testing.T) {
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesSequential(cfg, snapshot, src, &buf); err != nil {
+	if err := tr.DumpChangesSequential(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesSequential failed: %v", err)
 	}
 	logs := observed.FilterMessage("Logger sync error").All()

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -100,8 +100,8 @@ func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger
 }
 
 // dumpChangesCore handles core transfer logic; logger must be non-nil.
-func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
-	ranges, err := prepareRanges(cfg, snapshot, source, t.Logger)
+func (t *Transfer) dumpChangesCore(ctx context.Context, cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy, handshake string) (err error) {
+	ranges, err := prepareRanges(ctx, cfg, snapshot, source, t.Logger)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (t *Transfer) dumpChangesCore(cfg *config.Config, snapshot, source string, 
 	var totalBytesTransferred int64
 	var skippedBlocks int
 	var finalDigest []byte
-	totalBytesTransferred, skippedBlocks, finalDigest, err = iterateBlocks(cfg, ranges, srcFile, bufOut, dedup, pipeFds, t.Logger, t.Tracker)
+	totalBytesTransferred, skippedBlocks, finalDigest, err = iterateBlocks(ctx, cfg, ranges, srcFile, bufOut, dedup, pipeFds, t.Logger, t.Tracker)
 	if err != nil {
 		return err
 	}
@@ -163,29 +163,29 @@ func (t *Transfer) setupDedup(cfg *config.Config) (DeduplicationStrategy, func()
 }
 
 // DumpChangesSequential streams changed blocks from snapshot to out sequentially and saves dedup state if enabled.
-func (t *Transfer) DumpChangesSequential(cfg *config.Config, snapshot, source string, out io.Writer) error {
+func (t *Transfer) DumpChangesSequential(ctx context.Context, cfg *config.Config, snapshot, source string, out io.Writer) error {
 	dedup, cleanup := t.setupDedup(cfg)
 	if dedup != nil {
 		defer cleanup()
 	}
-	return t.dumpChangesCore(cfg, snapshot, source, out, dedup, "")
+	return t.dumpChangesCore(ctx, cfg, snapshot, source, out, dedup, "")
 }
 
 // DumpChangesWithDeduplication transfers changed blocks using the provided dedup strategy and a checksum-dedup handshake, updating the strategy's state.
-func (t *Transfer) DumpChangesWithDeduplication(cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy) error {
-	return t.dumpChangesCore(cfg, snapshot, source, out, dedup, "checksum-dedup")
+func (t *Transfer) DumpChangesWithDeduplication(ctx context.Context, cfg *config.Config, snapshot, source string, out io.Writer, dedup DeduplicationStrategy) error {
+	return t.dumpChangesCore(ctx, cfg, snapshot, source, out, dedup, "checksum-dedup")
 }
 
 // DumpChanges chooses an appropriate transfer mode and persists dedup state when a strategy is configured.
-func (t *Transfer) DumpChanges(cfg *config.Config, snapshot, source string, out io.Writer) error {
+func (t *Transfer) DumpChanges(ctx context.Context, cfg *config.Config, snapshot, source string, out io.Writer) error {
 	dedup, cleanup := t.setupDedup(cfg)
 	if dedup != nil {
 		defer cleanup()
 		t.Logger.Info("Deduplication enabled", zap.String("strategy", cfg.DedupStrategy))
-		return t.DumpChangesWithDeduplication(cfg, snapshot, source, out, dedup)
+		return t.DumpChangesWithDeduplication(ctx, cfg, snapshot, source, out, dedup)
 	}
 	t.Logger.Info("Deduplication disabled, performing full block transfer")
-	return t.DumpChangesSequential(cfg, snapshot, source, out)
+	return t.DumpChangesSequential(ctx, cfg, snapshot, source, out)
 }
 
 const manifestHeaderSize = 136

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"math"
@@ -22,7 +23,7 @@ func TestIterateBlocksOffsetOverflow(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: 4096}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, _, err := iterateBlocks(cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop(), nil)
+	_, _, _, err := iterateBlocks(context.Background(), cfg, []Range{{Start: math.MaxUint64, End: math.MaxUint64}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop(), nil)
 	if err == nil || !strings.Contains(err.Error(), "offset") {
 		t.Fatalf("expected offset error, got %v", err)
 	}
@@ -34,7 +35,7 @@ func TestIterateBlocksOversizedBlockSize(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: int(math.MaxUint32) + 1}
 	bufOut := bufio.NewWriter(io.Discard)
-	_, _, _, err := iterateBlocks(cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop(), nil)
+	_, _, _, err := iterateBlocks(context.Background(), cfg, []Range{{Start: 0, End: 0}}, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop(), nil)
 	if err == nil || !strings.Contains(err.Error(), "block size") {
 		t.Fatalf("expected block size error, got %v", err)
 	}

--- a/transfer/worker.go
+++ b/transfer/worker.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -16,7 +17,10 @@ import (
 )
 
 // detectBlockSize sets cfg.BlockSize by probing source; logger must be non-nil.
-func detectBlockSize(cfg *config.Config, source string, logger *zap.Logger) error {
+func detectBlockSize(ctx context.Context, cfg *config.Config, source string, logger *zap.Logger) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if cfg.BlockSize != 0 {
 		return nil
 	}
@@ -30,7 +34,10 @@ func detectBlockSize(cfg *config.Config, source string, logger *zap.Logger) erro
 }
 
 // gatherChangedRanges returns ranges of changed blocks; logger must be non-nil.
-func gatherChangedRanges(snapshot string, blockSize int64, logger *zap.Logger) ([]Range, error) {
+func gatherChangedRanges(ctx context.Context, snapshot string, blockSize int64, logger *zap.Logger) ([]Range, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	metadataDevice := GetMetadataDevice(snapshot)
 	if metadataDevice == "" {
 		return nil, fmt.Errorf("failed to determine metadata device from snapshot %s", snapshot)
@@ -44,8 +51,11 @@ func gatherChangedRanges(snapshot string, blockSize int64, logger *zap.Logger) (
 }
 
 // prepareRanges calculates changed block ranges; logger must be non-nil.
-func prepareRanges(cfg *config.Config, snapshot, source string, logger *zap.Logger) ([]Range, error) {
-	if err := detectBlockSize(cfg, source, logger); err != nil {
+func prepareRanges(ctx context.Context, cfg *config.Config, snapshot, source string, logger *zap.Logger) ([]Range, error) {
+	if err := detectBlockSize(ctx, cfg, source, logger); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	logger.Info("Using block size", zap.Int("block_size_bytes", cfg.BlockSize))
@@ -54,7 +64,7 @@ func prepareRanges(cfg *config.Config, snapshot, source string, logger *zap.Logg
 	if err != nil {
 		return nil, err
 	}
-	ranges, err := gatherChangedRanges(snapshot, int64(blockSize), logger)
+	ranges, err := gatherChangedRanges(ctx, snapshot, int64(blockSize), logger)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +115,7 @@ func setupPipe(cfg *config.Config, logger *zap.Logger) ([2]int, func(), error) {
 }
 
 // startParallelWorkers launches worker goroutines; logger must be non-nil.
-func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ranges []Range, resumeStart int, logger *zap.Logger) <-chan *BlockResult {
+func (t *Transfer) startParallelWorkers(ctx context.Context, cfg *config.Config, srcFile *os.File, ranges []Range, resumeStart int, logger *zap.Logger) <-chan *BlockResult {
 	numBlocks := len(ranges)
 	taskBuf := cfg.Parallel
 	if taskBuf < 1 {
@@ -115,12 +125,16 @@ func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ra
 	results := make(chan *BlockResult, taskBuf)
 	for i := 0; i < cfg.Parallel; i++ {
 		t.workerWG.Add(1)
-		go worker(cfg, srcFile, tasks, results, t.workerWG, logger)
+		go worker(ctx, cfg, srcFile, tasks, results, t.workerWG, logger)
 	}
 
 	go func() {
 		for i := resumeStart; i < numBlocks; i++ {
-			tasks <- BlockTask{Index: i, R: ranges[i]}
+			select {
+			case <-ctx.Done():
+				break
+			case tasks <- BlockTask{Index: i, R: ranges[i]}:
+			}
 		}
 		close(tasks)
 	}()
@@ -130,15 +144,18 @@ func (t *Transfer) startParallelWorkers(cfg *config.Config, srcFile *os.File, ra
 }
 
 // DumpChangesParallel streams changes in parallel; logger must be non-nil.
-func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
+func (t *Transfer) DumpChangesParallel(ctx context.Context, cfg *config.Config, snapshot, source string, out io.Writer) (err error) {
 	defer rootcmd.SyncLogger(t.Logger)
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if cfg.ZeroCopy {
 		t.Logger.Warn("ZeroCopy mode enabled, falling back to sequential execution")
-		return t.DumpChangesSequential(cfg, snapshot, source, out)
+		return t.DumpChangesSequential(ctx, cfg, snapshot, source, out)
 	}
 
-	ranges, err := prepareRanges(cfg, snapshot, source, t.Logger)
+	ranges, err := prepareRanges(ctx, cfg, snapshot, source, t.Logger)
 	if err != nil {
 		return err
 	}
@@ -162,13 +179,13 @@ func (t *Transfer) DumpChangesParallel(cfg *config.Config, snapshot, source stri
 
 	checkpoint := readResumeState(cfg, t.Logger)
 	resumeStart := findResumeIndex(cfg, srcFile, ranges, checkpoint, t.Logger)
-	results := t.startParallelWorkers(cfg, srcFile, ranges, resumeStart, t.Logger)
+	results := t.startParallelWorkers(ctx, cfg, srcFile, ranges, resumeStart, t.Logger)
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
 	var totalBytesTransferred int64
 	var finalDigest []byte
-	totalBytesTransferred, finalDigest, err = processParallelResults(cfg, results, bufOut, checksum, totalDataSize, startTime, t.Logger, t.Tracker)
+	totalBytesTransferred, finalDigest, err = processParallelResults(ctx, cfg, results, bufOut, checksum, totalDataSize, startTime, t.Logger, t.Tracker)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- thread context through dump APIs and helpers
- update callers to pass context
- add tests ensuring context cancellation aborts transfers

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestStreamBadCRC timeout; transport handshake timeouts)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1297fff688323a744eba0977f96fc