### PR TITLE
Use table-driven cases for IsMountedRW

### DIFF
--- a/device/info.go
+++ b/device/info.go
@@ -23,14 +23,14 @@ type DeviceInfoProvider interface {
 	GetLVMUUID(ctx context.Context, path string) (string, error)
 	GetDeviceID(ctx context.Context, path string) (string, error)
 	IDsMatch(ctx context.Context, src, dest string) (bool, error)
-	IsMountedRW(path string) (bool, error)
+	IsMountedRW(ctx context.Context, path string) (bool, error)
 }
 
 // Info implements DeviceInfoProvider using configurable helpers.
 type Info struct {
 	uuidFunc    func(context.Context, string) (string, error)
 	lvmUUIDFunc func(context.Context, string) (string, error)
-	mountFunc   func(string) (bool, error)
+	mountFunc   func(context.Context, string) (bool, error)
 }
 
 // NewInfo returns an Info using production dependencies.
@@ -47,7 +47,7 @@ func NewInfo() *Info {
 func NewInfoWithDeps(
 	uuid func(context.Context, string) (string, error),
 	lvmUUID func(context.Context, string) (string, error),
-	mount func(string) (bool, error),
+	mount func(context.Context, string) (bool, error),
 ) *Info {
 	if uuid == nil {
 		uuid = defaultUUIDFunc
@@ -62,10 +62,7 @@ func NewInfoWithDeps(
 }
 
 var (
-	uuidFunc    = defaultUUIDFunc
-	lvmUUIDFunc = defaultLVMUUIDFunc
-	mountFunc   = defaultMountFunc
-	detectFunc  = Detect
+	detectFunc = Detect
 )
 
 var defaultInfo = NewInfo()
@@ -84,14 +81,6 @@ func SetUUIDFunc(f func(context.Context, string) (string, error)) func(context.C
 func SetLVMUUIDFunc(f func(context.Context, string) (string, error)) func(context.Context, string) (string, error) {
 	prev := defaultInfo.lvmUUIDFunc
 	defaultInfo.lvmUUIDFunc = f
-	return prev
-}
-
-// SetMountFunc allows tests to override the mount status checker. It returns
-// the previous function for restoration.
-func SetMountFunc(f func(string) (bool, error)) func(string) (bool, error) {
-	prev := defaultInfo.mountFunc
-	defaultInfo.mountFunc = f
 	return prev
 }
 
@@ -146,7 +135,17 @@ func (i *Info) IDsMatch(ctx context.Context, src, dest string) (bool, error) {
 	return sid == did, nil
 }
 
-func (i *Info) IsMountedRW(path string) (bool, error) { return i.mountFunc(path) }
+func (i *Info) IsMountedRW(ctx context.Context, path string) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, mountTimeout)
+		defer cancel()
+	}
+	return i.mountFunc(ctx, path)
+}
 
 func defaultUUIDFunc(ctx context.Context, path string) (string, error) {
 	out, err := exec.CommandContext(ctx, "blkid", "-o", "value", "-s", "UUID", path).Output()
@@ -168,41 +167,12 @@ func defaultLVMUUIDFunc(ctx context.Context, path string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// IDsMatch reports whether the devices at src and dest share the same
-// identifier. For LVM volumes the logical volume UUID is compared; otherwise
-// blkid or GPT serial numbers are used.
-func IDsMatch(ctx context.Context, src, dest string) (bool, error) {
-	sid, err := GetDeviceID(ctx, src)
-	if err != nil {
-		return false, err
-	}
-	did, err := GetDeviceID(ctx, dest)
-	if err != nil {
-		return false, err
-	}
-	return sid == did, nil
-}
-
 // SetMountFunc allows tests to override the mount status checker. It returns
 // the previous function for restoration.
 func SetMountFunc(f func(context.Context, string) (bool, error)) func(context.Context, string) (bool, error) {
-	prev := mountFunc
-	mountFunc = f
+	prev := defaultInfo.mountFunc
+	defaultInfo.mountFunc = f
 	return prev
-}
-
-// IsMountedRW reports whether the device at path is mounted read-write.
-// If ctx has no deadline, a default timeout is applied.
-func IsMountedRW(ctx context.Context, path string) (bool, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if _, ok := ctx.Deadline(); !ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, mountTimeout)
-		defer cancel()
-	}
-	return mountFunc(ctx, path)
 }
 
 func defaultMountFunc(ctx context.Context, path string) (bool, error) {
@@ -255,7 +225,9 @@ func IDsMatch(ctx context.Context, src, dest string) (bool, error) {
 	return defaultInfo.IDsMatch(ctx, src, dest)
 }
 
-func IsMountedRW(path string) (bool, error) { return defaultInfo.IsMountedRW(path) }
+func IsMountedRW(ctx context.Context, path string) (bool, error) {
+	return defaultInfo.IsMountedRW(ctx, path)
+}
 
 // SizeBytes returns the total size of the device at path in bytes.
 // If ctx has no deadline, a default timeout is applied.

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -94,19 +95,29 @@ func TestIDsMatch(t *testing.T) {
 }
 
 func TestSetMountFunc(t *testing.T) {
-	orig := mountFunc
+	orig := defaultInfo.mountFunc
 	stub := func(context.Context, string) (bool, error) { return true, nil }
 	prev := SetMountFunc(stub)
 	if reflect.ValueOf(prev).Pointer() != reflect.ValueOf(orig).Pointer() {
 		t.Fatalf("expected previous function to be original")
 	}
-	if reflect.ValueOf(mountFunc).Pointer() != reflect.ValueOf(stub).Pointer() {
+	if reflect.ValueOf(defaultInfo.mountFunc).Pointer() != reflect.ValueOf(stub).Pointer() {
 		t.Fatalf("mountFunc not replaced")
 	}
 	SetMountFunc(prev)
 }
 
+func TestIsMountedRW(t *testing.T) {
+	tests := []struct {
+		name string
+		val  bool
+	}{
+		{name: "mounted", val: true},
+		{name: "not mounted", val: false},
+	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			prev := SetMountFunc(func(context.Context, string) (bool, error) { return tt.val, nil })
 			defer SetMountFunc(prev)
@@ -119,8 +130,6 @@ func TestSetMountFunc(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tt.val, got)
 			}
 		})
-	if !got {
-		t.Fatalf("expected mounted read-write")
 	}
 }
 
@@ -297,10 +306,6 @@ func TestDefaultMountFuncError(t *testing.T) {
 		t.Fatalf("expected error when reading mountinfo file")
 	}
 }
-
-func mountFuncFromMountInfoFile(p string) func(context.Context, string) (bool, error) {
-	return func(_ context.Context, path string) (bool, error) {
-
 func TestSizeBytes(t *testing.T) {
 	dev := &stubDevice{size: 123}
 	prev := detectFunc
@@ -346,8 +351,8 @@ func (s *stubDevice) Snapshot(context.Context, string) (Device, error) { return 
 func (s *stubDevice) Cleanup(context.Context) error                    { return nil }
 func (s *stubDevice) Close() error                                     { return s.closeErr }
 
-func mountFuncFromMountInfoFile(p string) func(string) (bool, error) {
-	return func(path string) (bool, error) {
+func mountFuncFromMountInfoFile(p string) func(context.Context, string) (bool, error) {
+	return func(_ context.Context, path string) (bool, error) {
 		real, err := filepath.EvalSymlinks(path)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
## Summary
- convert IsMountedRW checks into table-driven tests
- align device info helpers with context-aware mount detection

## Testing
- `go test ./device`


------
https://chatgpt.com/codex/tasks/task_e_68a2217415808323825a6b070ab3283e