### PR TITLE
Add success runner test and exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func (r *Runner) Run() {
 		return
 	}
 	r.SyncLogger(logger)
+	r.Exit(exitcode.OK)
 }
 
 func main() {

--- a/runner_success_test.go
+++ b/runner_success_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/exitcode"
+)
+
+func TestRunnerSuccess(t *testing.T) {
+	logger := zap.NewNop()
+
+	synced := false
+	exitCalled := false
+	exitCode := -1
+
+	r := NewRunnerWithDeps(
+		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error { return nil },
+		func(_ *zap.Logger) { synced = true },
+		func(code int) { exitCalled = true; exitCode = code },
+		func() *zap.Logger { return zap.NewNop() },
+		"linux",
+	)
+
+	r.Run()
+
+	if !synced {
+		t.Fatalf("expected SyncLogger to be called")
+	}
+
+	if !exitCalled {
+		t.Fatalf("expected Exit to be called")
+	}
+	if exitCode != exitcode.OK {
+		t.Fatalf("expected exit code %d, got %d", exitcode.OK, exitCode)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure runner exits with code 0 on success
- test Runner success path for logger sync and exit

## Testing
- `go build ./...`
- `go test ./...` *(fails: TestStreamBadCRC timeout; transfer build; transport handshake tests)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a14a1724f4832384b888c1c8811f13