### PR TITLE
ssh: require host key path

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -112,4 +112,5 @@ lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-ke
 - Verifies server host keys using `known_hosts` or an explicit `--ssh_host_key`; unknown hosts are rejected
 - Key authentication via `--ssh_key`/`LVMSYNC_SSH_KEY`
 - Optional agent auth with `--ssh_agent`/`LVMSYNC_SSH_AGENT` using `SSH_AUTH_SOCK`
+- Listeners require a persistent host key via `--ssh_host_key_path` unless `--allow_insecure` is enabled
 - Flags: `--ssh_user`, `--ssh_password`, `--ssh_key`, `--ssh_host_key`, `--ssh_host_key_path`, `--ssh_agent`, `--allow_insecure`

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	} else if cfg.AllowInsecure {
 		hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
 			return nil, err
@@ -73,6 +73,8 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		return nil, fmt.Errorf("host key path required when allow_insecure is false")
 	}
 
 	serverConf := &ssh.ServerConfig{

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -187,7 +187,8 @@ func TestNewWithHostKeyPath(t *testing.T) {
 	if err := os.WriteFile(keyPath, pemBytes, 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", HostKeyPath: keyPath, AllowInsecure: true}
+	kh := emptyKnownHosts(t)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", HostKeyPath: keyPath, SSHKnownHosts: kh}
 	trIface, err := New(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -199,6 +200,14 @@ func TestNewWithHostKeyPath(t *testing.T) {
 	}
 	if !bytes.Equal(tr.hostSigner.PublicKey().Marshal(), signer.PublicKey().Marshal()) {
 		t.Fatalf("loaded host key does not match file")
+	}
+}
+
+func TestNewHostKeyRequired(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p"}
+	if _, err := New(context.Background(), cfg); err == nil || !strings.Contains(err.Error(), "host key path required") {
+		t.Fatalf("expected host key requirement error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- return error when host key path missing and allow_insecure false
- add tests for host key requirement
- document need for persistent SSH host key

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestStreamBadCRC timeout, TestPerformH2HandshakeTimeout i/o timeout, TestTCPTLSTransportSelectBestHandshake and TestTCPTLSDialUnreachable EOF/i/o timeout)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7d6fe188323a57f50a498a3de4b