### PR TITLE
Propagate flag binding errors

### DIFF
--- a/cmd/grpcd/cobra.go
+++ b/cmd/grpcd/cobra.go
@@ -73,7 +73,14 @@ func NewRunnerWithDeps(start func(ctx context.Context, opts Options, logger *zap
 	return &Runner{Start: start}
 }
 
-func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
+type flagBinder interface {
+	BindPFlags(*pflag.FlagSet) error
+	SetEnvPrefix(string)
+	SetEnvKeyReplacer(*strings.Replacer)
+	AutomaticEnv()
+}
+
+func bindFlagSets(cmd *cobra.Command, v flagBinder) error {
 	general := pflag.NewFlagSet("General Options", pflag.ExitOnError)
 	general.String("config", "", "config file")
 
@@ -91,10 +98,13 @@ func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
 	fs.AddFlagSet(general)
 	fs.AddFlagSet(grpc)
 
-	v.BindPFlags(fs)
+	if err := v.BindPFlags(fs); err != nil {
+		return err
+	}
 	v.SetEnvPrefix("LVMSYNC_GRPC")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
+	return nil
 }
 
 func loadConfig(v *viper.Viper) (Options, error) {
@@ -123,13 +133,24 @@ func loadConfig(v *viper.Viper) (Options, error) {
 }
 
 // NewCmd creates the root cobra command.
-func (r *Runner) NewCmd(logger *zap.Logger) *cobra.Command {
-	v := viper.New()
+func (r *Runner) NewCmd(logger *zap.Logger, v flagBinder) (*cobra.Command, error) {
+	if v == nil {
+		v = viper.New()
+	}
+	vv, ok := v.(*viper.Viper)
+	if !ok {
+		type viperGetter interface{ Underlying() *viper.Viper }
+		getter, ok := v.(viperGetter)
+		if !ok {
+			return nil, fmt.Errorf("invalid viper binder")
+		}
+		vv = getter.Underlying()
+	}
 	cmd := &cobra.Command{
 		Use:   "lvmsync-grpcd",
 		Short: "LVMSync gRPC daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts, err := loadConfig(v)
+			opts, err := loadConfig(vv)
 			if err != nil {
 				return err
 			}
@@ -140,8 +161,10 @@ func (r *Runner) NewCmd(logger *zap.Logger) *cobra.Command {
 			return r.Start(ctx, opts, logger)
 		},
 	}
-	bindFlagSets(cmd, v)
-	return cmd
+	if err := bindFlagSets(cmd, v); err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }
 
 // Execute runs the command with provided args.
@@ -150,7 +173,10 @@ func (r *Runner) Execute(args []string, logger *zap.Logger) error {
 		logger = zap.NewNop()
 	}
 	defer rootcmd.SyncLogger(logger)
-	cmd := r.NewCmd(logger)
+	cmd, err := r.NewCmd(logger, nil)
+	if err != nil {
+		return err
+	}
 	if args != nil {
 		cmd.SetArgs(args)
 	}

--- a/cmd/grpcd/cobra_test.go
+++ b/cmd/grpcd/cobra_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
 
@@ -61,6 +64,20 @@ func TestGRPCPortPrecedence(t *testing.T) {
 	}
 	if got.GRPCPort != 2222 {
 		t.Fatalf("expected 2222, got %d", got.GRPCPort)
+	}
+}
+
+type bindErrViper struct {
+	*viper.Viper
+}
+
+func (b *bindErrViper) BindPFlags(_ *pflag.FlagSet) error { return errors.New("bind fail") }
+func (b *bindErrViper) Underlying() *viper.Viper          { return b.Viper }
+
+func TestNewCmdBindError(t *testing.T) {
+	r := NewRunner()
+	if _, err := r.NewCmd(zap.NewNop(), &bindErrViper{Viper: viper.New()}); err == nil || err.Error() != "bind fail" {
+		t.Fatalf("expected bind fail, got %v", err)
 	}
 }
 

--- a/cmd/lvmsyncd/cobra.go
+++ b/cmd/lvmsyncd/cobra.go
@@ -65,7 +65,14 @@ func NewRunnerWithDeps(start func(ctx context.Context, opts Options, logger *zap
 	return &Runner{Start: start}
 }
 
-func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
+type flagBinder interface {
+	BindPFlags(*pflag.FlagSet) error
+	SetEnvPrefix(string)
+	SetEnvKeyReplacer(*strings.Replacer)
+	AutomaticEnv()
+}
+
+func bindFlagSets(cmd *cobra.Command, v flagBinder) error {
 	daemon := pflag.NewFlagSet("Daemon Options", pflag.ExitOnError)
 	daemon.StringSlice("listen", nil, "listen URI (repeatable)")
 	daemon.StringSlice("module", nil, "module path to load (repeatable)")
@@ -75,10 +82,13 @@ func bindFlagSets(cmd *cobra.Command, v *viper.Viper) {
 	fs := cmd.Flags()
 	fs.AddFlagSet(daemon)
 
-	v.BindPFlags(fs)
+	if err := v.BindPFlags(fs); err != nil {
+		return err
+	}
 	v.SetEnvPrefix("LVMSYNC_DAEMON")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
+	return nil
 }
 
 func loadConfig(v *viper.Viper) (Options, error) {
@@ -103,13 +113,24 @@ func loadConfig(v *viper.Viper) (Options, error) {
 }
 
 // NewCmd creates the lvmsyncd cobra command.
-func (r *Runner) NewCmd(logger *zap.Logger) *cobra.Command {
-	v := viper.New()
+func (r *Runner) NewCmd(logger *zap.Logger, v flagBinder) (*cobra.Command, error) {
+	if v == nil {
+		v = viper.New()
+	}
+	vv, ok := v.(*viper.Viper)
+	if !ok {
+		type viperGetter interface{ Underlying() *viper.Viper }
+		getter, ok := v.(viperGetter)
+		if !ok {
+			return nil, fmt.Errorf("invalid viper binder")
+		}
+		vv = getter.Underlying()
+	}
 	cmd := &cobra.Command{
 		Use:   "lvmsyncd",
 		Short: "LVMSync daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts, err := loadConfig(v)
+			opts, err := loadConfig(vv)
 			if err != nil {
 				return err
 			}
@@ -120,13 +141,18 @@ func (r *Runner) NewCmd(logger *zap.Logger) *cobra.Command {
 			return r.Start(ctx, opts, logger)
 		},
 	}
-	bindFlagSets(cmd, v)
-	return cmd
+	if err := bindFlagSets(cmd, v); err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }
 
 // Execute runs the command with provided args.
 func (r *Runner) Execute(args []string, logger *zap.Logger) error {
-	cmd := r.NewCmd(logger)
+	cmd, err := r.NewCmd(logger, nil)
+	if err != nil {
+		return err
+	}
 	if args != nil {
 		cmd.SetArgs(args)
 	}

--- a/cmd/lvmsyncd/cobra_test.go
+++ b/cmd/lvmsyncd/cobra_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
 
@@ -34,5 +37,19 @@ func TestFlagParsing(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+type bindErrViper struct {
+	*viper.Viper
+}
+
+func (b *bindErrViper) BindPFlags(_ *pflag.FlagSet) error { return errors.New("bind fail") }
+func (b *bindErrViper) Underlying() *viper.Viper          { return b.Viper }
+
+func TestNewCmdBindError(t *testing.T) {
+	r := NewRunner()
+	if _, err := r.NewCmd(zap.NewNop(), &bindErrViper{Viper: viper.New()}); err == nil || err.Error() != "bind fail" {
+		t.Fatalf("expected bind fail, got %v", err)
 	}
 }

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -59,12 +59,21 @@ func Run(args []string, logger *zap.Logger) error {
 			return startServer(ctx, opts, logger)
 		},
 	}
-	bindFlags(cmd, v)
+	if err := bindFlags(cmd, v); err != nil {
+		return err
+	}
 	cmd.SetArgs(args)
 	return cmd.Execute()
 }
 
-func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+type flagBinder interface {
+	BindPFlags(*pflag.FlagSet) error
+	SetEnvPrefix(string)
+	SetEnvKeyReplacer(*strings.Replacer)
+	AutomaticEnv()
+}
+
+func bindFlags(cmd *cobra.Command, v flagBinder) error {
 	fs := pflag.NewFlagSet("serve", pflag.ExitOnError)
 	fs.String("transport", "quic", "transport to use")
 	fs.String("quic-listen", ":12000", "QUIC listen address")
@@ -73,10 +82,13 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	fs.String("ca-cert", "", "CA certificate file")
 	fs.Bool("allow-insecure", false, "allow insecure (no TLS)")
 	cmd.Flags().AddFlagSet(fs)
-	v.BindPFlags(fs)
+	if err := v.BindPFlags(fs); err != nil {
+		return err
+	}
 	v.SetEnvPrefix("LVMSYNC_SERVE")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
+	return nil
 }
 
 func startServer(ctx context.Context, opts Options, logger *zap.Logger) error {

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -17,17 +17,22 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
+
+	"errors"
 )
 
 func TestEnvVarPrecedence(t *testing.T) {
 	v := viper.New()
 	cmd := &cobra.Command{Use: "serve"}
-	bindFlags(cmd, v)
+	if err := bindFlags(cmd, v); err != nil {
+		t.Fatalf("bindFlags: %v", err)
+	}
 
 	t.Setenv("LVMSYNC_SERVE_TRANSPORT", "envtransport")
 	t.Setenv("LVMSYNC_SERVE_QUIC_LISTEN", "envaddr:1234")
@@ -63,6 +68,20 @@ func TestEnvVarPrecedence(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %+v want %+v", got, want)
+	}
+}
+
+type bindErrViper struct {
+	*viper.Viper
+}
+
+func (b *bindErrViper) BindPFlags(_ *pflag.FlagSet) error { return errors.New("bind fail") }
+
+func TestBindFlagsError(t *testing.T) {
+	v := &bindErrViper{Viper: viper.New()}
+	cmd := &cobra.Command{Use: "serve"}
+	if err := bindFlags(cmd, v); err == nil || err.Error() != "bind fail" {
+		t.Fatalf("expected bind fail, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- return and propagate errors from flag bindings in serve, lvmsyncd, and grpcd commands
- add unit tests to ensure flag binding failures surface to callers

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f0d2686883238fef351a0835f461