### PR TITLE
test: verify exit code constants

### DIFF
--- a/internal/exitcode/exitcode_test.go
+++ b/internal/exitcode/exitcode_test.go
@@ -1,0 +1,23 @@
+package exitcode
+
+import "testing"
+
+func TestExitCodeValues(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		want int
+	}{
+		{"OK", OK, 0},
+		{"ErrCapability", ErrCapability, 10},
+		{"ErrDevice", ErrDevice, 20},
+		{"ErrPlatform", ErrPlatform, 30},
+		{"ErrConfig", ErrConfig, 40},
+		{"ErrRuntime", ErrRuntime, 50},
+	}
+	for _, c := range cases {
+		if c.code != c.want {
+			t.Errorf("%s = %d; want %d", c.name, c.code, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test asserting exit codes retain their intended numeric values

## Testing
- `go build ./...` (fails: cmd/manifest/rebuild.go:33:10: undefined: rootcmd.RunManifest)
- `go test -coverprofile=coverage.out ./...` (fails: cmd/dump/client.go:178:10: undefined: rootcmd.RunDump)
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a20f0929d08323b1703d03a27910fe