### PR TITLE
manifest: add two-level hash index

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -87,6 +87,17 @@ Each subsequent entry describes one chunk and also uses little‑endian encoding
 The header `version` field allows future format changes without breaking
 backwards compatibility.
 
+## Two-Level Index
+
+When a manifest is opened, LVMSync builds an in-memory two-level index to
+accelerate lookups. A primary open-addressed hash table maps each chunk's XXH3
+value to its entry index. To avoid unnecessary BLAKE3 computations, every
+1&nbsp;MiB region also maintains a 64‑bit Bloom filter of XXH3 hashes present in
+that range. During `Match`, the Bloom filter for the chunk's range is checked
+first; only if it may contain the hash does the hash table probe proceed and, if
+needed, the strong digest is computed. `Rebuild` streams the device and
+populates both the hash table and Bloom filters on the fly.
+
 Device identifiers are stored in a fixed 64-byte field; creation fails if the
 ID exceeds this limit.
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/bits"
 	"os"
 	"time"
 
@@ -28,6 +29,11 @@ const (
 
 	// FlagCDC marks chunks produced by content-defined chunking.
 	FlagCDC uint32 = 1 << 0
+
+	// bloomRange is the size in bytes of each range tracked by a Bloom filter.
+	bloomRange = 1 << 20 // 1 MiB
+
+	emptySlot = ^uint64(0)
 )
 
 // Header describes the device tracked by the manifest.
@@ -52,6 +58,10 @@ type Index struct {
 	data      []byte
 	hdr       Header
 	closeHook func() error
+
+	table []uint64
+	bloom []uint64
+	mask  uint64
 }
 
 // indexOptions collects constructor options for Index and helpers like Rebuild.
@@ -218,6 +228,7 @@ func Create(path, deviceID string, size uint64, blockSize, cdcMin, cdcAvg, cdcMa
 	copy(idx.hdr.DeviceID[:], []byte(deviceID))
 	idx.hdr.MAC = headerMAC(&idx.hdr)
 	idx.writeHeader()
+	idx.initTables()
 	return idx, nil
 }
 
@@ -244,6 +255,7 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 		idx.Close()
 		return nil, err
 	}
+	idx.buildTables()
 	return idx, nil
 }
 
@@ -282,10 +294,62 @@ func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 			return nil, fmt.Errorf("manifest: unsupported version %d", idx.hdr.Version)
 		}
 	}
+	idx.buildTables()
 	return idx, nil
 }
 
 func entryOffset(i uint64) uint64 { return uint64(HeaderSize) + i*entrySize }
