### PR TITLE
Normalize config key style to underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--max-retries` | `LVMSYNC_MAX_RETRIES` | `max_retries` | Maximum number of retries per block |
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file (records dedup mode and last chunk boundary) |
 | `--speed` | `LVMSYNC_SPEED` | `speed` | Transfer speed limit |
-| `--sync-interval` | `LVMSYNC_SYNC_INTERVAL` | `sync-interval` | Bytes between fdatasync calls (accepts size suffixes like `64KB`; invalid values error) |
+| `--sync-interval` | `LVMSYNC_SYNC_INTERVAL` | `sync_interval` | Bytes between fdatasync calls (accepts size suffixes like `64KB`; invalid values error) |
 | `--checkpoint-bytes` | `LVMSYNC_CHECKPOINT_BYTES` | `checkpoint_bytes` | Bytes between resume checkpoints |
 | `--checkpoint-interval` | `LVMSYNC_CHECKPOINT_INTERVAL` | `checkpoint_interval` | Duration between checkpoints |
 | `--block-size` | `LVMSYNC_BLOCK_SIZE` | `block_size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |

--- a/config.yaml
+++ b/config.yaml
@@ -5,13 +5,13 @@
 # and apply to destination device
 apply: ""
 stdout: false  # Write change dump to STDOUT
-dry-run: false  # Print actions without executing (same as --dry-run)
+dry_run: false  # Print actions without executing (same as --dry-run)
 parallel: 4  # Number of concurrent workers
 # Enable zero-copy transfers (only in sequential mode)
 zerocopy: false
 max_retries: 3  # Maximum number of retries per block
 resume: ""  # Path to resume state file
-sync-interval: "1GB"  # Bytes between fdatasync calls (supports size suffixes like "64KB"; invalid values error)
+sync_interval: "1GB"  # Bytes between fdatasync calls (supports size suffixes like "64KB"; invalid values error)
 
 # Manifest Options
 manifest_timeout: 1m  # Timeout for manifest rebuild (0 disables)

--- a/internal/config/config_yaml_test.go
+++ b/internal/config/config_yaml_test.go
@@ -30,7 +30,7 @@ func TestConfigYAMLContainsGroups(t *testing.T) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	keys := []string{"dedup-strategy", "compress", "transport", "lvm-escalation", "grpc-port"}
+	keys := []string{"dedup_strategy", "compress", "transport", "lvm_escalation", "grpc_port"}
 	for _, k := range keys {
 		if _, ok := cfg[k]; !ok {
 			t.Fatalf("missing %s key", k)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -31,7 +31,7 @@ type Config struct {
 	ConfigFile               string        `mapstructure:"config"`
 	ApplyMode                string        `mapstructure:"apply"`
 	StdoutMode               bool          `mapstructure:"stdout"`
-	DryRun                   bool          `mapstructure:"dry-run"`
+	DryRun                   bool          `mapstructure:"dry_run"`
 	Force                    bool          `mapstructure:"force"`
 	Discard                  bool          `mapstructure:"discard"`
 	Offline                  bool          `mapstructure:"offline"`
@@ -118,7 +118,7 @@ type Config struct {
 	TCPPort                  int           `mapstructure:"tcp_port"`
 	TCPParallel              int           `mapstructure:"tcp_parallel"`
 	TCPNotSentLowAt          int           `mapstructure:"tcp_lowat"`
-	SyncInterval             string        `mapstructure:"sync-interval"`
+	SyncInterval             string        `mapstructure:"sync_interval"`
 	CheckpointInterval       time.Duration `mapstructure:"checkpoint_interval"`
 	CheckpointBytesRaw       string        `mapstructure:"checkpoint_bytes"`
 	SyncIntervalBytes        int           `mapstructure:"-"`

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -121,7 +121,7 @@ func (b *builder) applyDefaults(conf *Config) error {
 	}
 	conf.SpeedLimit = sl
 
-	si, err := b.parseBytesOrFallback("sync-interval", b.defaults.SyncInterval)
+	si, err := b.parseBytesOrFallback("sync_interval", b.defaults.SyncInterval)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (b *builder) applyThroughput(conf *Config) {
 	if !b.v.IsSet("odirect") {
 		conf.ODirect = true
 	}
-	if !b.v.IsSet("sync-interval") {
+	if !b.v.IsSet("sync_interval") {
 		conf.SyncInterval = "1GB"
 		conf.SyncIntervalBytes = 1000000000
 	}


### PR DESCRIPTION
## Summary
- use underscores for config YAML keys
- check new key names in config YAML tests
- document sync_interval config option

## Testing
- `go build ./...` (fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected ()
- `go test -cover ./...` (fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected ()
- `golangci-lint run` (fails: build failed)


------
https://chatgpt.com/codex/tasks/task_e_68a22948dd9c83238259c6c3bc17a019