### PR TITLE
Add timeout context to privilege escalation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
 | `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; validated at startup |
-| `--lvm_timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations |
+| `--lvm_timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations and privilege checks |
 | `--sig-cache-ttl` | `LVMSYNC_LVM_SIG_CACHE_TTL` | `sig-cache-ttl` | TTL for cached LVM signatures |
 | `--sig-cache-max` | `LVMSYNC_LVM_SIG_CACHE_MAX` | `sig-cache-max` | Maximum cached LVM signatures |
 | `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
@@ -1170,9 +1170,12 @@ timeouts or cancellations are reported separately.
 | `--target_volume_group` | Volume group name of the target LVM volume | "" |
 | `--target_vgs` | Candidate target volume groups for auto-selection | [] |
 | `--lvm-escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n"); validated at startup | "sudo -n" |
-| `--lvm_timeout` | Timeout for LVM operations | 10s |
+| `--lvm_timeout` | Timeout for LVM operations and privilege checks | 10s |
 | `--sig-cache-ttl` | TTL for cached LVM signatures | 24h |
 | `--sig-cache-max` | Maximum cached LVM signatures | 128 |
+
+`lvm_timeout` also bounds the startup privilege check to avoid hanging when
+escalation commands stall.
 
 #### gRPC Options
 
@@ -1531,11 +1534,13 @@ For example, the `privilege` package exposes an `Escalator` interface so tests
 can stub command execution:
 
 ```go
