### PR TITLE
transfer: check for nil context

### DIFF
--- a/transfer/manifest_ctx_test.go
+++ b/transfer/manifest_ctx_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -28,6 +29,15 @@ func writeHeader(t *testing.T, path string) {
 		t.Fatalf("write header: %v", err)
 	}
 	f.Close()
+}
+
+func TestReadManifestHeaderNilContext(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "man")
+	writeHeader(t, p)
+	if _, err := readManifestHeader(nil, p, 0); err == nil || !strings.Contains(err.Error(), "nil context") {
+		t.Fatalf("expected nil context error, got %v", err)
+	}
 }
 
 func TestReadManifestHeaderCanceled(t *testing.T) {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -206,7 +206,7 @@ func manifestHeaderMAC(h *manifestpkg.Header) [32]byte {
 
 func readManifestHeader(ctx context.Context, path string, timeout time.Duration) (*manifestpkg.Header, error) {
 	if ctx == nil {
-		ctx = context.Background()
+		return nil, fmt.Errorf("nil context")
 	}
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -233,7 +233,7 @@ func readManifestHeader(ctx context.Context, path string, timeout time.Duration)
 
 func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, destPath string) error {
 	if ctx == nil {
-		ctx = context.Background()
+		return fmt.Errorf("nil context")
 	}
 	if cfg.ManifestPath != "" {
 		hdr, err := readManifestHeader(ctx, cfg.ManifestPath, 0)

--- a/transfer/verify_destination_ctx_test.go
+++ b/transfer/verify_destination_ctx_test.go
@@ -1,0 +1,59 @@
+package transfer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/device"
+	"lvmsync_go/internal/config"
+)
+
+func TestVerifyDestinationNilContext(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	cfg := &config.Config{}
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, []byte("data"), 0600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	if err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
+		t.Fatalf("expected nil context error, got %v", err)
+	}
+}
+
+func TestVerifyDestinationCanceledContext(t *testing.T) {
+	prevUUID := device.SetUUIDFunc(func(ctx context.Context, _ string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	defer device.SetUUIDFunc(prevUUID)
+	prevMount := device.SetMountFunc(func(string) (bool, error) { return false, nil })
+	defer device.SetMountFunc(prevMount)
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{})
+	cfg := &config.Config{DeviceUUID: "id"}
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, nil, 0600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.verifyDestination(ctx, cfg, dest) }()
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("verifyDestination did not respect context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary
- return an error when `readManifestHeader` or `verifyDestination` receive a nil context
- exercise nil-context and cancellation paths in manifest and destination verification tests

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestStreamBadCRC timed out; TestPerformH2HandshakeTimeout; TestTCPTLSTransportSelectBestHandshake)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a12982bb30832389901c98c2a95bb0