### PR TITLE
remote: rename ssh agent log field to socket_path

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -99,7 +99,7 @@ func selectAuthMethods(ctx context.Context, logger *zap.Logger, keyPath string, 
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					return nil, ctxErr
 				}
-				logger.Warn("ssh agent dial failed", zap.String("sock", sshAgentSock), zap.Error(err))
+				logger.Warn("ssh agent dial failed", zap.String("socket_path", sshAgentSock), zap.Error(err))
 			} else {
 				agentClient := agent.NewClient(conn)
 				authMethods = append(authMethods, ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {

--- a/remote/select_auth_methods_test.go
+++ b/remote/select_auth_methods_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/crypto/ssh/agent"
 )
 
@@ -68,3 +69,30 @@ func TestSelectAuthMethodsCanceled(t *testing.T) {
 	}
 }
 
+func TestSelectAuthMethodsLogsAgentFailure(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "missing.sock")
+	t.Setenv("SSH_AUTH_SOCK", sock)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	core, obs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	_, err := selectAuthMethods(ctx, logger, "", 50*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	logs := obs.All()
+	if len(logs) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(logs))
+	}
+	if logs[0].Message != "ssh agent dial failed" {
+		t.Fatalf("unexpected log message %q", logs[0].Message)
+	}
+	if logs[0].ContextMap()["socket_path"] != sock {
+		t.Fatalf("expected socket_path %q, got %v", sock, logs[0].ContextMap()["socket_path"])
+	}
+	if _, ok := logs[0].ContextMap()["sock"]; ok {
+		t.Fatalf("unexpected sock field in log context")
+	}
+}


### PR DESCRIPTION
## Summary
- rename ssh agent log field `sock` to `socket_path`
- ensure remote logging uses snake_case fields
- test logging field key for selectAuthMethods

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./remote -run TestSelectAuthMethods -count=1`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a19d6fc59c8323bce81abd202ea81c