### PR TITLE
refactor: introduce runners

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -18,28 +19,51 @@ import (
 	"lvmsync_go/transfer"
 )
 
-// applyFunc allows tests to override the apply implementation.
-var (
-	applyFunc = func(cfg *config.Config, applyFile, destDevice string, logger *zap.Logger) error {
-		t := transfer.NewTransfer(logger, &sync.WaitGroup{})
-		return t.RunApply(cfg, applyFile, destDevice)
+// Runner manages external interactions for the apply command.
+type Runner struct {
+	applyFunc    func(*config.Config, string, string, *zap.Logger) error
+	detectDevice func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error)
+}
+
+// NewRunner constructs a Runner with production dependencies.
+func NewRunner() *Runner {
+	return &Runner{
+		applyFunc: func(cfg *config.Config, applyFile, destDevice string, logger *zap.Logger) error {
+			t := transfer.NewTransfer(logger, &sync.WaitGroup{})
+			return t.RunApply(cfg, applyFile, destDevice)
+		},
+		detectDevice: device.Detect,
 	}
-	detectDevice = device.Detect
-)
+}
+
+// NewRunnerWithDeps constructs a Runner overriding defaults.
+func NewRunnerWithDeps(deps *Runner) *Runner {
+	r := NewRunner()
+	if deps == nil {
+		return r
+	}
+	if deps.applyFunc != nil {
+		r.applyFunc = deps.applyFunc
+	}
+	if deps.detectDevice != nil {
+		r.detectDevice = deps.detectDevice
+	}
+	return r
+}
 
 func init() {
-	rootcmd.RunApply = Run
+	rootcmd.RegisterApply(NewRunner().Run)
 }
 
 // Run executes apply mode using the provided configuration and arguments.
 // args should contain the destination device as the first element.
