### PR TITLE
Add tests for proto and transports

### DIFF
--- a/proto/ack_test.go
+++ b/proto/ack_test.go
@@ -1,0 +1,10 @@
+package proto
+
+import "testing"
+
+func TestAckDefaults(t *testing.T) {
+	var a Ack
+	if a.GetSessionId() != "" || a.GetMessage() != "" || a.GetOk() {
+		t.Fatalf("unexpected defaults: %+v", a)
+	}
+}

--- a/remote/testutil/ssh_mock_test.go
+++ b/remote/testutil/ssh_mock_test.go
@@ -1,0 +1,57 @@
+package testutil
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestMockSSHServerRecordsCommands(t *testing.T) {
+	srv := NewMockSSHServer(t, func(cmd string) int { return 0 })
+	defer srv.Close()
+	client, err := ssh.Dial("tcp", srv.Addr, &ssh.ClientConfig{
+		User:            "test",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	defer sess.Close()
+	var b bytes.Buffer
+	sess.Stdout = &b
+	if err := sess.Run("echo hello"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	cmds := srv.Commands()
+	if len(cmds) != 1 || cmds[0] != "echo hello" {
+		t.Fatalf("unexpected commands %v", cmds)
+	}
+}
+
+func TestCreateKnownHostsFile(t *testing.T) {
+	srv := NewMockSSHServer(t, func(cmd string) int { return 0 })
+	defer srv.Close()
+	path := CreateKnownHostsFile(t, srv)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	host, port, err := net.SplitHostPort(srv.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	expected := "[" + host + "]:" + port
+	if !strings.Contains(string(data), expected) {
+		t.Fatalf("missing host entry")
+	}
+}

--- a/transport/quic/basic_test.go
+++ b/transport/quic/basic_test.go
@@ -1,0 +1,38 @@
+package quic
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+)
+
+func TestNewRequiresTLS(t *testing.T) {
+	if _, err := New(transport.Config{Logger: zap.NewNop()}); err == nil {
+		t.Fatalf("expected error when tls roots missing")
+	}
+}
+
+func TestNegotiateWithPipe(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := tr.Negotiate(ctx, c1, transport.Client, hs)
+		errCh <- err
+	}()
+	if _, err := tr.Negotiate(ctx, c2, transport.Server, hs); err != nil {
+		t.Fatalf("server negotiate: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+}

--- a/transport/ssh/basic_test.go
+++ b/transport/ssh/basic_test.go
@@ -1,0 +1,54 @@
+package ssh
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+)
+
+func TestNewRequiresUser(t *testing.T) {
+	if _, err := New(context.Background(), transport.Config{SSHPassword: "p"}); err == nil {
+		t.Fatalf("expected error for missing user")
+	}
+}
+
+func TestDialAndNegotiate(t *testing.T) {
+	cfg := transport.Config{Logger: zap.NewNop(), SSHUser: "u", SSHPassword: "p", AllowInsecure: true}
+	trIface, err := New(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	done := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		_, err = tr.Negotiate(ctx, conn, transport.Server, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true})
+		done <- err
+	}()
+	conn, err := tr.Dial(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := tr.Negotiate(ctx, conn, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("server negotiate: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add basic coverage for protobuf messages
- exercise QUIC and SSH handshake helpers
- test remote MockSSH server utilities

## Testing
- `go build ./...` *(fails: cmd/manifest/rebuild.go:33:10: undefined: rootcmd.RunManifest)*
- `go test -coverprofile=coverage.out $PACKAGES` *(pass)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a20f3dc4608323854f1d712e5e2240