### PR TITLE
test: disable escalation checker

### DIFF
--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -64,6 +64,8 @@ func TestOpenLVMChecks(t *testing.T) {
 
 func TestRunLVMPrivilegeEscalation(t *testing.T) {
 	ctx := context.Background()
+	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	defer restore()
 	var gotName string
 	var gotArgs []string
 	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {


### PR DESCRIPTION
## Summary
- disable LVM escalation checking in `TestRunLVMPrivilegeEscalation` to allow test to run

## Testing
- `go build ./...` *(fails: cannot use clientpkg.ExecuteClient as func with logger arg)*
- `go test -cover ./...` *(fails: cannot use clientpkg.ExecuteClient as func with logger arg)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a1fe0036d88323a3cb5d2ede0caa54