### PR TITLE
Restrict TLS cipher suites and add negotiation tests

### DIFF
--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -24,8 +24,6 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
-
-	"errors"
 )
 
 func TestEnvVarPrecedence(t *testing.T) {

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -47,12 +47,14 @@ func initTransports() {
 Handshake validation rejects mismatched ALPN protocols or TLS versions to ensure
 both peers agree on the connection parameters.
 
-TLS-based transports enable mutual TLS by default and restrict cipher suites to
+TLS-based transports enable mutual TLS by default. Both client and server
+explicitly restrict `tls.Config.CipherSuites` to
 `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, and
-`TLS_CHACHA20_POLY1305_SHA256`. TLS transports require an explicit set of
-trusted CA roots. Connections are rejected if no roots are provided unless the
-transport configuration sets `AllowInsecure` to skip verification. Enabling this
-option logs a warning.
+`TLS_CHACHA20_POLY1305_SHA256`; handshakes fail if peers do not support one of
+these ciphers. TLS transports require an explicit set of trusted CA roots.
+Connections are rejected if no roots are provided unless the transport
+configuration sets `AllowInsecure` to skip verification. Enabling this option
+logs a warning.
 
 ## Examples
 

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -75,17 +75,19 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		NextProtos:         []string{"h2"},
 		MinVersion:         tls.VersionTLS13,
 		MaxVersion:         tls.VersionTLS13,
+		CipherSuites:       []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_CHACHA20_POLY1305_SHA256},
 		InsecureSkipVerify: cfg.AllowInsecure,
 	}
 	if len(cfg.ClientCert.Certificate) != 0 {
 		clientConf.Certificates = []tls.Certificate{cfg.ClientCert}
 	}
 	serverConf := &tls.Config{
-		ClientCAs:  cfg.Roots,
-		ClientAuth: clientAuth,
-		MinVersion: tls.VersionTLS13,
-		MaxVersion: tls.VersionTLS13,
-		NextProtos: []string{"h2"},
+		ClientCAs:    cfg.Roots,
+		ClientAuth:   clientAuth,
+		MinVersion:   tls.VersionTLS13,
+		MaxVersion:   tls.VersionTLS13,
+		CipherSuites: []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_CHACHA20_POLY1305_SHA256},
+		NextProtos:   []string{"h2"},
 	}
 	if len(cfg.ServerCert.Certificate) != 0 {
 		serverConf.Certificates = []tls.Certificate{cfg.ServerCert}

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -543,6 +543,40 @@ func TestH2TransportTLSHandshakeError(t *testing.T) {
 	checkLogFields(t, logs, "listen_end", 1, false, zapcore.InfoLevel)
 }
 
+func TestH2TransportUnsupportedCipher(t *testing.T) {
+	cert, pool := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: pool, ClientCert: cert, ServerCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	srvErr := make(chan error, 1)
+	go func() {
+		_, err := ln.Accept()
+		srvErr <- err
+	}()
+	badCfg := &tls.Config{
+		RootCAs:      pool,
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS12,
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+		NextProtos:   []string{"h2"},
+	}
+	if _, err := tls.Dial("tcp", ln.Addr().String(), badCfg); err == nil {
+		t.Fatalf("expected handshake error")
+	}
+	if err := <-srvErr; err == nil {
+		t.Fatalf("expected server error")
+	}
+}
+
 func TestH2TransportTLSCDCMismatch(t *testing.T) {
 	cert, pool := generateSelfSignedCert(t)
 	core, logs := observer.New(zap.InfoLevel)

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -46,15 +46,17 @@ func New(cfg transport.Config) (transport.Interface, error) {
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverConf := &tls.Config{
-		ClientCAs:  cfg.Roots,
-		ClientAuth: clientAuth,
-		MinVersion: tls.VersionTLS13,
-		NextProtos: []string{alpn},
+		ClientCAs:    cfg.Roots,
+		ClientAuth:   clientAuth,
+		MinVersion:   tls.VersionTLS13,
+		CipherSuites: []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_CHACHA20_POLY1305_SHA256},
+		NextProtos:   []string{alpn},
 	}
 	clientConf := &tls.Config{
 		RootCAs:            cfg.Roots,
 		InsecureSkipVerify: cfg.AllowInsecure,
 		MinVersion:         tls.VersionTLS13,
+		CipherSuites:       []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_CHACHA20_POLY1305_SHA256},
 		NextProtos:         []string{alpn},
 	}
 	if len(cert.Certificate) > 0 {

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -398,6 +398,40 @@ func TestTCPTLSNegotiateInvalidRole(t *testing.T) {
 	}
 }
 
+func TestTCPTLSUnsupportedCipher(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	srvErr := make(chan error, 1)
+	go func() {
+		_, err := ln.Accept()
+		srvErr <- err
+	}()
+	badCfg := &tls.Config{
+		RootCAs:      root,
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS12,
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+		NextProtos:   []string{alpn},
+	}
+	if _, err := tls.Dial("tcp", ln.Addr().String(), badCfg); err == nil {
+		t.Fatalf("expected handshake error")
+	}
+	if err := <-srvErr; err == nil {
+		t.Fatalf("expected server error")
+	}
+}
+
 func TestTCPTLSCertValidation(t *testing.T) {
 	root := x509.NewCertPool()
 	cert, _ := generateSelfSignedCert(t)


### PR DESCRIPTION
## Summary
- enforce TLS 1.3 cipher suite allow-list for tcp+tls and h2 transports
- document cipher suite policy
- test handshake failure when peers only offer unsupported ciphers

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7ea03748323b69edb0915a85ae8