### PR TITLE
test: cover signal handling

### DIFF
--- a/cmd/lvmsync/signals/signals_test.go
+++ b/cmd/lvmsync/signals/signals_test.go
@@ -2,8 +2,11 @@ package signals
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 
 	"go.uber.org/zap"
@@ -11,17 +14,69 @@ import (
 	"lvmsync_go/internal/config"
 )
 
-func TestHandle(t *testing.T) {
+func TestHandleInterruptNoCleanup(t *testing.T) {
 	cfg := &config.Config{SkipSnapshotCreation: true}
 	sigCh := make(chan os.Signal, 1)
 	errCh := make(chan error, 1)
-	var snap string
-	logger := zap.NewNop()
-	runner := NewRunner()
-	go runner.Handle(context.Background(), cfg, logger, sigCh, &snap, errCh)
+	snap := "lvmsnap"
+	var called atomic.Bool
+	runner := NewRunnerWithDeps(func(context.Context, string, *zap.Logger) error {
+		called.Store(true)
+		return nil
+	})
+	go runner.Handle(context.Background(), cfg, zap.NewNop(), sigCh, &snap, errCh)
 	sigCh <- os.Interrupt
 	err := <-errCh
 	if err == nil || !strings.Contains(err.Error(), "received signal") {
 		t.Fatalf("expected signal error, got %v", err)
+	}
+	if called.Load() {
+		t.Fatal("RemoveSnapshot should not be called when SkipSnapshotCreation is true")
+	}
+}
+
+func TestHandleTerminationCleanup(t *testing.T) {
+	cfg := &config.Config{SkipSnapshotCreation: false}
+	sigCh := make(chan os.Signal, 1)
+	errCh := make(chan error, 1)
+	snap := "snapA"
+	var called atomic.Bool
+	runner := NewRunnerWithDeps(func(_ context.Context, path string, _ *zap.Logger) error {
+		if path != snap {
+			t.Fatalf("unexpected snapshot path %q", path)
+		}
+		called.Store(true)
+		return nil
+	})
+	go runner.Handle(context.Background(), cfg, zap.NewNop(), sigCh, &snap, errCh)
+	sigCh <- syscall.SIGTERM
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "terminated") {
+		t.Fatalf("expected terminated signal error, got %v", err)
+	}
+	if !called.Load() {
+		t.Fatal("RemoveSnapshot was not called")
+	}
+}
+
+func TestHandleCleanupFailure(t *testing.T) {
+	cfg := &config.Config{SkipSnapshotCreation: false}
+	sigCh := make(chan os.Signal, 1)
+	errCh := make(chan error, 1)
+	snap := "snapB"
+	var count atomic.Int32
+	removeErr := errors.New("boom")
+	runner := NewRunnerWithDeps(func(context.Context, string, *zap.Logger) error {
+		count.Add(1)
+		return removeErr
+	})
+	go runner.Handle(context.Background(), cfg, zap.NewNop(), sigCh, &snap, errCh)
+	sigCh <- os.Interrupt
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "interrupt") {
+		t.Fatalf("expected interrupt signal error, got %v", err)
+	}
+	if count.Load() != 1 {
+		t.Fatalf("RemoveSnapshot called %d times, want 1", count.Load())
 	}
 }


### PR DESCRIPTION
## Summary
- add tests for interrupt, terminate and cleanup error cases in signal handler
- verify snapshot removal logic and error handling

## Testing
- `go build ./...` *(fails: cmd/manifest/rebuild.go:33:10: undefined: rootcmd.RunManifest)*
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/dump/client.go:178:10: undefined: rootcmd.RunDump)*
- `go test -coverprofile=signals_coverage.out ./cmd/lvmsync/signals`
- `go tool cover -func=signals_coverage.out | grep signals.go:44`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a20f06bbc48323a28a87f987b7ac33