### PR TITLE
serve: negotiate connections and run replication server

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -5,9 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -15,6 +17,8 @@ import (
 	"go.uber.org/zap"
 
 	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/common"
+	grpcserver "lvmsync_go/grpc/server"
 	"lvmsync_go/transport"
 	_ "lvmsync_go/transport/quic"
 )
@@ -109,15 +113,90 @@ func startServer(ctx context.Context, opts Options, logger *zap.Logger) error {
 		return fmt.Errorf("listen: %w", err)
 	}
 	defer ln.Close()
+
 	go func() {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				logger.Error("accept_failed", zap.Error(err))
 				return
 			}
-			conn.Close()
+			go handleConn(ctx, conn, tr, opts, logger)
 		}
 	}()
+
 	<-ctx.Done()
+	ln.Close()
 	return nil
+}
+
+type singleConnListener struct {
+	conn net.Conn
+	ch   chan net.Conn
+	once sync.Once
+}
+
+func newSingleConnListener(c net.Conn) *singleConnListener {
+	ch := make(chan net.Conn, 1)
+	ch <- c
+	return &singleConnListener{conn: c, ch: ch}
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	c, ok := <-l.ch
+	if !ok {
+		return nil, net.ErrClosed
+	}
+	return c, nil
+}
+
+func (l *singleConnListener) Close() error {
+	var err error
+	l.once.Do(func() {
+		close(l.ch)
+		err = l.conn.Close()
+	})
+	return err
+}
+
+func (l *singleConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+func handleConn(ctx context.Context, conn net.Conn, tr transport.Interface, opts Options, logger *zap.Logger) {
+	remote := conn.RemoteAddr().String()
+	logger.Info("conn_accepted", zap.String("remote_addr", remote))
+	defer func() {
+		_ = conn.Close()
+		logger.Info("conn_closed", zap.String("remote_addr", remote))
+	}()
+
+	if _, err := tr.Negotiate(ctx, conn, transport.Server, common.Handshake{}); err != nil {
+		logger.Error("handshake_failed", zap.String("remote_addr", remote), zap.Error(err))
+		return
+	}
+	logger.Info("handshake_succeeded", zap.String("remote_addr", remote))
+
+	srvCfg := grpcserver.Config{
+		TLSCert:       opts.TLSCert,
+		TLSKey:        opts.TLSKey,
+		CACert:        opts.CACert,
+		AllowInsecure: opts.AllowInsecure,
+	}
+	srv, cleanup, err := grpcserver.New(srvCfg, nil, logger)
+	if err != nil {
+		logger.Error("grpc_init_failed", zap.Error(err))
+		return
+	}
+	l := newSingleConnListener(conn)
+	go func() {
+		<-ctx.Done()
+		l.Close()
+		srv.GracefulStop()
+	}()
+	if err := srv.Serve(l); err != nil && err != net.ErrClosed {
+		logger.Error("grpc_serve_error", zap.Error(err))
+	}
+	cleanup()
 }

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,6 +19,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
 )
 
 func TestEnvVarPrecedence(t *testing.T) {
@@ -143,6 +148,92 @@ func TestStartServerUnknownTransport(t *testing.T) {
 	}
 }
 
+func TestStartServerHandshakeSuccess(t *testing.T) {
+	logger := zap.NewNop()
+	addr := freeUDPAddr(t)
+	cert, key := writeKeyPair(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	opts := Options{Transport: "quic", QUICListen: addr, TLSCert: cert, TLSKey: key, CACert: cert}
+	errCh := make(chan error, 1)
+	go func() { errCh <- startServer(ctx, opts, logger) }()
+	time.Sleep(50 * time.Millisecond)
+
+	pem, _ := os.ReadFile(cert)
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(pem)
+	tlsCert, _ := tls.LoadX509KeyPair(cert, key)
+	cfg := transport.Config{Logger: logger, Roots: roots, ClientCert: tlsCert}
+	tr, err := transport.Get("quic", cfg)
+	if err != nil {
+		t.Fatalf("get transport: %v", err)
+	}
+	conn, err := tr.Dial(context.Background(), addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if _, err := tr.Negotiate(context.Background(), conn, transport.Client, common.Handshake{}); err != nil {
+		t.Fatalf("negotiate: %v", err)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("startServer: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err == nil {
+		t.Fatalf("expected connection closed")
+	}
+	conn.Close()
+}
+
+func TestStartServerHandshakeFailure(t *testing.T) {
+	logger := zap.NewNop()
+	addr := freeUDPAddr(t)
+	cert, key := writeKeyPair(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	opts := Options{Transport: "quic", QUICListen: addr, TLSCert: cert, TLSKey: key, CACert: cert}
+	errCh := make(chan error, 1)
+	go func() { errCh <- startServer(ctx, opts, logger) }()
+	time.Sleep(50 * time.Millisecond)
+
+	pem, _ := os.ReadFile(cert)
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(pem)
+	tlsCert, _ := tls.LoadX509KeyPair(cert, key)
+	cfg := transport.Config{Logger: logger, Roots: roots, ClientCert: tlsCert}
+	tr, err := transport.Get("quic", cfg)
+	if err != nil {
+		t.Fatalf("get transport: %v", err)
+	}
+	conn, err := tr.Dial(context.Background(), addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if _, err := tr.Negotiate(context.Background(), conn, transport.Client, common.Handshake{CRC32C: true}); err == nil {
+		t.Fatalf("expected handshake failure")
+	}
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err == nil {
+		t.Fatalf("expected connection closed")
+	}
+	conn.Close()
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("startServer: %v", err)
+	}
+}
+
+func freeUDPAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	addr := l.LocalAddr().String()
+	l.Close()
+	return addr
+}
+
 func writeKeyPair(t *testing.T) (string, string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -150,7 +241,7 @@ func writeKeyPair(t *testing.T) (string, string) {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
-	tmpl := x509.Certificate{SerialNumber: big.NewInt(1), NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour)}
+	tmpl := x509.Certificate{SerialNumber: big.NewInt(1), NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour), IPAddresses: []net.IP{net.ParseIP("127.0.0.1")}}
 	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
 	if err != nil {
 		t.Fatalf("create cert: %v", err)


### PR DESCRIPTION
## Summary
- handle incoming connections by negotiating transports
- log lifecycle events and run the replication server
- test connection handshake success/failure and cleanup

## Testing
- `go build ./...`
- `go test -cover ./cmd/serve`
- `go test -cover ./...` *(failed: timed out)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a19d2bb3b48323b3a224b3d14bab9d