### PR TITLE
test: capture handshake in tcp+tls negotiate

### DIFF
--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -197,7 +197,7 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 			return
 		}
 		srvCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
-		err = tr.Negotiate(srvCtx, conn, transport.Server, srvHS)
+		_, err = tr.Negotiate(srvCtx, conn, transport.Server, srvHS)
 		cancel()
 		srvErr <- err
 		if err == nil {


### PR DESCRIPTION
## Summary
- capture error from server-side negotiate in tcp+tls test

## Testing
- `go build ./...` *(fails: cannot use clientpkg.ExecuteClient)*
- `go test -cover ./...` *(fails: cannot use clientpkg.ExecuteClient)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a205de56f483238b92d5d4bb05cf60