### PR TITLE
Use snake_case for device log messages

### DIFF
--- a/device/detect.go
+++ b/device/detect.go
@@ -21,27 +21,27 @@ var openRawFunc = OpenRaw
 func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
 	dev, err := OpenFile(path, logger)
 	if err != nil {
-		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeFile), zap.Error(err))
+		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeFile), zap.Error(err))
 		return nil, err
 	}
-	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", TypeFile))
+	logger.Info("detect_device_success", zap.String("path", path), zap.String("device_type", TypeFile))
 	return dev, nil
 }
 
 // detectLVMDevice opens an LVM logical volume.
 func detectLVMDevice(path, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
 	if err := lvm.VerifyEscalationCommand(lvmEscalation); err != nil {
-		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
+		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
 	}
 	cache := lvm.NewDeviceFDCache(logger)
 	defer cache.Close()
 	dev, err := runner.OpenLVM(path, cache, lvmEscalation, logger)
 	if err != nil {
-		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
+		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
 	}
-	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", TypeLVM))
+	logger.Info("detect_device_success", zap.String("path", path), zap.String("device_type", TypeLVM))
 	return dev, nil
 }
 
@@ -53,7 +53,7 @@ func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd
 		parts, err := shellquote.Split(fsFreezeCmd)
 		if err != nil {
 			err = fmt.Errorf("invalid freeze command: %w", err)
-			logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
+			logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 			return nil, err
 		}
 		if len(parts) > 0 {
@@ -65,7 +65,7 @@ func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd
 		parts, err := shellquote.Split(fsThawCmd)
 		if err != nil {
 			err = fmt.Errorf("invalid thaw command: %w", err)
-			logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
+			logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 			return nil, err
 		}
 		if len(parts) > 0 {
@@ -75,10 +75,10 @@ func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd
 	}
 	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger)
 	if err != nil {
-		logger.Error("detect device failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
+		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err
 	}
-	logger.Info("detect device success", zap.String("path", path), zap.String("device_type", TypeRaw))
+	logger.Info("detect_device_success", zap.String("path", path), zap.String("device_type", TypeRaw))
 	return dev, nil
 }
 
@@ -105,12 +105,12 @@ func Detect(
 	}
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		logger.Error("device detect failed", zap.String("path", path), zap.String("device_type", "symlink"), zap.Error(err))
+		logger.Error("device_detect_failed", zap.String("path", path), zap.String("device_type", "symlink"), zap.Error(err))
 		return nil, err
 	}
 	info, err := os.Stat(resolved)
 	if err != nil {
-		logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
+		logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
 		return nil, err
 	}
 	if explicitType != "" && explicitType != TypeAuto {
@@ -146,6 +146,6 @@ func Detect(
 		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger)
 	}
 	err = fmt.Errorf("unsupported path type: %s", resolved)
-	logger.Error("device detect failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))
+	logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))
 	return nil, err
 }

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -30,7 +30,7 @@ func TestDetectFileDeviceSuccess(t *testing.T) {
 		t.Fatalf("expected FileDevice, got %T", dev)
 	}
 	dev.Close()
