### PR TITLE
Allow net timeout errors in TCP+TLS dial test

### DIFF
--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -345,8 +345,15 @@ func TestTCPTLSDialUnreachable(t *testing.T) {
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if _, err := tr.Dial(ctx, ln.Addr().String()); err == nil || !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected context deadline exceeded, got %v", err)
+	_, err = tr.Dial(ctx, ln.Addr().String())
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		var netErr net.Error
+		if !errors.As(err, &netErr) || !netErr.Timeout() {
+			t.Fatalf("expected context deadline exceeded or timeout, got %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- broaden TCP+TLS dial timeout test to accept net.Error timeouts in addition to context.DeadlineExceeded

## Testing
- `go build ./...` *(fails: cannot use clientpkg.ExecuteClient)*
- `go test -coverprofile=coverage.out ./...` *(fails: cannot use clientpkg.ExecuteClient)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a1fe127340832392d5f0c248c1de02