-esc := privilege.New()
-if err := esc.Ensure(context.Background()); err != nil {
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+esc := privilege.New(ctx)
+if err := esc.Ensure(ctx); err != nil {
     // handle missing capabilities or sudo
 }
-cmd := esc.Command(context.Background(), "lvs", "--version")
+cmd := esc.Command(ctx, "lvs", "--version")
 _ = cmd
 ```
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -142,8 +142,10 @@ func Configure() (*config.Config, []string, *zap.Logger, error) {
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("configuration error: %w", err)
 	}
-	esc := privilege.New()
-	if err = esc.Ensure(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.LVMTimeout)
+	defer cancel()
+	esc := privilege.New(ctx)
+	if err = esc.Ensure(ctx); err != nil {
 		return nil, nil, nil, fmt.Errorf("privilege check failed: %w", err)
 	}
 	if err = cfg.Validate(); err != nil {

--- a/config.yaml
+++ b/config.yaml
@@ -88,7 +88,7 @@ target_vgs: [ ]  # Candidate target VGs for auto-selection
 # Command used to re-execute the program with elevated privileges
 # when required
 lvm_escalation: "sudo -n"
-lvm_timeout: 10s  # Timeout for LVM operations
+lvm_timeout: 10s  # Timeout for LVM operations and privilege checks
 progress: true  # Enable progress display during transfer
 # Block size for LVM operations ('auto' or 0 for automatic detection)
 block_size: "auto"

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -150,7 +150,7 @@ func initLVMFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("skip_disk_check", cfg.SkipDiskCheck, "Skip disk space check")
 	fs.String("snapshot_size", cfg.SnapshotSize, "Snapshot size (bytes or percentage)")
 	fs.String("lvm-escalation", cfg.LVMEscalation, "Command to use for privilege escalation")
-	fs.Duration("lvm_timeout", cfg.LVMTimeout, "Timeout for LVM commands")
+	fs.Duration("lvm_timeout", cfg.LVMTimeout, "Timeout for LVM commands and privilege checks")
 	fs.Duration("sig-cache-ttl", cfg.SigCacheTTL, "TTL for LVM signature cache entries")
 	fs.Int("sig-cache-max", cfg.SigCacheMax, "Maximum LVM signature cache entries")
 	fs.String("volume_group", cfg.VolumeGroup, "LVM volume group")

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -54,10 +54,10 @@ type agent struct {
 
 // NewAgent constructs an Agent that delegates LVM operations to the provided
 // lvmAPI and ensures privileges using the given Escalator. When esc is nil,
-// privilege.New() supplies a default implementation.
+// privilege.New(context.Background()) supplies a default implementation.
 func NewAgent(lvm lvmAPI, esc privilege.Escalator) Agent {
 	if esc == nil {
-		esc = privilege.New()
+		esc = privilege.New(context.Background())
 	}
 	return &agent{esc: esc, lvm: lvm}
 }

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -23,7 +23,7 @@ func fakeLookPath(err error) func(string) (string, error) {
 
 func TestEnsureWithCaps(t *testing.T) {
 	HasCaps = func() bool { return true }
-	esc := New().(*sudoEscalator)
+	esc := New(context.Background()).(*sudoEscalator)
 	if esc.useSudo {
 		t.Fatalf("expected capabilities to be used")
 	}
@@ -37,7 +37,7 @@ func TestEnsureWithSudo(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(r).(*sudoEscalator)
+	esc := NewWithRunner(context.Background(), r).(*sudoEscalator)
 	if !esc.useSudo {
 		t.Fatalf("expected sudo usage")
 	}
@@ -48,7 +48,7 @@ func TestEnsureWithSudo(t *testing.T) {
 
 func TestEnsureNoSudo(t *testing.T) {
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(&Runner{LookPath: fakeLookPath(errors.New("missing"))}).(*sudoEscalator)
+	esc := NewWithRunner(context.Background(), &Runner{LookPath: fakeLookPath(errors.New("missing"))}).(*sudoEscalator)
 	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -56,13 +56,13 @@ func TestEnsureNoSudo(t *testing.T) {
 
 func TestCommand(t *testing.T) {
 	HasCaps = func() bool { return false }
-	esc := New()
+	esc := New(context.Background())
 	cmd := esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] != "sudo" {
 		t.Fatalf("expected sudo prefix")
 	}
 	HasCaps = func() bool { return true }
-	esc = New()
+	esc = New(context.Background())
 	cmd = esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] == "sudo" {
 		t.Fatalf("unexpected sudo prefix")
@@ -74,7 +74,7 @@ func TestEnsureSudoFailure(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(r).(*sudoEscalator)
+	esc := NewWithRunner(context.Background(), r).(*sudoEscalator)
 	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -95,7 +95,7 @@ func TestSudoSuccess(t *testing.T) {
 		t.Skip("root required")
 	}
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
 	})})
 	cmd := esc.Command(context.Background(), "echo")
@@ -109,7 +109,7 @@ func TestSudoPermissionDenied(t *testing.T) {
 		t.Skip("root required")
 	}
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
 	})})
 	cmd := esc.Command(context.Background(), "echo")
@@ -127,7 +127,7 @@ func TestSudoCommandNotFound(t *testing.T) {
 		t.Skip("root required")
 	}
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(&Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(127)(name, args...)
 	})})
 	cmd := esc.Command(context.Background(), "echo")
@@ -163,7 +163,7 @@ func TestEnsureContextCanceled(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(r)
+	esc := NewWithRunner(context.Background(), r)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	err := esc.Ensure(ctx)

--- a/internal/privilege/runner.go
+++ b/internal/privilege/runner.go
@@ -23,11 +23,12 @@ type Runner struct {
 }
 
 // New returns an Escalator with production dependencies.
-func New() Escalator { return NewWithRunner(nil) }
+// ctx is currently unused but reserved for future use.
+func New(ctx context.Context) Escalator { return NewWithRunner(ctx, nil) }
 
 // NewWithRunner constructs an Escalator with the provided Runner.
 // Nil fields default to exec.CommandContext and exec.LookPath.
-func NewWithRunner(r *Runner) Escalator {
+func NewWithRunner(_ context.Context, r *Runner) Escalator {
 	cmd := Commander(commanderFunc(exec.CommandContext))
 	lp := exec.LookPath
 	if r != nil {


### PR DESCRIPTION
## Summary
- derive `cfg.LVMTimeout` context before verifying privileges
- allow `privilege.New` to accept a context
- document LVM timeout use in privilege checks

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: undefined dumpChangesSequential, etc.)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a2171289a48323ad1459ece2b5f99a