### PR TITLE
Close rsynkwire stream writer after sending bad frame

### DIFF
--- a/internal/rsynkwire/client_test.go
+++ b/internal/rsynkwire/client_test.go
@@ -139,13 +139,22 @@ func TestStreamBadCRC(t *testing.T) {
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(payload)))
 	binary.BigEndian.PutUint32(hdr[4:8], 0)
-	if _, err := c1.Write(hdr[:]); err != nil {
-		t.Fatalf("write hdr: %v", err)
-	}
-	if _, err := c1.Write(payload); err != nil {
-		t.Fatalf("write payload: %v", err)
-	}
+	errCh := make(chan error, 1)
+	go func() {
+		if _, err := c1.Write(hdr[:]); err != nil {
+			errCh <- fmt.Errorf("write hdr: %w", err)
+			return
+		}
+		if _, err := c1.Write(payload); err != nil {
+			errCh <- fmt.Errorf("write payload: %w", err)
+			return
+		}
+		errCh <- c1.Close()
+	}()
 	if _, err := s.Recv(); err == nil {
 		t.Fatalf("expected CRC error")
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("write: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- send malformed frame from a goroutine in TestStreamBadCRC
- close the pipe writer after sending to trigger EOF for Recv

## Testing
- `go build ./...` *(fails: cannot use clientpkg.ExecuteClient as func(..., *zap.Logger) error)*
- `go test -cover ./...` *(fails: cannot use clientpkg.ExecuteClient as func(..., *zap.Logger) error, plus multiple test failures)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1fe0a8f24832398d027d19dcf24dc