### PR TITLE
refactor: inject commanders

### DIFF
--- a/device/cmdfunc_test.go
+++ b/device/cmdfunc_test.go
@@ -1,0 +1,12 @@
+package device
+
+import (
+	"context"
+	"os/exec"
+)
+
+type cmdFunc func(context.Context, string, ...string) *exec.Cmd
+
+func (f cmdFunc) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return f(ctx, name, args...)
+}

--- a/device/detect.go
+++ b/device/detect.go
@@ -46,7 +46,7 @@ func detectLVMDevice(path, lvmEscalation string, runner *Runner, logger *zap.Log
 }
 
 // detectRawDevice opens a raw block device.
-func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (Device, error) {
+func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (Device, error) {
 	var freezePath, thawPath string
 	var freezeArgs, thawArgs []string
 	if fsFreezeCmd != "" {
@@ -73,7 +73,7 @@ func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd
 			thawArgs = parts[1:]
 		}
 	}
-	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
+	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger, runner)
 	if err != nil {
 		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err
@@ -129,7 +129,7 @@ func Detect(
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
 			}
-			return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger)
+			return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger, runner)
 		default:
 			return nil, fmt.Errorf("unknown device type %q", explicitType)
 		}
@@ -138,12 +138,12 @@ func Detect(
 		return detectFileDevice(resolved, logger)
 	}
 	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
