### PR TITLE
dedup: switch flags to hyphenated names

### DIFF
--- a/dedup/config.go
+++ b/dedup/config.go
@@ -21,7 +21,9 @@ type Config struct {
 // LoadConfig loads configuration from the provided YAML file, environment
 // variables and CLI arguments. CLI arguments have highest precedence.
 // Environment variables are expected to be prefixed with LVMSYNC_ and use
-// uppercase names matching the struct fields.
+// uppercase names matching the struct fields. CLI flags use hyphenated names
+// and map to underscored configuration keys for consistency with environment
+// variables.
 func LoadConfig(path string, args []string) (Config, error) {
 	v := viper.New()
 	v.SetConfigFile(path)
@@ -34,17 +36,32 @@ func LoadConfig(path string, args []string) (Config, error) {
 	v.SetDefault("ram_bytes", uint64(1<<30))
 
 	flags := pflag.NewFlagSet("dedup", pflag.ContinueOnError)
-	flags.Int("min_chunk_size", 4*1024, "minimum chunk size in bytes")
-	flags.Int("max_chunk_size", 1024*1024, "maximum chunk size in bytes")
-	flags.Float64("false_positive_rate", 0.001, "Bloom filter false positive rate")
-	flags.Uint64("ram_bytes", uint64(1<<30), "RAM budget for Bloom filter")
-	flags.Uint64("volume_size", 0, "size of the volume being processed")
-	flags.String("hash_key", "", "optional hex encoded key for BLAKE3")
+	flags.Int("min-chunk-size", 4*1024, "minimum chunk size in bytes")
+	flags.Int("max-chunk-size", 1024*1024, "maximum chunk size in bytes")
+	flags.Float64("false-positive-rate", 0.001, "Bloom filter false positive rate")
+	flags.Uint64("ram-bytes", uint64(1<<30), "RAM budget for Bloom filter")
+	flags.Uint64("volume-size", 0, "size of the volume being processed")
+	flags.String("hash-key", "", "optional hex encoded key for BLAKE3")
 	if err := flags.Parse(args); err != nil {
 		return Config{}, err
 	}
 
-	if err := v.BindPFlags(flags); err != nil {
+	if err := v.BindPFlag("min_chunk_size", flags.Lookup("min-chunk-size")); err != nil {
+		return Config{}, err
+	}
+	if err := v.BindPFlag("max_chunk_size", flags.Lookup("max-chunk-size")); err != nil {
+		return Config{}, err
+	}
+	if err := v.BindPFlag("false_positive_rate", flags.Lookup("false-positive-rate")); err != nil {
+		return Config{}, err
+	}
+	if err := v.BindPFlag("ram_bytes", flags.Lookup("ram-bytes")); err != nil {
+		return Config{}, err
+	}
+	if err := v.BindPFlag("volume_size", flags.Lookup("volume-size")); err != nil {
+		return Config{}, err
+	}
+	if err := v.BindPFlag("hash_key", flags.Lookup("hash-key")); err != nil {
 		return Config{}, err
 	}
 	v.SetEnvPrefix("LVMSYNC")

--- a/dedup/config_test.go
+++ b/dedup/config_test.go
@@ -40,6 +40,17 @@ func TestLoadConfigPrecedence(t *testing.T) {
 			t.Fatalf("expected min_chunk_size 1024, got %d", cfg.MinChunkSize)
 		}
 	})
+
+	t.Run("flags_override_env_max", func(t *testing.T) {
+		t.Setenv("LVMSYNC_MAX_CHUNK_SIZE", "2048")
+		cfg, err := LoadConfig(cfgPath, []string{"--max-chunk-size", "4096"})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.MaxChunkSize != 4096 {
+			t.Fatalf("expected max_chunk_size 4096, got %d", cfg.MaxChunkSize)
+		}
+	})
 }
 
 func TestLoadConfigFailures(t *testing.T) {


### PR DESCRIPTION
## Summary
- rename dedup config flags to hyphenated forms and bind them explicitly
- ensure env variables keep underscore names
- cover max-chunk-size flag precedence in tests

## Testing
- `go build ./...` *(fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected ()*
- `go test -cover ./...` *(fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected () and other tests fail)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a2294b8cc08323a0f97537a0f91440