### PR TITLE
chore: standardize flags and add escalation timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to the device's NUMA node.
 - **LVM Snapshot Management**:
   - Automatic snapshot creation and removal.
-  - Configurable snapshot size (absolute or percentage-based) via `--snapshot_size`,
+  - Configurable snapshot size (absolute or percentage-based) via `--snapshot-size`,
     `LVMSYNC_SNAPSHOT_SIZE`, or the `snapshot_size` config key.
   - Configurable volume group for constructing the snapshot device path.
   - Auto-selection of target volume groups with sufficient free space.
@@ -95,7 +95,7 @@ Force SSH only:
 lvmsync run --transport ssh user@backup:/dev/vg1/target /dev/vg0/source
 ```
 
-The CLI groups transport flags using [`pflag`](https://github.com/spf13/pflag) and binds them to [`viper`](https://github.com/spf13/viper) while emitting structured logs via [`zap`](https://github.com/uber-go/zap):
+The CLI groups transport flags using [`pflag`](https://github.com/spf13/pflag) and binds them to [`viper`](https://github.com/spf13/viper) while emitting structured logs via [`zap`](https://github.com/uber-go/zap). All flags use **kebab-case** (e.g., `--tls-cert`, `--allow-insecure`) for consistency across commands:
 
 ```go
 import (
@@ -306,7 +306,7 @@ for `run` and `verify` are provided as positional arguments after any flags:
 lvmsync run [flags] <source> <dest>
 ```
 
-When run with `--dry-run`, LVMSync loads any manifest at `--manifest_path` and samples up to 100 blocks to estimate the bytes that would be transmitted. The estimate and ETA in seconds (`eta_seconds`) are logged without sending data. For example:
+When run with `--dry-run`, LVMSync loads any manifest at `--manifest-path` and samples up to 100 blocks to estimate the bytes that would be transmitted. The estimate and ETA in seconds (`eta_seconds`) are logged without sending data. For example:
 
 ```json
 {"level":"info","msg":"dry run","size_bytes":4096,"estimated_tx_bytes":4096,"eta_seconds":2}
@@ -396,13 +396,13 @@ $ lvmsync manifest rebuild --help
 General Options:
       --dry-run   skip execution
 Manifest Options:
-      --manifest_path string   manifest file path
+      --manifest-path string   manifest file path
 
 $ lvmsync verify --help
 General Options:
-      --block_size string   block size for comparisons
+      --block-size string   block size for comparisons
 Manifest Options:
-      --manifest_path string   manifest to verify against
+      --manifest-path string   manifest to verify against
 
 This groups related flags once and lets Viper merge values from flags, `LVMSYNC_*` variables, and the
 `config.yaml` file.
@@ -419,20 +419,20 @@ The overall loading flow now passes an explicit `FlagSet` and argument slice:
 
 Recent refactors added several configuration options:
 
-- `--tcp_port` and `--ssh_port` expose TCP+TLS and SSH endpoints.
-- `--tcp_parallel` controls the number of parallel TCP connections (2–4).
-- `--tcp_lowat` sets TCP_NOTSENT_LOWAT to limit unsent bytes.
+- `--tcp-port` and `--ssh-port` expose TCP+TLS and SSH endpoints.
+- `--tcp-parallel` controls the number of parallel TCP connections (2–4).
+- `--tcp-lowat` sets TCP_NOTSENT_LOWAT to limit unsent bytes.
 - `--sync-interval` controls how many bytes are written between `fdatasync` calls. Accepts size suffixes like `64KB` or `1GB`; invalid values return an error.
-- `--checkpoint_interval` sets how often resume state is persisted.
-- `--checkpoint_bytes` sets how many bytes are written between resume checkpoints.
-- `--block_size` sets the transfer block size (use `auto` for detection).
+- `--checkpoint-interval` sets how often resume state is persisted.
+- `--checkpoint-bytes` sets how many bytes are written between resume checkpoints.
+- `--block-size` sets the transfer block size (use `auto` for detection).
 
 ### I/O tuning
 
-- `--block_size` selects the transfer block size. Use `auto` to match the destination's physical sector size.
+- `--block-size` selects the transfer block size. Use `auto` to match the destination's physical sector size.
 - `--sync-interval` sets how many bytes are written between `fdatasync` calls. Accepts size suffixes like `64KB` or `1GB`; invalid values cause startup errors.
 - `--odirect` uses O_DIRECT with block-size aligned buffers.
-- `--numa_pin` pins worker goroutines to CPUs local to the source device's NUMA node.
+- `--numa-pin` pins worker goroutines to CPUs local to the source device's NUMA node.
 
 ### Device types
 
@@ -442,7 +442,7 @@ examines the path to select the correct handling:
 | Type | Detection | Notes |
 |------|-----------|-------|
 | `lvm` | `/dev/<vg>/<lv>` or `/dev/mapper/<vg>-<lv>` | A snapshot is created and removed automatically |
-| `raw` | Other block devices | Require `--skip_snapshot_creation` and either `--offline` or `--fs-freeze-command`/`--fs-thaw-command` |
+| `raw` | Other block devices | Require `--skip-snapshot-creation` and either `--offline` or `--fs-freeze-command`/`--fs-thaw-command` |
 | `file` | Regular files | Used as-is with no snapshot |
 
 Override detection with `--source-type` and `--dest-type` when necessary.
@@ -560,84 +560,84 @@ Flags override environment variables, which override `config.yaml` values.
 | `--concurrency` | `LVMSYNC_TRANSPORT_CONCURRENCY` | `concurrency` | Stream concurrency (0 to autotune based on BDP) |
 | `--zerocopy` | `LVMSYNC_ZEROCOPY` | `zerocopy` | Enable zero-copy transfers |
 | `--odirect` | `LVMSYNC_ODIRECT` | `odirect` | Use O_DIRECT for device I/O when possible |
-| `--numa_pin` | `LVMSYNC_NUMA_PIN` | `numa_pin` | Pin worker goroutines to device NUMA node |
-| `--max_retries` | `LVMSYNC_MAX_RETRIES` | `max_retries` | Maximum number of retries per block |
+| `--numa-pin` | `LVMSYNC_NUMA_PIN` | `numa_pin` | Pin worker goroutines to device NUMA node |
+| `--max-retries` | `LVMSYNC_MAX_RETRIES` | `max_retries` | Maximum number of retries per block |
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file (records dedup mode and last chunk boundary) |
 | `--speed` | `LVMSYNC_SPEED` | `speed` | Transfer speed limit |
 | `--sync-interval` | `LVMSYNC_SYNC_INTERVAL` | `sync-interval` | Bytes between fdatasync calls (accepts size suffixes like `64KB`; invalid values error) |
-| `--checkpoint_bytes` | `LVMSYNC_CHECKPOINT_BYTES` | `checkpoint_bytes` | Bytes between resume checkpoints |
-| `--checkpoint_interval` | `LVMSYNC_CHECKPOINT_INTERVAL` | `checkpoint_interval` | Duration between checkpoints |
-| `--block_size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
+| `--checkpoint-bytes` | `LVMSYNC_CHECKPOINT_BYTES` | `checkpoint_bytes` | Bytes between resume checkpoints |
+| `--checkpoint-interval` | `LVMSYNC_CHECKPOINT_INTERVAL` | `checkpoint_interval` | Duration between checkpoints |
+| `--block-size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
 | `--verbose` | `LVMSYNC_VERBOSE` | `verbose` | Verbosity level |
-| `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
+| `--verify-checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
 | `--verify` | `LVMSYNC_VERIFY` | `verify` | Verification level: `full`, `sampled`, or `none` |
 | `--digest` | `LVMSYNC_DIGEST` | `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
-| `--manifest_path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
+| `--manifest-path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
 | `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |
-| `--manifest_timeout` | `LVMSYNC_MANIFEST_TIMEOUT` | `manifest_timeout` | Timeout for manifest rebuild (0 disables) |
-| `--manifest_allow_mounted` | `LVMSYNC_MANIFEST_ALLOW_MOUNTED` | `manifest_allow_mounted` | Allow rebuilding when device is mounted read-write |
-| `--ssh_host` | `LVMSYNC_SSH_HOST` | `ssh_host` | SSH host |
-| `--ssh_user` | `LVMSYNC_SSH_USER` | `ssh_user` | SSH username |
-| `--ssh_key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key |
-| `--ssh_host_key_path` | `LVMSYNC_SSH_HOST_KEY_PATH` | `ssh_host_key_path` | Path to SSH host private key |
-| `--ssh_agent` | `LVMSYNC_SSH_AGENT` | `ssh_agent` | Use SSH agent for authentication |
-| `--ssh_port` | `LVMSYNC_SSH_PORT` | `ssh_port` | SSH port |
-| `--ssh_timeout` | `LVMSYNC_SSH_TIMEOUT` | `ssh_timeout` | SSH connection timeout |
-| `--ssh_keepalive` | `LVMSYNC_SSH_KEEPALIVE` | `ssh_keepalive` | SSH keepalive interval |
-| `--ssh_host_key` | `LVMSYNC_SSH_HOST_KEY` | `ssh_host_key` | Expected SSH host public key |
-| `--known_hosts` | `LVMSYNC_KNOWN_HOSTS` | `known_hosts` | Path to known_hosts file |
-| `--strict_host_key_checking` | `LVMSYNC_STRICT_HOST_KEY_CHECKING` | `strict_host_key_checking` | Require host keys to be present in `known_hosts`; when `false`, host key verification is disabled |
-| `--lvmsync_path` | `LVMSYNC_LVMSYNC_PATH` | `lvmsync_path` | Remote command to run (basename sanitized; only `[a-zA-Z0-9._-]+` allowed) |
-| `--remote_pre_script` | `LVMSYNC_REMOTE_PRE_SCRIPT` | `remote_pre_script` | Remote script to run before transfer (times out after `ssh_timeout`) |
-| `--remote_post_script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer (separate `ssh_timeout`) |
-| `--dedup_strategy` | `LVMSYNC_DEDUP_STRATEGY` | `dedup_strategy` | Deduplication strategy: `none`, `auto`, `checksum`, `rolling_hash`, or `bloom` |
-| `--dedup_state_file` | `LVMSYNC_DEDUP_STATE_FILE` | `dedup_state_file` | Path to deduplication state file |
+| `--manifest-timeout` | `LVMSYNC_MANIFEST_TIMEOUT` | `manifest_timeout` | Timeout for manifest rebuild (0 disables) |
+| `--manifest-allow-mounted` | `LVMSYNC_MANIFEST_ALLOW_MOUNTED` | `manifest_allow_mounted` | Allow rebuilding when device is mounted read-write |
+| `--ssh-host` | `LVMSYNC_SSH_HOST` | `ssh_host` | SSH host |
+| `--ssh-user` | `LVMSYNC_SSH_USER` | `ssh_user` | SSH username |
+| `--ssh-key` | `LVMSYNC_SSH_KEY` | `ssh_key` | Path to SSH private key |
+| `--ssh-host-key-path` | `LVMSYNC_SSH_HOST_KEY_PATH` | `ssh_host_key_path` | Path to SSH host private key |
+| `--ssh-agent` | `LVMSYNC_SSH_AGENT` | `ssh_agent` | Use SSH agent for authentication |
+| `--ssh-port` | `LVMSYNC_SSH_PORT` | `ssh_port` | SSH port |
+| `--ssh-timeout` | `LVMSYNC_SSH_TIMEOUT` | `ssh_timeout` | SSH connection timeout |
+| `--ssh-keepalive` | `LVMSYNC_SSH_KEEPALIVE` | `ssh_keepalive` | SSH keepalive interval |
+| `--ssh-host-key` | `LVMSYNC_SSH_HOST_KEY` | `ssh_host_key` | Expected SSH host public key |
+| `--known-hosts` | `LVMSYNC_KNOWN_HOSTS` | `known_hosts` | Path to known_hosts file |
+| `--strict-host-key-checking` | `LVMSYNC_STRICT_HOST_KEY_CHECKING` | `strict_host_key_checking` | Require host keys to be present in `known_hosts`; when `false`, host key verification is disabled |
+| `--lvmsync-path` | `LVMSYNC_LVMSYNC_PATH` | `lvmsync_path` | Remote command to run (basename sanitized; only `[a-zA-Z0-9._-]+` allowed) |
+| `--remote-pre-script` | `LVMSYNC_REMOTE_PRE_SCRIPT` | `remote_pre_script` | Remote script to run before transfer (times out after `ssh_timeout`) |
+| `--remote-post-script` | `LVMSYNC_REMOTE_POST_SCRIPT` | `remote_post_script` | Remote script to run after transfer (separate `ssh_timeout`) |
+| `--dedup-strategy` | `LVMSYNC_DEDUP_STRATEGY` | `dedup_strategy` | Deduplication strategy: `none`, `auto`, `checksum`, `rolling_hash`, or `bloom` |
+| `--dedup-state-file` | `LVMSYNC_DEDUP_STATE_FILE` | `dedup_state_file` | Path to deduplication state file |
 | `--intra-dedup` | `LVMSYNC_DEDUP_INTRA_DEDUP` | `intra_dedup` | Enable intra-run deduplication |
 | `--cdc-min` | `LVMSYNC_DEDUP_CDC_MIN` | `cdc_min` | Minimum chunk size for CDC (must be at least 64 bytes) |
 | `--cdc-avg` | `LVMSYNC_DEDUP_CDC_AVG` | `cdc_avg` | Target average chunk size for CDC |
 | `--cdc-max` | `LVMSYNC_DEDUP_CDC_MAX` | `cdc_max` | Maximum chunk size for CDC |
-| `--bloom_entries` | `LVMSYNC_DEDUP_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
-| `--bloom_fp_rate` | `LVMSYNC_DEDUP_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
-| `--bloom_mbits` | `LVMSYNC_DEDUP_BLOOM_MBITS` | `bloom_mbits` | Bloom filter m bits power |
+| `--bloom-entries` | `LVMSYNC_DEDUP_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
+| `--bloom-fp-rate` | `LVMSYNC_DEDUP_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
+| `--bloom-mbits` | `LVMSYNC_DEDUP_BLOOM_MBITS` | `bloom_mbits` | Bloom filter m bits power |
 | `--compress` | `LVMSYNC_COMPRESSION_COMPRESS` | `compress` | Compression type: `none`, `lz4`, `zstd`, or `auto` |
 | `--zstd-level` | `LVMSYNC_COMPRESSION_ZSTD_LEVEL` | `zstd_level` | Zstd compression level (`1-5`) |
 | `--lz4-level` | `LVMSYNC_COMPRESSION_LZ4_LEVEL` | `lz4_level` | LZ4 compression level: `fast` or `hc` |
-| `--compress_concurrency` | `LVMSYNC_COMPRESSION_COMPRESS_CONCURRENCY` | `compress_concurrency` | Compression concurrency (0 to use `GOMAXPROCS`) |
+| `--compress-concurrency` | `LVMSYNC_COMPRESSION_COMPRESS_CONCURRENCY` | `compress_concurrency` | Compression concurrency (0 to use `GOMAXPROCS`) |
 | `--compress-threshold` | `LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD` | `compress_threshold` | Skip compression when estimated ratio exceeds this value |
-| `--skip_snapshot_creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
-| `--skip_disk_check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
-| `--snapshot_size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
+| `--skip-snapshot-creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
+| `--skip-disk-check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
+| `--snapshot-size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
 | `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; validated at startup |
-| `--lvm_timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations and privilege checks |
+| `--lvm-timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations and privilege checks |
 | `--sig-cache-ttl` | `LVMSYNC_LVM_SIG_CACHE_TTL` | `sig-cache-ttl` | TTL for cached LVM signatures |
 | `--sig-cache-max` | `LVMSYNC_LVM_SIG_CACHE_MAX` | `sig-cache-max` | Maximum cached LVM signatures |
-| `--volume_group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
-| `--target_volume_group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
-| `--target_vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
+| `--volume-group` | `LVMSYNC_VOLUME_GROUP` | `volume_group` | Source volume group; derived from the source device path when empty |
+| `--target-volume-group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
+| `--target-vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
 | `--force` | `LVMSYNC_FORCE` | `force` | Override safety checks and proceed on mounted destination |
 | `--discard` | `LVMSYNC_DISCARD` | `discard` | Issue BLKDISCARD before writing blocks |
 | `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Log estimated transfer bytes without sending data; uses manifest sampling when available |
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | `transport` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) |
-| `--tcp_port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |
-| `--tcp_parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | `tcp_parallel` | Number of parallel TCP connections |
-| `--tcp_lowat` | `LVMSYNC_TRANSPORT_TCP_LOWAT` | `tcp_lowat` | TCP_NOTSENT_LOWAT in bytes |
-| `--grpc_listen` | `LVMSYNC_GRPC_LISTEN` | `grpc_listen` | gRPC listen address |
-| `--grpc_connect` | `LVMSYNC_GRPC_CONNECT` | `grpc_connect` | gRPC server address to connect to |
-| `--grpc_port` | `LVMSYNC_GRPC_PORT` | `grpc_port` | gRPC port to listen on |
-| `--grpc_dial_timeout` | `LVMSYNC_GRPC_DIAL_TIMEOUT` | `grpc_dial_timeout` | gRPC dial timeout |
-| `--grpc_setup_timeout` | `LVMSYNC_GRPC_SETUP_TIMEOUT` | `grpc_setup_timeout` | gRPC setup timeout |
-| `--grpc_heartbeat_interval` | `LVMSYNC_GRPC_HEARTBEAT_INTERVAL` | `grpc_heartbeat_interval` | gRPC heartbeat interval |
-| `--grpc_heartbeat_send_timeout` | `LVMSYNC_GRPC_HEARTBEAT_SEND_TIMEOUT` | `grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout |
-| `--keepalive_time` | `LVMSYNC_GRPC_KEEPALIVE_TIME` | `keepalive_time` | Interval between server pings |
-| `--keepalive_timeout` | `LVMSYNC_GRPC_KEEPALIVE_TIMEOUT` | `keepalive_timeout` | Wait for ping ack before closing |
-| `--request_timeout` | `LVMSYNC_GRPC_REQUEST_TIMEOUT` | `request_timeout` | Deadline for unary RPC handlers |
-| `--tls_cert` | `LVMSYNC_TLS_CERT` | `tls_cert` | TLS certificate file |
-| `--tls_key` | `LVMSYNC_TLS_KEY` | `tls_key` | TLS key file |
-| `--ca_cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
-| `--allow_insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
+| `--tcp-port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |
+| `--tcp-parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | `tcp_parallel` | Number of parallel TCP connections |
+| `--tcp-lowat` | `LVMSYNC_TRANSPORT_TCP_LOWAT` | `tcp_lowat` | TCP_NOTSENT_LOWAT in bytes |
+| `--grpc-listen` | `LVMSYNC_GRPC_LISTEN` | `grpc_listen` | gRPC listen address |
+| `--grpc-connect` | `LVMSYNC_GRPC_CONNECT` | `grpc_connect` | gRPC server address to connect to |
+| `--grpc-port` | `LVMSYNC_GRPC_PORT` | `grpc_port` | gRPC port to listen on |
+| `--grpc-dial-timeout` | `LVMSYNC_GRPC_DIAL_TIMEOUT` | `grpc_dial_timeout` | gRPC dial timeout |
+| `--grpc-setup-timeout` | `LVMSYNC_GRPC_SETUP_TIMEOUT` | `grpc_setup_timeout` | gRPC setup timeout |
+| `--grpc-heartbeat-interval` | `LVMSYNC_GRPC_HEARTBEAT_INTERVAL` | `grpc_heartbeat_interval` | gRPC heartbeat interval |
+| `--grpc-heartbeat-send-timeout` | `LVMSYNC_GRPC_HEARTBEAT_SEND_TIMEOUT` | `grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout |
+| `--keepalive-time` | `LVMSYNC_GRPC_KEEPALIVE_TIME` | `keepalive_time` | Interval between server pings |
+| `--keepalive-timeout` | `LVMSYNC_GRPC_KEEPALIVE_TIMEOUT` | `keepalive_timeout` | Wait for ping ack before closing |
+| `--request-timeout` | `LVMSYNC_GRPC_REQUEST_TIMEOUT` | `request_timeout` | Deadline for unary RPC handlers |
+| `--tls-cert` | `LVMSYNC_TLS_CERT` | `tls_cert` | TLS certificate file |
+| `--tls-key` | `LVMSYNC_TLS_KEY` | `tls_key` | TLS key file |
+| `--ca-cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
+| `--allow-insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
 
-If `--ssh_key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh_timeout` as its deadline.
+If `--ssh-key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh-timeout` as its deadline.
 SSH transport negotiation also derives read and write deadlines from the caller's context; when the context expires, the handshake fails quickly and deadlines are cleared afterward.
 
 ### Common deployment scenarios
@@ -651,13 +651,13 @@ SSH transport negotiation also derives read and write deadlines from the caller'
 - **Remote over SSH**:
 
   ```sh
-  lvmsync run /dev/vg0/source user@backup:/dev/vg1/target --ssh_key ~/.ssh/id_ed25519
+  lvmsync run /dev/vg0/source user@backup:/dev/vg1/target --ssh-key ~/.ssh/id_ed25519
   ```
 
 - **Using the gRPC control plane**:
 
   ```sh
-  lvmsync run --grpc_connect backup:9443 /dev/vg0/source /dev/vg1/target
+  lvmsync run --grpc-connect backup:9443 /dev/vg0/source /dev/vg1/target
   ```
 
 - **Throughput-optimized transfer**:
@@ -747,10 +747,10 @@ tls-key: key.pem
 ca-cert: ca.pem
 ```
 
-Clients connect using `--grpc_connect`:
+Clients connect using `--grpc-connect`:
 
 ```sh
-lvmsync run --grpc_connect localhost:9443 /dev/vg0/snap0 /dev/vg0/data
+lvmsync run --grpc-connect localhost:9443 /dev/vg0/snap0 /dev/vg0/data
 ```
 
 ```sh
@@ -782,7 +782,7 @@ With flags:
 ```sh
 lvmsync run --parallel 8 \
   --compress auto --zstd-level 3 --lz4-level hc --compress-threshold 0.9 \
-  --snapshot_size 10% /dev/vg0/snap0 /mnt/backup
+  --snapshot-size 10% /dev/vg0/snap0 /mnt/backup
 ```
 
 With environment variables:
@@ -803,8 +803,8 @@ Transport selection is controlled by the `--transport` flag, which accepts a com
 transports to attempt (for example `quic,h2,tcp+tls,ssh`). The `quic` transport runs over TLS 1.3 with mutual
 authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional streams and datagrams. The `h2`
 transport also requires TLS 1.3 with client certificates and negotiates the `h2` ALPN. Provide certificates via
-`--tls_cert`, `--tls_key`, and `--ca_cert`. TLS transports require a trusted CA certificate and refuse
-connections when no roots are provided unless insecure mode is explicitly acknowledged with the `--allow_insecure`
+`--tls-cert`, `--tls-key`, and `--ca-cert`. TLS transports require a trusted CA certificate and refuse
+connections when no roots are provided unless insecure mode is explicitly acknowledged with the `--allow-insecure`
 flag or the `LVMSYNC_ALLOW_INSECURE` environment variable. This bypasses certificate verification and is intended
 for development only; configuration files alone cannot enable it. Client certificates must be supplied explicitly;
 transports no longer generate self-signed certificates automatically. The [transport documentation](docs/transports.md) covers each option in depth. The flags below
@@ -816,30 +816,30 @@ configure transport behavior.
 |------|----------------------|-------------|------||
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) |
 | `--concurrency` | `LVMSYNC_TRANSPORT_CONCURRENCY` | Stream concurrency (0 to autotune based on BDP) |
-| `--tcp_port` | `LVMSYNC_TRANSPORT_TCP_PORT` | TCP+TLS port |
+| `--tcp-port` | `LVMSYNC_TRANSPORT_TCP_PORT` | TCP+TLS port |
 | `--h2-port` | `LVMSYNC_H2_PORT` | HTTP/2 port |
-| `--tcp_parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | Number of parallel TCP connections |
-| `--tcp_lowat` | `LVMSYNC_TRANSPORT_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes |
-| `--ssh_port` | `LVMSYNC_SSH_PORT` | SSH port |
-| `--ssh_port` | `LVMSYNC_SSH_PORT` | SSH port | ❌ |
-| `--tls_cert` | `LVMSYNC_TLS_CERT` | TLS certificate file | ✅ |
-| `--tls_key` | `LVMSYNC_TLS_KEY` | TLS key file | ✅ |
-| `--ca_cert` | `LVMSYNC_CA_CERT` | CA certificate file | ✅ |
-| `--tcp_parallel` | `LVMSYNC_TCP_PARALLEL` | Number of parallel TCP connections | n/a |
-| `--tcp_lowat` | `LVMSYNC_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes | n/a |
+| `--tcp-parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | Number of parallel TCP connections |
+| `--tcp-lowat` | `LVMSYNC_TRANSPORT_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes |
+| `--ssh-port` | `LVMSYNC_SSH_PORT` | SSH port |
+| `--ssh-port` | `LVMSYNC_SSH_PORT` | SSH port | ❌ |
+| `--tls-cert` | `LVMSYNC_TLS_CERT` | TLS certificate file | ✅ |
+| `--tls-key` | `LVMSYNC_TLS_KEY` | TLS key file | ✅ |
+| `--ca-cert` | `LVMSYNC_CA_CERT` | CA certificate file | ✅ |
+| `--tcp-parallel` | `LVMSYNC_TCP_PARALLEL` | Number of parallel TCP connections | n/a |
+| `--tcp-lowat` | `LVMSYNC_TCP_LOWAT` | TCP_NOTSENT_LOWAT in bytes | n/a |
 
 ### Usage examples
 
 **Multiple transports**
 
 ```sh
-lvmsync run --transport quic,h2,tcp+tls,ssh --tcp_port 9443 /dev/vg0/snap0 /mnt/backup
+lvmsync run --transport quic,h2,tcp+tls,ssh --tcp-port 9443 /dev/vg0/snap0 /mnt/backup
 ```
 
 **QUIC**
 
 ```sh
-lvmsync run --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
+lvmsync run --transport quic --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 # or
 LVMSYNC_TRANSPORT_TRANSPORT=quic LVMSYNC_TLS_CERT=cert.pem LVMSYNC_TLS_KEY=key.pem LVMSYNC_CA_CERT=ca.pem lvmsync run
 ```
@@ -847,7 +847,7 @@ LVMSYNC_TRANSPORT_TRANSPORT=quic LVMSYNC_TLS_CERT=cert.pem LVMSYNC_TLS_KEY=key.p
 **TCP+TLS**
 
 ```sh
-lvmsync run --transport tcp+tls --tcp_port 9443
+lvmsync run --transport tcp+tls --tcp-port 9443
 # or
 LVMSYNC_TRANSPORT_TRANSPORT=tcp+tls LVMSYNC_TRANSPORT_TCP_PORT=9443 lvmsync run
 ```
@@ -855,13 +855,13 @@ LVMSYNC_TRANSPORT_TRANSPORT=tcp+tls LVMSYNC_TRANSPORT_TCP_PORT=9443 lvmsync run
 **HTTP/2**
 
 ```sh
-lvmsync run --transport h2 --h2-port 9443 --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
+lvmsync run --transport h2 --h2-port 9443 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
 
 **SSH**
 
 ```sh
-lvmsync run --transport ssh backup@host:/dev/vg1/target --ssh_port 2222
+lvmsync run --transport ssh backup@host:/dev/vg1/target --ssh-port 2222
 # or
 LVMSYNC_TRANSPORT_TRANSPORT=ssh LVMSYNC_SSH_PORT=2222 lvmsync run backup@host:/dev/vg1/target
 ```
@@ -879,7 +879,7 @@ Hybrid dedup combines fixed-size and content-defined chunking. Enable it with `-
 The three values must be positive, with `--cdc-min` at least 64 bytes, and satisfy `--cdc-min ≤ --cdc-avg ≤ --cdc-max`.
 LVMSync aborts when the sizes are non-positive, below the minimum, or unordered.
 
-The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom_entries` and desired false positive rate via `--bloom_fp_rate`. For an mmap-backed index, `--bloom_mbits` controls the bitmap size in megabits.
+The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom-entries` and desired false positive rate via `--bloom-fp-rate`. For an mmap-backed index, `--bloom-mbits` controls the bitmap size in megabits.
 
 Compression samples 8 KiB from each chunk and skips when the estimated ratio exceeds `--compress-threshold`. `--compress auto` selects LZ4 for chunks under 256 KiB and Zstd for larger chunks when AVX2 or NEON is available, falling back to LZ4 otherwise.
 
@@ -921,12 +921,12 @@ are resolved with the following precedence (highest first):
 
 | Flag | Environment variable | Config key | Description | Default |
 |------|----------------------|------------|-------------|---------|
-| `--min_chunk_size` | `LVMSYNC_MIN_CHUNK_SIZE` | `min_chunk_size` | Minimum chunk size in bytes | `4096` |
-| `--max_chunk_size` | `LVMSYNC_MAX_CHUNK_SIZE` | `max_chunk_size` | Maximum chunk size in bytes | `1048576` |
-| `--false_positive_rate` | `LVMSYNC_FALSE_POSITIVE_RATE` | `false_positive_rate` | Bloom filter false positive rate | `0.001` |
-| `--ram_bytes` | `LVMSYNC_RAM_BYTES` | `ram_bytes` | RAM budget for the Bloom filter | `1073741824` |
-| `--volume_size` | `LVMSYNC_VOLUME_SIZE` | `volume_size` | Size of the volume being processed | `0` |
-| `--hash_key` | `LVMSYNC_HASH_KEY` | `hash_key` | Optional hex-encoded key for BLAKE3 hashing | `""` |
+| `--min-chunk-size` | `LVMSYNC_MIN_CHUNK_SIZE` | `min_chunk_size` | Minimum chunk size in bytes | `4096` |
+| `--max-chunk-size` | `LVMSYNC_MAX_CHUNK_SIZE` | `max_chunk_size` | Maximum chunk size in bytes | `1048576` |
+| `--false-positive-rate` | `LVMSYNC_FALSE_POSITIVE_RATE` | `false_positive_rate` | Bloom filter false positive rate | `0.001` |
+| `--ram-bytes` | `LVMSYNC_RAM_BYTES` | `ram_bytes` | RAM budget for the Bloom filter | `1073741824` |
+| `--volume-size` | `LVMSYNC_VOLUME_SIZE` | `volume_size` | Size of the volume being processed | `0` |
+| `--hash-key` | `LVMSYNC_HASH_KEY` | `hash_key` | Optional hex-encoded key for BLAKE3 hashing | `""` |
 
 Two presets are available via `--mode`: `default` and `throughput`. Any other value causes configuration validation to fail.
 
@@ -1030,7 +1030,7 @@ Run an initial transfer and write a manifest for later verification or
 incremental runs:
 
 ```sh
-lvmsync run --manifest_path snapshot.manifest /dev/vg0/source /dev/vg1/target
+lvmsync run --manifest-path snapshot.manifest /dev/vg0/source /dev/vg1/target
 ```
 
 See the [manifest documentation](docs/manifest.md) for details on the binary
@@ -1048,7 +1048,7 @@ Rebuild a manifest index for an existing device:
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
 Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
-The command times out after 1m unless overridden with `--manifest_timeout` (0 disables).
+The command times out after 1m unless overridden with `--manifest-timeout` (0 disables).
 Rebuild refuses to run if the device is mounted read-write; pass `--manifest-allow-mounted` to override.
 Mount detection parses `/proc/self/mountinfo` using `github.com/moby/sys/mountinfo` to correctly handle devices with spaces or special characters.
 Rebuild fails if the device reports a block size of 0.
@@ -1071,7 +1071,7 @@ lvmsync verify --dry-run /dev/vg0/source /dev/vg1/target
 To verify using 4 KiB blocks and a manifest generated earlier:
 
 ```sh
-lvmsync verify --block_size 4K /dev/vg0/source /dev/vg1/target
+lvmsync verify --block-size 4K /dev/vg0/source /dev/vg1/target
 ```
 
 Flags are parsed via Viper, so the same settings can be provided through
@@ -1088,13 +1088,13 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--stdout`          | Write change dump to STDOUT                                                                             | `false`   |
 | `--parallel`        | Number of concurrent workers                                                                            | `4`       |
 | `--zerocopy`        | Enable zero-copy transfers (only used in sequential mode)                                               | `false`   |
-| `--max_retries`     | Maximum number of retries per block                                                                     | `3`       |
+| `--max-retries`     | Maximum number of retries per block                                                                     | `3`       |
 | `--resume`          | Path to resume state file                                                                               | `""`      |
 | `--speed`           | Transfer speed limit (e.g., `"100MB"`)                                                                  | `"100MB"` |
 | `-v, --verbose`     | Verbosity level (e.g., `-v`, `-vv`, `-vvv`)                                                             | `0`       |
-| `--verify_checksum` | Enable checksum verification for data integrity                                                         | `false`   |
+| `--verify-checksum` | Enable checksum verification for data integrity                                                         | `false`   |
 | `--progress`        | Show progress percentage during the transfer                                                            | `true`    |
-| `--block_size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
+| `--block-size`      | Block size for data transfer (e.g., `"4K"`, `"64K"`, `"512K"`, `"1M"`), use `0` for automatic detection | `"4K"`    |
 | `--dry-run`         | Print actions without executing | `false`   |
 | `--discard`         | Issue BLKDISCARD before writing blocks | `false`   |
 | `--offline`         | Assume source raw device is offline | `false`   |
@@ -1108,17 +1108,17 @@ Flags are parsed via Viper, so the same settings can be provided through
 
 | Option                    | Description                                                     | Default                  |
 | ------------------------- | --------------------------------------------------------------- | ------------------------ |
-| `--ssh_host`              | SSH host                                                        | `"localhost"`            |
-| `--ssh_user`              | SSH username                                                    | `"root"`                 |
-| `--ssh_key`               | Path to SSH private key                                          | `""`                     |
-| `--ssh_host_key_path`     | Path to SSH host private key (generates one if empty)            | `""`                     |
-| `--ssh_agent`             | Use the SSH agent for authentication                            | `false`                  |
-| `--ssh_port`              | SSH port number                                                 | `22`                     |
-| `--known_hosts`           | Path to known_hosts file (defaults to `$HOME/.ssh/known_hosts`) | `$HOME/.ssh/known_hosts` |
-| `--strict_host_key_checking` | Require host keys to be present in `known_hosts`; when `false`, host key verification is disabled | `true`                   |
-| `--ssh_host_key`          | Expected SSH host public key (authorized_keys format)          | `""`                    |
+| `--ssh-host`              | SSH host                                                        | `"localhost"`            |
+| `--ssh-user`              | SSH username                                                    | `"root"`                 |
+| `--ssh-key`               | Path to SSH private key                                          | `""`                     |
+| `--ssh-host-key-path`     | Path to SSH host private key (generates one if empty)            | `""`                     |
+| `--ssh-agent`             | Use the SSH agent for authentication                            | `false`                  |
+| `--ssh-port`              | SSH port number                                                 | `22`                     |
+| `--known-hosts`           | Path to known_hosts file (defaults to `$HOME/.ssh/known_hosts`) | `$HOME/.ssh/known_hosts` |
+| `--strict-host-key-checking` | Require host keys to be present in `known_hosts`; when `false`, host key verification is disabled | `true`                   |
+| `--ssh-host-key`          | Expected SSH host public key (authorized_keys format)          | `""`                    |
 
-Unknown hosts are rejected unless their keys are present in `known_hosts` or match `--ssh_host_key`.
+Unknown hosts are rejected unless their keys are present in `known_hosts` or match `--ssh-host-key`.
 The host key can also be supplied via `LVMSYNC_SSH_HOST_KEY_PATH` or the `ssh_host_key_path` YAML option; precedence follows flags over environment variables over YAML.
 
 Programmatic use of the SSH transport requires a configuration populated with
@@ -1136,14 +1136,14 @@ tr, err := ssh.New(ctx, cfg)
 
 #### Remote Options
 
-The `--lvmsync_path` value is sanitized to its basename and must match
+The `--lvmsync-path` value is sanitized to its basename and must match
 `[a-zA-Z0-9._-]+` to prevent shell injection.
 
 | Option                 | Description                                       | Default     |
 | ---------------------- | ------------------------------------------------- | ----------- |
-| `--lvmsync_path`       | Remote command to run (sanitized basename)         | `"lvmsync"` |
-| `--remote_pre_script`  | Remote script to run before starting the transfer (`ssh_timeout` applies) | `""`        |
-| `--remote_post_script` | Remote script to run after finishing the transfer (uses a fresh `ssh_timeout`) | `""`        |
+| `--lvmsync-path`       | Remote command to run (sanitized basename)         | `"lvmsync"` |
+| `--remote-pre-script`  | Remote script to run before starting the transfer (`ssh_timeout` applies) | `""`        |
+| `--remote-post-script` | Remote script to run after finishing the transfer (uses a fresh `ssh_timeout`) | `""`        |
 
 Both scripts are run with the configured `ssh_timeout`. The post script uses its
 own timeout and still attempts to execute even when the main transfer fails;
@@ -1157,11 +1157,11 @@ timeouts or cancellations are reported separately.
 | `--cdc-min`          | Minimum chunk size for CDC                                                                              | 4096             |
 | `--cdc-avg`          | Average chunk size for CDC                                                                              | 65536            |
 | `--cdc-max`          | Maximum chunk size for CDC                                                                              | 1048576          |
-| `--dedup_strategy`   | Deduplication strategy ("none", "auto", "checksum", "rolling_hash", or "bloom"); use `none` to disable | "none"           |
-| `--dedup_state_file` | Path to deduplication state file                                                                        | ~/.lvmsync_dedup |
-| `--bloom_entries`    | Estimated number of entries for bloom filter                                                            | 1000000          |
-| `--bloom_fp_rate`    | False positive rate for bloom filter                                                                    | 0.01             |
-| `--bloom_mbits`      | Size of Bloom filter bitmap in megabits (mmap index)                                                   | 0                |
+| `--dedup-strategy`   | Deduplication strategy ("none", "auto", "checksum", "rolling_hash", or "bloom"); use `none` to disable | "none"           |
+| `--dedup-state-file` | Path to deduplication state file                                                                        | ~/.lvmsync_dedup |
+| `--bloom-entries`    | Estimated number of entries for bloom filter                                                            | 1000000          |
+| `--bloom-fp-rate`    | False positive rate for bloom filter                                                                    | 0.01             |
+| `--bloom-mbits`      | Size of Bloom filter bitmap in megabits (mmap index)                                                   | 0                |
 
 #### Compression Options
 
@@ -1170,21 +1170,21 @@ timeouts or cancellations are reported separately.
 | `--compress`             | Compression type (options: `"none"`, `"lz4"`, `"zstd"`, `"auto"`) | `"auto"` |
 | `--zstd-level`           | Zstd compression level (`1-5`)                                   | `1`      |
 | `--lz4-level`            | LZ4 compression level: `fast` or `hc`                            | `fast`   |
-| `--compress_concurrency` | Number of goroutines used for compression (`0` to use all cores)  | `0`      |
+| `--compress-concurrency` | Number of goroutines used for compression (`0` to use all cores)  | `0`      |
 | `--compress-threshold`   | Skip compression when estimated ratio exceeds this value         | `0.9`    |
 
 #### LVM Options
 
 | Option | Description | Default |
 | ------ | ----------- | ------- |
-| `--skip_snapshot_creation` | Skip automatic snapshot creation | `false` |
-| `--skip_disk_check` | Skip disk space check before snapshot creation | `false` |
-| `--snapshot_size` | Snapshot size as an absolute value (e.g., "20G") or as a percentage (e.g., "20%") | "20%" |
-| `--volume_group` | Source volume group. Derived from the source device path when empty | "" |
-| `--target_volume_group` | Volume group name of the target LVM volume | "" |
-| `--target_vgs` | Candidate target volume groups for auto-selection | [] |
+| `--skip-snapshot-creation` | Skip automatic snapshot creation | `false` |
+| `--skip-disk-check` | Skip disk space check before snapshot creation | `false` |
+| `--snapshot-size` | Snapshot size as an absolute value (e.g., "20G") or as a percentage (e.g., "20%") | "20%" |
+| `--volume-group` | Source volume group. Derived from the source device path when empty | "" |
+| `--target-volume-group` | Volume group name of the target LVM volume | "" |
+| `--target-vgs` | Candidate target volume groups for auto-selection | [] |
 | `--lvm-escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n"); validated at startup | "sudo -n" |
-| `--lvm_timeout` | Timeout for LVM operations and privilege checks | 10s |
+| `--lvm-timeout` | Timeout for LVM operations and privilege checks | 10s |
 | `--sig-cache-ttl` | TTL for cached LVM signatures | 24h |
 | `--sig-cache-max` | Maximum cached LVM signatures | 128 |
 
@@ -1194,22 +1194,22 @@ escalation commands stall.
 #### gRPC Options
 
 The client aborts dialing if a connection cannot be established within
-`--grpc_dial_timeout`, which defaults to `5s`.
+`--grpc-dial-timeout`, which defaults to `5s`.
 
 | Option             | Description                  | Default         |
 | ------------------ | ---------------------------- | --------------- |
-| `--grpc_port`      | gRPC port to listen on       | `8443`          |
-| `--grpc_dial_timeout` | gRPC dial timeout          | `5s`            |
-| `--grpc_setup_timeout` | gRPC setup timeout        | `10s`           |
-| `--grpc_heartbeat_interval` | gRPC heartbeat interval | `30s`          |
-| `--grpc_heartbeat_send_timeout` | gRPC heartbeat send timeout | `5s` |
-| `--keepalive_time` | Interval between server pings | `2m` |
-| `--keepalive_timeout` | Timeout waiting for keepalive ack | `20s` |
-| `--request_timeout` | Deadline for unary RPCs | `15s` |
-| `--tls_cert`       | TLS certificate file         | `""`            |
-| `--tls_key`        | TLS key file                 | `""`            |
-| `--ca_cert`        | CA certificate file          | `""`            |
-| `--allow_insecure` | Allow insecure (disable TLS) | `false`         |
+| `--grpc-port`      | gRPC port to listen on       | `8443`          |
+| `--grpc-dial-timeout` | gRPC dial timeout          | `5s`            |
+| `--grpc-setup-timeout` | gRPC setup timeout        | `10s`           |
+| `--grpc-heartbeat-interval` | gRPC heartbeat interval | `30s`          |
+| `--grpc-heartbeat-send-timeout` | gRPC heartbeat send timeout | `5s` |
+| `--keepalive-time` | Interval between server pings | `2m` |
+| `--keepalive-timeout` | Timeout waiting for keepalive ack | `20s` |
+| `--request-timeout` | Deadline for unary RPCs | `15s` |
+| `--tls-cert`       | TLS certificate file         | `""`            |
+| `--tls-key`        | TLS key file                 | `""`            |
+| `--ca-cert`        | CA certificate file          | `""`            |
+| `--allow-insecure` | Allow insecure (disable TLS) | `false`         |
 
 ### Examples
 
@@ -1266,7 +1266,7 @@ lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data
 #### Full LVM Operation Example
 
 ```sh
-lvmsync run --skip_disk_check=false --snapshot_size "25%" --volume_group "vg_data" --lvm-escalation "sudo -n" /dev/vg_data/original /dev/vg_data/destination
+lvmsync run --skip-disk-check=false --snapshot-size "25%" --volume-group "vg_data" --lvm-escalation "sudo -n" /dev/vg_data/original /dev/vg_data/destination
 ```
 
 In this example, LVMSync will:
@@ -1287,7 +1287,7 @@ Rebuild a manifest for an existing device when the index is missing or stale:
 lvmsync manifest rebuild /dev/vg0/lv0
 ```
 Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
-The command times out after 1m unless overridden with `--manifest_timeout` (0 disables).
+The command times out after 1m unless overridden with `--manifest-timeout` (0 disables).
 
 Compare source and destination devices against a manifest:
 
@@ -1339,7 +1339,7 @@ resume: statefile
 CLI:
 
 ```sh
-lvmsync run --ssh_user backup --ssh_port 2222 /dev/vg0/snap0 backup:/dev/vg0/data
+lvmsync run --ssh-user backup --ssh-port 2222 /dev/vg0/snap0 backup:/dev/vg0/data
 ```
 
 Environment:
@@ -1361,7 +1361,7 @@ ssh_port: 2222
 CLI:
 
 ```sh
-lvmsync run --lvmsync_path /usr/bin/lvmsync --remote_pre_script /tmp/pre.sh /dev/vg0/snap0 user@host:/dev/vg0/data
+lvmsync run --lvmsync-path /usr/bin/lvmsync --remote-pre-script /tmp/pre.sh /dev/vg0/snap0 user@host:/dev/vg0/data
 ```
 
 Environment:
@@ -1382,7 +1382,7 @@ remote_pre_script: /tmp/pre.sh
 CLI:
 
 ```sh
-lvmsync run --dedup_strategy bloom --dedup_state_file ~/.lvmsync_state /dev/vg0/snap0 /dev/vg0/data
+lvmsync run --dedup-strategy bloom --dedup-state-file ~/.lvmsync_state /dev/vg0/snap0 /dev/vg0/data
 ```
 
 Environment:
@@ -1434,7 +1434,7 @@ compress_threshold: 0.85
 CLI:
 
 ```sh
-lvmsync run --snapshot_size 25% --volume_group vg_data /dev/vg_data/original /dev/vg_data/destination
+lvmsync run --snapshot-size 25% --volume-group vg_data /dev/vg_data/original /dev/vg_data/destination
 ```
 
 Environment:

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -90,7 +90,7 @@ func (r *Runner) Run(cfg *config.Config, applyFile string, args []string, logger
 	if cfg.DestType == "raw" && !cfg.SkipSnapshotCreation {
 		dev.Cleanup(context.Background())
 		dev.Close()
-		return fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
+		return fmt.Errorf("raw destinations require --skip-snapshot-creation or external freeze hooks")
 	}
 	err = r.applyFunc(cfg, applyFile, dev.Path(), logger)
 	cleanupErr := dev.Cleanup(context.Background())

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -221,7 +221,7 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 	if cfg.SourceType == "raw" && !cfg.SkipSnapshotCreation {
 		dev.Close()
 		dev.Cleanup(ctx)
-		return cfg.DestType, fmt.Errorf("raw sources require --skip_snapshot_creation and either --offline or --fs-freeze-command/--fs-thaw-command")
+		return cfg.DestType, fmt.Errorf("raw sources require --skip-snapshot-creation and either --offline or --fs-freeze-command/--fs-thaw-command")
 	}
 	snapDev, err := dev.Snapshot(ctx, cfg.SnapshotSize)
 	if err != nil {
@@ -258,7 +258,7 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {
 					dev.Close()
-					return destType, fmt.Errorf("raw destinations require --skip_snapshot_creation or external freeze hooks")
+					return destType, fmt.Errorf("raw destinations require --skip-snapshot-creation or external freeze hooks")
 				}
 				destType = "raw"
 			case *device.LVMDevice:

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -121,7 +121,7 @@ func TestManifestRebuildInvalidConfig(t *testing.T) {
 		called = true
 		return nil
 	}, nil, nil)
-	if err := ExecuteWithRunner([]string{"manifest", "rebuild", "--ssh_keepalive=0s", "/dev/vg0"}, zap.NewNop(), r); err == nil {
+	if err := ExecuteWithRunner([]string{"manifest", "rebuild", "--ssh-keepalive=0s", "/dev/vg0"}, zap.NewNop(), r); err == nil {
 		t.Fatalf("expected error for invalid config")
 	}
 	if called {

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -86,7 +86,7 @@ func TestRunManifestPathFlag(t *testing.T) {
 	}
 
 	outputPath := filepath.Join(dir, "custom.manifest")
-	args := []string{"rebuild", "--manifest_path", outputPath, devicePath}
+	args := []string{"rebuild", "--manifest-path", outputPath, devicePath}
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 	if err := Run(cfg, args, logger); err != nil {

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -157,7 +157,7 @@ func TestSetupGRPCSuccess(t *testing.T) {
 
 func TestConfigureLogsBlockSizeBytes(t *testing.T) {
 	origArgs := os.Args
-	os.Args = []string{origArgs[0], "--block_size", "4KB"}
+	os.Args = []string{origArgs[0], "--block-size", "4KB"}
 	defer func() { os.Args = origArgs }()
 
 	origCaps := privilege.HasCaps

--- a/dedup/config_test.go
+++ b/dedup/config_test.go
@@ -32,7 +32,7 @@ func TestLoadConfigPrecedence(t *testing.T) {
 
 	t.Run("flags_override_env", func(t *testing.T) {
 		t.Setenv("LVMSYNC_MIN_CHUNK_SIZE", "2048")
-		cfg, err := LoadConfig(cfgPath, []string{"--min_chunk_size", "1024"})
+		cfg, err := LoadConfig(cfgPath, []string{"--min-chunk-size", "1024"})
 		if err != nil {
 			t.Fatalf("LoadConfig: %v", err)
 		}
@@ -43,15 +43,15 @@ func TestLoadConfigPrecedence(t *testing.T) {
 }
 
 func TestLoadConfigFailures(t *testing.T) {
-	t.Run("invalid_yaml", func(t *testing.T) {
+	t.Run("invalid-yaml", func(t *testing.T) {
 		cfgPath := writeTempConfig(t, ":\n")
 		if _, err := LoadConfig(cfgPath, nil); err == nil {
 			t.Fatalf("expected error for invalid YAML")
 		}
 	})
 
-	t.Run("parse_error", func(t *testing.T) {
-		if _, err := LoadConfig("", []string{"--min_chunk_size", "abc"}); err == nil {
+	t.Run("parse-error", func(t *testing.T) {
+		if _, err := LoadConfig("", []string{"--min-chunk-size", "abc"}); err == nil {
 			t.Fatalf("expected parse error")
 		}
 	})

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -17,17 +17,17 @@ copies can be verified.
 - `lvmsync manifest rebuild <device>` regenerates a manifest when one is
   missing or out of date.
 - `lvmsync verify <source> <dest>` compares a destination against the manifest
-  for the source. Override the manifest path with `--manifest_path` if needed.
+  for the source. Override the manifest path with `--manifest-path` if needed.
 
 Manifest commands group flags with pflag and bind them to Viper while logging progress with zap.
 Flags override environment variables, which override `config.yaml` values.
 
 | Flag | Environment variable | Config key | Description |
 |------|----------------------|------------|-------------|
-| `--manifest_path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
-| `--manifest_timeout` | `LVMSYNC_MANIFEST_TIMEOUT` | `manifest_timeout` | Timeout for manifest rebuild (0 disables) |
-| `--manifest_progress_interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |
-| `--manifest_allow_mounted` | `LVMSYNC_MANIFEST_ALLOW_MOUNTED` | `manifest_allow_mounted` | Allow rebuilding when device is mounted read-write |
+| `--manifest-path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
+| `--manifest-timeout` | `LVMSYNC_MANIFEST_TIMEOUT` | `manifest_timeout` | Timeout for manifest rebuild (0 disables) |
+| `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |
+| `--manifest-allow-mounted` | `LVMSYNC_MANIFEST_ALLOW_MOUNTED` | `manifest_allow_mounted` | Allow rebuilding when device is mounted read-write |
 
 ## Flag Group Example
 
@@ -128,7 +128,7 @@ lvmsync manifest rebuild /dev/vg0/lv0
 
 Progress logs are emitted every 10s by default; adjust with
 `--manifest-progress-interval`. The rebuild operation times out after 1m unless
-`--manifest_timeout` is set (0 disables).
+`--manifest-timeout` is set (0 disables).
 
 ### Verify
 
@@ -143,7 +143,7 @@ lvmsync verify /dev/vg0/snap0 /dev/null
 | Flag | Environment variable | Config key | Description |
 |------|----------------------|------------|-------------|
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file |
-| `--verify_checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
+| `--verify-checksum` | `LVMSYNC_VERIFY_CHECKSUM` | `verify_checksum` | Enable checksum verification |
 | `--digest` | `LVMSYNC_DIGEST` | `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` |
 
 ### Freeze and Thaw Live Filesystems

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -55,7 +55,7 @@ explicitly restrict `tls.Config.CipherSuites` to
 these ciphers. TLS transports require an explicit set of trusted CA roots.
 Connections are rejected if no roots are provided unless the transport
 configuration sets `AllowInsecure` and the user explicitly acknowledges the risk
-with the `--allow_insecure` flag or `LVMSYNC_ALLOW_INSECURE` environment
+with the `--allow-insecure` flag or `LVMSYNC_ALLOW_INSECURE` environment
 variable. This disables certificate verification, logs a warning, and should be
 used only in development.
 
@@ -81,12 +81,12 @@ clients. Defaults:
 - ALPN negotiation using `lvmsync`
 - Bidirectional streams and datagram support
 - BBR congestion control
-- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`
+- Flags: `--tls-cert`, `--tls-key`, `--ca-cert`, `--allow-insecure`
 
 Example:
 
 ```sh
-lvmsync --transport quic --tls_cert cert.pem --tls_key key.pem --ca_cert ca.pem
+lvmsync --transport quic --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
 
 Run a listener with the `serve` subcommand:
@@ -100,22 +100,22 @@ lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-ke
 - Runs over TLS 1.3 with mutual authentication
 - Provides stream-level back-pressure
 - Enforces context deadlines during connection and HTTP/2 handshakes
-- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`, `--tcp_port`
+- Flags: `--tls-cert`, `--tls-key`, `--ca-cert`, `--allow-insecure`, `--tcp-port`
 
 ## TCP+TLS
 
 - Plain TCP encapsulated in TLS 1.3
 - Requires mutual TLS authentication
 - Logs a warning if listener shutdown encounters an error
-- Flags: `--tls_cert`, `--tls_key`, `--ca_cert`, `--allow_insecure`, `--tcp_port`
+- Flags: `--tls-cert`, `--tls-key`, `--ca-cert`, `--allow-insecure`, `--tcp-port`
 
 ## SSH
 
 - Establishes sessions using `golang.org/x/crypto/ssh`
 - Supports `sudo -n` escalation hooks
 - Uses context deadlines for handshake I/O, failing fast when the caller's context times out
-- Verifies server host keys using `known_hosts` or an explicit `--ssh_host_key`; unknown hosts are rejected
-- Key authentication via `--ssh_key`/`LVMSYNC_SSH_KEY`
-- Optional agent auth with `--ssh_agent`/`LVMSYNC_SSH_AGENT` using `SSH_AUTH_SOCK`
-- Listeners require a persistent host key via `--ssh_host_key_path` unless `--allow_insecure` is enabled
-- Flags: `--ssh_user`, `--ssh_password`, `--ssh_key`, `--ssh_host_key`, `--ssh_host_key_path`, `--ssh_agent`, `--allow_insecure`
+- Verifies server host keys using `known_hosts` or an explicit `--ssh-host-key`; unknown hosts are rejected
+- Key authentication via `--ssh-key`/`LVMSYNC_SSH_KEY`
+- Optional agent auth with `--ssh-agent`/`LVMSYNC_SSH_AGENT` using `SSH_AUTH_SOCK`
+- Listeners require a persistent host key via `--ssh-host-key-path` unless `--allow-insecure` is enabled
+- Flags: `--ssh-user`, `--ssh-password`, `--ssh-key`, `--ssh-host-key`, `--ssh-host-key-path`, `--ssh-agent`, `--allow-insecure`

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -15,7 +15,7 @@ lvmsync verify /dev/vg0/source /dev/vg1/target
 Restrict verification to ranges recorded in a manifest and use 4 KiB blocks:
 
 ```sh
-lvmsync verify --block_size 4K --manifest_path snapshot.manifest /dev/vg0/source /dev/vg1/target
+lvmsync verify --block-size 4K --manifest-path snapshot.manifest /dev/vg0/source /dev/vg1/target
 ```
 
 All flags can also be provided via `LVMSYNC_*` environment variables or a

--- a/internal/config/allow_insecure_ack_test.go
+++ b/internal/config/allow_insecure_ack_test.go
@@ -34,7 +34,7 @@ func TestAllowInsecureRequiresFlagOrEnv(t *testing.T) {
 
 	os.Unsetenv("LVMSYNC_ALLOW_INSECURE")
 	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
-	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow_insecure"}); err != nil {
+	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow-insecure"}); err != nil {
 		t.Fatalf("unexpected error with flag ack: %v", err)
 	}
 }

--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -61,11 +61,11 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	if cfg.AllowInsecure {
 		_, envSet := os.LookupEnv("LVMSYNC_ALLOW_INSECURE")
 		flagSet := false
-		if f := fs.Lookup("allow_insecure"); f != nil && f.Changed {
+		if f := fs.Lookup("allow-insecure"); f != nil && f.Changed {
 			flagSet = true
 		}
 		if !envSet && !flagSet {
-			return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow_insecure flag or LVMSYNC_ALLOW_INSECURE environment variable")
+			return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow-insecure flag or LVMSYNC_ALLOW_INSECURE environment variable")
 		}
 	}
 	if err := cfg.Validate(); err != nil {

--- a/internal/config/builder_build_test.go
+++ b/internal/config/builder_build_test.go
@@ -10,7 +10,7 @@ import (
 // when no explicit settings are provided.
 func TestBuilderBuildSuccess(t *testing.T) {
 	v := viper.New()
-	v.Set("allow_insecure", true)
+	v.Set("allow-insecure", true)
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
@@ -29,8 +29,8 @@ func TestBuilderBuildSuccess(t *testing.T) {
 // unsupported compression algorithm is specified.
 func TestBuilderBuildUnsupportedCompression(t *testing.T) {
 	v := viper.New()
-	v.Set("allow_insecure", true)
-	v.Set("compress_threshold", 2.0)
+	v.Set("allow-insecure", true)
+	v.Set("compress-threshold", 2.0)
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -130,9 +130,9 @@ func TestBlockSizeBytes(t *testing.T) {
 func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", "1KB")
+		v.Set("block-size", "1KB")
 		b := &builder{v: v}
-		got, err := b.parseBytesOrFallback("block_size", "4KB")
+		got, err := b.parseBytesOrFallback("block-size", "4KB")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -144,7 +144,7 @@ func TestParseBytesOrFallback(t *testing.T) {
 	t.Run("fallback", func(t *testing.T) {
 		v := viper.New()
 		b := &builder{v: v}
-		got, err := b.parseBytesOrFallback("block_size", "2KB")
+		got, err := b.parseBytesOrFallback("block-size", "2KB")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -155,18 +155,18 @@ func TestParseBytesOrFallback(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", "notbytes")
+		v.Set("block-size", "notbytes")
 		b := &builder{v: v}
-		if _, err := b.parseBytesOrFallback("block_size", "4KB"); err == nil {
+		if _, err := b.parseBytesOrFallback("block-size", "4KB"); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("nearMaxInt", func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", fmt.Sprintf("%d", uint64(math.MaxInt-1023)))
+		v.Set("block-size", fmt.Sprintf("%d", uint64(math.MaxInt-1023)))
 		b := &builder{v: v}
-		got, err := b.parseBytesOrFallback("block_size", "4KB")
+		got, err := b.parseBytesOrFallback("block-size", "4KB")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -177,9 +177,9 @@ func TestParseBytesOrFallback(t *testing.T) {
 
 	t.Run("overflow", func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", fmt.Sprintf("%d", uint64(math.MaxInt)+1))
+		v.Set("block-size", fmt.Sprintf("%d", uint64(math.MaxInt)+1))
 		b := &builder{v: v}
-		if _, err := b.parseBytesOrFallback("block_size", "4KB"); err == nil {
+		if _, err := b.parseBytesOrFallback("block-size", "4KB"); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
@@ -217,7 +217,7 @@ func TestBuilderApplyDefaults(t *testing.T) {
 
 	t.Run("invalidBlockSize", func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", "bad")
+		v.Set("block-size", "bad")
 		b := &builder{v: v, defaults: defaults}
 		if err := b.applyDefaults(&conf); err == nil {
 			t.Fatalf("expected error")
@@ -670,7 +670,7 @@ func TestValidateCDCOrdering(t *testing.T) {
 func TestBuildBlockSize(t *testing.T) {
 	t.Run(Auto, func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", Auto)
+		v.Set("block-size", Auto)
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -687,7 +687,7 @@ func TestBuildBlockSize(t *testing.T) {
 
 	t.Run("numeric", func(t *testing.T) {
 		v := viper.New()
-		v.Set("block_size", "8KB")
+		v.Set("block-size", "8KB")
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -708,7 +708,7 @@ func TestCompressionLevelValidation(t *testing.T) {
 	t.Run(Zstd+"Valid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Zstd)
-		v.Set("zstd_level", 3)
+		v.Set("zstd-level", 3)
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -722,7 +722,7 @@ func TestCompressionLevelValidation(t *testing.T) {
 	t.Run(Zstd+"Invalid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Zstd)
-		v.Set("zstd_level", 6)
+		v.Set("zstd-level", 6)
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -737,9 +737,9 @@ func TestCompressionLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Auto)
 		if compressiondetect.DetectOptimalCompression() == Zstd {
-			v.Set("zstd_level", 2)
+			v.Set("zstd-level", 2)
 		} else {
-			v.Set("lz4_level", "fast")
+			v.Set("lz4-level", "fast")
 		}
 		defaults, err := DefaultConfig()
 		if err != nil {
@@ -755,9 +755,9 @@ func TestCompressionLevelValidation(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", Auto)
 		if compressiondetect.DetectOptimalCompression() == Zstd {
-			v.Set("zstd_level", 6)
+			v.Set("zstd-level", 6)
 		} else {
-			v.Set("lz4_level", "bad")
+			v.Set("lz4-level", "bad")
 		}
 		defaults, err := DefaultConfig()
 		if err != nil {
@@ -772,7 +772,7 @@ func TestCompressionLevelValidation(t *testing.T) {
 	t.Run("lz4Valid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "lz4")
-		v.Set("lz4_level", "hc")
+		v.Set("lz4-level", "hc")
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -786,7 +786,7 @@ func TestCompressionLevelValidation(t *testing.T) {
 	t.Run("lz4Invalid", func(t *testing.T) {
 		v := viper.New()
 		v.Set("compress", "lz4")
-		v.Set("lz4_level", "slow")
+		v.Set("lz4-level", "slow")
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -817,7 +817,7 @@ func TestCompressConcurrency(t *testing.T) {
 
 	t.Run("override", func(t *testing.T) {
 		v := viper.New()
-		v.Set("compress_concurrency", 8)
+		v.Set("compress-concurrency", 8)
 		defaults, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig returned error: %v", err)
@@ -841,7 +841,7 @@ func TestTLSFileValidation(t *testing.T) {
 
 	t.Run("insecure", func(t *testing.T) {
 		v := viper.New()
-		v.Set("allow_insecure", true)
+		v.Set("allow-insecure", true)
 		b := &builder{v: v, defaults: defaults}
 		if _, err := b.Build(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -850,8 +850,8 @@ func TestTLSFileValidation(t *testing.T) {
 
 	t.Run("missingFiles", func(t *testing.T) {
 		v := viper.New()
-		v.Set("allow_insecure", false)
-		v.Set("grpc_listen", ":1")
+		v.Set("allow-insecure", false)
+		v.Set("grpc-listen", ":1")
 		b := &builder{v: v, defaults: defaults}
 		if _, err := b.Build(); err == nil {
 			t.Fatalf("expected error")
@@ -869,11 +869,11 @@ func TestTLSFileValidation(t *testing.T) {
 			}
 		}
 		v := viper.New()
-		v.Set("allow_insecure", false)
-		v.Set("grpc_listen", ":1")
-		v.Set("tls_cert", cert)
-		v.Set("tls_key", key)
-		v.Set("ca_cert", ca)
+		v.Set("allow-insecure", false)
+		v.Set("grpc-listen", ":1")
+		v.Set("tls-cert", cert)
+		v.Set("tls-key", key)
+		v.Set("ca-cert", ca)
 		b := &builder{v: v, defaults: defaults}
 		if _, err := b.Build(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -897,7 +897,7 @@ func TestDefaultCDCTunables(t *testing.T) {
 func TestLoadConfigPrecedence(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
-	t.Setenv("LVMSYNC_PARALLEL", "2")
+	t.Setenv("LVMSYNC-PARALLEL", "2")
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)

--- a/internal/config/config_yaml_test.go
+++ b/internal/config/config_yaml_test.go
@@ -30,7 +30,7 @@ func TestConfigYAMLContainsGroups(t *testing.T) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	keys := []string{"dedup_strategy", "compress", "transport", "lvm_escalation", "grpc_port"}
+	keys := []string{"dedup-strategy", "compress", "transport", "lvm-escalation", "grpc-port"}
 	for _, k := range keys {
 		if _, ok := cfg[k]; !ok {
 			t.Fatalf("missing %s key", k)

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -70,16 +70,16 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Int("parallel", cfg.Parallel, "Number of concurrent workers")
 	fs.Bool("zerocopy", cfg.ZeroCopy, "Enable zero-copy transfers")
 	fs.Bool("odirect", cfg.ODirect, "Use O_DIRECT for device I/O when possible")
-	fs.Bool("numa_pin", cfg.NumaPin, "Pin worker goroutines to device NUMA node")
-	fs.Int("max_retries", cfg.MaxRetries, "Maximum number of retries per block")
+	fs.Bool("numa-pin", cfg.NumaPin, "Pin worker goroutines to device NUMA node")
+	fs.Int("max-retries", cfg.MaxRetries, "Maximum number of retries per block")
 	fs.String("resume", cfg.ResumeState, "Path to resume state file")
 	fs.String("speed", cfg.Speed, "Transfer speed limit")
 	fs.String("sync-interval", cfg.SyncInterval, "Bytes between fdatasync calls")
-	fs.String("checkpoint_bytes", cfg.CheckpointBytesRaw, "Bytes between resume checkpoints")
-	fs.Duration("checkpoint_interval", cfg.CheckpointInterval, "Duration between checkpoints")
-	fs.String("block_size", cfg.BlockSizeRaw, "Block size for data transfer; specify 'auto' or 0 for automatic detection")
+	fs.String("checkpoint-bytes", cfg.CheckpointBytesRaw, "Bytes between resume checkpoints")
+	fs.Duration("checkpoint-interval", cfg.CheckpointInterval, "Duration between checkpoints")
+	fs.String("block-size", cfg.BlockSizeRaw, "Block size for data transfer; specify 'auto' or 0 for automatic detection")
 	fs.CountP("verbose", "v", "Verbosity level")
-	fs.Bool("verify_checksum", cfg.VerifyChecksum, "Enable checksum verification")
+	fs.Bool("verify-checksum", cfg.VerifyChecksum, "Enable checksum verification")
 	fs.String("verify", cfg.VerifyLevel, "Verification level: full, sampled, or none")
 	fs.String("digest", cfg.ChecksumAlgorithm, fmt.Sprintf("Digest algorithm: %v", SupportedChecksumAlgorithms))
 	fs.Bool("progress", cfg.Progress, "Show progress during transfer")
@@ -88,33 +88,33 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 
 func initManifestFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Manifest Options", pflag.ExitOnError)
-	fs.String("manifest_path", cfg.ManifestPath, "Path to manifest file")
-	fs.Duration("manifest_timeout", cfg.ManifestTimeout, "Timeout for manifest rebuild (0 to disable)")
-	fs.Duration("manifest_progress_interval", cfg.ManifestProgressInterval, "Interval between progress logs during manifest rebuild")
-	fs.Bool("manifest_allow_mounted", cfg.ManifestAllowMounted, "Allow rebuilding when device is mounted read-write")
+	fs.String("manifest-path", cfg.ManifestPath, "Path to manifest file")
+	fs.Duration("manifest-timeout", cfg.ManifestTimeout, "Timeout for manifest rebuild (0 to disable)")
+	fs.Duration("manifest-progress-interval", cfg.ManifestProgressInterval, "Interval between progress logs during manifest rebuild")
+	fs.Bool("manifest-allow-mounted", cfg.ManifestAllowMounted, "Allow rebuilding when device is mounted read-write")
 	return fs
 }
 
 func initSSHFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
-	fs.String("ssh_host", cfg.SSHHost, "SSH host")
-	fs.String("ssh_user", cfg.SSHUser, "SSH username")
-	fs.String("ssh_key", cfg.SSHKeyPath, "Path to SSH private key or use agent")
-	fs.String("ssh_host_key_path", cfg.SSHHostKeyPath, "Path to SSH host private key")
-	fs.Int("ssh_port", cfg.SSHPort, "SSH port")
-	fs.Duration("ssh_timeout", cfg.SSHTimeout, "SSH connection timeout")
-	fs.Duration("ssh_keepalive", cfg.SSHKeepAliveInterval, "SSH keepalive interval")
-	fs.String("ssh_host_key", cfg.SSHHostKey, "Expected SSH host public key")
-	fs.String("known_hosts", cfg.KnownHosts, "Path to known_hosts file")
-	fs.Bool("strict_host_key_checking", cfg.StrictHostKeyCheck, "Require host keys to be present in known_hosts")
+	fs.String("ssh-host", cfg.SSHHost, "SSH host")
+	fs.String("ssh-user", cfg.SSHUser, "SSH username")
+	fs.String("ssh-key", cfg.SSHKeyPath, "Path to SSH private key or use agent")
+	fs.String("ssh-host-key-path", cfg.SSHHostKeyPath, "Path to SSH host private key")
+	fs.Int("ssh-port", cfg.SSHPort, "SSH port")
+	fs.Duration("ssh-timeout", cfg.SSHTimeout, "SSH connection timeout")
+	fs.Duration("ssh-keepalive", cfg.SSHKeepAliveInterval, "SSH keepalive interval")
+	fs.String("ssh-host-key", cfg.SSHHostKey, "Expected SSH host public key")
+	fs.String("known-hosts", cfg.KnownHosts, "Path to known_hosts file")
+	fs.Bool("strict-host-key-checking", cfg.StrictHostKeyCheck, "Require host keys to be present in known_hosts")
 	return fs
 }
 
 func initRemoteFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Remote Options", pflag.ExitOnError)
-	fs.String("lvmsync_path", cfg.LVMSyncPath, "Remote command to run")
-	fs.String("remote_pre_script", cfg.RemotePreScript, "Remote script to run before transfer")
-	fs.String("remote_post_script", cfg.RemotePostScript, "Remote script to run after transfer")
+	fs.String("lvmsync-path", cfg.LVMSyncPath, "Remote command to run")
+	fs.String("remote-pre-script", cfg.RemotePreScript, "Remote script to run before transfer")
+	fs.String("remote-post-script", cfg.RemotePostScript, "Remote script to run after transfer")
 	return fs
 }
 
@@ -125,12 +125,12 @@ func initDedupFlags(cfg *Config) *pflag.FlagSet {
 	fs.Int("cdc-avg", cfg.CDCAvg, "Average chunk size for CDC")
 	fs.Int("cdc-max", cfg.CDCMax, "Maximum chunk size for CDC")
 	fs.Uint64("chunk-seed", cfg.ChunkSeed, "Seed for chunking")
-	fs.String("dedup_strategy", cfg.DedupStrategy, fmt.Sprintf("Deduplication strategy: %v", SupportedDedupStrategies))
-	fs.String("dedup_state_file", cfg.DedupStateFile, "Path to deduplication state file")
+	fs.String("dedup-strategy", cfg.DedupStrategy, fmt.Sprintf("Deduplication strategy: %v", SupportedDedupStrategies))
+	fs.String("dedup-state-file", cfg.DedupStateFile, "Path to deduplication state file")
 	fs.Bool("intra-dedup", cfg.IntraDedup, "Enable intra-run deduplication")
-	fs.Int("bloom_entries", cfg.BloomEntries, "Bloom filter entries")
-	fs.Float64("bloom_fp_rate", cfg.BloomFpRate, "Bloom filter false positive rate")
-	fs.Uint("bloom_mbits", cfg.BloomMBits, "Bloom filter M bits per entry")
+	fs.Int("bloom-entries", cfg.BloomEntries, "Bloom filter entries")
+	fs.Float64("bloom-fp-rate", cfg.BloomFpRate, "Bloom filter false positive rate")
+	fs.Uint("bloom-mbits", cfg.BloomMBits, "Bloom filter M bits per entry")
 	return fs
 }
 
@@ -139,39 +139,39 @@ func initCompressionFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("compress", cfg.Compress, fmt.Sprintf("Compression algorithm: %v", SupportedCompression))
 	fs.Int("zstd-level", cfg.ZstdLevel, "Zstd compression level (1-5)")
 	fs.String("lz4-level", cfg.LZ4Level, "LZ4 compression level: fast or hc")
-	fs.Int("compress_concurrency", cfg.CompressConcurrency, "Compression concurrency")
+	fs.Int("compress-concurrency", cfg.CompressConcurrency, "Compression concurrency")
 	fs.Float64("compress-threshold", cfg.CompressThreshold, "Skip compression when estimated ratio exceeds this value")
 	return fs
 }
 
 func initLVMFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("LVM Options", pflag.ExitOnError)
-	fs.Bool("skip_snapshot_creation", cfg.SkipSnapshotCreation, "Skip snapshot creation")
-	fs.Bool("skip_disk_check", cfg.SkipDiskCheck, "Skip disk space check")
-	fs.String("snapshot_size", cfg.SnapshotSize, "Snapshot size (bytes or percentage)")
+	fs.Bool("skip-snapshot-creation", cfg.SkipSnapshotCreation, "Skip snapshot creation")
+	fs.Bool("skip-disk-check", cfg.SkipDiskCheck, "Skip disk space check")
+	fs.String("snapshot-size", cfg.SnapshotSize, "Snapshot size (bytes or percentage)")
 	fs.String("lvm-escalation", cfg.LVMEscalation, "Command to use for privilege escalation")
-	fs.Duration("lvm_timeout", cfg.LVMTimeout, "Timeout for LVM commands and privilege checks")
+	fs.Duration("lvm-timeout", cfg.LVMTimeout, "Timeout for LVM commands and privilege checks")
 	fs.Duration("sig-cache-ttl", cfg.SigCacheTTL, "TTL for LVM signature cache entries")
 	fs.Int("sig-cache-max", cfg.SigCacheMax, "Maximum LVM signature cache entries")
-	fs.String("volume_group", cfg.VolumeGroup, "LVM volume group")
-	fs.String("target_volume_group", cfg.TargetVolumeGroup, "Target LVM volume group")
-	fs.StringSlice("target_vgs", cfg.TargetVGCandidates, "Candidate target VGs for volume selection")
+	fs.String("volume-group", cfg.VolumeGroup, "LVM volume group")
+	fs.String("target-volume-group", cfg.TargetVolumeGroup, "Target LVM volume group")
+	fs.StringSlice("target-vgs", cfg.TargetVGCandidates, "Candidate target VGs for volume selection")
 	return fs
 }
 
 func initGRPCFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("gRPC Options", pflag.ExitOnError)
-	fs.Int("grpc_port", cfg.GRPCPort, "gRPC server port")
-	fs.String("grpc_listen", cfg.GRPCListen, "gRPC listen address")
-	fs.String("grpc_connect", cfg.GRPCConnect, "gRPC connect address")
-	fs.Duration("grpc_dial_timeout", cfg.GRPCDialTimeout, "gRPC dial timeout")
-	fs.Duration("grpc_setup_timeout", cfg.GRPCSetupTimeout, "gRPC setup timeout")
-	fs.Duration("grpc_heartbeat_interval", cfg.HeartbeatInterval, "gRPC heartbeat interval")
-	fs.Duration("grpc_heartbeat_send_timeout", cfg.HeartbeatSendTimeout, "gRPC heartbeat send timeout")
-	fs.String("tls_cert", cfg.TLSCert, "Path to TLS certificate")
-	fs.String("tls_key", cfg.TLSKey, "Path to TLS private key")
-	fs.String("ca_cert", cfg.CACert, "Path to CA certificate")
-	fs.Bool("allow_insecure", cfg.AllowInsecure, "Allow insecure connections")
+	fs.Int("grpc-port", cfg.GRPCPort, "gRPC server port")
+	fs.String("grpc-listen", cfg.GRPCListen, "gRPC listen address")
+	fs.String("grpc-connect", cfg.GRPCConnect, "gRPC connect address")
+	fs.Duration("grpc-dial-timeout", cfg.GRPCDialTimeout, "gRPC dial timeout")
+	fs.Duration("grpc-setup-timeout", cfg.GRPCSetupTimeout, "gRPC setup timeout")
+	fs.Duration("grpc-heartbeat-interval", cfg.HeartbeatInterval, "gRPC heartbeat interval")
+	fs.Duration("grpc-heartbeat-send-timeout", cfg.HeartbeatSendTimeout, "gRPC heartbeat send timeout")
+	fs.String("tls-cert", cfg.TLSCert, "Path to TLS certificate")
+	fs.String("tls-key", cfg.TLSKey, "Path to TLS private key")
+	fs.String("ca-cert", cfg.CACert, "Path to CA certificate")
+	fs.Bool("allow-insecure", cfg.AllowInsecure, "Allow insecure connections")
 	return fs
 }
 
@@ -179,9 +179,9 @@ func initTransportFlags(cfg *Config) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("Transport Options", pflag.ExitOnError)
 	fs.String("transport", cfg.Transport, "Transport modes (comma-separated)")
 	fs.Int("concurrency", cfg.Concurrency, "Number of concurrent connections")
-	fs.Int("tcp_port", cfg.TCPPort, "TCP port")
-	fs.Int("tcp_parallel", cfg.TCPParallel, "Number of parallel TCP connections per worker")
-	fs.Int("tcp_lowat", cfg.TCPNotSentLowAt, "TCP_NOTSENT_LOWAT threshold in bytes")
+	fs.Int("tcp-port", cfg.TCPPort, "TCP port")
+	fs.Int("tcp-parallel", cfg.TCPParallel, "Number of parallel TCP connections per worker")
+	fs.Int("tcp-lowat", cfg.TCPNotSentLowAt, "TCP_NOTSENT_LOWAT threshold in bytes")
 	return fs
 }
 
@@ -226,7 +226,7 @@ func bindDedupEnv(fs *pflag.FlagSet, v *viper.Viper) error {
 		}
 		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 		name = strings.TrimPrefix(name, "DEDUP_")
-		env := "LVMSYNC_DEDUP"
+		env := "LVMSYNC-DEDUP"
 		if name != "" {
 			env += "_" + name
 		}
@@ -263,7 +263,7 @@ func bindLVMEnv(fs *pflag.FlagSet, v *viper.Viper) error {
 		}
 		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 		name = strings.TrimPrefix(name, "LVM_")
-		env := "LVMSYNC_LVM"
+		env := "LVMSYNC-LVM"
 		if name != "" {
 			env += "_" + name
 		}
@@ -284,7 +284,7 @@ func bindGRPCEnv(fs *pflag.FlagSet, v *viper.Viper) error {
 		}
 		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 		name = strings.TrimPrefix(name, "GRPC_")
-		env := "LVMSYNC_GRPC"
+		env := "LVMSYNC-GRPC"
 		if name != "" {
 			env += "_" + name
 		}

--- a/internal/config/flagsets_test.go
+++ b/internal/config/flagsets_test.go
@@ -31,16 +31,16 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"parallel", strconv.Itoa(cfg.Parallel)},
 		{"zerocopy", strconv.FormatBool(cfg.ZeroCopy)},
 		{"odirect", strconv.FormatBool(cfg.ODirect)},
-		{"numa_pin", strconv.FormatBool(cfg.NumaPin)},
-		{"max_retries", strconv.Itoa(cfg.MaxRetries)},
+		{"numa-pin", strconv.FormatBool(cfg.NumaPin)},
+		{"max-retries", strconv.Itoa(cfg.MaxRetries)},
 		{"resume", cfg.ResumeState},
 		{"speed", cfg.Speed},
 		{"sync-interval", cfg.SyncInterval},
-		{"checkpoint_bytes", cfg.CheckpointBytesRaw},
-		{"checkpoint_interval", cfg.CheckpointInterval.String()},
-		{"block_size", cfg.BlockSizeRaw},
+		{"checkpoint-bytes", cfg.CheckpointBytesRaw},
+		{"checkpoint-interval", cfg.CheckpointInterval.String()},
+		{"block-size", cfg.BlockSizeRaw},
 		{"verbose", "0"},
-		{"verify_checksum", strconv.FormatBool(cfg.VerifyChecksum)},
+		{"verify-checksum", strconv.FormatBool(cfg.VerifyChecksum)},
 		{"verify", cfg.VerifyLevel},
 		{"digest", cfg.ChecksumAlgorithm},
 		{"progress", strconv.FormatBool(cfg.Progress)},
@@ -54,7 +54,7 @@ func TestInitGeneralFlags(t *testing.T) {
 			t.Fatalf("%s default %s want %s", tt.name, f.DefValue, tt.want)
 		}
 	}
-	if f := fs.Lookup("checksum_algorithm"); f != nil {
+	if f := fs.Lookup("checksum-algorithm"); f != nil {
 		t.Fatalf("unexpected checksum_algorithm flag")
 	}
 }
@@ -88,15 +88,15 @@ func TestInitSSHFlags(t *testing.T) {
 	}
 	fs := initSSHFlags(cfg)
 	cases := []struct{ name, want string }{
-		{"ssh_host", cfg.SSHHost},
-		{"ssh_user", cfg.SSHUser},
-		{"ssh_key", cfg.SSHKeyPath},
+		{"ssh-host", cfg.SSHHost},
+		{"ssh-user", cfg.SSHUser},
+		{"ssh-key", cfg.SSHKeyPath},
 		{"ssh_host_key_path", cfg.SSHHostKeyPath},
-		{"ssh_port", strconv.Itoa(cfg.SSHPort)},
-		{"ssh_timeout", cfg.SSHTimeout.String()},
-		{"ssh_keepalive", cfg.SSHKeepAliveInterval.String()},
+		{"ssh-port", strconv.Itoa(cfg.SSHPort)},
+		{"ssh-timeout", cfg.SSHTimeout.String()},
+		{"ssh-keepalive", cfg.SSHKeepAliveInterval.String()},
 		{"ssh_host_key", cfg.SSHHostKey},
-		{"known_hosts", cfg.KnownHosts},
+		{"known-hosts", cfg.KnownHosts},
 		{"strict_host_key_checking", strconv.FormatBool(cfg.StrictHostKeyCheck)},
 	}
 	for _, tt := range cases {
@@ -117,7 +117,7 @@ func TestInitRemoteFlags(t *testing.T) {
 	}
 	fs := initRemoteFlags(cfg)
 	cases := []struct{ name, want string }{
-		{"lvmsync_path", cfg.LVMSyncPath},
+		{"lvmsync-path", cfg.LVMSyncPath},
 		{"remote_pre_script", cfg.RemotePreScript},
 		{"remote_post_script", cfg.RemotePostScript},
 	}
@@ -143,12 +143,12 @@ func TestInitDedupFlags(t *testing.T) {
 		{"cdc-min", strconv.Itoa(cfg.CDCMin)},
 		{"cdc-avg", strconv.Itoa(cfg.CDCAvg)},
 		{"cdc-max", strconv.Itoa(cfg.CDCMax)},
-		{"dedup_strategy", cfg.DedupStrategy},
+		{"dedup-strategy", cfg.DedupStrategy},
 		{"dedup_state_file", cfg.DedupStateFile},
 		{"intra-dedup", strconv.FormatBool(cfg.IntraDedup)},
-		{"bloom_entries", strconv.Itoa(cfg.BloomEntries)},
+		{"bloom-entries", strconv.Itoa(cfg.BloomEntries)},
 		{"bloom_fp_rate", fmt.Sprint(cfg.BloomFpRate)},
-		{"bloom_mbits", strconv.FormatUint(uint64(cfg.BloomMBits), 10)},
+		{"bloom-mbits", strconv.FormatUint(uint64(cfg.BloomMBits), 10)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)
@@ -171,7 +171,7 @@ func TestInitCompressionFlags(t *testing.T) {
 		{"compress", cfg.Compress},
 		{"zstd-level", strconv.Itoa(cfg.ZstdLevel)},
 		{"lz4-level", cfg.LZ4Level},
-		{"compress_concurrency", strconv.Itoa(cfg.CompressConcurrency)},
+		{"compress-concurrency", strconv.Itoa(cfg.CompressConcurrency)},
 		{"compress-threshold", strconv.FormatFloat(cfg.CompressThreshold, 'f', -1, 64)},
 	}
 	for _, tt := range cases {
@@ -194,14 +194,14 @@ func TestInitLVMFlags(t *testing.T) {
 	cases := []struct{ name, want string }{
 		{"skip_snapshot_creation", strconv.FormatBool(cfg.SkipSnapshotCreation)},
 		{"skip_disk_check", strconv.FormatBool(cfg.SkipDiskCheck)},
-		{"snapshot_size", cfg.SnapshotSize},
+		{"snapshot-size", cfg.SnapshotSize},
 		{"lvm-escalation", cfg.LVMEscalation},
-		{"lvm_timeout", cfg.LVMTimeout.String()},
+		{"lvm-timeout", cfg.LVMTimeout.String()},
 		{"sig-cache-ttl", cfg.SigCacheTTL.String()},
 		{"sig-cache-max", strconv.Itoa(cfg.SigCacheMax)},
-		{"volume_group", cfg.VolumeGroup},
+		{"volume-group", cfg.VolumeGroup},
 		{"target_volume_group", cfg.TargetVolumeGroup},
-		{"target_vgs", "[]"},
+		{"target-vgs", "[]"},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)
@@ -221,17 +221,17 @@ func TestInitGRPCFlags(t *testing.T) {
 	}
 	fs := initGRPCFlags(cfg)
 	cases := []struct{ name, want string }{
-		{"grpc_port", strconv.Itoa(cfg.GRPCPort)},
-		{"grpc_listen", cfg.GRPCListen},
-		{"grpc_connect", cfg.GRPCConnect},
+		{"grpc-port", strconv.Itoa(cfg.GRPCPort)},
+		{"grpc-listen", cfg.GRPCListen},
+		{"grpc-connect", cfg.GRPCConnect},
 		{"grpc_dial_timeout", cfg.GRPCDialTimeout.String()},
 		{"grpc_setup_timeout", cfg.GRPCSetupTimeout.String()},
 		{"grpc_heartbeat_interval", cfg.HeartbeatInterval.String()},
 		{"grpc_heartbeat_send_timeout", cfg.HeartbeatSendTimeout.String()},
-		{"tls_cert", cfg.TLSCert},
-		{"tls_key", cfg.TLSKey},
-		{"ca_cert", cfg.CACert},
-		{"allow_insecure", strconv.FormatBool(cfg.AllowInsecure)},
+		{"tls-cert", cfg.TLSCert},
+		{"tls-key", cfg.TLSKey},
+		{"ca-cert", cfg.CACert},
+		{"allow-insecure", strconv.FormatBool(cfg.AllowInsecure)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)
@@ -251,8 +251,8 @@ func TestInitManifestFlags(t *testing.T) {
 	}
 	fs := initManifestFlags(cfg)
 	cases := []struct{ name, want string }{
-		{"manifest_path", cfg.ManifestPath},
-		{"manifest_timeout", cfg.ManifestTimeout.String()},
+		{"manifest-path", cfg.ManifestPath},
+		{"manifest-timeout", cfg.ManifestTimeout.String()},
 		{"manifest_progress_interval", cfg.ManifestProgressInterval.String()},
 		{"manifest_allow_mounted", strconv.FormatBool(cfg.ManifestAllowMounted)},
 	}
@@ -276,9 +276,9 @@ func TestInitTransportFlags(t *testing.T) {
 	cases := []struct{ name, want string }{
 		{"transport", cfg.Transport},
 		{"concurrency", strconv.Itoa(cfg.Concurrency)},
-		{"tcp_port", strconv.Itoa(cfg.TCPPort)},
-		{"tcp_parallel", strconv.Itoa(cfg.TCPParallel)},
-		{"tcp_lowat", strconv.Itoa(cfg.TCPNotSentLowAt)},
+		{"tcp-port", strconv.Itoa(cfg.TCPPort)},
+		{"tcp-parallel", strconv.Itoa(cfg.TCPParallel)},
+		{"tcp-lowat", strconv.Itoa(cfg.TCPNotSentLowAt)},
 	}
 	for _, tt := range cases {
 		f := fs.Lookup(tt.name)
@@ -304,7 +304,7 @@ func TestBindLVMEnv(t *testing.T) {
 	t.Setenv("LVMSYNC_LVM_SNAPSHOT_SIZE", "10%")
 	t.Setenv("LVMSYNC_LVM_ESCALATION", "doas")
 	t.Setenv("LVMSYNC_LVM_SIG_CACHE_TTL", "1m")
-	if got := v.GetString("snapshot_size"); got != "10%" {
+	if got := v.GetString("snapshot-size"); got != "10%" {
 		t.Fatalf("snapshot_size got %q want %q", got, "10%")
 	}
 	if got := v.GetString("lvm-escalation"); got != "doas" {
@@ -327,10 +327,10 @@ func TestBindGRPCEnv(t *testing.T) {
 	}
 	t.Setenv("LVMSYNC_GRPC_PORT", "9443")
 	t.Setenv("LVMSYNC_GRPC_TLS_CERT", "cert.pem")
-	if got := v.GetInt("grpc_port"); got != 9443 {
+	if got := v.GetInt("grpc-port"); got != 9443 {
 		t.Fatalf("grpc_port got %d want %d", got, 9443)
 	}
-	if got := v.GetString("tls_cert"); got != "cert.pem" {
+	if got := v.GetString("tls-cert"); got != "cert.pem" {
 		t.Fatalf("tls_cert got %q want %q", got, "cert.pem")
 	}
 }

--- a/internal/config/loadconfig_test.go
+++ b/internal/config/loadconfig_test.go
@@ -35,7 +35,7 @@ func TestRegisterFlags(t *testing.T) {
 	}
 	fs := NewFlagSets(cfg)
 	registerFlags(fs, rootFS)
-	names := []string{"parallel", "ssh_user", "grpc_port"}
+	names := []string{"parallel", "ssh-user", "grpc-port"}
 	for _, name := range names {
 		if f := rootFS.Lookup(name); f == nil {
 			t.Fatalf("missing %s flag", name)
@@ -68,7 +68,7 @@ func TestBuildViperPrecedence(t *testing.T) {
 
 	t.Run("env_overrides_config", func(t *testing.T) {
 		rootFS, args := newFlagSet([]string{"--config", cfgPath})
-		t.Setenv("LVMSYNC_PARALLEL", "2")
+		t.Setenv("LVMSYNC-PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
@@ -89,7 +89,7 @@ func TestBuildViperPrecedence(t *testing.T) {
 
 	t.Run("flags_override_env", func(t *testing.T) {
 		rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
-		t.Setenv("LVMSYNC_PARALLEL", "2")
+		t.Setenv("LVMSYNC-PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
@@ -123,12 +123,12 @@ func TestUsageOutput(t *testing.T) {
 	out := buf.String()
 	wants := []string{
 		"General Options:", "--config",
-		"SSH Options:", "--ssh_user",
-		"Remote Options:", "--lvmsync_path",
-		"Deduplication Options:", "--dedup_strategy",
+		"SSH Options:", "--ssh-user",
+		"Remote Options:", "--lvmsync-path",
+		"Deduplication Options:", "--dedup-strategy",
 		"Compression Options:", "--compress",
-		"LVM Options:", "--skip_snapshot_creation",
-		"gRPC Options:", "--grpc_port",
+		"LVM Options:", "--skip-snapshot-creation",
+		"gRPC Options:", "--grpc-port",
 	}
 	for _, w := range wants {
 		if !strings.Contains(out, w) {

--- a/internal/config/precedence_binding_test.go
+++ b/internal/config/precedence_binding_test.go
@@ -10,7 +10,7 @@ import (
 func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
-	t.Setenv("LVMSYNC_PARALLEL", "2")
+	t.Setenv("LVMSYNC-PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -39,7 +39,7 @@ func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 func TestEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	rootFS, args := newFlagSet([]string{"--config", cfgPath})
-	t.Setenv("LVMSYNC_PARALLEL", "2")
+	t.Setenv("LVMSYNC-PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -126,14 +126,14 @@ func TestCDCMinEnvOverridesConfig(t *testing.T) {
 func TestFlagSetsBindToViper(t *testing.T) {
 	args := []string{
 		"--parallel", "5",
-		"--ssh_user", "alice",
-		"--lvmsync_path", "/usr/bin/lvmsync",
-		"--dedup_strategy", "checksum",
+		"--ssh-user", "alice",
+		"--lvmsync-path", "/usr/bin/lvmsync",
+		"--dedup-strategy", "checksum",
 		"--compress", "lz4",
-		"--skip_snapshot_creation=true",
-		"--grpc_port", "9999",
-		"--grpc_heartbeat_interval", "2s",
-		"--grpc_heartbeat_send_timeout", "1s",
+		"--skip-snapshot-creation=true",
+		"--grpc-port", "9999",
+		"--grpc-heartbeat-interval", "2s",
+		"--grpc-heartbeat-send-timeout", "1s",
 	}
 	rootFS, parseArgs := newFlagSet(args)
 
@@ -155,13 +155,13 @@ func TestFlagSetsBindToViper(t *testing.T) {
 	if got := v.GetInt("parallel"); got != 5 {
 		t.Fatalf("parallel got %d want 5", got)
 	}
-	if got := v.GetString("ssh_user"); got != "alice" {
+	if got := v.GetString("ssh-user"); got != "alice" {
 		t.Fatalf("ssh_user got %q want %q", got, "alice")
 	}
-	if got := v.GetString("lvmsync_path"); got != "/usr/bin/lvmsync" {
+	if got := v.GetString("lvmsync-path"); got != "/usr/bin/lvmsync" {
 		t.Fatalf("lvmsync_path got %q want %q", got, "/usr/bin/lvmsync")
 	}
-	if got := v.GetString("dedup_strategy"); got != "checksum" {
+	if got := v.GetString("dedup-strategy"); got != "checksum" {
 		t.Fatalf("dedup_strategy got %q want %q", got, "checksum")
 	}
 	if got := v.GetString("compress"); got != "lz4" {
@@ -170,7 +170,7 @@ func TestFlagSetsBindToViper(t *testing.T) {
 	if got := v.GetBool("skip_snapshot_creation"); !got {
 		t.Fatalf("skip_snapshot_creation got %v want true", got)
 	}
-	if got := v.GetInt("grpc_port"); got != 9999 {
+	if got := v.GetInt("grpc-port"); got != 9999 {
 		t.Fatalf("grpc_port got %d want 9999", got)
 	}
 	if got := v.GetDuration("grpc_heartbeat_interval"); got != 2*time.Second {
@@ -183,7 +183,7 @@ func TestFlagSetsBindToViper(t *testing.T) {
 
 func TestSSHUserCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "ssh_user: config\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh_user", "cli"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh-user", "cli"})
 	t.Setenv("LVMSYNC_SSH_USER", "env")
 
 	defaults, err := DefaultConfig()
@@ -241,7 +241,7 @@ func TestSSHUserEnvOverridesConfig(t *testing.T) {
 
 func TestSSHHostCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "ssh_host: config\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh_host", "cli"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh-host", "cli"})
 	t.Setenv("LVMSYNC_SSH_HOST", "env")
 
 	defaults, err := DefaultConfig()
@@ -415,7 +415,7 @@ func TestConcurrencyEnvOverridesConfig(t *testing.T) {
 
 func TestTCPPortCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "tcp_port: 1111\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--tcp_port", "3333"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--tcp-port", "3333"})
 	t.Setenv("LVMSYNC_TRANSPORT_TCP_PORT", "2222")
 
 	defaults, err := DefaultConfig()
@@ -473,8 +473,8 @@ func TestTCPPortEnvOverridesConfig(t *testing.T) {
 
 func TestDedupStrategyCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "dedup_strategy: checksum\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--dedup_strategy", "bloom"})
-	t.Setenv("LVMSYNC_DEDUP_STRATEGY", "rolling_hash")
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--dedup-strategy", "bloom"})
+	t.Setenv("LVMSYNC_DEDUP_STRATEGY", "rolling-hash")
 
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -647,7 +647,7 @@ func TestCompressEnvOverridesConfig(t *testing.T) {
 
 func TestGRPCPortCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "grpc_port: 1111\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--grpc_port", "3333"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--grpc-port", "3333"})
 	t.Setenv("LVMSYNC_GRPC_PORT", "2222")
 
 	defaults, err := DefaultConfig()
@@ -705,7 +705,7 @@ func TestGRPCPortEnvOverridesConfig(t *testing.T) {
 
 func TestTLSCertCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "tls_cert: cfg.pem\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--tls_cert", "cli.pem"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--tls-cert", "cli.pem"})
 	t.Setenv("LVMSYNC_TLS_CERT", "env.pem")
 
 	defaults, err := DefaultConfig()
@@ -764,7 +764,7 @@ func TestTLSCertEnvOverridesConfig(t *testing.T) {
 // CLI flag should win over LVMSYNC_MANIFEST_PATH and manifest_path in YAML.
 func TestManifestPathCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "manifest_path: cfg.manifest\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest_path", "cli.manifest"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest-path", "cli.manifest"})
 	t.Setenv("LVMSYNC_MANIFEST_PATH", "env.manifest")
 
 	defaults, err := DefaultConfig()
@@ -823,7 +823,7 @@ func TestManifestPathEnvOverridesConfig(t *testing.T) {
 
 func TestManifestProgressIntervalCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "manifest_progress_interval: 1s\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest_progress_interval", "3s"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest-progress-interval", "3s"})
 	t.Setenv("LVMSYNC_MANIFEST_PROGRESS_INTERVAL", "2s")
 
 	defaults, err := DefaultConfig()
@@ -882,7 +882,7 @@ func TestManifestProgressIntervalEnvOverridesConfig(t *testing.T) {
 // CLI flag takes precedence over LVMSYNC_MANIFEST_TIMEOUT and YAML.
 func TestManifestTimeoutCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "manifest_timeout: 1s\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest_timeout", "3s"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest-timeout", "3s"})
 	t.Setenv("LVMSYNC_MANIFEST_TIMEOUT", "2s")
 
 	defaults, err := DefaultConfig()
@@ -942,7 +942,7 @@ func TestManifestTimeoutEnvOverridesConfig(t *testing.T) {
 // CLI flag should override environment variable and YAML for manifest_allow_mounted.
 func TestManifestAllowMountedCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "manifest_allow_mounted: true\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest_allow_mounted=false"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest-allow-mounted=false"})
 	t.Setenv("LVMSYNC_MANIFEST_ALLOW_MOUNTED", "true")
 
 	defaults, err := DefaultConfig()
@@ -1002,7 +1002,7 @@ func TestManifestAllowMountedEnvOverridesConfig(t *testing.T) {
 // Subsetting FlagSets should still bind remaining flags and omit removed ones.
 func TestSubsetFlagSetsBinding(t *testing.T) {
 	cfgPath := writeTempConfig(t, "manifest_path: cfg.manifest\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest_path", "cli.manifest"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--manifest-path", "cli.manifest"})
 
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -1025,10 +1025,10 @@ func TestSubsetFlagSetsBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}
-	if got := v.GetString("manifest_path"); got != "cli.manifest" {
+	if got := v.GetString("manifest-path"); got != "cli.manifest" {
 		t.Fatalf("manifest_path got %q want %q", got, "cli.manifest")
 	}
-	if rootFS.Lookup("ssh_user") != nil {
+	if rootFS.Lookup("ssh-user") != nil {
 		t.Fatalf("unexpected ssh_user flag present")
 	}
 }

--- a/internal/config/ssh_host_key_path_test.go
+++ b/internal/config/ssh_host_key_path_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestSSHHostKeyPathCLIOverridesEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "ssh_host_key_path: config.key\n")
-	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh_host_key_path", "cli.key"})
+	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--ssh-host-key-path", "cli.key"})
 	t.Setenv("LVMSYNC_SSH_HOST_KEY_PATH", "env.key")
 
 	defaults, err := DefaultConfig()

--- a/internal/config/usage_test.go
+++ b/internal/config/usage_test.go
@@ -18,12 +18,12 @@ func TestFlagSetUsage(t *testing.T) {
 		want string
 	}{
 		{initGeneralFlags(cfg), "--config"},
-		{initSSHFlags(cfg), "--ssh_host"},
-		{initRemoteFlags(cfg), "--lvmsync_path"},
-		{initDedupFlags(cfg), "--dedup_strategy"},
+		{initSSHFlags(cfg), "--ssh-host"},
+		{initRemoteFlags(cfg), "--lvmsync-path"},
+		{initDedupFlags(cfg), "--dedup-strategy"},
 		{initCompressionFlags(cfg), "--compress"},
-		{initLVMFlags(cfg), "--skip_snapshot_creation"},
-		{initGRPCFlags(cfg), "--grpc_port"},
+		{initLVMFlags(cfg), "--skip-snapshot-creation"},
+		{initGRPCFlags(cfg), "--grpc-port"},
 	}
 	for _, tt := range sets {
 		buf := &bytes.Buffer{}

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pierrec/lz4/v4"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 
@@ -46,10 +47,10 @@ func (b *builder) applyDefaults(conf *Config) error {
 	if conf.Mode == "" {
 		conf.Mode = b.defaults.Mode
 	}
-	if !b.v.IsSet("allow_insecure") {
+	if !b.v.IsSet("allow-insecure") {
 		conf.AllowInsecure = b.defaults.AllowInsecure
 	}
-	if !b.v.IsSet("numa_pin") {
+	if !b.v.IsSet("numa-pin") {
 		conf.NumaPin = b.defaults.NumaPin
 	}
 	if conf.GRPCPort == 0 {
@@ -64,7 +65,7 @@ func (b *builder) applyDefaults(conf *Config) error {
 	if conf.ManifestProgressInterval == 0 {
 		conf.ManifestProgressInterval = b.defaults.ManifestProgressInterval
 	}
-	if !b.v.IsSet("manifest_allow_mounted") {
+	if !b.v.IsSet("manifest-allow-mounted") {
 		conf.ManifestAllowMounted = b.defaults.ManifestAllowMounted
 	}
 
@@ -129,7 +130,7 @@ func (b *builder) applyDefaults(conf *Config) error {
 		conf.SyncInterval = b.defaults.SyncInterval
 	}
 
-	cb, err := b.parseBytesOrFallback("checkpoint_bytes", b.defaults.CheckpointBytesRaw)
+	cb, err := b.parseBytesOrFallback("checkpoint-bytes", b.defaults.CheckpointBytesRaw)
 	if err != nil {
 		return err
 	}
@@ -169,17 +170,17 @@ func (b *builder) applyThroughput(conf *Config) {
 	if !b.v.IsSet("dedup") {
 		conf.DedupMode = "hybrid"
 	}
-	if !b.v.IsSet("block_size") {
+	if !b.v.IsSet("block-size") {
 		conf.BlockSize = 2 * 1024 * 1024
 		conf.BlockSizeRaw = "2097152"
 	}
-	if !b.v.IsSet("cdc_min") {
+	if !b.v.IsSet("cdc-min") {
 		conf.CDCMin = 256 * 1024
 	}
-	if !b.v.IsSet("cdc_avg") {
+	if !b.v.IsSet("cdc-avg") {
 		conf.CDCAvg = 2 * 1024 * 1024
 	}
-	if !b.v.IsSet("cdc_max") {
+	if !b.v.IsSet("cdc-max") {
 		conf.CDCMax = 8 * 1024 * 1024
 	}
 	if !b.v.IsSet("compress") {
@@ -192,7 +193,7 @@ func (b *builder) applyThroughput(conf *Config) {
 		conf.SyncInterval = "1GB"
 		conf.SyncIntervalBytes = 1000000000
 	}
-	if !b.v.IsSet("checkpoint_interval") && conf.CheckpointInterval == 0 {
+	if !b.v.IsSet("checkpoint-interval") && conf.CheckpointInterval == 0 {
 		conf.CheckpointInterval = 10 * time.Second
 	}
 }
@@ -235,17 +236,17 @@ func (b *builder) finalizeConfig(conf *Config) error {
 
 	if !conf.AllowInsecure && (conf.GRPCListen != "" || conf.GRPCConnect != "") {
 		if conf.TLSCert == "" || conf.TLSKey == "" {
-			return fmt.Errorf("tls_cert and tls_key must be specified unless allow_insecure is set")
+			return fmt.Errorf("tls-cert and tls-key must be specified unless allow-insecure is set")
 		}
 		if _, err := os.Stat(conf.TLSCert); err != nil {
-			return fmt.Errorf("tls_cert: %w", err)
+			return fmt.Errorf("tls-cert: %w", err)
 		}
 		if _, err := os.Stat(conf.TLSKey); err != nil {
-			return fmt.Errorf("tls_key: %w", err)
+			return fmt.Errorf("tls-key: %w", err)
 		}
 		if conf.CACert != "" {
 			if _, err := os.Stat(conf.CACert); err != nil {
-				return fmt.Errorf("ca_cert: %w", err)
+				return fmt.Errorf("ca-cert: %w", err)
 			}
 		}
 	}
@@ -269,7 +270,7 @@ func (b *builder) parseBytesOrFallback(key, fallback string) (int, error) {
 }
 
 func (b *builder) parseBlockSize() (int, string, error) {
-	raw := strings.ReplaceAll(strings.TrimSpace(b.v.GetString("block_size")), " ", "")
+	raw := strings.ReplaceAll(strings.TrimSpace(b.v.GetString("block-size")), " ", "")
 	if raw == "" {
 		raw = b.defaults.BlockSizeRaw
 	}
@@ -278,11 +279,11 @@ func (b *builder) parseBlockSize() (int, string, error) {
 	}
 	val, isPercent, err := sizeparse.Parse(raw)
 	if err != nil || isPercent {
-		return 0, "", fmt.Errorf("invalid block_size value %q: %w", raw, err)
+		return 0, "", fmt.Errorf("invalid block-size value %q: %w", raw, err)
 	}
 	u := uint64(val)
 	if float64(u) != val || u > uint64(math.MaxInt) {
-		return 0, "", fmt.Errorf("block_size value %q overflows int", raw)
+		return 0, "", fmt.Errorf("block-size value %q overflows int", raw)
 	}
 	return int(u), raw, nil
 }
@@ -308,19 +309,12 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 		if err := v.BindPFlags(fs); err != nil {
 			return nil, nil, err
 		}
+		fs.VisitAll(func(f *pflag.Flag) {
+			if strings.Contains(f.Name, "-") {
+				v.RegisterAlias(strings.ReplaceAll(f.Name, "-", "_"), f.Name)
+			}
+		})
 	}
-	v.RegisterAlias("cdc_min", "cdc-min")
-	v.RegisterAlias("cdc_avg", "cdc-avg")
-	v.RegisterAlias("cdc_max", "cdc-max")
-	v.RegisterAlias("chunk_seed", "chunk-seed")
-	v.RegisterAlias("zstd_level", "zstd-level")
-	v.RegisterAlias("lz4_level", "lz4-level")
-	v.RegisterAlias("compress_threshold", "compress-threshold")
-	v.RegisterAlias("lvm_escalation", "lvm-escalation")
-	v.RegisterAlias("intra_dedup", "intra-dedup")
-	v.RegisterAlias("freeze_timeout", "freeze-timeout")
-	v.RegisterAlias("thaw_timeout", "thaw-timeout")
-	v.RegisterAlias("sync_interval", "sync-interval")
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
 		return nil, nil, err
 	}

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -184,3 +184,32 @@ func TestCommandContextCanceled(t *testing.T) {
 		t.Fatalf("expected context deadline exceeded, got err=%v ctxErr=%v", err, ctx.Err())
 	}
 }
+
+func TestEnsureDefaultTimeout(t *testing.T) {
+	HasCaps = func() bool { return false }
+	orig := escalationTimeout
+	escalationTimeout = 10 * time.Millisecond
+	defer func() { escalationTimeout = orig }()
+	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "10")
+	}), LookPath: fakeLookPath(nil)}
+	esc := NewWithRunner(context.Background(), r)
+	err := esc.Ensure(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestCommandDefaultTimeout(t *testing.T) {
+	orig := escalationTimeout
+	escalationTimeout = 10 * time.Millisecond
+	defer func() { escalationTimeout = orig }()
+	esc := &sudoEscalator{useSudo: false, runner: &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "10")
+	})}}
+	cmd := esc.Command(context.Background(), "sleep", "10")
+	err := cmd.Run()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -6,11 +6,25 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"time"
 )
+
+// escalationTimeout limits how long privilege checks and escalated commands may run
+// when the caller does not provide a deadline.
+var escalationTimeout = 5 * time.Second
+
+func withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, escalationTimeout)
+}
 
 // Ensure verifies that either the required capabilities are present or that
 // sudo is available when escalation is necessary.
 func (s *sudoEscalator) Ensure(ctx context.Context) error {
+	ctx, cancel := withTimeout(ctx)
+	defer cancel()
 	if s.useSudo {
 		if _, err := s.runner.LookPath("sudo"); err != nil {
 			return fmt.Errorf("sudo not found: %w", err)
@@ -26,6 +40,7 @@ func (s *sudoEscalator) Ensure(ctx context.Context) error {
 // Command returns an *exec.Cmd that runs the given program. sudo -n is inserted
 // when capabilities are missing.
 func (s *sudoEscalator) Command(ctx context.Context, name string, args ...string) *exec.Cmd {
+	ctx, _ = withTimeout(ctx)
 	if s.useSudo {
 		all := append([]string{"-n", name}, args...)
 		return s.runner.Cmd.CommandContext(ctx, "sudo", all...)

--- a/reports/doc-updates.md
+++ b/reports/doc-updates.md
@@ -1,6 +1,6 @@
 - README.md: removed transport selection example and marked `--transport` flag as currently ignored in option list and configuration tables.
 - README.md: document `--transport` as reserved; examples note "transport not implemented" error.
-- README.md: clarified `--strict_host_key_checking` flag; disabling it now skips SSH host key verification.
-- README.md: documented SSH agent usage when `--ssh_key` is unset and that the connection respects `--ssh_timeout`.
+- README.md: clarified `--strict-host-key-checking` flag; disabling it now skips SSH host key verification.
+- README.md: documented SSH agent usage when `--ssh-key` is unset and that the connection respects `--ssh-timeout`.
 - README.md: describe gRPC dial timeout behavior and default.
 - README.md: document validation for raw freeze/thaw commands.

--- a/reports/gaps.json
+++ b/reports/gaps.json
@@ -1,18 +1,1 @@
-[
-  {
-    "type": "bug",
-    "component": "cli flags",
-    "evidence": "inconsistent flag naming across commands",
-    "impact": "confusing user experience",
-    "fix": "normalize flag names to kebab-case and document consistent style",
-    "priority": "medium"
-  },
-  {
-    "type": "bug",
-    "component": "privilege escalation",
-    "evidence": "escalation command lacks timeout",
-    "impact": "operations may hang indefinitely",
-    "fix": "add context-aware timeout to privilege escalation",
-    "priority": "high"
-  }
-]
+[]

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -1,4 +1,2 @@
 | Type | Component | Evidence | Impact | Fix | Priority |
 |------|-----------|----------|--------|-----|----------|
-| Bug | CLI flags | inconsistent flag naming across commands | confusing user experience | normalize flag names to kebab-case and document consistent style | medium |
-| Bug | Privilege escalation | escalation command lacks timeout | operations may hang indefinitely | add context-aware timeout to privilege escalation | high |


### PR DESCRIPTION
## Summary
- use consistent kebab-case across CLI flag definitions
- document flag naming convention
- add default timeout to privilege escalation

## Testing
- `go build ./...` *(fails: redeclarations in device package)*
- `go test -cover ./...` *(fails: device tests fail to compile)*
- `golangci-lint run`
- `go test ./reports`

------
https://chatgpt.com/codex/tasks/task_e_68a221776ad08323b0562db24a1a1d60