### PR TITLE
Fix SizeBytes and remove duplicate helpers in device package

### DIFF
--- a/device/info.go
+++ b/device/info.go
@@ -68,14 +68,13 @@ func NewInfoWithDeps(
 }
 
 var (
- defaultInfo = &Info{
-	uuidFunc:    defaultUUIDFunc,
-	lvmUUIDFunc: defaultLVMUUIDFunc,
-	mountFunc:   defaultMountFunc,
-}
+	defaultInfo = &Info{
+		uuidFunc:    defaultUUIDFunc,
+		lvmUUIDFunc: defaultLVMUUIDFunc,
+		mountFunc:   defaultMountFunc,
+	}
 	detectFunc = Detect
 )
-
 
 func init() { defaultInfo.detectFunc = Detect }
 
@@ -208,20 +207,6 @@ func defaultLVMUUIDFunc(ctx context.Context, path string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// IsMountedRW reports whether the device at path is mounted read-write.
-// If ctx has no deadline, a default timeout is applied.
-func (i *Info) IsMountedRW(ctx context.Context, path string) (bool, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if _, ok := ctx.Deadline(); !ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, mountTimeout)
-		defer cancel()
-	}
-	return i.mountFunc(ctx, path)
-}
-
 // SizeBytes returns the total size of the device at path in bytes.
 // If ctx has no deadline, a default timeout is applied.
 func (i *Info) SizeBytes(ctx context.Context, path string) (size uint64, err error) {
@@ -239,13 +224,6 @@ func (i *Info) SizeBytes(ctx context.Context, path string) (size uint64, err err
 	}()
 	size = dev.SizeBytes()
 	return size, err
-
-// SetMountFunc allows tests to override the mount status checker. It returns
-// the previous function for restoration.
-func SetMountFunc(f func(context.Context, string) (bool, error)) func(context.Context, string) (bool, error) {
-	prev := defaultInfo.mountFunc
-	defaultInfo.mountFunc = f
-	return prev
 }
 
 func defaultMountFunc(ctx context.Context, path string) (bool, error) {

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -380,33 +380,3 @@ func (s *stubDevice) BlockSize() uint64                                { return 
 func (s *stubDevice) Snapshot(context.Context, string) (Device, error) { return nil, nil }
 func (s *stubDevice) Cleanup(context.Context) error                    { return nil }
 func (s *stubDevice) Close() error                                     { return s.closeErr }
-
-func mountFuncFromMountInfoFile(p string) func(context.Context, string) (bool, error) {
-	return func(_ context.Context, path string) (bool, error) {
-		real, err := filepath.EvalSymlinks(path)
-		if err != nil {
-			return false, err
-		}
-		f, err := os.Open(p)
-		if err != nil {
-			return false, err
-		}
-		defer f.Close()
-		infos, err := mountinfo.GetMountsFromReader(f, nil)
-		if err != nil {
-			return false, err
-		}
-		for _, mi := range infos {
-			if mi.Source != real {
-				continue
-			}
-			for _, opt := range strings.Split(mi.Options, ",") {
-				if opt == "rw" {
-					return true, nil
-				}
-			}
-		}
-		return false, nil
-	}
-}
-


### PR DESCRIPTION
## Summary
- close SizeBytes implementation and remove duplicated IsMountedRW and SetMountFunc definitions
- drop extra mountFuncFromMountInfoFile test helper to keep vet clean

## Testing
- `go vet ./device`
- `go build ./device`
- `go build ./...`
- `go test -cover ./...` *(fails: undefined: Run)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2293be57c8323b68c00022d9bf156