-		out, err := execCommand(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
+		out, err := runner.command.CommandContext(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
 		fsType := strings.TrimSpace(string(out))
 		if err == nil && fsType == "LVM2_member" {
 			return detectLVMDevice(resolved, lvmEscalation, runner, logger)
 		}
-		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger)
+		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger, runner)
 	}
 	err = fmt.Errorf("unsupported path type: %s", resolved)
 	logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -105,7 +105,7 @@ func TestDetectLVMDeviceEscalationError(t *testing.T) {
 
 func TestDetectRawDeviceSuccess(t *testing.T) {
 	orig := openRawFunc
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (*RawDevice, error) {
+	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
 		f, err := os.CreateTemp(t.TempDir(), "raw")
 		if err != nil {
 			return nil, err
@@ -115,7 +115,7 @@ func TestDetectRawDeviceSuccess(t *testing.T) {
 	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := detectRawDevice(context.Background(), "/dev/test", true, "", "", 0, 0, logger)
+	dev, err := detectRawDevice(context.Background(), "/dev/test", true, "", "", 0, 0, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestDetectRawDeviceSuccess(t *testing.T) {
 }
 
 func TestDetectRawDeviceError(t *testing.T) {
-	if _, err := detectRawDevice(context.Background(), "/dev/null", true, "", "", 0, 0, zap.NewNop()); err == nil {
+	if _, err := detectRawDevice(context.Background(), "/dev/null", true, "", "", 0, 0, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -144,14 +144,14 @@ func TestDetectRawDeviceError(t *testing.T) {
 func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 	orig := openRawFunc
 	called := false
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (*RawDevice, error) {
+	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
 	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
-	_, err := detectRawDevice(context.Background(), "/dev/test", true, "/bin/echo \"unterminated", "", 0, 0, logger)
+	_, err := detectRawDevice(context.Background(), "/dev/test", true, "/bin/echo \"unterminated", "", 0, 0, logger, NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "invalid freeze command") {
 		t.Fatalf("expected freeze parse error, got %v", err)
 	}
@@ -170,14 +170,14 @@ func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 func TestDetectRawDeviceThawParseError(t *testing.T) {
 	orig := openRawFunc
 	called := false
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger) (*RawDevice, error) {
+	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
 	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
-	_, err := detectRawDevice(context.Background(), "/dev/test", true, "", "/bin/echo \"unterminated", 0, 0, logger)
+	_, err := detectRawDevice(context.Background(), "/dev/test", true, "", "/bin/echo \"unterminated", 0, 0, logger, NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "invalid thaw command") {
 		t.Fatalf("expected thaw parse error, got %v", err)
 	}

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -177,15 +177,13 @@ func TestDetectLVM(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	origExec := execCommand
-	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		if name == "blkid" {
 			return exec.CommandContext(ctx, "sh", "-c", "echo LVM2_member")
 		}
 		return exec.CommandContext(ctx, name, args...)
-	}
-	defer func() { execCommand = origExec }()
-	runner := NewRunner()
+	})
+	runner := NewDeviceRunner(cmd)
 	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
@@ -209,18 +207,16 @@ func TestDetectRawCommandQuoting(t *testing.T) {
 		name string
 		args []string
 	}
-	origExec := execCommand
-	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		calls = append(calls, struct {
 			name string
 			args []string
 		}{name: name, args: append([]string(nil), args...)})
 		return exec.CommandContext(ctx, "/bin/true")
-	}
-	defer func() { execCommand = origExec }()
+	})
 	freeze := "/bin/echo 'freeze path with spaces'"
 	thaw := "/bin/echo 'thaw path with spaces'"
-	dev, err := Detect(context.Background(), loop, false, "raw", freeze, thaw, "", 0, 0, zap.NewNop(), NewRunner())
+	dev, err := Detect(context.Background(), loop, false, "raw", freeze, thaw, "", 0, 0, zap.NewNop(), NewDeviceRunner(cmd))
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/exec.go
+++ b/device/exec.go
@@ -1,8 +1,0 @@
-//go:build linux
-
-package device
-
-import "os/exec"
-
-// execCommand is a helper for running external commands. It can be stubbed in tests.
-var execCommand = exec.CommandContext

--- a/device/info.go
+++ b/device/info.go
@@ -80,7 +80,7 @@ func defaultUUIDFunc(ctx context.Context, path string) (string, error) {
 }
 
 func defaultLVMUUIDFunc(ctx context.Context, path string) (string, error) {
-	out, err := execCommand(ctx, "lvs", "--noheadings", "-o", "lv_uuid", path).Output()
+	out, err := exec.CommandContext(ctx, "lvs", "--noheadings", "-o", "lv_uuid", path).Output()
 	if err != nil {
 		return "", err
 	}

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -16,44 +16,6 @@ import (
 	"lvmsync_go/lvm"
 )
 
-// Runner coordinates interactions with LVM helpers.
-type Runner struct {
-	volumeExists      func(context.Context, string) (bool, error)
-	autoExtendEnabled func(context.Context, string) (bool, error)
-	discardEnabled    func(context.Context, string) (bool, error)
-	isMountedRW       func(string) (bool, error)
-	lockAcquire       func(string, string) (*lock.Lock, error)
-	openLVMOverride   func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error)
-}
-
-// NewRunner returns a Runner using real LVM helpers.
-func NewRunner() *Runner {
-	return &Runner{
-		volumeExists:      lvm.VolumeExists,
-		autoExtendEnabled: lvm.AutoExtendEnabled,
-		discardEnabled:    lvm.DiscardEnabled,
-		isMountedRW:       IsMountedRW,
-		lockAcquire:       lock.Acquire,
-	}
-}
-
-// NewRunnerWithDeps constructs a Runner with custom dependencies.
-func NewRunnerWithDeps(
-	volumeExists func(context.Context, string) (bool, error),
-	autoExtendEnabled func(context.Context, string) (bool, error),
-	discardEnabled func(context.Context, string) (bool, error),
-	isMountedRW func(string) (bool, error),
-	lockAcquire func(string, string) (*lock.Lock, error),
-) *Runner {
-	return &Runner{
-		volumeExists:      volumeExists,
-		autoExtendEnabled: autoExtendEnabled,
-		discardEnabled:    discardEnabled,
-		isMountedRW:       isMountedRW,
-		lockAcquire:       lockAcquire,
-	}
-}
-
 // LVMDevice represents a logical volume managed by LVM.
 type LVMDevice struct {
 	f           *os.File
@@ -152,7 +114,7 @@ var (
 	geteuid          = os.Geteuid
 )
 
-func runLVM(ctx context.Context, escalation, cmdName string, args ...string) error {
+func (r *Runner) runLVM(ctx context.Context, escalation, cmdName string, args ...string) error {
 	if err := lvm.VerifyEscalationCommand(escalation); err != nil {
 		return err
 	}
@@ -164,7 +126,7 @@ func runLVM(ctx context.Context, escalation, cmdName string, args ...string) err
 			args = append(parts[1:], append([]string{lvmCmd}, args...)...)
 		}
 	}
-	cmd := execCommand(ctx, cmdName, args...)
+	cmd := r.command.CommandContext(ctx, cmdName, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
@@ -180,19 +142,19 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 		return nil, err
 	}
 	snapName := generateSnapshot()
-	if err := runLVM(ctx, d.escalation, "lvcreate", "-s", "-n", snapName, "-L", snapshotSize, d.path); err != nil {
+	if err := d.runner.runLVM(ctx, d.escalation, "lvcreate", "-s", "-n", snapName, "-L", snapshotSize, d.path); err != nil {
 		return nil, err
 	}
 	snapPath := lvm.GetSnapshotDevicePath(snapName, vg, d.logger)
-	if err := runLVM(ctx, d.escalation, "lvchange", "-ay", snapPath); err != nil {
-		_ = runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
+	if err := d.runner.runLVM(ctx, d.escalation, "lvchange", "-ay", snapPath); err != nil {
+		_ = d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err
 	}
 	cache := lvm.NewDeviceFDCache(d.logger)
 	defer cache.Close()
 	snapDev, err := d.runner.OpenLVM(snapPath, cache, d.escalation, d.logger)
 	if err != nil {
-		_ = runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
+		_ = d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err
 	}
 	snapDev.cleanupPath = snapPath
@@ -208,7 +170,7 @@ func (d *LVMDevice) Cleanup(ctx context.Context) error {
 	if d.cleanupPath == "" {
 		return nil
 	}
-	if err := runLVM(ctx, d.escalation, "lvremove", "-f", d.cleanupPath); err != nil {
+	if err := d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", d.cleanupPath); err != nil {
 		return err
 	}
 	d.cleanupPath = ""

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -56,7 +56,7 @@ func TestOpenLVMNonBlockDevice(t *testing.T) {
 func TestOpenLVMChecks(t *testing.T) {
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
-	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, IsMountedRW, lock.Acquire)
+	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, IsMountedRW, lock.Acquire, nil)
 	if _, err := runner.OpenLVM("/dev/missing", cache, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error when volume missing")
 	}
@@ -66,17 +66,16 @@ func TestRunLVMPrivilegeEscalation(t *testing.T) {
 	ctx := context.Background()
 	var gotName string
 	var gotArgs []string
-	origExec := execCommand
-	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		gotName = name
 		gotArgs = append([]string(nil), args...)
 		return exec.CommandContext(ctx, "true")
-	}
-	t.Cleanup(func() { execCommand = origExec })
+	})
+	runner := NewDeviceRunner(cmd)
 	origEuid := geteuid
 	geteuid = func() int { return 1 }
 	t.Cleanup(func() { geteuid = origEuid })
-	if err := runLVM(ctx, "doas -n", "lvremove", "-f", "/dev/vg0/snap"); err != nil {
+	if err := runner.runLVM(ctx, "doas -n", "lvremove", "-f", "/dev/vg0/snap"); err != nil {
 		t.Fatalf("runLVM: %v", err)
 	}
 	if gotName != "doas" || !reflect.DeepEqual(gotArgs, []string{"-n", "lvremove", "-f", "/dev/vg0/snap"}) {
@@ -86,12 +85,11 @@ func TestRunLVMPrivilegeEscalation(t *testing.T) {
 
 func TestRunLVMFailure(t *testing.T) {
 	ctx := context.Background()
-	origExec := execCommand
-	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "false")
-	}
-	t.Cleanup(func() { execCommand = origExec })
-	if err := runLVM(ctx, "", "lvremove", "-f", "/dev/vg0/snap"); err == nil {
+	})
+	runner := NewDeviceRunner(cmd)
+	if err := runner.runLVM(ctx, "", "lvremove", "-f", "/dev/vg0/snap"); err == nil {
 		t.Fatalf("expected error from runLVM")
 	}
 }

--- a/device/raw.go
+++ b/device/raw.go
@@ -29,6 +29,7 @@ type RawDevice struct {
 	thawTimeout   time.Duration
 	thawCmdPath   string
 	thawCmdArgs   []string
+	runner        *Runner
 }
 
 // prepareFreeze validates and runs the filesystem freeze command when offline is false.
@@ -41,6 +42,7 @@ func prepareFreeze(
 	fsThawCmdArgs []string,
 	freezeTimeout time.Duration,
 	logger *zap.Logger,
+	runner *Runner,
 ) (bool, error) {
 	if offline {
 		return false, nil
@@ -61,7 +63,7 @@ func prepareFreeze(
 		freezeCtx, cancel = context.WithTimeout(ctx, freezeTimeout)
 		defer cancel()
 	}
-	out, cmdErr := execCommand(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).CombinedOutput()
+	out, cmdErr := runner.command.CommandContext(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).CombinedOutput()
 	if cmdErr != nil {
 		output := strings.TrimSpace(string(out))
 		logger.Error("fs freeze failed", zap.Error(cmdErr), zap.String("output", output))
@@ -114,15 +116,19 @@ func OpenRaw(
 	freezeTimeout time.Duration,
 	thawTimeout time.Duration,
 	logger *zap.Logger,
+	runner *Runner,
 ) (_ *RawDevice, err error) {
 	if logger == nil {
 		return nil, fmt.Errorf("logger is nil")
 	}
+	if runner == nil {
+		runner = NewRunner()
+	}
 	d := &RawDevice{
 		logger: logger, freezeTimeout: freezeTimeout, thawTimeout: thawTimeout,
-		thawCmdPath: fsThawCmdPath, thawCmdArgs: fsThawCmdArgs,
+		thawCmdPath: fsThawCmdPath, thawCmdArgs: fsThawCmdArgs, runner: runner,
 	}
-	freezeIssued, err := prepareFreeze(ctx, offline, fsFreezeCmdPath, fsFreezeCmdArgs, fsThawCmdPath, fsThawCmdArgs, freezeTimeout, logger)
+	freezeIssued, err := prepareFreeze(ctx, offline, fsFreezeCmdPath, fsFreezeCmdArgs, fsThawCmdPath, fsThawCmdArgs, freezeTimeout, logger, runner)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +192,7 @@ func (d *RawDevice) Cleanup(ctx context.Context) error {
 			thawCtx, cancel = context.WithTimeout(ctx, d.thawTimeout)
 			defer cancel()
 		}
-		out, cmdErr := execCommand(thawCtx, d.thawCmdPath, d.thawCmdArgs...).CombinedOutput()
+		out, cmdErr := d.runner.command.CommandContext(thawCtx, d.thawCmdPath, d.thawCmdArgs...).CombinedOutput()
 		if cmdErr != nil {
 			output := strings.TrimSpace(string(out))
 			d.logger.Error("fs thaw failed", zap.Error(cmdErr), zap.String("output", output))

--- a/device/raw_helpers_test.go
+++ b/device/raw_helpers_test.go
@@ -15,7 +15,7 @@ func TestPrepareFreezeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing true binary: %v", err)
 	}
-	issued, err := prepareFreeze(context.Background(), false, truePath, nil, truePath, nil, time.Second, zap.NewNop())
+	issued, err := prepareFreeze(context.Background(), false, truePath, nil, truePath, nil, time.Second, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("prepareFreeze: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestPrepareFreezeFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing true binary: %v", err)
 	}
-	if _, err := prepareFreeze(context.Background(), false, falsePath, nil, truePath, nil, time.Second, zap.NewNop()); err == nil {
+	if _, err := prepareFreeze(context.Background(), false, falsePath, nil, truePath, nil, time.Second, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }

--- a/device/raw_nonlinux.go
+++ b/device/raw_nonlinux.go
@@ -14,7 +14,7 @@ import (
 type RawDevice struct{}
 
 // OpenRaw returns an error on non-Linux systems.
-func OpenRaw(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, *zap.Logger) (*RawDevice, error) {
+func OpenRaw(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, *zap.Logger, *Runner) (*RawDevice, error) {
 	return nil, fmt.Errorf("raw devices are only supported on Linux")
 }
 

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -31,7 +31,7 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger)
+	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 }
 
 func TestOpenRawNilLogger(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "", true, "", nil, "", nil, 0, 0, nil); err == nil {
+	if _, err := OpenRaw(context.Background(), "", true, "", nil, "", nil, 0, 0, nil, NewRunner()); err == nil {
 		t.Fatalf("expected error when logger is nil")
 	}
 }
@@ -69,7 +69,7 @@ func TestRawDeviceCloseErrorLogging(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger)
+	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -90,14 +90,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, 0, 0, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, 0, 0, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, zap.NewNop()); err == nil {
+		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, zap.NewNop(), NewRunner()); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -106,7 +106,7 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected offline or freeze command error")
 	}
 }
@@ -120,7 +120,7 @@ func TestOpenRawFreezeCommandFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing true binary: %v", err)
 	}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, falsePath, nil, truePath, nil, time.Second, time.Second, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, falsePath, nil, truePath, nil, time.Second, time.Second, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -134,7 +134,7 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 	}
 	freezeArgs := []string{freezeTmp}
 	thawArgs := []string{thawTmp}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, touchPath, freezeArgs, touchPath, thawArgs, time.Second, time.Second, zap.NewNop()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, touchPath, freezeArgs, touchPath, thawArgs, time.Second, time.Second, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {
@@ -151,7 +151,7 @@ func TestCleanupRunsThawCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing touch binary: %v", err)
 	}
-	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: touchPath, thawCmdArgs: []string{tmp}}
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: touchPath, thawCmdArgs: []string{tmp}, runner: NewRunner()}
 	if err := d.Cleanup(context.Background()); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestCleanupThawCommandFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing false binary: %v", err)
 	}
-	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: falsePath}
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: falsePath, runner: NewRunner()}
 	if err := d.Cleanup(context.Background()); err == nil {
 		t.Fatalf("expected thaw command failure")
 	}
@@ -180,7 +180,7 @@ func TestOpenRawFreezeTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing true binary: %v", err)
 	}
-	_, err = OpenRaw(context.Background(), "/dev/null", false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, zap.NewNop())
+	_, err = OpenRaw(context.Background(), "/dev/null", false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, zap.NewNop(), NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze command to be killed, got %v", err)
 	}
@@ -191,7 +191,7 @@ func TestCleanupThawTimeout(t *testing.T) {
 	if err != nil {
 		t.Skip("sleep command not found")
 	}
-	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawTimeout: 100 * time.Millisecond, thawCmdPath: sleepPath, thawCmdArgs: []string{"2"}}
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawTimeout: 100 * time.Millisecond, thawCmdPath: sleepPath, thawCmdArgs: []string{"2"}, runner: NewRunner()}
 	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected thaw command to be killed, got %v", err)
 	}
@@ -212,7 +212,7 @@ func TestOpenRawStoresThawConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing touch binary: %v", err)
 	}
