### PR TITLE
refactor: remove MustRegister

### DIFF
--- a/transport/registry.go
+++ b/transport/registry.go
@@ -28,14 +28,6 @@ func Register(name string, f Factory) error {
 	return nil
 }
 
-// MustRegister registers a transport factory and panics on duplicate names.
-// Deprecated: callers should prefer Register and handle the error.
-func MustRegister(name string, f Factory) {
-	if err := Register(name, f); err != nil {
-		panic(fmt.Sprintf("register_transport %q: %v", name, err))
-	}
-}
-
 // Get returns a transport from the registry by name.
 func Get(name string, cfg Config) (Interface, error) {
 	regMu.RLock()

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -59,19 +59,6 @@ func TestDuplicateRegister(t *testing.T) {
 	}
 }
 
-func TestMustRegisterDuplicate(t *testing.T) {
-	name := "must-dupe-test"
-	if err := Register(name, func(Config) (Interface, error) { return nil, nil }); err != nil {
-		t.Fatalf("first register: %v", err)
-	}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	MustRegister(name, func(Config) (Interface, error) { return nil, nil })
-}
-
 func TestGetOrdered(t *testing.T) {
 	regMu.Lock()
 	original := registry
@@ -83,8 +70,12 @@ func TestGetOrdered(t *testing.T) {
 		regMu.Unlock()
 	}()
 
-	Register("a", func(Config) (Interface, error) { return &orderStub{name: "a"}, nil })
-	Register("b", func(Config) (Interface, error) { return &orderStub{name: "b"}, nil })
+	if err := Register("a", func(Config) (Interface, error) { return &orderStub{name: "a"}, nil }); err != nil {
+		t.Fatalf("register a: %v", err)
+	}
+	if err := Register("b", func(Config) (Interface, error) { return &orderStub{name: "b"}, nil }); err != nil {
+		t.Fatalf("register b: %v", err)
+	}
 
 	trs, err := GetOrdered([]string{"b", "a"}, Config{Logger: zap.NewNop()})
 	if err != nil {


### PR DESCRIPTION
## Summary
- drop deprecated `MustRegister` from transport registry
- update registry tests to use `Register` and check errors

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: hung, terminated)*
- `go test ./transport -count=1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f087fb10832387e5c1ae29f7abf1