### PR TITLE
test(privilege): skip sudo tests when absent

### DIFF
--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -94,6 +94,9 @@ func TestSudoSuccess(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("root required")
 	}
+	if _, err := exec.LookPath("sudo"); err != nil {
+		t.Skip("sudo not available")
+	}
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
@@ -107,6 +110,9 @@ func TestSudoSuccess(t *testing.T) {
 func TestSudoPermissionDenied(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("root required")
+	}
+	if _, err := exec.LookPath("sudo"); err != nil {
+		t.Skip("sudo not available")
 	}
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
@@ -125,6 +131,9 @@ func TestSudoPermissionDenied(t *testing.T) {
 func TestSudoCommandNotFound(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("root required")
+	}
+	if _, err := exec.LookPath("sudo"); err != nil {
+		t.Skip("sudo not available")
 	}
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
@@ -153,9 +162,7 @@ func TestHelperProcess(t *testing.T) {
 func TestMain(m *testing.M) {
 	code := m.Run()
 	HasCaps = RealHasCaps
-	if code != 0 {
-		panic(code)
-	}
+	os.Exit(code)
 }
 
 func TestEnsureContextCanceled(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure privilege tests skip when `sudo` binary is missing
- replace panic with graceful `os.Exit` in privilege test main

## Testing
- `go build ./...` *(fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected ()*
- `go test -cover ./...` *(fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected ()*
- `go test ./internal/privilege -run TestSudo -count=1 -v`
- `golangci-lint run` *(warns: Can't process result by diff processor: can't read from patch file path/to/patch/file: open path/to/patch/file: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2294fb7c48323bfa722098d9f2444