-	d, err := OpenRaw(context.Background(), loop, false, truePath, nil, touchPath, []string{thawTmp}, time.Second, time.Second, zap.NewNop())
+	d, err := OpenRaw(context.Background(), loop, false, truePath, nil, touchPath, []string{thawTmp}, time.Second, time.Second, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -231,11 +231,9 @@ func TestOpenRawStoresThawConfig(t *testing.T) {
 func TestOpenRawFreezeThawLogs(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	oldExec := execCommand
-	execCommand = fakeExecCommandContext
-	t.Cleanup(func() { execCommand = oldExec })
 	helper := helperCommand(t)
-	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-success"}, time.Second, time.Second, logger)
+	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-success"}, time.Second, time.Second, logger, runner)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -250,11 +248,9 @@ func TestOpenRawFreezeThawLogs(t *testing.T) {
 func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	oldExec := execCommand
-	execCommand = fakeExecCommandContext
-	t.Cleanup(func() { execCommand = oldExec })
 	helper := helperCommand(t)
-	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, logger)
+	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze timeout, got %v", err)
 	}
@@ -272,11 +268,9 @@ func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 func TestOpenRawThawFailure(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	oldExec := execCommand
-	execCommand = fakeExecCommandContext
-	t.Cleanup(func() { execCommand = oldExec })
 	helper := helperCommand(t)
-	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-fail"}, time.Second, time.Second, logger)
+	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-fail"}, time.Second, time.Second, logger, runner)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -297,15 +291,13 @@ func TestOpenRawThawFailure(t *testing.T) {
 func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	oldExec := execCommand
-	execCommand = fakeExecCommandContext
-	t.Cleanup(func() { execCommand = oldExec })
 	helper := helperCommand(t)
 	truePath, err := exec.LookPath("true")
 	if err != nil {
 		t.Fatalf("missing true binary: %v", err)
 	}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
+	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, logger, runner); err == nil || !strings.Contains(err.Error(), "freeze output") {
 		t.Fatalf("expected freeze output in error, got %v", err)
 	}
 	entries := logs.FilterMessage("fs freeze failed").All()
@@ -320,9 +312,6 @@ func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	oldExec := execCommand
-	execCommand = fakeExecCommandContext
-	t.Cleanup(func() { execCommand = oldExec })
 	helper := helperCommand(t)
 	d := &RawDevice{
 		freezeIssued: true,
@@ -330,6 +319,7 @@ func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
 		thawCmdArgs:  []string{"thaw-fail-output"},
 		thawTimeout:  time.Second,
 		logger:       logger,
+		runner:       NewDeviceRunner(cmdFunc(fakeExecCommandContext)),
 	}
 	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "thaw output") {
 		t.Fatalf("expected thaw output in error, got %v", err)
@@ -346,9 +336,6 @@ func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
 func TestRawDeviceCleanupThawErrorLogs(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	oldExec := execCommand
-	execCommand = fakeExecCommandContext
-	defer func() { execCommand = oldExec }()
 	helper := helperCommand(t)
 	d := &RawDevice{
 		freezeIssued: true,
@@ -356,6 +343,7 @@ func TestRawDeviceCleanupThawErrorLogs(t *testing.T) {
 		thawCmdArgs:  []string{"thaw-fail"},
 		thawTimeout:  time.Second,
 		logger:       logger,
+		runner:       NewDeviceRunner(cmdFunc(fakeExecCommandContext)),
 	}
 	if err := d.Cleanup(context.Background()); err == nil {
 		t.Fatalf("expected thaw command failure")
@@ -368,9 +356,6 @@ func TestRawDeviceCleanupThawErrorLogs(t *testing.T) {
 func TestRawDeviceCleanupThawTimeoutLogs(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	oldExec := execCommand
-	execCommand = fakeExecCommandContext
-	defer func() { execCommand = oldExec }()
 	helper := helperCommand(t)
 	d := &RawDevice{
 		freezeIssued: true,
@@ -378,6 +363,7 @@ func TestRawDeviceCleanupThawTimeoutLogs(t *testing.T) {
 		thawCmdArgs:  []string{"thaw-timeout"},
 		thawTimeout:  100 * time.Millisecond,
 		logger:       logger,
+		runner:       NewDeviceRunner(cmdFunc(fakeExecCommandContext)),
 	}
 	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "killed") {
 		t.Fatalf("expected thaw command to be killed, got %v", err)

--- a/device/runner.go
+++ b/device/runner.go
@@ -1,0 +1,75 @@
+package device
+
+import (
+	"context"
+	"os/exec"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/lock"
+	"lvmsync_go/lvm"
+)
+
+// Commander abstracts exec.CommandContext for testability.
+type Commander interface {
+	CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd
+}
+
+type commanderFunc func(context.Context, string, ...string) *exec.Cmd
+
+func (f commanderFunc) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return f(ctx, name, args...)
+}
+
+// Runner coordinates interactions with external helpers.
+type Runner struct {
+	command           Commander
+	volumeExists      func(context.Context, string) (bool, error)
+	autoExtendEnabled func(context.Context, string) (bool, error)
+	discardEnabled    func(context.Context, string) (bool, error)
+	isMountedRW       func(string) (bool, error)
+	lockAcquire       func(string, string) (*lock.Lock, error)
+	openLVMOverride   func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error)
+}
+
+// NewDeviceRunner returns a Runner using production dependencies and the provided Commander.
+// If cmd is nil, exec.CommandContext is used.
+func NewDeviceRunner(cmd Commander) *Runner {
+	if cmd == nil {
+		cmd = commanderFunc(exec.CommandContext)
+	}
+	return &Runner{
+		command:           cmd,
+		volumeExists:      lvm.VolumeExists,
+		autoExtendEnabled: lvm.AutoExtendEnabled,
+		discardEnabled:    lvm.DiscardEnabled,
+		isMountedRW:       IsMountedRW,
+		lockAcquire:       lock.Acquire,
+	}
+}
+
+// NewRunner is retained for compatibility; it uses exec.CommandContext.
+func NewRunner() *Runner { return NewDeviceRunner(nil) }
+
+// NewRunnerWithDeps constructs a Runner with custom dependencies.
+// If cmd is nil, exec.CommandContext is used.
+func NewRunnerWithDeps(
+	volumeExists func(context.Context, string) (bool, error),
+	autoExtendEnabled func(context.Context, string) (bool, error),
+	discardEnabled func(context.Context, string) (bool, error),
+	isMountedRW func(string) (bool, error),
+	lockAcquire func(string, string) (*lock.Lock, error),
+	cmd Commander,
+) *Runner {
+	if cmd == nil {
+		cmd = commanderFunc(exec.CommandContext)
+	}
+	return &Runner{
+		command:           cmd,
+		volumeExists:      volumeExists,
+		autoExtendEnabled: autoExtendEnabled,
+		discardEnabled:    discardEnabled,
+		isMountedRW:       isMountedRW,
+		lockAcquire:       lockAcquire,
+	}
+}

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -55,18 +55,16 @@ func TestSnapshotLifecycle(t *testing.T) {
 
 	// LVM device snapshot creates and removes snapshots via a custom escalation command when non-root.
 	var cmds []string
-	origCmd := execCommand
-	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		cmds = append(cmds, name+" "+strings.Join(args, " "))
 		return exec.CommandContext(ctx, "true")
-	}
-	t.Cleanup(func() { execCommand = origCmd })
+	})
 
 	origName := generateSnapshot
 	generateSnapshot = func() string { return "snap" }
 	defer func() { generateSnapshot = origName }()
 
-	runner := NewRunner()
+	runner := NewDeviceRunner(cmd)
 	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop(), runner: runner}, nil
 	}
@@ -103,21 +101,19 @@ func TestSnapshotLVCreateFailure(t *testing.T) {
 	}
 	ctx := context.Background()
 	var cmds []string
-	origCmd := execCommand
-	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		cmds = append(cmds, name+" "+strings.Join(args, " "))
 		if strings.Contains(strings.Join(args, " "), "lvcreate") {
 			return exec.CommandContext(ctx, "false")
 		}
 		return exec.CommandContext(ctx, "true")
-	}
-	defer func() { execCommand = origCmd }()
+	})
 
 	origEuid := geteuid
 	geteuid = func() int { return 1 }
 	defer func() { geteuid = origEuid }()
 
