### PR TITLE
Capture peer from negotiate in TCP/TLS test

### DIFF
--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -197,10 +197,11 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 			return
 		}
 		srvCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
-		_, err = tr.Negotiate(srvCtx, conn, transport.Server, srvHS)
+		peer, err := tr.Negotiate(srvCtx, conn, transport.Server, srvHS)
 		cancel()
 		srvErr <- err
 		if err == nil {
+			_ = peer
 			var buf [1]byte
 			conn.Read(buf[:])
 		}


### PR DESCRIPTION
## Summary
- capture peer result from `Negotiate` in TCP/TLS test and discard when unused

## Testing
- `go test ./transport/tcp_tls -run TestTCPTLSTransportHandshake -count=1 -v`
- `go test -run TestTCPTLSTransportSelectBestHandshake -count=1 -v ./transport/tcp_tls` *(fails: read handshake EOF)*
- `go build ./...` *(fails: undefined rootcmd.*)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a20f2e0bb8832398410a5c717891e3