### PR TITLE
logging: add debug level test

### DIFF
--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/zap"
+
 	config "lvmsync_go/internal/config"
 )
 
@@ -23,5 +25,15 @@ func TestNewLoggerSamplingDefaults(t *testing.T) {
 	thereafter := rv.FieldByName("thereafter").Uint()
 	if first != 100 || thereafter != 100 {
 		t.Fatalf("sampling defaults first=%d thereafter=%d", first, thereafter)
+	}
+}
+
+func TestNewLoggerVerboseLevel(t *testing.T) {
+	logger, err := NewLogger(&config.Config{Verbose: 1})
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	if !logger.Core().Enabled(zap.DebugLevel) {
+		t.Fatalf("logger level %v, want debug", zap.DebugLevel)
 	}
 }


### PR DESCRIPTION
## Summary
- test that verbose config enables debug logging

## Testing
- `go test ./internal/logging`
- `golangci-lint run internal/logging/...`


------
https://chatgpt.com/codex/tasks/task_e_68a14a2910848323bfbf746b1ed34f1a