### PR TITLE
grpcd: defer logger sync

### DIFF
--- a/cmd/grpcd/main.go
+++ b/cmd/grpcd/main.go
@@ -15,9 +15,9 @@ func run(newLogger func() (*zap.Logger, error), runner *Runner) int {
 	if err != nil {
 		return exitcode.ErrConfig
 	}
+	defer rootcmd.SyncLogger(logger)
 	if err := runner.Execute(nil, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
-		rootcmd.SyncLogger(logger)
 		return exitcode.ErrRuntime
 	}
 	return exitcode.OK


### PR DESCRIPTION
## Summary
- defer `SyncLogger` to ensure gRPC daemon logs always flush

## Testing
- `go build ./...`
- `go test ./cmd/grpcd/...`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7b776f88323b56df8cfb0a181c6