### PR TITLE
remote: disallow newline characters in command

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -166,7 +166,7 @@ func dialWithRetry(ctx context.Context, logger *zap.Logger, addr string, config 
 // executable on the remote host by attempting to run it with a --version flag.
 // It returns an error if the command is missing or cannot be executed.
 func (c *SSHClient) ValidateRemoteCommand(ctx context.Context, remoteCmd string) error {
-	if strings.ContainsAny(remoteCmd, "&|;<>$`\"'!*") {
+	if strings.ContainsAny(remoteCmd, "&|;<>$`\"'!\n\r*") {
 		return fmt.Errorf("remote command contains shell metacharacters")
 	}
 	tokens := strings.Fields(remoteCmd)

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -103,3 +103,14 @@ func TestValidateRemoteCommandInvalidChars(t *testing.T) {
 		t.Fatalf("expected invalid characters error, got %v", err)
 	}
 }
+
+func TestValidateRemoteCommandNewlines(t *testing.T) {
+	client := &SSHClient{Logger: zap.NewNop()}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for _, cmd := range []string{"echo\nfoo", "echo\rfoo"} {
+		if err := client.ValidateRemoteCommand(ctx, cmd); err == nil || !strings.Contains(err.Error(), "shell metacharacters") {
+			t.Fatalf("expected shell metacharacters error for %q, got %v", cmd, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- extend remote command validation to reject newline and carriage return characters
- test remote command validation for newline presence

## Testing
- `go build ./...`
- `go test -cover ./...`
- `go test ./remote -run ValidateRemoteCommandNewlines -count=1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f0d98ec88323b605b82dffeebf4f