### PR TITLE
Validate sync interval parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Recent refactors added several configuration options:
 - `--tcp_port` and `--ssh_port` expose TCP+TLS and SSH endpoints.
 - `--tcp_parallel` controls the number of parallel TCP connections (2–4).
 - `--tcp_lowat` sets TCP_NOTSENT_LOWAT to limit unsent bytes.
-- `--sync-interval` controls how many bytes are written between `fdatasync` calls (flag uses underscores in the CLI: `--sync_interval`).
+- `--sync-interval` controls how many bytes are written between `fdatasync` calls (flag uses underscores in the CLI: `--sync_interval`). Accepts size suffixes like `64KB` or `1GB`; invalid values return an error.
 - `--checkpoint_interval` sets how often resume state is persisted.
 - `--checkpoint_bytes` sets how many bytes are written between resume checkpoints.
 - `--block_size` sets the transfer block size (use `auto` for detection).
@@ -417,7 +417,7 @@ Recent refactors added several configuration options:
 ### I/O tuning
 
 - `--block_size` selects the transfer block size. Use `auto` to match the destination's physical sector size.
-- `--sync-interval` sets how many bytes are written between `fdatasync` calls (flag uses underscores in the CLI: `--sync_interval`).
+- `--sync-interval` sets how many bytes are written between `fdatasync` calls (flag uses underscores in the CLI: `--sync_interval`). Accepts size suffixes like `64KB` or `1GB`; invalid values cause startup errors.
 - `--odirect` uses O_DIRECT with block-size aligned buffers.
 - `--numa_pin` pins worker goroutines to CPUs local to the source device's NUMA node.
 
@@ -549,7 +549,7 @@ LVMSYNC_LVM_SNAPSHOT_SIZE=25% lvmsync run /dev/vg0/snap0 /mnt/backup
 | `--max_retries` | `LVMSYNC_MAX_RETRIES` | `max_retries` | Maximum number of retries per block |
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file (records dedup mode and last chunk boundary) |
 | `--speed` | `LVMSYNC_SPEED` | `speed` | Transfer speed limit |
-| `--sync-interval` | `LVMSYNC_SYNC_INTERVAL` | `sync_interval` | Bytes between fdatasync calls (CLI flag: `--sync_interval`) |
+| `--sync-interval` | `LVMSYNC_SYNC_INTERVAL` | `sync_interval` | Bytes between fdatasync calls (CLI flag: `--sync_interval`; accepts size suffixes like `64KB`; invalid values error) |
 | `--checkpoint_bytes` | `LVMSYNC_CHECKPOINT_BYTES` | `checkpoint_bytes` | Bytes between resume checkpoints |
 | `--checkpoint_interval` | `LVMSYNC_CHECKPOINT_INTERVAL` | `checkpoint_interval` | Duration between checkpoints |
 | `--block_size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ parallel: 4  # Number of concurrent workers
 zerocopy: false
 max_retries: 3  # Maximum number of retries per block
 resume: ""  # Path to resume state file
-sync_interval: "1GB"  # Bytes between fdatasync calls
+sync_interval: "1GB"  # Bytes between fdatasync calls (supports size suffixes like "64KB"; invalid values error)
 
 # Manifest Options
 manifest_timeout: 1m  # Timeout for manifest rebuild (0 disables)

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"math"
 	"os"
 
 	"github.com/zeebo/blake3"
@@ -44,9 +45,15 @@ func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrate
 		}
 	}
 	if cfg.SyncIntervalBytes == 0 && cfg.SyncInterval != "" {
-		if val, _, err := sizeparse.Parse(cfg.SyncInterval); err == nil {
-			cfg.SyncIntervalBytes = int(val)
+		val, isPercent, err := sizeparse.Parse(cfg.SyncInterval)
+		if err != nil || isPercent {
+			return nil, fmt.Errorf("invalid sync interval %q: %w", cfg.SyncInterval, err)
 		}
+		u := uint64(val)
+		if float64(u) != val || u > uint64(math.MaxInt) {
+			return nil, fmt.Errorf("sync interval %q overflows int", cfg.SyncInterval)
+		}
+		cfg.SyncIntervalBytes = int(u)
 	}
 	bw := &blockWriter{
 		cfg:      cfg,

--- a/transfer/block_writer_test.go
+++ b/transfer/block_writer_test.go
@@ -55,3 +55,19 @@ func TestBlockWriterSyncIntervalTriggers(t *testing.T) {
 		t.Fatalf("expected 1 sync, got %d", calls)
 	}
 }
+
+func TestBlockWriterInvalidSyncInterval(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "dest-*.img")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer tmp.Close()
+
+	cases := []string{"bogus", "10%"}
+	for _, interval := range cases {
+		cfg := &config.Config{BlockSize: 4, SyncInterval: interval}
+		if _, err := newBlockWriter(cfg, tmp, nil, false, nil, zap.NewNop()); err == nil {
+			t.Fatalf("newBlockWriter(%q) expected error", interval)
+		}
+	}
+}

--- a/transfer/sync_logger_error_test.go
+++ b/transfer/sync_logger_error_test.go
@@ -53,7 +53,7 @@ func TestDumpChangesLogsSyncErrorOnEarlyFailure(t *testing.T) {
 
 	cfg := &config.Config{BlockSize: 0, Compress: "none", MaxRetries: 1}
 	var buf bytes.Buffer
-	if err := tr.DumpChangesSequential(cfg, "snapshot", "/nonexistent", &buf); err == nil {
+	if err := tr.DumpChangesSequential(context.Background(), cfg, "snapshot", "/nonexistent", &buf); err == nil {
 		t.Fatalf("expected DumpChangesSequential error")
 	}
 	logs := observed.FilterMessage("Logger sync error").All()


### PR DESCRIPTION
## Summary
- return an error when sync interval parsing fails
- test invalid sync interval strings
- document supported sync interval formats

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a149eb275c8323b96e5df83fcca16e