-	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop(), runner: NewRunner()}
+	lvd := &LVMDevice{path: "/dev/vg0/origin", escalation: "doas -n", logger: zap.NewNop(), runner: NewDeviceRunner(cmd)}
 	if _, err := lvd.Snapshot(ctx, "1G"); err == nil {
 		t.Fatalf("expected error from lvcreate failure")
 	}

--- a/internal/privilege/escalate.go
+++ b/internal/privilege/escalate.go
@@ -17,11 +17,7 @@ type Escalator interface {
 
 // sudoEscalator implements Escalator using Linux capabilities when present
 // and sudo -n as a fallback.
-type sudoEscalator struct{ useSudo bool }
-
-// New returns an Escalator. If the current process lacks the required
-// capabilities, commands will be executed via sudo -n.
-func New() Escalator { return &sudoEscalator{useSudo: !HasCaps()} }
-
-// execCommand wraps exec.Command for injection in tests.
-var execCommand = exec.Command
+type sudoEscalator struct {
+	useSudo bool
+	runner  *Runner
+}

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -1,12 +1,19 @@
 package privilege
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
 	"strconv"
 	"testing"
 )
+
+type cmdFunc func(context.Context, string, ...string) *exec.Cmd
+
+func (f cmdFunc) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return f(ctx, name, args...)
+}
 
 // fakeLookPath stubs exec.LookPath.
 func fakeLookPath(err error) func(string) (string, error) {
@@ -26,11 +33,10 @@ func TestEnsureWithCaps(t *testing.T) {
 
 func TestEnsureWithSudo(t *testing.T) {
 	HasCaps = func() bool { return false }
-	lookPath = fakeLookPath(nil)
-	orig := execCommand
-	execCommand = fakeSudo(0)
-	defer func() { execCommand = orig }()
-	esc := New().(*sudoEscalator)
+	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeSudo(0)(name, args...)
+	}), LookPath: fakeLookPath(nil)}
+	esc := NewWithRunner(r).(*sudoEscalator)
 	if !esc.useSudo {
 		t.Fatalf("expected sudo usage")
 	}
