### PR TITLE
test: add fs freeze precedence tests

### DIFF
--- a/internal/config/fs_freeze_precedence_test.go
+++ b/internal/config/fs_freeze_precedence_test.go
@@ -1,0 +1,117 @@
+package config
+
+import "testing"
+
+func TestFSFreezeThawCLIOverridesEnvAndConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "fs-freeze-command: /cfg/freeze\nfs-thaw-command: /cfg/thaw\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--fs-freeze-command", "/cli/freeze", "--fs-thaw-command", "/cli/thaw"})
+	t.Setenv("LVMSYNC_FS_FREEZE_COMMAND", "/env/freeze")
+	t.Setenv("LVMSYNC_FS_THAW_COMMAND", "/env/thaw")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, _, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.FSFreezeCommand != "/cli/freeze" {
+		t.Fatalf("expected fs-freeze-command /cli/freeze, got %s", conf.FSFreezeCommand)
+	}
+	if conf.FSThawCommand != "/cli/thaw" {
+		t.Fatalf("expected fs-thaw-command /cli/thaw, got %s", conf.FSThawCommand)
+	}
+}
+
+func TestFSFreezeThawEnvOverridesConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, "fs-freeze-command: /cfg/freeze\nfs-thaw-command: /cfg/thaw\n")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath})
+	t.Setenv("LVMSYNC_FS_FREEZE_COMMAND", "/env/freeze")
+	t.Setenv("LVMSYNC_FS_THAW_COMMAND", "/env/thaw")
+
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, _, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if conf.FSFreezeCommand != "/env/freeze" {
+		t.Fatalf("expected fs-freeze-command /env/freeze, got %s", conf.FSFreezeCommand)
+	}
+	if conf.FSThawCommand != "/env/thaw" {
+		t.Fatalf("expected fs-thaw-command /env/thaw, got %s", conf.FSThawCommand)
+	}
+}
+
+func TestFSFreezeCommandRejectsRelativePath(t *testing.T) {
+	rootFS, args := newFlagSet([]string{"--fs-freeze-command", "freeze"})
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, _, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if err := conf.Validate(); err == nil {
+		t.Fatalf("expected error for relative path")
+	}
+}
+
+func TestFSThawCommandRejectsRelativePath(t *testing.T) {
+	rootFS, args := newFlagSet([]string{"--fs-thaw-command", "thaw"})
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := NewFlagSets(defaults)
+	registerFlags(fs, rootFS)
+	if err := rootFS.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, _, err := buildViper(fs)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	builder := &builder{v: v, defaults: defaults}
+	conf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if err := conf.Validate(); err == nil {
+		t.Fatalf("expected error for relative path")
+	}
+}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kballard/go-shellquote"
+
 	digest "lvmsync_go/internal/digest"
 	"lvmsync_go/lvm"
 )
@@ -27,6 +29,24 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	}
 	if c.DestType != "" && c.DestType != "auto" && c.DestType != "file" && c.DestType != "raw" && c.DestType != "lvm" {
 		return fmt.Errorf("invalid dest type %q", c.DestType)
+	}
+	if c.FSFreezeCommand != "" {
+		parts, err := shellquote.Split(c.FSFreezeCommand)
+		if err != nil {
+			return fmt.Errorf("invalid fs-freeze-command: %w", err)
+		}
+		if len(parts) == 0 || !filepath.IsAbs(parts[0]) {
+			return fmt.Errorf("fs-freeze-command path %q must be absolute", c.FSFreezeCommand)
+		}
+	}
+	if c.FSThawCommand != "" {
+		parts, err := shellquote.Split(c.FSThawCommand)
+		if err != nil {
+			return fmt.Errorf("invalid fs-thaw-command: %w", err)
+		}
+		if len(parts) == 0 || !filepath.IsAbs(parts[0]) {
+			return fmt.Errorf("fs-thaw-command path %q must be absolute", c.FSThawCommand)
+		}
 	}
 	if c.SSHKeepAliveInterval <= 0 {
 		return fmt.Errorf("ssh keepalive interval must be > 0")


### PR DESCRIPTION
## Summary
- validate fs freeze/thaw commands require absolute paths
- add tests covering flag, env, and YAML precedence for freeze/thaw commands
- reject relative fs freeze/thaw commands in validation

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: internal/rsynkwire tests did not complete)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f0aa2c8483239fb922cd419d0dd7