### PR TITLE
Log clear deadline failure in h2 transport

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -27,9 +27,10 @@ const (
 
 // Transport implements HTTP/2 over TLS1.3 with mutual authentication.
 type Transport struct {
-	clientConf *tls.Config
-	serverConf *tls.Config
-	logger     *zap.Logger
+	clientConf    *tls.Config
+	serverConf    *tls.Config
+	logger        *zap.Logger
+	clearDeadline func(net.Conn) error
 }
 
 // Conn wraps a single HTTP/2 stream to satisfy net.Conn.
@@ -89,7 +90,12 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if len(cfg.ServerCert.Certificate) != 0 {
 		serverConf.Certificates = []tls.Certificate{cfg.ServerCert}
 	}
-	return &Transport{clientConf: clientConf, serverConf: serverConf, logger: cfg.Logger}, nil
+	return &Transport{
+		clientConf:    clientConf,
+		serverConf:    serverConf,
+		logger:        cfg.Logger,
+		clearDeadline: func(conn net.Conn) error { return conn.SetDeadline(time.Time{}) },
+	}, nil
 }
 
 func init() {
@@ -286,7 +292,8 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		return nil, err
 	}
 	logDialResult(ctx, t.logger, address, role, start, nil)
-	if err := conn.SetDeadline(time.Time{}); err != nil {
+	if err := t.clearDeadline(conn); err != nil {
+		t.logger.Error("clear_deadline_failed", zap.Error(err))
 		conn.Close()
 		return nil, err
 	}

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -374,6 +374,46 @@ func TestH2TransportTLSHandshake(t *testing.T) {
 	checkHandshakeFields(t, logs, "negotiate_end", 2)
 }
 
+func TestDialClearDeadlineError(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	core, logs := observer.New(zapcore.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: pool, ClientCert: cert, ServerCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	tr.clearDeadline = func(net.Conn) error { return errors.New("boom") }
+
+	ln, err := tr.Listen(context.Background(), "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		<-done
+	}()
+
+	if _, err := tr.Dial(context.Background(), ln.Addr().String()); err == nil {
+		t.Fatalf("expected dial error")
+	}
+	close(done)
+
+	entries := logs.FilterMessage("clear_deadline_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 clear_deadline_failed log, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}
+
 func TestH2TransportSelectBestHandshake(t *testing.T) {
 	t.Skip("TODO: h2 select-best handshake flaky: investigate EOF")
 	cert, pool := generateSelfSignedCert(t)


### PR DESCRIPTION
## Summary
- log errors clearing connection deadlines in h2 transport
- cover clear deadline failure with unit test

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: signal: interrupt in internal/rsynkwire after ~180s)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a1298801988323b14fabc54acf07fc