### PR TITLE
propagate device close error

### DIFF
--- a/device/info.go
+++ b/device/info.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ var (
 	uuidFunc    = defaultUUIDFunc
 	lvmUUIDFunc = defaultLVMUUIDFunc
 	mountFunc   = defaultMountFunc
+	detectFunc  = Detect
 )
 
 // SetUUIDFunc allows tests to override the implementation used to lookup a
@@ -137,14 +139,19 @@ func defaultMountFunc(path string) (bool, error) {
 
 // SizeBytes returns the total size of the device at path in bytes.
 // If ctx has no deadline, a default timeout is applied.
-func SizeBytes(ctx context.Context, path string) (uint64, error) {
+func SizeBytes(ctx context.Context, path string) (size uint64, err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	dev, err := Detect(ctx, path, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
+	dev, err := detectFunc(ctx, path, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
 	if err != nil {
 		return 0, err
 	}
-	defer dev.Close()
-	return dev.SizeBytes(), nil
+	defer func() {
+		if closeErr := dev.Close(); closeErr != nil {
+			err = fmt.Errorf("close block device: %w", closeErr)
+		}
+	}()
+	size = dev.SizeBytes()
+	return size, err
 }

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -9,8 +9,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/moby/sys/mountinfo"
+	"go.uber.org/zap"
 )
 
 func TestGetUUIDCanceledContext(t *testing.T) {
@@ -325,6 +327,51 @@ func TestDefaultMountFuncError(t *testing.T) {
 		t.Fatalf("expected error when reading mountinfo file")
 	}
 }
+
+func TestSizeBytes(t *testing.T) {
+	dev := &stubDevice{size: 123}
+	prev := detectFunc
+	detectFunc = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error) {
+		return dev, nil
+	}
+	defer func() { detectFunc = prev }()
+	got, err := SizeBytes(context.Background(), "/dev/fake")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 123 {
+		t.Fatalf("SizeBytes() = %d, want 123", got)
+	}
+}
+
+func TestSizeBytesCloseError(t *testing.T) {
+	want := errors.New("close boom")
+	dev := &stubDevice{size: 456, closeErr: want}
+	prev := detectFunc
+	detectFunc = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error) {
+		return dev, nil
+	}
+	defer func() { detectFunc = prev }()
+	got, err := SizeBytes(context.Background(), "/dev/fake")
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+	if got != 456 {
+		t.Fatalf("SizeBytes() = %d, want 456", got)
+	}
+}
+
+type stubDevice struct {
+	size     uint64
+	closeErr error
+}
+
+func (s *stubDevice) Path() string                                     { return "" }
+func (s *stubDevice) SizeBytes() uint64                                { return s.size }
+func (s *stubDevice) BlockSize() uint64                                { return 0 }
+func (s *stubDevice) Snapshot(context.Context, string) (Device, error) { return nil, nil }
+func (s *stubDevice) Cleanup(context.Context) error                    { return nil }
+func (s *stubDevice) Close() error                                     { return s.closeErr }
 
 func mountFuncFromMountInfoFile(p string) func(string) (bool, error) {
 	return func(path string) (bool, error) {


### PR DESCRIPTION
## Summary
- return a wrapped close error from `device.SizeBytes`
- add tests ensuring `SizeBytes` reports close failures

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: undefined: dumpChangesSequential)*
- `go test -run SizeBytes ./device`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a21795df68832392b68ae288616af1