-func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error {
+func (r *Runner) Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error {
 	defer rootcmd.SyncLogger(logger)
 	if len(args) < 1 {
 		return fmt.Errorf("no destination device specified for apply mode")
 	}
 	destPath := args[0]
-	dev, err := detectDevice(
+	dev, err := r.detectDevice(
 		context.Background(),
 		destPath,
 		cfg.Offline,
@@ -68,7 +92,7 @@ func Run(cfg *config.Config, applyFile string, args []string, logger *zap.Logger
 		dev.Close()
 		return fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
 	}
-	err = applyFunc(cfg, applyFile, dev.Path(), logger)
+	err = r.applyFunc(cfg, applyFile, dev.Path(), logger)
 	cleanupErr := dev.Cleanup(context.Background())
 	closeErr := dev.Close()
 	if err != nil {

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -25,9 +25,8 @@ func TestRun(t *testing.T) {
 	dest := "/dev/null"
 
 	called := false
-	origApply := applyFunc
-	origDetect := detectDevice
-	applyFunc = func(c *config.Config, applyFileArg, destDevice string, _ *zap.Logger) error {
+	r := NewRunner()
+	r.applyFunc = func(c *config.Config, applyFileArg, destDevice string, _ *zap.Logger) error {
 		called = true
 		if applyFileArg != applyFile {
 			t.Fatalf("expected applyFile %s, got %s", applyFile, applyFileArg)
@@ -37,12 +36,11 @@ func TestRun(t *testing.T) {
 		}
 		return nil
 	}
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+	r.detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: dest}, nil
 	}
-	defer func() { applyFunc = origApply; detectDevice = origDetect }()
 
-	if err := Run(cfg, applyFile, []string{dest}, zap.NewNop()); err != nil {
+	if err := r.Run(cfg, applyFile, []string{dest}, zap.NewNop()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if !called {
@@ -69,14 +67,12 @@ func TestRunSyncsLogger(t *testing.T) {
 	logger := zap.New(core)
 	applyFile := "dumpfile"
 	dest := "/dev/null"
-	origApply := applyFunc
-	origDetect := detectDevice
-	applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+	r := NewRunner()
+	r.applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
+	r.detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: dest}, nil
 	}
-	defer func() { applyFunc = origApply; detectDevice = origDetect }()
-	if err := Run(cfg, applyFile, []string{dest}, logger); err != nil {
+	if err := r.Run(cfg, applyFile, []string{dest}, logger); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if core.count != 1 {
@@ -141,14 +137,12 @@ func TestRunVerifyModes(t *testing.T) {
 			if d := tc.setDigest(destFile); d != "" {
 				t.Setenv("LVMSYNC_SOURCE_DIGEST", d)
 			}
-			origApply := applyFunc
-			origDetect := detectDevice
-			applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
-			detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+			r := NewRunner()
+			r.applyFunc = func(*config.Config, string, string, *zap.Logger) error { return nil }
+			r.detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
 				return &fakeDevice{path: destFile}, nil
 			}
-			defer func() { applyFunc = origApply; detectDevice = origDetect }()
-			err = Run(cfg, "-", []string{destFile}, zap.NewNop())
+			err = r.Run(cfg, "-", []string{destFile}, zap.NewNop())
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
@@ -33,22 +34,77 @@ var ErrRemoteCommand = errors.New("remote command error")
 
 const maxFrame = 1 << 20
 
-var (
-	dumpChangesSequential = func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
-		return t.DumpChangesSequential(ctx, cfg, snap, origin, out)
+// Runner manages external interactions for dump operations.
+type Runner struct {
+	dumpSeq        func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error
+	dumpPar        func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error
+	dumpDedup      func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer, transfer.DeduplicationStrategy) error
+	newSSHClient   func(context.Context, string, string, string, int, string, bool, time.Duration, time.Duration, int, *zap.Logger) (*remote.SSHClient, error)
+	openFile       func(string, int, os.FileMode) (*os.File, error)
+	detectDevice   func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error)
+	sumFile        func(string, string) ([32]byte, error)
+	streamToRemote func(context.Context, *config.Config, io.WriteCloser, string, string, string, *zap.Logger) error
+}
+
+// NewRunner constructs a Runner with production dependencies.
+func NewRunner() *Runner {
+	r := &Runner{
+		dumpSeq: func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
+			return t.DumpChangesSequential(ctx, cfg, snap, origin, out)
+		},
+		dumpPar: func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
+			return t.DumpChangesParallel(ctx, cfg, snap, origin, out)
+		},
+		dumpDedup: func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
+			return t.DumpChangesWithDeduplication(ctx, cfg, snap, origin, out, d)
+		},
+		newSSHClient: remote.NewSSHClient,
+		openFile:     os.OpenFile,
+		detectDevice: device.Detect,
+		sumFile:      digestpkg.SumFile,
 	}
-	dumpChangesParallel = func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
-		return t.DumpChangesParallel(ctx, cfg, snap, origin, out)
+	r.streamToRemote = r.StreamToRemote
+	return r
+}
+
+// NewRunnerWithDeps constructs a Runner overriding defaults.
+func NewRunnerWithDeps(deps *Runner) *Runner {
+	r := NewRunner()
+	if deps == nil {
+		return r
 	}
-	dumpChangesWithDeduplication = func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer, d transfer.DeduplicationStrategy) error {
-		return t.DumpChangesWithDeduplication(ctx, cfg, snap, origin, out, d)
+	if deps.dumpSeq != nil {
+		r.dumpSeq = deps.dumpSeq
 	}
-	newSSHClient   = remote.NewSSHClient
-	openFile       = os.OpenFile
-	detectDevice   = device.Detect
-	sumFile        = digestpkg.SumFile
-	streamToRemote = StreamToRemote
-)
+	if deps.dumpPar != nil {
+		r.dumpPar = deps.dumpPar
+	}
+	if deps.dumpDedup != nil {
+		r.dumpDedup = deps.dumpDedup
+	}
+	if deps.newSSHClient != nil {
+		r.newSSHClient = deps.newSSHClient
+	}
+	if deps.openFile != nil {
+		r.openFile = deps.openFile
+	}
+	if deps.detectDevice != nil {
+		r.detectDevice = deps.detectDevice
+	}
+	if deps.sumFile != nil {
+		r.sumFile = deps.sumFile
+	}
+	if deps.streamToRemote != nil {
+		r.streamToRemote = deps.streamToRemote
+	}
+	return r
+}
+
+func init() {
+	r := NewRunner()
+	rootcmd.RegisterDump(r.Run)
+	rootcmd.RegisterSelectTransport(SelectTransport)
+}
 
 var copyBufferPool = sync.Pool{New: func() any {
 	buf := make([]byte, 32*1024)
@@ -124,7 +180,7 @@ func init() {
 }
 
 // ExecuteDump selects the appropriate dump implementation based on configuration.
-func ExecuteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice string, out io.Writer, logger *zap.Logger) error {
+func (r *Runner) ExecuteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice string, out io.Writer, logger *zap.Logger) error {
 	t := transfer.NewTransfer(logger, &sync.WaitGroup{})
 	dedup := transfer.NewDeduplicationStrategy(cfg, logger)
 	if dedup != nil {
@@ -133,18 +189,18 @@ func ExecuteDump(ctx context.Context, cfg *config.Config, snapshotDevice, origin
 				logger.Error("Failed to save dedup state", zap.Error(err))
 			}
 		}()
-		return dumpChangesWithDeduplication(ctx, t, cfg, snapshotDevice, originDevice, out, dedup)
+		return r.dumpDedup(ctx, t, cfg, snapshotDevice, originDevice, out, dedup)
 	}
 	if cfg.Parallel <= 1 {
-		return dumpChangesSequential(ctx, t, cfg, snapshotDevice, originDevice, out)
+		return r.dumpSeq(ctx, t, cfg, snapshotDevice, originDevice, out)
 	}
-	return dumpChangesParallel(ctx, t, cfg, snapshotDevice, originDevice, out)
+	return r.dumpPar(ctx, t, cfg, snapshotDevice, originDevice, out)
 }
 
 // Run executes client mode transferring data to dest and returns the destination type.
-func Run(ctx context.Context, cfg *config.Config, source, dest string, logger *zap.Logger) (string, error) {
+func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest string, logger *zap.Logger) (string, error) {
 	defer rootcmd.SyncLogger(logger)
-	dev, err := detectDevice(ctx, source, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner())
+	dev, err := r.detectDevice(ctx, source, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner())
 	if err != nil {
 		return cfg.DestType, err
 	}
@@ -179,16 +235,16 @@ func Run(ctx context.Context, cfg *config.Config, source, dest string, logger *z
 	}()
 	if cfg.StdoutMode {
 		limitedOut := transfer.WrapRateLimitedWriter(os.Stdout, cfg.SpeedLimit)
-		return cfg.DestType, ExecuteDump(ctx, cfg, snapshotDevice, originDevice, limitedOut, logger)
+		return cfg.DestType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, limitedOut, logger)
 	}
 	if strings.Contains(dest, ":") {
-		return cfg.DestType, RunRemoteDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
+		return cfg.DestType, r.RunRemoteDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
 	}
-	return RunLocalDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
+	return r.RunLocalDump(ctx, cfg, snapshotDevice, originDevice, dest, logger)
 }
 
 // RunLocalDump dumps changes to a local destination device and returns the detected destination type.
-func RunLocalDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
+func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
 	destType := cfg.DestType
 	if destType == "auto" {
 		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner()); err == nil {
@@ -207,19 +263,19 @@ func RunLocalDump(ctx context.Context, cfg *config.Config, snapshotDevice, origi
 			dev.Close()
 		}
 	}
-	destFile, err := openFile(dest, os.O_RDWR, 0)
+	destFile, err := r.openFile(dest, os.O_RDWR, 0)
 	if err != nil {
 		return destType, fmt.Errorf("failed to open destination device %s: %w", dest, err)
 	}
 	defer common.CloseWithErr(destFile, &err, "close destination device")
 	limitedOut := transfer.WrapRateLimitedWriter(destFile, cfg.SpeedLimit)
-	return destType, ExecuteDump(ctx, cfg, snapshotDevice, originDevice, limitedOut, logger)
+	return destType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, limitedOut, logger)
 }
 
 // SetupSSHClient creates an SSH client for remote operations.
-func SetupSSHClient(ctx context.Context, cfg *config.Config, destHost string, logger *zap.Logger) (*remote.SSHClient, context.CancelFunc, error) {
+func (r *Runner) SetupSSHClient(ctx context.Context, cfg *config.Config, destHost string, logger *zap.Logger) (*remote.SSHClient, context.CancelFunc, error) {
 	ctx, cancel := context.WithTimeout(ctx, cfg.SSHTimeout)
-	client, err := newSSHClient(ctx, destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)
+	client, err := r.newSSHClient(ctx, destHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.SSHPort, cfg.KnownHosts, cfg.StrictHostKeyCheck, cfg.SSHTimeout, cfg.SSHKeepAliveInterval, cfg.MaxRetries, logger)
 	if err != nil {
 		cancel()
 		return nil, nil, fmt.Errorf("failed to create SSH client: %w", err)
@@ -266,8 +322,8 @@ func SetupSessionStreams(ctx context.Context, session pipeSession) (io.WriteClos
 
 // StreamToRemote dumps snapshot data to the remote stdin, then computes and
 // transmits the digest before closing the stream.
-func StreamToRemote(ctx context.Context, cfg *config.Config, remoteStdin io.WriteCloser, snapshotDevice, originDevice, alg string, logger *zap.Logger) error {
-	streamErr := ExecuteDump(ctx, cfg, snapshotDevice, originDevice, remoteStdin, logger)
+func (r *Runner) StreamToRemote(ctx context.Context, cfg *config.Config, remoteStdin io.WriteCloser, snapshotDevice, originDevice, alg string, logger *zap.Logger) error {
+	streamErr := r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, remoteStdin, logger)
 	if streamErr != nil {
 		if err := remoteStdin.Close(); err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("%v; failed to close remote stdin: %w", streamErr, err)
@@ -275,7 +331,7 @@ func StreamToRemote(ctx context.Context, cfg *config.Config, remoteStdin io.Writ
 		return fmt.Errorf("error during dumpChanges: %w", streamErr)
 	}
 
-	sum, err := sumFile(snapshotDevice, alg)
+	sum, err := r.sumFile(snapshotDevice, alg)
 	if err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("compute digest: %w", err)
@@ -313,7 +369,7 @@ func WaitForRemoteCompletion(session waitSession, stdoutErrCh, stderrErrCh <-cha
 }
 
 // ExecuteRemoteCommand runs the remote apply command over SSH.
-func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remote.SSHClient, destDevice, snapshotDevice, originDevice, alg string, logger *zap.Logger) (err error) {
+func (r *Runner) ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remote.SSHClient, destDevice, snapshotDevice, originDevice, alg string, logger *zap.Logger) (err error) {
 	if err = client.ValidateRemoteCommand(ctx, cfg.LVMSyncPath); err != nil {
 		return fmt.Errorf("remote command validation failed: %w", err)
 	}
@@ -340,7 +396,7 @@ func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remot
 		return fmt.Errorf("failed to start remote command: %w", err)
 	}
 
-	if err = streamToRemote(ctx, cfg, remoteStdin, snapshotDevice, originDevice, alg, logger); err != nil {
+	if err = r.streamToRemote(ctx, cfg, remoteStdin, snapshotDevice, originDevice, alg, logger); err != nil {
 		return err
 	}
 
@@ -348,13 +404,13 @@ func ExecuteRemoteCommand(ctx context.Context, cfg *config.Config, client *remot
 }
 
 // RunRemoteDump streams snapshot data to a remote host over SSH.
-func RunRemoteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
+func (r *Runner) RunRemoteDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (err error) {
 	parts := strings.SplitN(dest, ":", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid destination %q: expected host:device", dest)
 	}
 	destHost, destDevice := parts[0], parts[1]
-	client, cancel, err := SetupSSHClient(ctx, cfg, destHost, logger)
+	client, cancel, err := r.SetupSSHClient(ctx, cfg, destHost, logger)
 	if err != nil {
 		return err
 	}
@@ -410,7 +466,7 @@ func RunRemoteDump(ctx context.Context, cfg *config.Config, snapshotDevice, orig
 	)
 	validationCtx, cancel := context.WithTimeout(ctx, cfg.SSHTimeout)
 	defer cancel()
-	return ExecuteRemoteCommand(validationCtx, cfg, client, destDevice, snapshotDevice, originDevice, alg, logger)
+	return r.ExecuteRemoteCommand(validationCtx, cfg, client, destDevice, snapshotDevice, originDevice, alg, logger)
 }
 
 // SelectTransport chooses the first supported transport from cfg.Transport and

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -17,33 +17,110 @@ import (
 	"lvmsync_go/transport"
 )
 
-// function variables for testing
-var (
-	startGRPCServer   = app.StartGRPCServer
-	clientHandshake   = app.ClientHandshake
-	setupSignalHandle = app.SetupSignalHandling
-	prepareSnapshotFn = app.PrepareSnapshot
-	executeClientFn   = clientpkg.ExecuteClient
-	RunApply          = func(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error {
-		return fmt.Errorf("apply command not registered")
-	}
-	SelectTransport = func(cfg *config.Config, logger *zap.Logger) (transport.Interface, error) {
-		return nil, fmt.Errorf("transport not registered")
-	}
-	RunDump = func(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) (string, error) {
-		return "", fmt.Errorf("dump command not registered")
-	}
-	RunManifest = func(cfg *config.Config, args []string, logger *zap.Logger) error {
-		return fmt.Errorf("manifest command not registered")
-	}
-	RunVerify = func(args []string, logger *zap.Logger) error {
-		return fmt.Errorf("verify command not registered")
-	}
-)
+// Runner manages external interactions for the root command.
+type Runner struct {
+	startGRPCServerFn   func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error)
+	clientHandshakeFn   func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error)
+	setupSignalHandleFn func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error)
+	prepareSnapshotFn   func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error)
+	executeClientFn     func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error
+	runApplyFn          func(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error
+	selectTransportFn   func(cfg *config.Config, logger *zap.Logger) (transport.Interface, error)
+	runDumpFn           func(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) (string, error)
+	runManifestFn       func(cfg *config.Config, args []string, logger *zap.Logger) error
+	runVerifyFn         func(args []string, logger *zap.Logger) error
+}
 
-func runDump(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) error {
-	_, err := RunDump(ctx, cfg, snapshot, dest, logger)
-	return err
+// NewRunner constructs a Runner with production dependencies.
+func NewRunner() *Runner {
+	return &Runner{
+		startGRPCServerFn:   app.StartGRPCServer,
+		clientHandshakeFn:   app.ClientHandshake,
+		setupSignalHandleFn: app.SetupSignalHandling,
+		prepareSnapshotFn:   app.PrepareSnapshot,
+		executeClientFn:     clientpkg.ExecuteClient,
+		runApplyFn: func(cfg *config.Config, applyFile string, args []string, logger *zap.Logger) error {
+			return fmt.Errorf("apply command not registered")
+		},
+		selectTransportFn: func(cfg *config.Config, logger *zap.Logger) (transport.Interface, error) {
+			return nil, fmt.Errorf("transport not registered")
+		},
+		runDumpFn: func(ctx context.Context, cfg *config.Config, snapshot, dest string, logger *zap.Logger) (string, error) {
+			return "", fmt.Errorf("dump command not registered")
+		},
+		runManifestFn: func(cfg *config.Config, args []string, logger *zap.Logger) error {
+			return fmt.Errorf("manifest command not registered")
+		},
+		runVerifyFn: func(args []string, logger *zap.Logger) error {
+			return fmt.Errorf("verify command not registered")
+		},
+	}
+}
+
+// NewRunnerWithDeps constructs a Runner overriding default dependencies.
+func NewRunnerWithDeps(deps *Runner) *Runner {
+	r := NewRunner()
+	if deps == nil {
+		return r
+	}
+	if deps.startGRPCServerFn != nil {
+		r.startGRPCServerFn = deps.startGRPCServerFn
+	}
+	if deps.clientHandshakeFn != nil {
+		r.clientHandshakeFn = deps.clientHandshakeFn
+	}
+	if deps.setupSignalHandleFn != nil {
+		r.setupSignalHandleFn = deps.setupSignalHandleFn
+	}
+	if deps.prepareSnapshotFn != nil {
+		r.prepareSnapshotFn = deps.prepareSnapshotFn
+	}
+	if deps.executeClientFn != nil {
+		r.executeClientFn = deps.executeClientFn
+	}
+	if deps.runApplyFn != nil {
+		r.runApplyFn = deps.runApplyFn
+	}
+	if deps.selectTransportFn != nil {
+		r.selectTransportFn = deps.selectTransportFn
+	}
+	if deps.runDumpFn != nil {
+		r.runDumpFn = deps.runDumpFn
+	}
+	if deps.runManifestFn != nil {
+		r.runManifestFn = deps.runManifestFn
+	}
+	if deps.runVerifyFn != nil {
+		r.runVerifyFn = deps.runVerifyFn
+	}
+	return r
+}
+
+var defaultRunner = NewRunner()
+
+// RegisterApply sets the apply handler used by the default Runner.
+func RegisterApply(fn func(*config.Config, string, []string, *zap.Logger) error) {
+	defaultRunner.runApplyFn = fn
+}
+
+// RegisterDump sets the dump handler used by the default Runner.
+func RegisterDump(fn func(context.Context, *config.Config, string, string, *zap.Logger) (string, error)) {
+	defaultRunner.runDumpFn = fn
+}
+
+// RegisterSelectTransport sets the transport selector used by the default Runner.
+func RegisterSelectTransport(fn func(*config.Config, *zap.Logger) (transport.Interface, error)) {
+	defaultRunner.selectTransportFn = fn
+}
+
+// RegisterManifest sets the manifest handler used by the default Runner.
+func RegisterManifest(fn func(*config.Config, []string, *zap.Logger) error) {
+	defaultRunner.runManifestFn = fn
+}
+
+// RegisterVerify sets the verify handler used by the default Runner.
+func RegisterVerify(fn func([]string, *zap.Logger) error) {
+	defaultRunner.runVerifyFn = fn
 }
 
 // SyncLogger flushes buffered log entries and logs if syncing fails.
@@ -102,8 +179,8 @@ func Configure() (*config.Config, []string, *zap.Logger, error) {
 }
 
 // SetupGRPC starts the server and performs client handshake returning cleanup functions and heartbeat error channel.
-func SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), func(), chan error, error) {
-	cleanupSrv, srvErrCh, err := startGRPCServer(ctx, cfg, logger)
+func (r *Runner) SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), func(), chan error, error) {
+	cleanupSrv, srvErrCh, err := r.startGRPCServerFn(ctx, cfg, logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -115,7 +192,7 @@ func SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (fun
 		}
 	default:
 	}
-	cleanupClient, hbErrCh, err := clientHandshake(ctx, cfg, logger)
+	cleanupClient, hbErrCh, err := r.clientHandshakeFn(ctx, cfg, logger)
 	if err != nil {
 		cleanupSrv()
 		<-srvErrCh
@@ -129,29 +206,45 @@ func SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (fun
 }
 
 // PrepareSnapshot wraps snapshot preparation.
-func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
-	return prepareSnapshotFn(ctx, cfg, originalVolume, logger)
+func (r *Runner) PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+	return r.prepareSnapshotFn(ctx, cfg, originalVolume, logger)
 }
 
 // ExecuteClient runs the client transfer logic.
+func (r *Runner) ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
+	return r.executeClientFn(ctx, func(ctx context.Context, snapshot, dest string) error {
+		_, err := r.runDumpFn(ctx, cfg, snapshot, dest, logger)
+		return err
+	}, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
+}
+
+// SetupGRPC wraps the default runner's SetupGRPC.
+func SetupGRPC(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), func(), chan error, error) {
+	return defaultRunner.SetupGRPC(ctx, cfg, logger)
+}
+
+// PrepareSnapshot wraps the default runner's PrepareSnapshot.
+func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+	return defaultRunner.PrepareSnapshot(ctx, cfg, originalVolume, logger)
+}
+
+// ExecuteClient wraps the default runner's ExecuteClient.
 func ExecuteClient(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
-	return executeClientFn(ctx, func(ctx context.Context, snapshot, dest string) error {
-		return runDump(ctx, cfg, snapshot, dest, logger)
-	}, snapshotPath, destPath, sigErrCh, monitorErrCh)
+	return defaultRunner.ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
 }
 
 // Run orchestrates the command execution.
-func dispatchSubcommand(cfg *config.Config, args []string, logger *zap.Logger) (bool, error) {
+func (r *Runner) dispatchSubcommand(cfg *config.Config, args []string, logger *zap.Logger) (bool, error) {
 	if len(args) > 0 {
 		switch args[0] {
 		case "manifest":
-			return true, RunManifest(cfg, args[1:], logger)
+			return true, r.runManifestFn(cfg, args[1:], logger)
 		case "verify":
-			return true, RunVerify(args[1:], logger)
+			return true, r.runVerifyFn(args[1:], logger)
 		}
 	}
 	if cfg.ApplyMode != "" {
-		if err := RunApply(cfg, cfg.ApplyMode, args, logger); err != nil {
+		if err := r.runApplyFn(cfg, cfg.ApplyMode, args, logger); err != nil {
 			return true, fmt.Errorf("apply operation failed: %w", err)
 		}
 		return true, nil
@@ -159,20 +252,20 @@ func dispatchSubcommand(cfg *config.Config, args []string, logger *zap.Logger) (
 	return false, nil
 }
 
-func prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (context.Context, func(), string, string, chan error, error) {
-	if _, err := SelectTransport(cfg, logger); err != nil {
+func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (context.Context, func(), string, string, chan error, error) {
+	if _, err := r.selectTransportFn(cfg, logger); err != nil {
 		return nil, nil, "", "", nil, fmt.Errorf("select transport: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.GRPCSetupTimeout)
-	cleanupSrv, cleanupClient, hbErrCh, err := SetupGRPC(ctx, cfg, logger)
+	cleanupSrv, cleanupClient, hbErrCh, err := r.SetupGRPC(ctx, cfg, logger)
 	if err != nil {
 		cancel()
 		return nil, nil, "", "", nil, err
 	}
 
 	var snapshotPath string
-	signals, sigErrCh := setupSignalHandle(ctx, cfg, &snapshotPath, logger)
+	signals, sigErrCh := r.setupSignalHandleFn(ctx, cfg, &snapshotPath, logger)
 
 	if hbErrCh != nil {
 		go func() {
@@ -207,23 +300,28 @@ func prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (conte
 	return ctx, cleanup, snapshotPath, destPath, sigErrCh, nil
 }
 
-func executeSync(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh chan error, logger *zap.Logger) error {
-	return ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, nil, logger)
+func (r *Runner) executeSync(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh chan error, logger *zap.Logger) error {
+	return r.ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, nil, logger)
 }
 
-func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
-	handled, err := dispatchSubcommand(cfg, args, logger)
+func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) error {
+	handled, err := r.dispatchSubcommand(cfg, args, logger)
 	if handled || err != nil {
 		return err
 	}
 
-	ctx, cleanup, snapshotPath, destPath, sigErrCh, err := prepareClient(cfg, args, logger)
+	ctx, cleanup, snapshotPath, destPath, sigErrCh, err := r.prepareClient(cfg, args, logger)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	return executeSync(ctx, cfg, snapshotPath, destPath, sigErrCh, logger)
+	return r.executeSync(ctx, cfg, snapshotPath, destPath, sigErrCh, logger)
+}
+
+// Run invokes the default runner's Run method.
+func Run(cfg *config.Config, args []string, logger *zap.Logger) error {
+	return defaultRunner.Run(cfg, args, logger)
 }
 
 // Execute is a helper that configures and runs the root command.

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -22,17 +22,16 @@ import (
 func TestDispatchSubcommandManifest(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
+	r := NewRunner()
 	called := false
-	origManifest := RunManifest
-	defer func() { RunManifest = origManifest }()
-	RunManifest = func(c *config.Config, args []string, l *zap.Logger) error {
+	r.runManifestFn = func(c *config.Config, args []string, l *zap.Logger) error {
 		called = true
 		if args[0] != "arg" {
 			t.Fatalf("unexpected arg")
 		}
 		return nil
 	}
-	handled, err := dispatchSubcommand(cfg, []string{"manifest", "arg"}, logger)
+	handled, err := r.dispatchSubcommand(cfg, []string{"manifest", "arg"}, logger)
 	if err != nil || !handled || !called {
 		t.Fatalf("dispatch failed")
 	}
@@ -41,10 +40,9 @@ func TestDispatchSubcommandManifest(t *testing.T) {
 func TestDispatchSubcommandApplyError(t *testing.T) {
 	cfg := &config.Config{ApplyMode: "apply"}
 	logger := zap.NewNop()
-	origApply := RunApply
-	defer func() { RunApply = origApply }()
-	RunApply = func(*config.Config, string, []string, *zap.Logger) error { return errors.New("boom") }
-	handled, err := dispatchSubcommand(cfg, []string{"vol"}, logger)
+	r := NewRunner()
+	r.runApplyFn = func(*config.Config, string, []string, *zap.Logger) error { return errors.New("boom") }
+	handled, err := r.dispatchSubcommand(cfg, []string{"vol"}, logger)
 	if !handled || err == nil || err.Error() != "apply operation failed: boom" {
 		t.Fatalf("expected wrapped apply error, got %v", err)
 	}
@@ -53,24 +51,15 @@ func TestDispatchSubcommandApplyError(t *testing.T) {
 func TestPrepareClientSuccess(t *testing.T) {
 	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second, SourceType: "file"}
 	logger := zap.NewNop()
+	r := NewRunner()
 	selectCalled := false
 	srvClean := false
 	clientClean := false
-	origSelect := SelectTransport
-	origStart := startGRPCServer
-	origClient := clientHandshake
-	origSetup := setupSignalHandle
-	defer func() {
-		SelectTransport = origSelect
-		startGRPCServer = origStart
-		clientHandshake = origClient
-		setupSignalHandle = origSetup
-	}()
-	SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) {
+	r.selectTransportFn = func(*config.Config, *zap.Logger) (transport.Interface, error) {
 		selectCalled = true
 		return nil, nil
 	}
-	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
+	r.startGRPCServerFn = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
 		ch := make(chan error, 1)
 		go func() {
 			ch <- nil
@@ -78,13 +67,13 @@ func TestPrepareClientSuccess(t *testing.T) {
 		}()
 		return func() { srvClean = true }, ch, nil
 	}
-	clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
+	r.clientHandshakeFn = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() { clientClean = true }, nil, nil
 	}
-	setupSignalHandle = func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+	r.setupSignalHandleFn = func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
 		return make(chan os.Signal), make(chan error)
 	}
-	ctx, cleanup, snap, dest, sigErrCh, err := prepareClient(cfg, []string{"vol"}, logger)
+	ctx, cleanup, snap, dest, sigErrCh, err := r.prepareClient(cfg, []string{"vol"}, logger)
 	if err != nil || ctx == nil || cleanup == nil || snap != "vol" || dest != "" || sigErrCh == nil || !selectCalled {
 		t.Fatalf("prepareClient failed: %v", err)
 	}
@@ -97,12 +86,11 @@ func TestPrepareClientSuccess(t *testing.T) {
 func TestPrepareClientSelectTransportError(t *testing.T) {
 	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second, SourceType: "file"}
 	logger := zap.NewNop()
-	origSelect := SelectTransport
-	defer func() { SelectTransport = origSelect }()
-	SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) {
+	r := NewRunner()
+	r.selectTransportFn = func(*config.Config, *zap.Logger) (transport.Interface, error) {
 		return nil, errors.New("bad")
 	}
-	_, _, _, _, _, err := prepareClient(cfg, []string{"vol"}, logger)
+	_, _, _, _, _, err := r.prepareClient(cfg, []string{"vol"}, logger)
 	if err == nil || err.Error() != "select transport: bad" {
 		t.Fatalf("expected select transport error, got %v", err)
 	}
@@ -112,19 +100,18 @@ func TestExecuteSync(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
 	called := false
-	origExec := executeClientFn
-	defer func() { executeClientFn = origExec }()
-	executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error) error {
+	r := NewRunner()
+	r.executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
 		called = true
 		return nil
 	}
-	if err := executeSync(context.Background(), cfg, "s", "d", nil, logger); err != nil || !called {
+	if err := r.executeSync(context.Background(), cfg, "s", "d", nil, logger); err != nil || !called {
 		t.Fatalf("executeSync failed: %v", err)
 	}
-	executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error) error {
+	r.executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
 		return errors.New("x")
 	}
-	if err := executeSync(context.Background(), cfg, "s", "d", nil, logger); err == nil || err.Error() != "x" {
+	if err := r.executeSync(context.Background(), cfg, "s", "d", nil, logger); err == nil || err.Error() != "x" {
 		t.Fatalf("expected error")
 	}
 }
@@ -134,23 +121,16 @@ func TestSetupGRPCSuccess(t *testing.T) {
 	logger := zap.NewNop()
 	srvCleanCalled := false
 	clientCleanCalled := false
-
-	origStart := startGRPCServer
-	origClient := clientHandshake
-	defer func() {
-		startGRPCServer = origStart
-		clientHandshake = origClient
-	}()
-
+	r := NewRunner()
 	srvErrCh := make(chan error)
-	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+	r.startGRPCServerFn = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		return func() { srvCleanCalled = true }, srvErrCh, nil
 	}
-	clientHandshake = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	r.clientHandshakeFn = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return func() { clientCleanCalled = true }, make(chan error), nil
 	}
 
-	cleanupSrv, cleanupClient, errCh, err := SetupGRPC(context.Background(), cfg, logger)
+	cleanupSrv, cleanupClient, errCh, err := r.SetupGRPC(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -234,12 +214,11 @@ func TestConfigureLogsBlockSizeBytes(t *testing.T) {
 func TestSetupGRPCServerError(t *testing.T) {
 	cfg := &config.Config{SourceType: "file"}
 	logger := zap.NewNop()
-	origStart := startGRPCServer
-	defer func() { startGRPCServer = origStart }()
-	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+	r := NewRunner()
+	r.startGRPCServerFn = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		return nil, nil, errors.New("srv fail")
 	}
-	if _, _, _, err := SetupGRPC(context.Background(), cfg, logger); err == nil {
+	if _, _, _, err := r.SetupGRPC(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -248,22 +227,17 @@ func TestSetupGRPCClientError(t *testing.T) {
 	cfg := &config.Config{SourceType: "file"}
 	logger := zap.NewNop()
 	srvCleanupCalled := false
-	origStart := startGRPCServer
-	origClient := clientHandshake
-	defer func() {
-		startGRPCServer = origStart
-		clientHandshake = origClient
-	}()
+	r := NewRunner()
 	srvErrCh := make(chan error)
-	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+	r.startGRPCServerFn = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		return func() { srvCleanupCalled = true }, srvErrCh, nil
 	}
-	clientHandshake = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	r.clientHandshakeFn = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		return nil, nil, errors.New("client fail")
 	}
 	done := make(chan struct{})
 	go func() {
-		_, _, _, err := SetupGRPC(context.Background(), cfg, logger)
+		_, _, _, err := r.SetupGRPC(context.Background(), cfg, logger)
 		if err == nil {
 			t.Errorf("expected error")
 		}
@@ -285,24 +259,19 @@ func TestSetupGRPCTimeout(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
 	srvCleanupCalled := false
-	origStart := startGRPCServer
-	origClient := clientHandshake
-	defer func() {
-		startGRPCServer = origStart
-		clientHandshake = origClient
-	}()
-	startGRPCServer = func(ctx context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	r := NewRunner()
+	r.startGRPCServerFn = func(ctx context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		ch := make(chan error, 1)
 		go func() { <-ctx.Done(); ch <- ctx.Err() }()
 		return func() { srvCleanupCalled = true }, ch, nil
 	}
-	clientHandshake = func(ctx context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	r.clientHandshakeFn = func(ctx context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		<-ctx.Done()
 		return func() {}, nil, ctx.Err()
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-	if _, _, _, err := SetupGRPC(ctx, cfg, logger); !errors.Is(err, context.DeadlineExceeded) {
+	if _, _, _, err := r.SetupGRPC(ctx, cfg, logger); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 	if !srvCleanupCalled {
@@ -314,22 +283,17 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
 	srvCleanupCalled := false
-	origStart := startGRPCServer
-	origClient := clientHandshake
-	defer func() {
-		startGRPCServer = origStart
-		clientHandshake = origClient
-	}()
-	startGRPCServer = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
+	r := NewRunner()
+	r.startGRPCServerFn = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), <-chan error, error) {
 		errCh := make(chan error, 1)
 		errCh <- errors.New("serve boom")
 		return func() { srvCleanupCalled = true; close(errCh) }, errCh, nil
 	}
-	clientHandshake = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
+	r.clientHandshakeFn = func(_ context.Context, _ *config.Config, _ *zap.Logger) (func(), chan error, error) {
 		t.Fatalf("client handshake should not be called")
 		return nil, nil, nil
 	}
-	if _, _, _, err := SetupGRPC(context.Background(), cfg, logger); err == nil {
+	if _, _, _, err := r.SetupGRPC(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error from serve failure")
 	}
 	if !srvCleanupCalled {
@@ -340,12 +304,11 @@ func TestSetupGRPCServeFailurePropagation(t *testing.T) {
 func TestPrepareSnapshot(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
-	orig := prepareSnapshotFn
-	defer func() { prepareSnapshotFn = orig }()
-	prepareSnapshotFn = func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+	r := NewRunner()
+	r.prepareSnapshotFn = func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil
 	}
-	snap, ch, cleanup, err := PrepareSnapshot(context.Background(), cfg, "vol", logger)
+	snap, ch, cleanup, err := r.PrepareSnapshot(context.Background(), cfg, "vol", logger)
 	if err != nil || snap != "snap" || ch != nil || cleanup == nil {
 		t.Fatalf("unexpected result")
 	}
@@ -355,20 +318,15 @@ func TestExecuteClient(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
 	called := false
-	origExec := executeClientFn
-	origRunDump := RunDump
-	defer func() {
-		executeClientFn = origExec
-		RunDump = origRunDump
-	}()
-	executeClientFn = func(ctx context.Context, f func(context.Context, string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
+	r := NewRunner()
+	r.executeClientFn = func(ctx context.Context, f func(context.Context, string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error, _ *zap.Logger) error {
 		called = true
 		if snap != "s" || dest != "d" {
 			t.Fatalf("unexpected args")
 		}
 		return f(ctx, snap, dest)
 	}
-	RunDump = func(_ context.Context, _ *config.Config, snap, dest string, _ *zap.Logger) (string, error) {
+	r.runDumpFn = func(_ context.Context, _ *config.Config, snap, dest string, _ *zap.Logger) (string, error) {
 		if snap != "s" || dest != "d" {
 			t.Fatalf("unexpected dump args")
 		}
@@ -376,7 +334,7 @@ func TestExecuteClient(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	if err := ExecuteClient(ctx, cfg, "s", "d", nil, nil, logger); err != nil {
+	if err := r.ExecuteClient(ctx, cfg, "s", "d", nil, nil, logger); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !called {
@@ -387,47 +345,30 @@ func TestExecuteClient(t *testing.T) {
 func TestRunHeartbeatError(t *testing.T) {
 	cfg := &config.Config{StdoutMode: true, GRPCSetupTimeout: time.Second, SourceType: "file"}
 	logger := zap.NewNop()
-
-	origStart := startGRPCServer
-	origClient := clientHandshake
-	origSetup := setupSignalHandle
-	origPrepare := prepareSnapshotFn
-	origExec := executeClientFn
-	origSelect := SelectTransport
-	defer func() {
-		startGRPCServer = origStart
-		clientHandshake = origClient
-		setupSignalHandle = origSetup
-		prepareSnapshotFn = origPrepare
-		executeClientFn = origExec
-		SelectTransport = origSelect
-	}()
-
+	r := NewRunner()
 	hbErrCh := make(chan error, 1)
 	hbErrCh <- errors.New("hb fail")
-
-	startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
+	r.startGRPCServerFn = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
 		ch := make(chan error)
 		close(ch)
 		return func() {}, ch, nil
 	}
-	clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
+	r.clientHandshakeFn = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 		return func() {}, hbErrCh, nil
 	}
-	SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
-
+	r.selectTransportFn = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
 	sigErrCh := make(chan error, 1)
-	setupSignalHandle = func(_ context.Context, _ *config.Config, _ *string, _ *zap.Logger) (chan os.Signal, chan error) {
+	r.setupSignalHandleFn = func(_ context.Context, _ *config.Config, _ *string, _ *zap.Logger) (chan os.Signal, chan error) {
 		return nil, sigErrCh
 	}
-	prepareSnapshotFn = func(ctx context.Context, _ *config.Config, _ string, _ *zap.Logger) (string, chan error, func(), error) {
+	r.prepareSnapshotFn = func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil
 	}
-	executeClientFn = func(ctx context.Context, f func(context.Context, string, string) error, snap, dest string, sigErrCh, monitorErrCh chan error) error {
+	r.executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
 		return <-sigErrCh
 	}
 
-	err := Run(cfg, []string{"vol"}, logger)
+	err := r.Run(cfg, []string{"vol"}, logger)
 	if err == nil || err.Error() != "hb fail" {
 		t.Fatalf("expected heartbeat error, got %v", err)
 	}
@@ -449,23 +390,8 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 
 			cfg := &config.Config{StdoutMode: true, GRPCConnect: tc.grpcConnect, GRPCSetupTimeout: time.Second, SourceType: "file"}
 			logger := zap.NewNop()
-
-			origStart := startGRPCServer
-			origClient := clientHandshake
-			origSetup := setupSignalHandle
-			origPrepare := prepareSnapshotFn
-			origExec := executeClientFn
-			origSelect := SelectTransport
-			defer func() {
-				startGRPCServer = origStart
-				clientHandshake = origClient
-				setupSignalHandle = origSetup
-				prepareSnapshotFn = origPrepare
-				executeClientFn = origExec
-				SelectTransport = origSelect
-			}()
-
-			startGRPCServer = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
+			r := NewRunner()
+			r.startGRPCServerFn = func(context.Context, *config.Config, *zap.Logger) (func(), <-chan error, error) {
 				ch := make(chan error)
 				close(ch)
 				return func() {}, ch, nil
@@ -473,30 +399,30 @@ func TestRunGRPCConnectGoroutineLeak(t *testing.T) {
 
 			if tc.hbChannel {
 				hbErrCh := make(chan error)
-				clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
+				r.clientHandshakeFn = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 					return func() { close(hbErrCh) }, hbErrCh, nil
 				}
 			} else {
-				clientHandshake = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
+				r.clientHandshakeFn = func(context.Context, *config.Config, *zap.Logger) (func(), chan error, error) {
 					return func() {}, nil, nil
 				}
 			}
 
-			setupSignalHandle = func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+			r.setupSignalHandleFn = func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
 				return nil, make(chan error, 1)
 			}
 
-			SelectTransport = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
+			r.selectTransportFn = func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil }
 
-			prepareSnapshotFn = func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			r.prepareSnapshotFn = func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
 				return "snap", nil, func() {}, nil
 			}
 
-			executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error) error {
+			r.executeClientFn = func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
 				return nil
 			}
 
-			if err := Run(cfg, []string{"vol"}, logger); err != nil {
+			if err := r.Run(cfg, []string{"vol"}, logger); err != nil {
 				t.Fatalf("Run returned error: %v", err)
 			}
 


### PR DESCRIPTION
## Summary
- add Runner structs for root, dump, and apply commands
- enable dependency injection via NewRunner and registration helpers
- update tests to use Runner methods

## Testing
- `go build ./cmd/...`
- `go test ./cmd/root ./cmd/apply` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f7c201e08323be872e43d80039dc