@@ -41,8 +47,7 @@ func TestEnsureWithSudo(t *testing.T) {
 
 func TestEnsureNoSudo(t *testing.T) {
 	HasCaps = func() bool { return false }
-	lookPath = fakeLookPath(errors.New("missing"))
-	esc := New().(*sudoEscalator)
+	esc := NewWithRunner(&Runner{LookPath: fakeLookPath(errors.New("missing"))}).(*sudoEscalator)
 	if err := esc.Ensure(); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -65,11 +70,10 @@ func TestCommand(t *testing.T) {
 
 func TestEnsureSudoFailure(t *testing.T) {
 	HasCaps = func() bool { return false }
-	lookPath = fakeLookPath(nil)
-	orig := execCommand
-	execCommand = fakeSudo(1)
-	defer func() { execCommand = orig }()
-	esc := New().(*sudoEscalator)
+	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeSudo(1)(name, args...)
+	}), LookPath: fakeLookPath(nil)}
+	esc := NewWithRunner(r).(*sudoEscalator)
 	if err := esc.Ensure(); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -90,8 +94,10 @@ func TestSudoSuccess(t *testing.T) {
 		t.Skip("root required")
 	}
 	HasCaps = func() bool { return false }
-	execCommand = fakeSudo(0)
-	cmd := New().Command("echo")
+	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeSudo(0)(name, args...)
+	})})
+	cmd := esc.Command("echo")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -102,8 +108,10 @@ func TestSudoPermissionDenied(t *testing.T) {
 		t.Skip("root required")
 	}
 	HasCaps = func() bool { return false }
