### PR TITLE
internal: skip block device test when not root

### DIFF
--- a/internal/blockio/blockio_test.go
+++ b/internal/blockio/blockio_test.go
@@ -206,6 +206,9 @@ func TestOpenNonexistentPath(t *testing.T) {
 }
 
 func TestOpenBlockDevice(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
 	entries, err := os.ReadDir("/dev")
 	if err != nil {
 		t.Fatalf("readdir /dev: %v", err)


### PR DESCRIPTION
## Summary
- avoid failing block device test when run as non-root

## Testing
- `go build ./...`
- `go test ./internal/blockio -run TestOpenBlockDevice -count=1`
- `go test -coverprofile=coverage.out ./...` (fails: cannot use ExecuteClient in cmd/root and other compilation issues)
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1fe06b6408323a275da22b6503c5c