### PR TITLE
transport: add MustRegister helper

### DIFF
--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -24,8 +24,6 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
-
-	"errors"
 )
 
 func TestEnvVarPrecedence(t *testing.T) {

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -99,9 +99,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	if err := transport.Register("h2", New); err != nil {
-		panic(err)
-	}
+	transport.MustRegister("h2", New)
 }
 
 func (t *Transport) Name() string { return "h2" }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -82,9 +82,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	if err := transport.Register("quic", New); err != nil {
-		panic(err)
-	}
+	transport.MustRegister("quic", New)
 }
 
 func (t *Transport) Name() string { return "quic" }

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -28,6 +28,19 @@ func Register(name string, f Factory) error {
 	return nil
 }
 
+// MustRegister adds a transport factory to the registry and panics on error.
+//
+// A log entry is emitted before panicking to aid debugging when duplicate
+// registrations occur.
+func MustRegister(name string, f Factory) {
+	if err := Register(name, f); err != nil {
+		logger := zap.L()
+		logger.Error("register_failed", zap.String("transport", name), zap.Error(err))
+		_ = logger.Sync()
+		panic(fmt.Sprintf("register transport %q: %v", name, err))
+	}
+}
+
 // Get returns a transport from the registry by name.
 func Get(name string, cfg Config) (Interface, error) {
 	regMu.RLock()

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 )
@@ -84,4 +86,35 @@ func TestGetOrdered(t *testing.T) {
 	if len(trs) != 2 || trs[0].Name() != "b" || trs[1].Name() != "a" {
 		t.Fatalf("unexpected order: %v %v", trs[0].Name(), trs[1].Name())
 	}
+}
+
+func TestMustRegisterPanics(t *testing.T) {
+	regMu.Lock()
+	original := registry
+	registry = map[string]Factory{}
+	regMu.Unlock()
+	defer func() {
+		regMu.Lock()
+		registry = original
+		regMu.Unlock()
+	}()
+
+	MustRegister("dup", func(Config) (Interface, error) { return nil, nil })
+
+	core, obs := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(core)
+	orig := zap.L()
+	zap.ReplaceGlobals(logger)
+	defer zap.ReplaceGlobals(orig)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+		if obs.FilterMessage("register_failed").Len() != 1 {
+			t.Fatalf("expected register_failed log")
+		}
+	}()
+
+	MustRegister("dup", func(Config) (Interface, error) { return nil, nil })
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -154,11 +154,9 @@ func agentSigners(ctx context.Context, sock string) ([]ssh.Signer, error) {
 }
 
 func init() {
-	if err := transport.Register("ssh", func(cfg transport.Config) (transport.Interface, error) {
+	transport.MustRegister("ssh", func(cfg transport.Config) (transport.Interface, error) {
 		return New(context.Background(), cfg)
-	}); err != nil {
-		panic(err)
-	}
+	})
 }
 
 func (t *Transport) Name() string { return "ssh" }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -65,9 +65,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	if err := transport.Register("tcp+tls", New); err != nil {
-		panic(err)
-	}
+	transport.MustRegister("tcp+tls", New)
 }
 
 func (t *Transport) Name() string { return "tcp+tls" }


### PR DESCRIPTION
## Summary
- add transport.MustRegister helper for centralized registration and logging
- use MustRegister in ssh, h2, quic, and tcp+tls transports
- test MustRegister panic and log behavior
- fix duplicate import in serve tests

## Testing
- `go build ./...`
- `go test -short -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7b876d083239b04efbca9e64164