### PR TITLE
test: verify CopyPipeAsync copies finite data

### DIFF
--- a/cmd/dump/client_test.go
+++ b/cmd/dump/client_test.go
@@ -69,6 +69,26 @@ func TestCopyPipeAsyncCanceledDuringWrite(t *testing.T) {
 	}
 }
 
+func TestCopyPipeAsyncReturnsNilAndCopiesData(t *testing.T) {
+	ctx := context.Background()
+	r, w := io.Pipe()
+	var dst bytes.Buffer
+	errCh := CopyPipeAsync(ctx, &dst, r)
+	data := []byte("hello world")
+	go func() {
+		defer w.Close()
+		if _, err := w.Write(data); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}()
+	if err := <-errCh; err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if got := dst.Bytes(); !bytes.Equal(got, data) {
+		t.Fatalf("output %q does not match input %q", got, data)
+	}
+}
+
 type countingSyncCore struct {
 	zapcore.Core
 	count int


### PR DESCRIPTION
## Summary
- add test to ensure CopyPipeAsync returns nil and output matches input for finite data

## Testing
- `go test ./cmd/dump`
- `golangci-lint run cmd/dump/...`


------
https://chatgpt.com/codex/tasks/task_e_68a14a1c9aa88323b37313d87f24f923