### PR TITLE
test(h2): handle net timeout errors in handshake test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- tests: accept net.Error timeouts in h2 handshake timeout
 - manifest: log configuration warnings with structured fields
 - lock: reject VG/LV names with invalid characters via regex validation
 - tests: flush H2 handshake data by buffering server errors, closing connections before sending, and applying context timeouts

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -235,11 +235,13 @@ func TestPerformH2HandshakeTimeout(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	if _, err := performH2Handshake(ctx, conn, zap.NewNop()); err == nil {
-		t.Fatalf("expected timeout error")
-	} else if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+        if _, err := performH2Handshake(ctx, conn, zap.NewNop()); err == nil {
+                t.Fatalf("expected timeout error")
+        } else if !errors.Is(err, context.DeadlineExceeded) {
+                if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+                        t.Fatalf("unexpected error: %v", err)
+                }
+        }
 }
 
 func TestPerformH2HandshakeCanceled(t *testing.T) {


### PR DESCRIPTION
## Summary
- broaden HTTP/2 handshake timeout test to accept net.Error timeout implementations
- document the change in changelog

## Testing
- `go build ./...` *(fails: cannot use clientpkg.ExecuteClient as func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error)*
- `go test -coverprofile=coverage.out ./...` *(fails: cannot use clientpkg.ExecuteClient as func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_68a1fe0d300483239ed6e2316ab5e0b8