### PR TITLE
device: disable escalation check in tests

### DIFF
--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -50,6 +50,8 @@ func TestDetectFileDeviceError(t *testing.T) {
 }
 
 func TestDetectLVMDeviceSuccess(t *testing.T) {
+	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	defer restore()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 	runner := NewRunner()
@@ -77,6 +79,8 @@ func TestDetectLVMDeviceSuccess(t *testing.T) {
 }
 
 func TestDetectLVMDeviceError(t *testing.T) {
+	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	defer restore()
 	runner := NewRunner()
 	runner.openLVMOverride = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 		return nil, errors.New("fail")


### PR DESCRIPTION
## Summary
- stub LVM escalation checker in detectLVMDevice tests so they pass without root privileges

## Testing
- `go build ./...` *(fails: cmd/root/root.go:41:24 cannot use clientpkg.ExecuteClient...)*
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/root/root.go:41:24 cannot use clientpkg.ExecuteClient...)*
- `go test ./device -run TestDetectLVMDevice`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1fdfdcdfc83239a5497009fa2acf9