+
+func nextPow2(v uint64) uint64 {
+	if v == 0 {
+		return 1
+	}
+	return 1 << (64 - bits.LeadingZeros64(v-1))
+}
+
+func (i *Index) initTables() {
+	size := nextPow2(i.hdr.ChunkCount * 2)
+	i.table = make([]uint64, size)
+	for j := range i.table {
+		i.table[j] = emptySlot
+	}
+	i.mask = uint64(size - 1)
+	ranges := (i.hdr.SizeBytes + bloomRange - 1) / bloomRange
+	i.bloom = make([]uint64, ranges)
+}
+
+func (i *Index) insert(offset, xxh, idx uint64) {
+	if len(i.table) == 0 {
+		return
+	}
+	pos := xxh & i.mask
+	for {
+		if i.table[pos] == emptySlot {
+			i.table[pos] = idx
+			break
+		}
+		pos = (pos + 1) & i.mask
+	}
+	r := offset / bloomRange
+	bit1 := xxh & 63
+	bit2 := (xxh >> 6) & 63
+	i.bloom[r] |= (1<<bit1 | 1<<bit2)
+}
+
+func (i *Index) buildTables() {
+	i.initTables()
+	for idx := uint64(0); idx < i.hdr.ChunkCount; idx++ {
+		off := entryOffset(idx)
+		start := int(off)
+		length := binary.LittleEndian.Uint32(i.data[start+8 : start+12])
+		if length == 0 {
+			continue
+		}
+		offset := binary.LittleEndian.Uint64(i.data[start : start+8])
+		xxh := binary.LittleEndian.Uint64(i.data[start+16 : start+24])
+		i.insert(offset, xxh, idx)
+	}
+}
 
 // Set records metadata for the chunk at the given offset.
 func (i *Index) Set(offset uint64, length, flags uint32, xxh uint64, digest [32]byte) error {
@@ -300,34 +364,47 @@ func (i *Index) Set(offset uint64, length, flags uint32, xxh uint64, digest [32]
 	binary.LittleEndian.PutUint32(i.data[start+12:start+16], flags)
 	binary.LittleEndian.PutUint64(i.data[start+16:start+24], xxh)
 	copy(i.data[start+24:start+56], digest[:])
+	i.insert(offset, xxh, idx)
 	return nil
 }
 
 // Match reports whether the manifest already has a record for the chunk at the
 // given offset, length, and flags. The provided digestFn is invoked to compute
-// the BLAKE3 digest only if the stored XXH3 hash matches the supplied xxh.
+// the BLAKE3 digest only after Bloom and XXH3 checks succeed.
 func (i *Index) Match(offset uint64, length, flags uint32, xxh uint64, digestFn func() [32]byte) bool {
-	idx := offset / uint64(i.hdr.BlockSize)
-	if idx >= i.hdr.ChunkCount {
+	if len(i.table) == 0 {
 		return false
 	}
-	off := entryOffset(idx)
-	start := int(off)
-	storedOffset := binary.LittleEndian.Uint64(i.data[start : start+8])
-	storedLen := binary.LittleEndian.Uint32(i.data[start+8 : start+12])
-	storedFlags := binary.LittleEndian.Uint32(i.data[start+12 : start+16])
-	if storedLen == 0 {
+	r := offset / bloomRange
+	if r >= uint64(len(i.bloom)) {
 		return false
 	}
-	if storedOffset != offset || storedLen != length || storedFlags != flags {
+	bit1 := xxh & 63
+	bit2 := (xxh >> 6) & 63
+	mask := (uint64(1) << bit1) | (uint64(1) << bit2)
+	if i.bloom[r]&mask != mask {
 		return false
 	}
-	storedXXH := binary.LittleEndian.Uint64(i.data[start+16 : start+24])
-	if storedXXH != xxh {
-		return false
+	pos := xxh & i.mask
+	for {
+		idx := i.table[pos]
+		if idx == emptySlot {
+			return false
+		}
+		off := entryOffset(idx)
+		start := int(off)
+		storedXXH := binary.LittleEndian.Uint64(i.data[start+16 : start+24])
+		if storedXXH == xxh {
+			storedOffset := binary.LittleEndian.Uint64(i.data[start : start+8])
+			storedLen := binary.LittleEndian.Uint32(i.data[start+8 : start+12])
+			storedFlags := binary.LittleEndian.Uint32(i.data[start+12 : start+16])
+			if storedOffset == offset && storedLen == length && storedFlags == flags {
+				digest := digestFn()
+				return bytes.Equal(i.data[start+24:start+56], digest[:])
+			}
+		}
+		pos = (pos + 1) & i.mask
 	}
-	digest := digestFn()
-	return bytes.Equal(i.data[start+24:start+56], digest[:])
 }
 
 // Entry returns metadata for the chunk at idx.

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -71,6 +71,75 @@ func TestIndexCRUD(t *testing.T) {
 	}
 }
 
+func TestMatchBloomNegative(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bloom.man")
+	idx, err := Create(path, "dev", 8192, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	data := make([]byte, 4096)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	xx := xxh3.Hash(data)
+	b3 := blake3.Sum256(data)
+	if err := idx.Set(0, uint32(len(data)), 0, xx, b3); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	bloom := idx.bloom[0]
+	var xx2 uint64
+	for h := uint64(0); ; h++ {
+		bit1 := h & 63
+		bit2 := (h >> 6) & 63
+		mask := (uint64(1) << bit1) | (uint64(1) << bit2)
+		if bloom&mask == 0 {
+			xx2 = h
+			break
+		}
+	}
+	called := false
+	match := idx.Match(0, uint32(len(data)), 0, xx2, func() [32]byte {
+		called = true
+		return blake3.Sum256(nil)
+	})
+	if match {
+		t.Fatalf("unexpected match")
+	}
+	if called {
+		t.Fatalf("digestFn invoked on negative lookup")
+	}
+}
+
+func TestHashCollision(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "collision.man")
+	idx, err := Create(path, "dev", 8192, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	a := []byte("aaaa")
+	b := []byte("bbbb")
+	xx := xxh3.Hash(a)
+	b1 := blake3.Sum256(a)
+	if err := idx.Set(0, uint32(len(a)), 0, xx, b1); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	b2 := blake3.Sum256(b)
+	if err := idx.Set(4096, uint32(len(b)), 0, xx, b2); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+	if !idx.Match(0, uint32(len(a)), 0, xx, func() [32]byte { return b1 }) {
+		t.Fatalf("match a failed")
+	}
+	if !idx.Match(4096, uint32(len(b)), 0, xx, func() [32]byte { return b2 }) {
+		t.Fatalf("match b failed")
+	}
+	if idx.Match(4096, uint32(len(b)), 0, xx, func() [32]byte { return b1 }) {
+		t.Fatalf("expected mismatch with wrong digest")
+	}
+}
+
 func TestDeviceIDLength(t *testing.T) {
 	dir := t.TempDir()
 	good := strings.Repeat("a", 64)


### PR DESCRIPTION
## Summary
- extend manifest index with XXH3 hash table and per-range Bloom filters
- check Bloom filters and hash table before computing strong digests
- document the two-level manifest index and add collision tests

## Testing
- `go build ./...`
- `go test -cover ./manifest`
- `go test -cover ./...` *(fails: transfer/sync_logger_error_test.go:56:70: not enough arguments in call to tr.DumpChangesSequential)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a149223d108323ab67a60b2728706c