### PR TITLE
client: add logger to ExecuteClient

### DIFF
--- a/internal/client/execute.go
+++ b/internal/client/execute.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"context"
-	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // ExecuteClient runs the client transfer logic and handles signal and monitor errors.
-func ExecuteClient(ctx context.Context, runClient func(context.Context, string, string) error, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error) error {
+func ExecuteClient(ctx context.Context, runClient func(context.Context, string, string) error, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
 	clientErrCh := make(chan error, 1)
 	go func() {
 		clientErrCh <- runClient(ctx, snapshotPath, destPath)
@@ -15,11 +16,16 @@ func ExecuteClient(ctx context.Context, runClient func(context.Context, string, 
 	select {
 	case err := <-clientErrCh:
 		if err != nil {
-			return fmt.Errorf("copy operation failed: %w", err)
+			logger.Error("copy operation failed", zap.Error(err))
+			return err
 		}
 	case err := <-sigErrCh:
+		if err != nil {
+			logger.Error("signal error", zap.Error(err))
+		}
 		return err
 	case <-ctx.Done():
+		logger.Error("context canceled", zap.Error(ctx.Err()))
 		return ctx.Err()
 	}
 
@@ -31,9 +37,11 @@ func ExecuteClient(ctx context.Context, runClient func(context.Context, string, 
 					return nil
 				}
 				if err != nil {
-					return fmt.Errorf("snapshot monitor error: %w", err)
+					logger.Error("snapshot monitor error", zap.Error(err))
+					return err
 				}
 			case <-ctx.Done():
+				logger.Error("context canceled", zap.Error(ctx.Err()))
 				return ctx.Err()
 			}
 		}

--- a/internal/client/execute_test.go
+++ b/internal/client/execute_test.go
@@ -3,9 +3,10 @@ package client
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 func TestExecuteRunError(t *testing.T) {
@@ -13,9 +14,10 @@ func TestExecuteRunError(t *testing.T) {
 	sigCh := make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, nil)
-	if err == nil || !strings.Contains(err.Error(), "copy operation failed") {
-		t.Fatalf("expected copy failure, got %v", err)
+	logger := zap.NewNop()
+	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, nil, logger)
+	if err == nil || err.Error() != "run" {
+		t.Fatalf("expected run error, got %v", err)
 	}
 }
 
@@ -32,9 +34,10 @@ func TestExecuteSignal(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		sigCh <- errors.New("signal")
 	}()
-	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, nil)
+	logger := zap.NewNop()
+	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, nil, logger)
 	close(block)
-	if err == nil || !strings.Contains(err.Error(), "signal") {
+	if err == nil || err.Error() != "signal" {
 		t.Fatalf("expected signal error, got %v", err)
 	}
 }
@@ -47,8 +50,9 @@ func TestExecuteMonitorError(t *testing.T) {
 	close(monitorCh)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, monitorCh)
-	if err == nil || !strings.Contains(err.Error(), "snapshot monitor error") {
+	logger := zap.NewNop()
+	err := ExecuteClient(ctx, runClient, "snap", "dest", sigCh, monitorCh, logger)
+	if err == nil || err.Error() != "monitor" {
 		t.Fatalf("expected monitor error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- accept a *zap.Logger in ExecuteClient
- log client and monitor failures instead of formatting errors
- update tests to use a zap logger

## Testing
- `go build ./...` *(fails: undefined: rootcmd.RunManifest)*
- `go test -cover ./...` *(fails: undefined: rootcmd.RunDump)*
- `go test -cover ./internal/client`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a205da6b648323b35fb779fac74577