-	entries := logs.FilterMessage("detect device success").All()
+	entries := logs.FilterMessage("detect_device_success").All()
 	found := false
 	for _, e := range entries {
 		if e.ContextMap()["device_type"] == "file" && e.ContextMap()["path"] == f.Name() {
@@ -64,7 +64,7 @@ func TestDetectLVMDeviceSuccess(t *testing.T) {
 		t.Fatalf("expected LVMDevice, got %T", dev)
 	}
 	dev.Close()
-	entries := logs.FilterMessage("detect device success").All()
+	entries := logs.FilterMessage("detect_device_success").All()
 	found := false
 	for _, e := range entries {
 		if e.ContextMap()["device_type"] == "lvm" && e.ContextMap()["path"] == "/dev/test" {
@@ -123,7 +123,7 @@ func TestDetectRawDeviceSuccess(t *testing.T) {
 		t.Fatalf("expected RawDevice, got %T", dev)
 	}
 	dev.Close()
-	entries := logs.FilterMessage("detect device success").All()
+	entries := logs.FilterMessage("detect_device_success").All()
 	found := false
 	for _, e := range entries {
 		if e.ContextMap()["device_type"] == "raw" && e.ContextMap()["path"] == "/dev/test" {
@@ -158,7 +158,7 @@ func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 	if called {
 		t.Fatalf("openRawFunc should not be called on parse error")
 	}
-	entries := logs.FilterMessage("detect device failed").All()
+	entries := logs.FilterMessage("detect_device_failed").All()
 	if len(entries) != 1 {
 		t.Fatalf("expected error log, got %v", logs.All())
 	}
@@ -184,7 +184,7 @@ func TestDetectRawDeviceThawParseError(t *testing.T) {
 	if called {
 		t.Fatalf("openRawFunc should not be called on parse error")
 	}
-	entries := logs.FilterMessage("detect device failed").All()
+	entries := logs.FilterMessage("detect_device_failed").All()
 	if len(entries) != 1 {
 		t.Fatalf("expected error log, got %v", logs.All())
 	}

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -53,7 +53,7 @@ func TestDetectFile(t *testing.T) {
 	}
 	dev.Close()
 
-	entries := logs.FilterMessage("detect device success").All()
+	entries := logs.FilterMessage("detect_device_success").All()
 	found := false
 	for _, e := range entries {
 		if e.ContextMap()["device_type"] == "file" && e.ContextMap()["path"] == f.Name() {
@@ -113,11 +113,11 @@ func TestDetectRaw(t *testing.T) {
 	rawSuccess := false
 	for _, e := range logs.All() {
 		switch e.Message {
-		case "detect device failed":
+		case "detect_device_failed":
 			if e.ContextMap()["device_type"] == "lvm" {
 				lvmFail = true
 			}
-		case "detect device success":
+		case "detect_device_success":
 			if e.ContextMap()["device_type"] == "raw" {
 				rawSuccess = true
 			}

--- a/device/file.go
+++ b/device/file.go
@@ -25,29 +25,29 @@ func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
+		logger.Error("file_device_open_failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
 	if !info.Mode().IsRegular() {
 		err := fmt.Errorf("%s is not a regular file", path)
-		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
+		logger.Error("file_device_open_failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
-		logger.Error("file device open failed", zap.String("path", path), zap.Error(err))
+		logger.Error("file_device_open_failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
-	logger.Info("file device opened", zap.String("path", path))
+	logger.Info("file_device_opened", zap.String("path", path))
 	var st unix.Stat_t
 	if err := unix.Fstat(int(f.Fd()), &st); err != nil {
 		f.Close()
-		logger.Error("file device stat failed", zap.String("path", path), zap.Error(err))
+		logger.Error("file_device_stat_failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
 	size := uint64(info.Size())
 	block := uint64(st.Blksize)
-	logger.Info("file device info", zap.String("path", path), zap.Uint64("size_bytes", size), zap.Uint64("block_size_bytes", block))
+	logger.Info("file_device_info", zap.String("path", path), zap.Uint64("size_bytes", size), zap.Uint64("block_size_bytes", block))
 	return &FileDevice{
 		f:         f,
 		size:      size,
@@ -69,9 +69,9 @@ func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 func (d *FileDevice) Close() error {
 	err := d.f.Close()
 	if err != nil {
-		d.logger.Error("file device close failed", zap.String("path", d.Path()), zap.Error(err))
+		d.logger.Error("file_device_close_failed", zap.String("path", d.Path()), zap.Error(err))
 	} else {
-		d.logger.Info("file device closed", zap.String("path", d.Path()))
+		d.logger.Info("file_device_closed", zap.String("path", d.Path()))
 	}
 	return err
 }
@@ -88,6 +88,6 @@ func (d *FileDevice) Snapshot(context.Context, string) (Device, error) {
 
 // Cleanup is a no-op for regular files.
 func (d *FileDevice) Cleanup(context.Context) error {
-	d.logger.Info("file device cleanup", zap.String("path", d.Path()))
+	d.logger.Info("file_device_cleanup", zap.String("path", d.Path()))
 	return nil
 }

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -38,10 +38,10 @@ func TestOpenFile(t *testing.T) {
 		t.Fatalf("expected non-zero block size")
 	}
 
-	if logs.FilterMessage("file device opened").Len() == 0 {
-		t.Fatalf("expected file device opened log")
+	if logs.FilterMessage("file_device_opened").Len() == 0 {
+		t.Fatalf("expected file_device_opened log")
 	}
-	entries := logs.FilterMessage("file device info").All()
+	entries := logs.FilterMessage("file_device_info").All()
 	found := false
 	for _, e := range entries {
 		if e.ContextMap()["path"] == path &&
@@ -51,10 +51,10 @@ func TestOpenFile(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected file device info log with fields, got %v", logs.All())
+		t.Fatalf("expected file_device_info log with fields, got %v", logs.All())
 	}
-	if logs.FilterMessage("file device closed").Len() == 0 {
-		t.Fatalf("expected file device closed log")
+	if logs.FilterMessage("file_device_closed").Len() == 0 {
+		t.Fatalf("expected file_device_closed log")
 	}
 }
 

--- a/device/raw.go
+++ b/device/raw.go
@@ -54,7 +54,7 @@ func prepareFreeze(
 	if err := validateCmd(fsThawCmdPath, fsThawCmdArgs); err != nil {
 		return false, fmt.Errorf("invalid thaw command: %w", err)
 	}
-	logger.Info("fs freeze start", zap.String("command", fsFreezeCmdPath), zap.Strings("args", fsFreezeCmdArgs))
+	logger.Info("fs_freeze_start", zap.String("command", fsFreezeCmdPath), zap.Strings("args", fsFreezeCmdArgs))
 	freezeCtx := ctx
 	if _, ok := ctx.Deadline(); !ok && freezeTimeout > 0 {
 		var cancel context.CancelFunc
@@ -64,10 +64,10 @@ func prepareFreeze(
 	out, cmdErr := execCommand(freezeCtx, fsFreezeCmdPath, fsFreezeCmdArgs...).CombinedOutput()
 	if cmdErr != nil {
 		output := strings.TrimSpace(string(out))
-		logger.Error("fs freeze failed", zap.Error(cmdErr), zap.String("output", output))
+		logger.Error("fs_freeze_failed", zap.Error(cmdErr), zap.String("output", output))
 		return false, fmt.Errorf("freeze command failed: %w: %s", cmdErr, output)
 	}
-	logger.Info("fs freeze complete")
+	logger.Info("fs_freeze_complete")
 	return true, nil
 }
 
@@ -93,7 +93,7 @@ func queryDeviceInfo(f *os.File, path string, logger *zap.Logger) (uint64, uint6
 	if err != nil {
 		return 0, 0, err
 	}
-	logger.Info("raw device info",
+	logger.Info("raw_device_info",
 		zap.String("path", path),
 		zap.Uint64("size_bytes", size),
 		zap.Uint64("block_size_bytes", uint64(bs)))
@@ -162,9 +162,9 @@ func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
 func (d *RawDevice) Close() error {
 	err := d.f.Close()
 	if err != nil {
-		d.logger.Error("raw device close failed", zap.String("path", d.Path()), zap.Error(err))
+		d.logger.Error("raw_device_close_failed", zap.String("path", d.Path()), zap.Error(err))
 	} else {
-		d.logger.Info("raw device closed", zap.String("path", d.Path()))
+		d.logger.Info("raw_device_closed", zap.String("path", d.Path()))
 	}
 	return err
 }
@@ -176,10 +176,10 @@ func (d *RawDevice) Snapshot(context.Context, string) (Device, error) { return d
 func (d *RawDevice) Cleanup(ctx context.Context) error {
 	if d.freezeIssued {
 		if err := validateCmd(d.thawCmdPath, d.thawCmdArgs); err != nil {
-			d.logger.Error("fs thaw failed", zap.Error(err))
+			d.logger.Error("fs_thaw_failed", zap.Error(err))
 			return fmt.Errorf("invalid thaw command: %w", err)
 		}
-		d.logger.Info("fs thaw start", zap.String("command", d.thawCmdPath), zap.Strings("args", d.thawCmdArgs))
+		d.logger.Info("fs_thaw_start", zap.String("command", d.thawCmdPath), zap.Strings("args", d.thawCmdArgs))
 		thawCtx := ctx
 		if _, ok := ctx.Deadline(); !ok && d.thawTimeout > 0 {
 			var cancel context.CancelFunc
@@ -189,10 +189,10 @@ func (d *RawDevice) Cleanup(ctx context.Context) error {
 		out, cmdErr := execCommand(thawCtx, d.thawCmdPath, d.thawCmdArgs...).CombinedOutput()
 		if cmdErr != nil {
 			output := strings.TrimSpace(string(out))
-			d.logger.Error("fs thaw failed", zap.Error(cmdErr), zap.String("output", output))
+			d.logger.Error("fs_thaw_failed", zap.Error(cmdErr), zap.String("output", output))
 			return fmt.Errorf("thaw command failed: %w: %s", cmdErr, output)
 		}
-		d.logger.Info("fs thaw complete")
+		d.logger.Info("fs_thaw_complete")
 	}
 	return nil
 }

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -38,7 +38,7 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	entries := logs.FilterMessage("raw device info").All()
+	entries := logs.FilterMessage("raw_device_info").All()
 	found := false
 	for _, e := range entries {
 		if e.ContextMap()["path"] == loop &&
@@ -48,10 +48,10 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected raw device info log with fields, got %v", logs.All())
+		t.Fatalf("expected raw_device_info log with fields, got %v", logs.All())
 	}
-	if logs.FilterMessage("raw device closed").Len() == 0 {
-		t.Fatalf("expected raw device closed log")
+	if logs.FilterMessage("raw_device_closed").Len() == 0 {
+		t.Fatalf("expected raw_device_closed log")
 	}
 }
 
@@ -79,8 +79,8 @@ func TestRawDeviceCloseErrorLogging(t *testing.T) {
 	if err := d.Close(); err == nil {
 		t.Fatalf("expected close error")
 	}
-	if logs.FilterMessage("raw device close failed").Len() == 0 {
-		t.Fatalf("expected raw device close failed log")
+	if logs.FilterMessage("raw_device_close_failed").Len() == 0 {
+		t.Fatalf("expected raw_device_close_failed log")
 	}
 }
 
@@ -239,11 +239,11 @@ func TestOpenRawFreezeThawLogs(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
-	if logs.FilterMessage("fs freeze start").Len() != 1 || logs.FilterMessage("fs freeze complete").Len() != 1 {
-		t.Fatalf("expected freeze start and complete logs, got %v", logs.All())
+	if logs.FilterMessage("fs_freeze_start").Len() != 1 || logs.FilterMessage("fs_freeze_complete").Len() != 1 {
+		t.Fatalf("expected fs_freeze_start and fs_freeze_complete logs, got %v", logs.All())
 	}
-	if logs.FilterMessage("fs thaw start").Len() != 1 || logs.FilterMessage("fs thaw complete").Len() != 1 {
-		t.Fatalf("expected thaw start and complete logs, got %v", logs.All())
+	if logs.FilterMessage("fs_thaw_start").Len() != 1 || logs.FilterMessage("fs_thaw_complete").Len() != 1 {
+		t.Fatalf("expected fs_thaw_start and fs_thaw_complete logs, got %v", logs.All())
 	}
 }
 
@@ -258,14 +258,14 @@ func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze timeout, got %v", err)
 	}
-	if logs.FilterMessage("fs freeze start").Len() != 1 {
-		t.Fatalf("expected freeze start log")
+	if logs.FilterMessage("fs_freeze_start").Len() != 1 {
+		t.Fatalf("expected fs_freeze_start log")
 	}
-	if logs.FilterMessage("fs freeze complete").Len() != 0 {
-		t.Fatalf("unexpected freeze complete log")
+	if logs.FilterMessage("fs_freeze_complete").Len() != 0 {
+		t.Fatalf("unexpected fs_freeze_complete log")
 	}
-	if logs.FilterMessage("fs thaw start").Len() != 0 || logs.FilterMessage("fs thaw complete").Len() != 0 {
-		t.Fatalf("unexpected thaw logs, got %v", logs.All())
+	if logs.FilterMessage("fs_thaw_start").Len() != 0 || logs.FilterMessage("fs_thaw_complete").Len() != 0 {
+		t.Fatalf("unexpected fs_thaw_* logs, got %v", logs.All())
 	}
 }
 
@@ -280,17 +280,17 @@ func TestOpenRawThawFailure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
-	if logs.FilterMessage("fs freeze start").Len() != 1 || logs.FilterMessage("fs freeze complete").Len() != 1 {
-		t.Fatalf("expected freeze start and complete logs, got %v", logs.All())
+	if logs.FilterMessage("fs_freeze_start").Len() != 1 || logs.FilterMessage("fs_freeze_complete").Len() != 1 {
+		t.Fatalf("expected fs_freeze_start and fs_freeze_complete logs, got %v", logs.All())
 	}
-	if logs.FilterMessage("fs thaw start").Len() != 1 {
-		t.Fatalf("expected thaw start log")
+	if logs.FilterMessage("fs_thaw_start").Len() != 1 {
+		t.Fatalf("expected fs_thaw_start log")
 	}
-	if logs.FilterMessage("fs thaw complete").Len() != 0 {
-		t.Fatalf("unexpected thaw complete log")
+	if logs.FilterMessage("fs_thaw_complete").Len() != 0 {
+		t.Fatalf("unexpected fs_thaw_complete log")
 	}
-	if logs.FilterMessage("fs thaw failed").Len() != 1 {
-		t.Fatalf("expected thaw failed log")
+	if logs.FilterMessage("fs_thaw_failed").Len() != 1 {
+		t.Fatalf("expected fs_thaw_failed log")
 	}
 }
 
@@ -308,9 +308,9 @@ func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, logger); err == nil || !strings.Contains(err.Error(), "freeze output") {
 		t.Fatalf("expected freeze output in error, got %v", err)
 	}
-	entries := logs.FilterMessage("fs freeze failed").All()
+	entries := logs.FilterMessage("fs_freeze_failed").All()
 	if len(entries) != 1 {
-		t.Fatalf("expected one freeze failed log, got %v", logs.All())
+		t.Fatalf("expected one fs_freeze_failed log, got %v", logs.All())
 	}
 	if v, ok := entries[0].ContextMap()["output"]; !ok || v != "freeze output" {
 		t.Fatalf("expected freeze output log, got %v", entries[0].ContextMap())
@@ -334,9 +334,9 @@ func TestRawDeviceCleanupFailureIncludesOutput(t *testing.T) {
 	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "thaw output") {
 		t.Fatalf("expected thaw output in error, got %v", err)
 	}
-	entries := logs.FilterMessage("fs thaw failed").All()
+	entries := logs.FilterMessage("fs_thaw_failed").All()
 	if len(entries) != 1 {
-		t.Fatalf("expected one thaw failed log, got %v", logs.All())
+		t.Fatalf("expected one fs_thaw_failed log, got %v", logs.All())
 	}
 	if v, ok := entries[0].ContextMap()["output"]; !ok || v != "thaw output" {
 		t.Fatalf("expected thaw output log, got %v", entries[0].ContextMap())
@@ -360,8 +360,8 @@ func TestRawDeviceCleanupThawErrorLogs(t *testing.T) {
 	if err := d.Cleanup(context.Background()); err == nil {
 		t.Fatalf("expected thaw command failure")
 	}
-	if logs.FilterMessage("fs thaw failed").Len() != 1 {
-		t.Fatalf("expected thaw failed log")
+	if logs.FilterMessage("fs_thaw_failed").Len() != 1 {
+		t.Fatalf("expected fs_thaw_failed log")
 	}
 }
 
@@ -382,8 +382,8 @@ func TestRawDeviceCleanupThawTimeoutLogs(t *testing.T) {
 	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "killed") {
 		t.Fatalf("expected thaw command to be killed, got %v", err)
 	}
-	if logs.FilterMessage("fs thaw failed").Len() != 1 {
-		t.Fatalf("expected thaw failed log")
+	if logs.FilterMessage("fs_thaw_failed").Len() != 1 {
+		t.Fatalf("expected fs_thaw_failed log")
 	}
 }
 

--- a/transfer/sync_logger_error_test.go
+++ b/transfer/sync_logger_error_test.go
@@ -53,7 +53,7 @@ func TestDumpChangesLogsSyncErrorOnEarlyFailure(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: 0, Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesSequential(cfg, "snapshot", "/nonexistent", &buf); err == nil {
+	if err := tr.DumpChangesSequential(context.Background(), cfg, "snapshot", "/nonexistent", &buf); err == nil {
 		t.Fatalf("expected DumpChangesSequential error")
 	}
 	logs := observed.FilterMessage("Logger sync error").All()


### PR DESCRIPTION
## Summary
- replace filesystem freeze/thaw log messages with snake_case variants
- convert other device log messages to snake_case and update tests
- fix transfer test to use context with DumpChangesSequential

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a149b77454832388e132eb5c0b6844