### PR TITLE
privilege: thread context through escalator

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -11,8 +11,8 @@ import (
 
 	"lvmsync_go/app"
 	clientpkg "lvmsync_go/internal/client"
-	"lvmsync_go/internal/logging"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/logging"
 	"lvmsync_go/internal/privilege"
 	"lvmsync_go/transport"
 )
@@ -66,7 +66,7 @@ func Configure() (*config.Config, []string, *zap.Logger, error) {
 		return nil, nil, nil, fmt.Errorf("configuration error: %w", err)
 	}
 	esc := privilege.New()
-	if err = esc.Ensure(); err != nil {
+	if err = esc.Ensure(context.Background()); err != nil {
 		return nil, nil, nil, fmt.Errorf("privilege check failed: %w", err)
 	}
 	if err = cfg.Validate(); err != nil {

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -73,7 +73,7 @@ func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error) Agent 
 }
 
 func (a *agent) Lock(ctx context.Context, volume, requester string) error {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return err
 	}
 	if a.lvm == nil {
@@ -83,7 +83,7 @@ func (a *agent) Lock(ctx context.Context, volume, requester string) error {
 }
 
 func (a *agent) Unlock(ctx context.Context, volume, requester string) error {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return err
 	}
 	if a.lvm == nil {
@@ -93,7 +93,7 @@ func (a *agent) Unlock(ctx context.Context, volume, requester string) error {
 }
 
 func (a *agent) GetMetadata(ctx context.Context, volume string) (VolumeMetadata, error) {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return VolumeMetadata{}, err
 	}
 	if a.lvm == nil {
@@ -103,7 +103,7 @@ func (a *agent) GetMetadata(ctx context.Context, volume string) (VolumeMetadata,
 }
 
 func (a *agent) SendMetadata(ctx context.Context, md VolumeMetadata) error {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return err
 	}
 	if a.lvm == nil {
@@ -113,7 +113,7 @@ func (a *agent) SendMetadata(ctx context.Context, md VolumeMetadata) error {
 }
 
 func (a *agent) StartTransferSession(ctx context.Context, volume, requester string) error {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return err
 	}
 	if a.lvm == nil {
@@ -123,7 +123,7 @@ func (a *agent) StartTransferSession(ctx context.Context, volume, requester stri
 }
 
 func (a *agent) FinalizeSync(ctx context.Context, volume, requester string) error {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return err
 	}
 	if a.lvm == nil {
@@ -133,7 +133,7 @@ func (a *agent) FinalizeSync(ctx context.Context, volume, requester string) erro
 }
 
 func (a *agent) GetStatus(ctx context.Context, volume, requester string) (string, error) {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return "", err
 	}
 	if a.lvm == nil {
@@ -143,7 +143,7 @@ func (a *agent) GetStatus(ctx context.Context, volume, requester string) (string
 }
 
 func (a *agent) VolumeExists(ctx context.Context, volume string) (bool, error) {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return false, err
 	}
 	if a.lvm == nil {
@@ -153,7 +153,7 @@ func (a *agent) VolumeExists(ctx context.Context, volume string) (bool, error) {
 }
 
 func (a *agent) AutoExtendEnabled(ctx context.Context, volume string) (bool, error) {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return false, err
 	}
 	if a.lvm == nil {
@@ -163,7 +163,7 @@ func (a *agent) AutoExtendEnabled(ctx context.Context, volume string) (bool, err
 }
 
 func (a *agent) DiscardEnabled(ctx context.Context, volume string) (bool, error) {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return false, err
 	}
 	if a.lvm == nil {
@@ -173,7 +173,7 @@ func (a *agent) DiscardEnabled(ctx context.Context, volume string) (bool, error)
 }
 
 func (a *agent) IsMounted(ctx context.Context, volume string) (bool, error) {
-	if err := a.esc.Ensure(); err != nil {
+	if err := a.esc.Ensure(ctx); err != nil {
 		return false, err
 	}
 	if a.lvm == nil {

--- a/internal/lvm/agent_test.go
+++ b/internal/lvm/agent_test.go
@@ -9,8 +9,10 @@ import (
 
 type fakeEsc struct{ err error }
 
-func (f fakeEsc) Ensure() error                               { return f.err }
-func (fakeEsc) Command(name string, args ...string) *exec.Cmd { return exec.Command(name, args...) }
+func (f fakeEsc) Ensure(context.Context) error { return f.err }
+func (fakeEsc) Command(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, args...)
+}
 
 type mockLVM struct {
 	lockErr         error

--- a/internal/privilege/escalate.go
+++ b/internal/privilege/escalate.go
@@ -3,16 +3,19 @@
 // falls back to sudo when capabilities are missing.
 package privilege
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 // Escalator validates privilege requirements and executes commands with
 // escalation when needed.
 type Escalator interface {
 	// Ensure verifies that the required capabilities or sudo are available.
-	Ensure() error
+	Ensure(context.Context) error
 	// Command constructs an *exec.Cmd, adding sudo when capabilities are
 	// insufficient.
-	Command(name string, args ...string) *exec.Cmd
+	Command(context.Context, string, ...string) *exec.Cmd
 }
 
 // sudoEscalator implements Escalator using Linux capabilities when present

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strconv"
 	"testing"
+	"time"
 )
 
 type cmdFunc func(context.Context, string, ...string) *exec.Cmd
@@ -26,7 +27,7 @@ func TestEnsureWithCaps(t *testing.T) {
 	if esc.useSudo {
 		t.Fatalf("expected capabilities to be used")
 	}
-	if err := esc.Ensure(); err != nil {
+	if err := esc.Ensure(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -40,7 +41,7 @@ func TestEnsureWithSudo(t *testing.T) {
 	if !esc.useSudo {
 		t.Fatalf("expected sudo usage")
 	}
-	if err := esc.Ensure(); err != nil {
+	if err := esc.Ensure(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -48,7 +49,7 @@ func TestEnsureWithSudo(t *testing.T) {
 func TestEnsureNoSudo(t *testing.T) {
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(&Runner{LookPath: fakeLookPath(errors.New("missing"))}).(*sudoEscalator)
-	if err := esc.Ensure(); err == nil {
+	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -56,13 +57,13 @@ func TestEnsureNoSudo(t *testing.T) {
 func TestCommand(t *testing.T) {
 	HasCaps = func() bool { return false }
 	esc := New()
-	cmd := esc.Command("echo", "hi")
+	cmd := esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] != "sudo" {
 		t.Fatalf("expected sudo prefix")
 	}
 	HasCaps = func() bool { return true }
 	esc = New()
-	cmd = esc.Command("echo", "hi")
+	cmd = esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] == "sudo" {
 		t.Fatalf("unexpected sudo prefix")
 	}
@@ -74,7 +75,7 @@ func TestEnsureSudoFailure(t *testing.T) {
 		return fakeSudo(1)(name, args...)
 	}), LookPath: fakeLookPath(nil)}
 	esc := NewWithRunner(r).(*sudoEscalator)
-	if err := esc.Ensure(); err == nil {
+	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -97,7 +98,7 @@ func TestSudoSuccess(t *testing.T) {
 	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
 	})})
-	cmd := esc.Command("echo")
+	cmd := esc.Command(context.Background(), "echo")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -111,7 +112,7 @@ func TestSudoPermissionDenied(t *testing.T) {
 	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
 	})})
-	cmd := esc.Command("echo")
+	cmd := esc.Command(context.Background(), "echo")
 	err := cmd.Run()
 	if err == nil {
 		t.Fatalf("expected error")
@@ -129,7 +130,7 @@ func TestSudoCommandNotFound(t *testing.T) {
 	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(127)(name, args...)
 	})})
-	cmd := esc.Command("echo")
+	cmd := esc.Command(context.Background(), "echo")
 	err := cmd.Run()
 	if err == nil {
 		t.Fatalf("expected error")
@@ -154,5 +155,32 @@ func TestMain(m *testing.M) {
 	HasCaps = RealHasCaps
 	if code != 0 {
 		panic(code)
+	}
+}
+
+func TestEnsureContextCanceled(t *testing.T) {
+	HasCaps = func() bool { return false }
+	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "10")
+	}), LookPath: fakeLookPath(nil)}
+	esc := NewWithRunner(r)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err := esc.Ensure(ctx)
+	if err == nil || ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("expected context deadline exceeded, got err=%v ctxErr=%v", err, ctx.Err())
+	}
+}
+
+func TestCommandContextCanceled(t *testing.T) {
+	esc := &sudoEscalator{useSudo: false, runner: &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "10")
+	})}}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	cmd := esc.Command(ctx, "sleep", "10")
+	err := cmd.Run()
+	if err == nil || ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("expected context deadline exceeded, got err=%v ctxErr=%v", err, ctx.Err())
 	}
 }

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -10,12 +10,12 @@ import (
 
 // Ensure verifies that either the required capabilities are present or that
 // sudo is available when escalation is necessary.
-func (s *sudoEscalator) Ensure() error {
+func (s *sudoEscalator) Ensure(ctx context.Context) error {
 	if s.useSudo {
 		if _, err := s.runner.LookPath("sudo"); err != nil {
 			return fmt.Errorf("sudo not found: %w", err)
 		}
-		if err := s.runner.Cmd.CommandContext(context.Background(), "sudo", "-n", "true").Run(); err != nil {
+		if err := s.runner.Cmd.CommandContext(ctx, "sudo", "-n", "true").Run(); err != nil {
 			return fmt.Errorf("sudo escalation failed: %w", err)
 		}
 		return nil
@@ -25,10 +25,10 @@ func (s *sudoEscalator) Ensure() error {
 
 // Command returns an *exec.Cmd that runs the given program. sudo -n is inserted
 // when capabilities are missing.
-func (s *sudoEscalator) Command(name string, args ...string) *exec.Cmd {
+func (s *sudoEscalator) Command(ctx context.Context, name string, args ...string) *exec.Cmd {
 	if s.useSudo {
 		all := append([]string{"-n", name}, args...)
-		return s.runner.Cmd.CommandContext(context.Background(), "sudo", all...)
+		return s.runner.Cmd.CommandContext(ctx, "sudo", all...)
 	}
-	return s.runner.Cmd.CommandContext(context.Background(), name, args...)
+	return s.runner.Cmd.CommandContext(ctx, name, args...)
 }


### PR DESCRIPTION
## Summary
- accept context in privilege escalator Ensure and Command
- propagate context through LVM agent and root configure flow
- add tests verifying escalator cancellation and timeouts

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f0dfe3308323b301452a9181fdf3