### PR TITLE
config: use underscore env prefixes for dedup and lvm

### DIFF
--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -226,7 +226,7 @@ func bindDedupEnv(fs *pflag.FlagSet, v *viper.Viper) error {
 		}
 		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 		name = strings.TrimPrefix(name, "DEDUP_")
-		env := "LVMSYNC-DEDUP"
+		env := "LVMSYNC_DEDUP"
 		if name != "" {
 			env += "_" + name
 		}
@@ -263,7 +263,7 @@ func bindLVMEnv(fs *pflag.FlagSet, v *viper.Viper) error {
 		}
 		name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 		name = strings.TrimPrefix(name, "LVM_")
-		env := "LVMSYNC-LVM"
+		env := "LVMSYNC_LVM"
 		if name != "" {
 			env += "_" + name
 		}

--- a/internal/config/flagsets_test.go
+++ b/internal/config/flagsets_test.go
@@ -291,6 +291,26 @@ func TestInitTransportFlags(t *testing.T) {
 	}
 }
 
+func TestBindDedupEnv(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	fs := initDedupFlags(cfg)
+	v := viper.New()
+	if err := bindDedupEnv(fs, v); err != nil {
+		t.Fatalf("bindDedupEnv: %v", err)
+	}
+	t.Setenv("LVMSYNC_DEDUP_STRATEGY", "checksum")
+	t.Setenv("LVMSYNC_DEDUP_INTRA_DEDUP", "true")
+	if got := v.GetString("dedup-strategy"); got != "checksum" {
+		t.Fatalf("dedup-strategy got %q want %q", got, "checksum")
+	}
+	if got := v.GetBool("intra-dedup"); !got {
+		t.Fatalf("intra-dedup got %v want true", got)
+	}
+}
+
 func TestBindLVMEnv(t *testing.T) {
 	cfg, err := DefaultConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary
- bind dedup and LVM flags to LVMSYNC_DEDUP_* and LVMSYNC_LVM_* environment variables
- cover dedup env binding with a new test

## Testing
- `go test ./internal/config -run TestBindDedupEnv -v`
- `go test ./internal/config -run TestBindLVMEnv -v`
- `go build ./...` *(fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected ()*
- `go test -cover ./...` *(fails: device/info.go:245:6: syntax error: unexpected name SetMountFunc, expected ()*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a229432b848323969d11ddfbcc0ab6