### PR TITLE
docs: mark ssh_host_key_path precedence tests complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ Run these commands locally before opening a pull request:
 golangci-lint run
 ```
 
-- [ ] Add precedence tests for `ssh_host_key_path` flag, environment variable, and YAML configuration.
+- [x] Add precedence tests for `ssh_host_key_path` flag, environment variable, and YAML configuration (see `internal/config/ssh_host_key_path_test.go`).
 
 - [x] Ensure SSH agent connections use context timeouts and cover SSHManager reuse in tests.
 - [x] common: add endianness mismatch handshake validation test.


### PR DESCRIPTION
## Summary
- mark ssh_host_key_path precedence tests as complete in AGENTS.md
- note existing coverage in internal/config/ssh_host_key_path_test.go

## Testing
- `go build ./...` *(fails: undefined rootcmd.RunManifest)*
- `go test -cover ./...` *(fails: undefined rootcmd.RunDump)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a20f0bf3d08323b83e777fd8adc251