-	execCommand = fakeSudo(1)
-	cmd := New().Command("echo")
+	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeSudo(1)(name, args...)
+	})})
+	cmd := esc.Command("echo")
 	err := cmd.Run()
 	if err == nil {
 		t.Fatalf("expected error")
@@ -118,8 +126,10 @@ func TestSudoCommandNotFound(t *testing.T) {
 		t.Skip("root required")
 	}
 	HasCaps = func() bool { return false }
-	execCommand = fakeSudo(127)
-	cmd := New().Command("echo")
+	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeSudo(127)(name, args...)
+	})})
+	cmd := esc.Command("echo")
 	err := cmd.Run()
 	if err == nil {
 		t.Fatalf("expected error")
@@ -142,8 +152,6 @@ func TestHelperProcess(t *testing.T) {
 func TestMain(m *testing.M) {
 	code := m.Run()
 	HasCaps = RealHasCaps
-	lookPath = exec.LookPath
-	execCommand = exec.Command
 	if code != 0 {
 		panic(code)
 	}

--- a/internal/privilege/runner.go
+++ b/internal/privilege/runner.go
@@ -1,0 +1,42 @@
+package privilege
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Commander abstracts exec.CommandContext for dependency injection.
+type Commander interface {
+	CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd
+}
+
+type commanderFunc func(context.Context, string, ...string) *exec.Cmd
+
+func (f commanderFunc) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return f(ctx, name, args...)
+}
+
+// Runner provides external dependencies for privilege escalation.
+type Runner struct {
+	Cmd      Commander
+	LookPath func(string) (string, error)
+}
+
+// New returns an Escalator with production dependencies.
+func New() Escalator { return NewWithRunner(nil) }
+
+// NewWithRunner constructs an Escalator with the provided Runner.
+// Nil fields default to exec.CommandContext and exec.LookPath.
+func NewWithRunner(r *Runner) Escalator {
+	cmd := Commander(commanderFunc(exec.CommandContext))
+	lp := exec.LookPath
+	if r != nil {
+		if r.Cmd != nil {
+			cmd = r.Cmd
+		}
+		if r.LookPath != nil {
+			lp = r.LookPath
+		}
+	}
+	return &sudoEscalator{useSudo: !HasCaps(), runner: &Runner{Cmd: cmd, LookPath: lp}}
+}

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -3,20 +3,19 @@
 package privilege
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 )
-
-var lookPath = exec.LookPath
 
 // Ensure verifies that either the required capabilities are present or that
 // sudo is available when escalation is necessary.
 func (s *sudoEscalator) Ensure() error {
 	if s.useSudo {
-		if _, err := lookPath("sudo"); err != nil {
+		if _, err := s.runner.LookPath("sudo"); err != nil {
 			return fmt.Errorf("sudo not found: %w", err)
 		}
-		if err := execCommand("sudo", "-n", "true").Run(); err != nil {
+		if err := s.runner.Cmd.CommandContext(context.Background(), "sudo", "-n", "true").Run(); err != nil {
 			return fmt.Errorf("sudo escalation failed: %w", err)
 		}
 		return nil
@@ -29,7 +28,7 @@ func (s *sudoEscalator) Ensure() error {
 func (s *sudoEscalator) Command(name string, args ...string) *exec.Cmd {
 	if s.useSudo {
 		all := append([]string{"-n", name}, args...)
-		return execCommand("sudo", all...)
+		return s.runner.Cmd.CommandContext(context.Background(), "sudo", all...)
 	}
-	return execCommand(name, args...)
+	return s.runner.Cmd.CommandContext(context.Background(), name, args...)
 }

--- a/transfer/sync_logger_error_test.go
+++ b/transfer/sync_logger_error_test.go
@@ -53,7 +53,7 @@ func TestDumpChangesLogsSyncErrorOnEarlyFailure(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: 0, Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesSequential(cfg, "snapshot", "/nonexistent", &buf); err == nil {
+	if err := tr.DumpChangesSequential(context.Background(), cfg, "snapshot", "/nonexistent", &buf); err == nil {
 		t.Fatalf("expected DumpChangesSequential error")
 	}
 	logs := observed.FilterMessage("Logger sync error").All()


### PR DESCRIPTION
## Summary
- add Commander interface and Runner to device package
- inject commander into privilege escalator via NewWithRunner
- replace package-level exec stubs and update tests

## Testing
- `go build ./...`
- `go test ./device ./internal/privilege ./transfer -cover`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a149b51ff8832386fb16f51ddcbd8c