### PR TITLE
test: skip sudo-dependent tests when unavailable

### DIFF
--- a/AGENTS/README
+++ b/AGENTS/README
@@ -1,0 +1,4 @@
+# Agent Notes
+
+Some unit tests exercise privilege escalation paths and require `sudo`.
+If `sudo` is not installed these tests will automatically skip.

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -90,13 +90,18 @@ func fakeSudo(code int) func(string, ...string) *exec.Cmd {
 	}
 }
 
-func TestSudoSuccess(t *testing.T) {
+func requireSudo(t *testing.T) {
+	t.Helper()
 	if os.Geteuid() != 0 {
 		t.Skip("root required")
 	}
 	if _, err := exec.LookPath("sudo"); err != nil {
 		t.Skip("sudo not available")
 	}
+}
+
+func TestSudoSuccess(t *testing.T) {
+	requireSudo(t)
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
@@ -108,12 +113,7 @@ func TestSudoSuccess(t *testing.T) {
 }
 
 func TestSudoPermissionDenied(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("root required")
-	}
-	if _, err := exec.LookPath("sudo"); err != nil {
-		t.Skip("sudo not available")
-	}
+	requireSudo(t)
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
@@ -129,12 +129,7 @@ func TestSudoPermissionDenied(t *testing.T) {
 }
 
 func TestSudoCommandNotFound(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("root required")
-	}
-	if _, err := exec.LookPath("sudo"); err != nil {
-		t.Skip("sudo not available")
-	}
+	requireSudo(t)
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(127)(name, args...)


### PR DESCRIPTION
## Summary
- skip privilege escalation tests when sudo isn't present
- document sudo requirement for these tests

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: cmd/dump build failed, internal/config & transfer tests failed)*
- `golangci-lint run` *(warnings: diff processor and exclusion path patterns)*

------
https://chatgpt.com/codex/tasks/task_e_68a22e17f0888323b8128db6576f7956