### PR TITLE
Require explicit acknowledgment for insecure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,10 +790,11 @@ Transport selection is controlled by the `--transport` flag, which accepts a com
 transports to attempt (for example `quic,h2,tcp+tls,ssh`). The `quic` transport runs over TLS 1.3 with mutual
 authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional streams and datagrams. The `h2`
 transport also requires TLS 1.3 with client certificates and negotiates the `h2` ALPN. Provide certificates via
-`--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and will refuse
-connections when no roots are provided unless `--allow_insecure` (or the `AllowInsecure` configuration flag) is
-set. Enabling this option logs a warning. Client certificates must be supplied explicitly; transports no longer generate self-signed certificates
-automatically. The [transport documentation](docs/transports.md) covers each option in depth. The flags below
+`--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and refuse
+connections when no roots are provided unless insecure mode is explicitly acknowledged with the `--allow_insecure`
+flag or the `LVMSYNC_ALLOW_INSECURE` environment variable. This bypasses certificate verification and is intended
+for development only; configuration files alone cannot enable it. Client certificates must be supplied explicitly;
+transports no longer generate self-signed certificates automatically. The [transport documentation](docs/transports.md) covers each option in depth. The flags below
 configure transport behavior.
 
 ### Flags and environment variables

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -97,7 +97,9 @@ func bindFlags(cmd *cobra.Command, v flagBinder) error {
 
 func startServer(ctx context.Context, opts Options, logger *zap.Logger) error {
 	cfg := transport.Config{Logger: logger, AllowInsecure: opts.AllowInsecure}
-	if !opts.AllowInsecure {
+	if opts.AllowInsecure {
+		logger.Warn("allow_insecure_enabled", zap.String("component", "serve"), zap.String("security", "tls_verification_disabled"), zap.String("usage", "development_only"))
+	} else {
 		if opts.TLSCert == "" || opts.TLSKey == "" || opts.CACert == "" {
 			return fmt.Errorf("tls-cert, tls-key, and ca-cert are required unless --allow-insecure is set")
 		}

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -54,8 +54,10 @@ explicitly restrict `tls.Config.CipherSuites` to
 `TLS_CHACHA20_POLY1305_SHA256`; handshakes fail if peers do not support one of
 these ciphers. TLS transports require an explicit set of trusted CA roots.
 Connections are rejected if no roots are provided unless the transport
-configuration sets `AllowInsecure` to skip verification. Enabling this option
-logs a warning.
+configuration sets `AllowInsecure` and the user explicitly acknowledges the risk
+with the `--allow_insecure` flag or `LVMSYNC_ALLOW_INSECURE` environment
+variable. This disables certificate verification, logs a warning, and should be
+used only in development.
 
 ## Examples
 

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -34,7 +34,7 @@ func Dial(ctx context.Context, addr string, conf Config, logger *zap.Logger, opt
 		logger = zap.NewNop()
 	}
 	if conf.AllowInsecure {
-		logger.Warn("allow_insecure_enabled", zap.String("component", "grpc_client"))
+		logger.Warn("allow_insecure_enabled", zap.String("component", "grpc_client"), zap.String("security", "tls_verification_disabled"), zap.String("usage", "development_only"))
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		cert, err := tls.LoadX509KeyPair(conf.TLSCert, conf.TLSKey)

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -54,7 +54,7 @@ func New(conf Config, a lvmagent.Agent, logger *zap.Logger) (*grpc.Server, func(
 		logger = zap.NewNop()
 	}
 	if conf.AllowInsecure {
-		logger.Warn("allow_insecure_enabled", zap.String("component", "grpc_server"))
+		logger.Warn("allow_insecure_enabled", zap.String("component", "grpc_server"), zap.String("security", "tls_verification_disabled"), zap.String("usage", "development_only"))
 	} else {
 		if conf.TLSCert == "" || conf.TLSKey == "" || conf.CACert == "" {
 			return nil, nil, fmt.Errorf("TLSCert, TLSKey, and CACert must be provided when AllowInsecure is false")

--- a/internal/config/allow_insecure_ack_test.go
+++ b/internal/config/allow_insecure_ack_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestAllowInsecureRequiresFlagOrEnv(t *testing.T) {
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	builder := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("allow_insecure: true\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err == nil {
+		t.Fatalf("expected error without explicit acknowledgment")
+	}
+
+	os.Setenv("LVMSYNC_ALLOW_INSECURE", "1")
+	defer os.Unsetenv("LVMSYNC_ALLOW_INSECURE")
+	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
+	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err != nil {
+		t.Fatalf("unexpected error with env ack: %v", err)
+	}
+
+	os.Unsetenv("LVMSYNC_ALLOW_INSECURE")
+	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
+	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow_insecure"}); err != nil {
+		t.Fatalf("unexpected error with flag ack: %v", err)
+	}
+}

--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -56,6 +57,16 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	cfg, err := vb.Build()
 	if err != nil {
 		return nil, nil, warns, err
+	}
+	if cfg.AllowInsecure {
+		_, envSet := os.LookupEnv("LVMSYNC_ALLOW_INSECURE")
+		flagSet := false
+		if f := fs.Lookup("allow_insecure"); f != nil && f.Changed {
+			flagSet = true
+		}
+		if !envSet && !flagSet {
+			return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow_insecure flag or LVMSYNC_ALLOW_INSECURE environment variable")
+		}
 	}
 	if err := cfg.Validate(); err != nil {
 		return nil, nil, warns, err

--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -67,7 +67,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
-		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "h2"))
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "h2"), zap.String("security", "tls_verification_disabled"), zap.String("usage", "development_only"))
 		clientAuth = tls.RequireAnyClientCert
 	}
 	clientConf := &tls.Config{

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -58,7 +58,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
-		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "quic"))
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "quic"), zap.String("security", "tls_verification_disabled"), zap.String("usage", "development_only"))
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverTLS := &tls.Config{

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -109,7 +109,7 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 		}
 		hkc = ssh.FixedHostKey(pk)
 	case cfg.AllowInsecure:
-		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "ssh"))
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "ssh"), zap.String("security", "host_key_verification_disabled"), zap.String("usage", "development_only"))
 		hkc = ssh.InsecureIgnoreHostKey()
 	default:
 		return nil, fmt.Errorf("known hosts or host key required")

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -42,7 +42,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	}
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
-		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "tcp+tls"))
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "tcp+tls"), zap.String("security", "tls_verification_disabled"), zap.String("usage", "development_only"))
 		clientAuth = tls.RequireAnyClientCert
 	}
 	serverConf := &tls.Config{


### PR DESCRIPTION
## Summary
- require LVMSYNC_ALLOW_INSECURE env or --allow_insecure flag before enabling insecure transport
- warn loudly when insecure mode disables verification
- document development-only insecure mode and add unit test coverage

## Testing
- `go build ./... && echo build-succeeded`
- `go test -cover ./...` *(fails: cmd/dump build failed; cmd/root timeout; transport tests panic)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a217151ee08323a2f112e61a03c0b5