### PR TITLE
serve: return accept errors

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -56,7 +57,10 @@ func Run(args []string, logger *zap.Logger) error {
 			}
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 			defer stop()
-			return startServer(ctx, opts, logger)
+			if err := startServer(ctx, opts, logger); err != nil && !errors.Is(err, context.Canceled) {
+				return err
+			}
+			return nil
 		},
 	}
 	bindFlags(cmd, v)
@@ -114,23 +118,31 @@ func startServer(ctx context.Context, opts Options, logger *zap.Logger) error {
 	}
 	defer ln.Close()
 
+	errCh := make(chan error, 1)
 	go func() {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
 				if ctx.Err() != nil {
-					return
+					errCh <- ctx.Err()
+				} else {
+					logger.Error("accept_failed", zap.Error(err))
+					errCh <- err
 				}
-				logger.Error("accept_failed", zap.Error(err))
 				return
 			}
 			go handleConn(ctx, conn, tr, opts, logger)
 		}
 	}()
 
-	<-ctx.Done()
-	ln.Close()
-	return nil
+	select {
+	case <-ctx.Done():
+		ln.Close()
+		return ctx.Err()
+	case err := <-errCh:
+		ln.Close()
+		return err
+	}
 }
 
 type singleConnListener struct {

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net"
 	"os"
@@ -75,7 +76,7 @@ func TestStartServer(t *testing.T) {
 	go func() { errCh <- startServer(ctx, opts, logger) }()
 	time.Sleep(50 * time.Millisecond)
 	cancel()
-	if err := <-errCh; err != nil {
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
 		t.Fatalf("startServer: %v", err)
 	}
 }
@@ -148,6 +149,21 @@ func TestStartServerUnknownTransport(t *testing.T) {
 	}
 }
 
+func TestRunAcceptFailure(t *testing.T) {
+	const name = "acceptfail"
+	acceptErr := errors.New("accept failed")
+	if err := transport.Register(name, func(cfg transport.Config) (transport.Interface, error) {
+		return &failTransport{err: acceptErr}, nil
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	logger := zap.NewNop()
+	err := Run([]string{"--transport", name, "--allow-insecure"}, logger)
+	if !errors.Is(err, acceptErr) {
+		t.Fatalf("got %v want %v", err, acceptErr)
+	}
+}
+
 func TestStartServerHandshakeSuccess(t *testing.T) {
 	logger := zap.NewNop()
 	addr := freeUDPAddr(t)
@@ -176,7 +192,7 @@ func TestStartServerHandshakeSuccess(t *testing.T) {
 	}
 
 	cancel()
-	if err := <-errCh; err != nil {
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
 		t.Fatalf("startServer: %v", err)
 	}
 	buf := make([]byte, 1)
@@ -218,10 +234,32 @@ func TestStartServerHandshakeFailure(t *testing.T) {
 	}
 	conn.Close()
 	cancel()
-	if err := <-errCh; err != nil {
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
 		t.Fatalf("startServer: %v", err)
 	}
 }
+
+type failTransport struct{ err error }
+
+func (t *failTransport) Name() string { return "acceptfail" }
+
+func (t *failTransport) Dial(ctx context.Context, addr string) (net.Conn, error) { return nil, nil }
+
+func (t *failTransport) Listen(ctx context.Context, addr string) (net.Listener, error) {
+	return &failListener{err: t.err}, nil
+}
+
+func (t *failTransport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (common.Handshake, error) {
+	return hs, nil
+}
+
+type failListener struct{ err error }
+
+func (l *failListener) Accept() (net.Conn, error) { return nil, l.err }
+
+func (l *failListener) Close() error { return nil }
+
+func (l *failListener) Addr() net.Addr { return &net.TCPAddr{} }
 
 func freeUDPAddr(t *testing.T) string {
 	t.Helper()


### PR DESCRIPTION
## Summary
- use an error channel in startServer to return accept errors
- ignore context cancellation in Run and surface other server errors
- add test covering accept failures

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: context deadline, command interrupted)*
- `golangci-lint run` *(fails: command interrupted)*
- `golangci-lint run ./cmd/serve/...`
- `go test ./cmd/serve -c`

------
https://chatgpt.com/codex/tasks/task_e_68a1f0ce6e808323bd4639abd5f3949a