### PR TITLE
transport: default to nop logger when nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ tooling to track transfer completion.
   `*zap.Logger` and accepts a `*lvmsync.Runner` for dependency injection instead of
   relying on `zap.L()`.
 - All commands receive an explicit `*zap.Logger` and default to `zap.NewNop()` when no logger is supplied.
-- Device constructors return an error when the logger is `nil`; use `zap.NewNop()` to disable logging.
+- Device constructors return an error when the logger is `nil`; transport constructors default to `zap.NewNop()` when no logger is supplied.
 - Log field keys in `snake_case` and include units where relevant (for example, `duration_ms`).
 - Provide raw byte values alongside human-readable sizes (for example, `block_size` and `block_size_bytes`).
 - Always defer `syncLogger(logger)` to flush buffers and log if the sync fails.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -6,6 +6,9 @@ LVMSync supports multiple transports selectable with the `--transport` flag.
 Transports are tried in order until a connection is established. The default
 order is `quic,h2,tcp+tls,ssh`.
 
+Each transport constructor accepts a configuration with an optional `zap.Logger`.
+When no logger is supplied, a no-op logger is used.
+
 Every session begins with a textual handshake starting with `lvmsync PROTO[3]`.
 Tokens advertise supported transports, compression algorithms, digests,
 endianness (`endian:<little|big>`), block sizes (`block:<n>`), deduplication

--- a/transport/config.go
+++ b/transport/config.go
@@ -14,8 +14,8 @@ type Config struct {
 	Roots         *x509.CertPool
 	ClientCert    tls.Certificate
 	ServerCert    tls.Certificate
-	Logger        *zap.Logger
-	AllowInsecure bool // Skip certificate verification (development only)
+	Logger        *zap.Logger // optional; defaults to zap.NewNop()
+	AllowInsecure bool        // Skip certificate verification (development only)
 	SSHUser       string
 	SSHPassword   string
 	SSHKnownHosts string

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -51,10 +51,10 @@ type listener struct {
 	ctx context.Context
 }
 
-// New returns a new Transport.
+// New returns a new Transport. Logger is optional; a no-op logger is used when nil.
 func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		return nil, fmt.Errorf("logger is required")
+		cfg.Logger = zap.NewNop()
 	}
 	if cfg.Roots == nil && !cfg.AllowInsecure {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -618,9 +618,9 @@ func TestH2DialUnreachable(t *testing.T) {
 	}
 }
 
-func TestH2TransportRequiresLogger(t *testing.T) {
-	if _, err := New(transport.Config{}); err == nil {
-		t.Fatalf("expected error when logger is nil")
+func TestH2TransportLoggerOptional(t *testing.T) {
+	if _, err := New(transport.Config{AllowInsecure: true}); err != nil {
+		t.Fatalf("New: %v", err)
 	}
 }
 

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -44,9 +44,10 @@ type listener struct {
 }
 
 // New constructs a Transport using the provided TLS roots and client cert.
+// Logger is optional; a no-op logger is used when nil.
 func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		return nil, fmt.Errorf("logger is required")
+		cfg.Logger = zap.NewNop()
 	}
 	if cfg.Roots == nil && !cfg.AllowInsecure {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -319,9 +319,9 @@ func TestQUICTransportAllowInsecureWarn(t *testing.T) {
 	}
 }
 
-func TestQUICTransportRequiresLogger(t *testing.T) {
-	if _, err := New(transport.Config{}); err == nil {
-		t.Fatalf("expected error when logger is nil")
+func TestQUICTransportLoggerOptional(t *testing.T) {
+	if _, err := New(transport.Config{AllowInsecure: true}); err != nil {
+		t.Fatalf("New: %v", err)
 	}
 }
 

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -31,10 +31,10 @@ type Transport struct {
 	logger     *zap.Logger
 }
 
-// New returns a new Transport using username/password authentication.
+// New returns a new Transport using username/password authentication. Logger is optional; a no-op logger is used when nil.
 func New(ctx context.Context, cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		return nil, fmt.Errorf("logger is required")
+		cfg.Logger = zap.NewNop()
 	}
 	if cfg.SSHUser == "" {
 		return nil, fmt.Errorf("ssh user is required")

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -740,9 +740,9 @@ func TestSSHTransportNegotiateTimeoutServer(t *testing.T) {
 	conn.Close()
 }
 
-func TestSSHTransportRequiresLogger(t *testing.T) {
-	if _, err := New(context.Background(), transport.Config{SSHUser: "u", SSHPassword: "p"}); err == nil {
-		t.Fatalf("expected error when logger is nil")
+func TestSSHTransportLoggerOptional(t *testing.T) {
+	if _, err := New(context.Background(), transport.Config{SSHUser: "u", SSHPassword: "p"}); err != nil {
+		t.Fatalf("New: %v", err)
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -28,9 +28,10 @@ type Transport struct {
 }
 
 // New creates a Transport using provided TLS roots and client certificate.
+// Logger is optional; a no-op logger is used when nil.
 func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		return nil, fmt.Errorf("logger is required")
+		cfg.Logger = zap.NewNop()
 	}
 	if cfg.Roots == nil && !cfg.AllowInsecure {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -492,10 +492,10 @@ func TestTCPTLSTransportAllowInsecureWarn(t *testing.T) {
 	}
 }
 
-func TestTCPTLSTransportRequiresLogger(t *testing.T) {
+func TestTCPTLSTransportLoggerOptional(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
-	if _, err := New(transport.Config{Roots: root, ClientCert: cert}); err == nil {
-		t.Fatalf("expected error when logger is nil")
+	if _, err := New(transport.Config{Roots: root, ClientCert: cert}); err != nil {
+		t.Fatalf("New: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- default to zap.NewNop when transport logger is nil
- update tests for optional logger
- document optional logger in transport config and docs

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`
- `pre-commit run --files README.md docs/transports.md transport/config.go transport/h2/h2.go transport/h2/h2_test.go transport/quic/quic.go transport/quic/quic_test.go transport/ssh/ssh.go transport/ssh/ssh_test.go transport/tcp_tls/tcp_tls.go transport/tcp_tls/tcp_tls_test.go` *(fails: invalid array length -delta \* delta)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f09323ac8323baec23ac800c1294