### PR TITLE
docs: document serve allow-insecure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,11 @@ Run a standalone QUIC listener:
 lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
 
+TLS is required by default. The server rejects plaintext clients unless
+`--allow-insecure` or `LVMSYNC_SERVE_ALLOW_INSECURE` is set, which disables
+encryption and authentication and should only be used in trusted development
+environments.
+
 | Flag | Environment | Description |
 |------|-------------|-------------|
 | `--transport` | `LVMSYNC_SERVE_TRANSPORT` | Transport to serve |
@@ -660,7 +665,7 @@ lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-ke
 | `--tls-cert` | `LVMSYNC_SERVE_TLS_CERT` | TLS certificate file |
 | `--tls-key` | `LVMSYNC_SERVE_TLS_KEY` | TLS key file |
 | `--ca-cert` | `LVMSYNC_SERVE_CA_CERT` | CA certificate file |
-| `--allow-insecure` | `LVMSYNC_SERVE_ALLOW_INSECURE` | Permit insecure (no TLS) connections |
+| `--allow-insecure` | `LVMSYNC_SERVE_ALLOW_INSECURE` | Permit insecure (no TLS) connections (disabled by default) |
 
 ## gRPC Control Plane
 


### PR DESCRIPTION
## Summary
- document the `--allow-insecure` serve option and `LVMSYNC_SERVE_ALLOW_INSECURE` env var
- note that insecure mode disables TLS and is only for trusted dev use

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: lvmsync_go/internal/rsynkwire – signal: interrupt)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a19d2e432883238a438d6915062d9e