### PR TITLE
transport: add timeout context to negotiation test util

### DIFF
--- a/transport/testutil/testutil.go
+++ b/transport/testutil/testutil.go
@@ -71,7 +71,8 @@ type Result struct {
 
 func RunNegotiation(t *testing.T, tr transport.Interface, serverHS, clientHS common.Handshake) (Result, Result) {
 	t.Helper()
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ln, err := tr.Listen(ctx, "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)


### PR DESCRIPTION
## Summary
- use context.WithTimeout in RunNegotiation and defer cancel
- pass timeout context to Listen, Dial, and Negotiate

## Testing
- `go build ./...` (fails: undefined rootcmd.RunManifest)
- `go test -cover ./...` (fails: transport tests panic and tcp+tls tests)
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a20f0f1d34832387960ea4868df044