### PR TITLE
transfer: inject device checks and gate integration tests

### DIFF
--- a/grpc/grpc_integration_test.go
+++ b/grpc/grpc_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package grpc
 
 import (

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -27,14 +27,13 @@ func minimalStream(t *testing.T) []byte {
 }
 
 func TestProcessDumpDataUUIDMismatch(t *testing.T) {
-	prevLVM := device.SetLVMUUIDFunc(func(context.Context, string) (string, error) { return "", errors.New("no lvm") })
-	defer device.SetLVMUUIDFunc(prevLVM)
-	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "actual", nil })
-	defer device.SetUUIDFunc(prevUUID)
-	prevMount := device.SetMountFunc(func(context.Context, string) (bool, error) { return false, nil })
-	defer device.SetMountFunc(prevMount)
-
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "actual", nil },
+		func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
 	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected", DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
 
 	dest := filepath.Join(t.TempDir(), "dest")
@@ -79,14 +78,13 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 }
 
 func TestProcessDumpDataMountedDevice(t *testing.T) {
-	prevLVM := device.SetLVMUUIDFunc(func(context.Context, string) (string, error) { return "", errors.New("no lvm") })
-	defer device.SetLVMUUIDFunc(prevLVM)
-	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
-	defer device.SetUUIDFunc(prevUUID)
-	prevMount := device.SetMountFunc(func(context.Context, string) (bool, error) { return true, nil })
-	defer device.SetMountFunc(prevMount)
-
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "id", nil },
+		func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+		func(context.Context, string) (bool, error) { return true, nil },
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
 	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
 
 	dest := filepath.Join(t.TempDir(), "dest")
@@ -144,14 +142,13 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 }
 
 func TestApplyDataUUIDMismatch(t *testing.T) {
-	prevLVM := device.SetLVMUUIDFunc(func(context.Context, string) (string, error) { return "", errors.New("no lvm") })
-	defer device.SetLVMUUIDFunc(prevLVM)
-	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "actual", nil })
-	defer device.SetUUIDFunc(prevUUID)
-	prevMount := device.SetMountFunc(func(context.Context, string) (bool, error) { return false, nil })
-	defer device.SetMountFunc(prevMount)
-
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "actual", nil },
+		func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
 	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected"}
 
 	dest := filepath.Join(t.TempDir(), "dest")
@@ -196,14 +193,13 @@ func TestApplyDataUUIDMismatch(t *testing.T) {
 }
 
 func TestApplyDataMountedDevice(t *testing.T) {
-	prevLVM := device.SetLVMUUIDFunc(func(context.Context, string) (string, error) { return "", errors.New("no lvm") })
-	defer device.SetLVMUUIDFunc(prevLVM)
-	prevUUID := device.SetUUIDFunc(func(context.Context, string) (string, error) { return "id", nil })
-	defer device.SetUUIDFunc(prevUUID)
-	prevMount := device.SetMountFunc(func(context.Context, string) (bool, error) { return true, nil })
-	defer device.SetMountFunc(prevMount)
-
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "id", nil },
+		func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+		func(context.Context, string) (bool, error) { return true, nil },
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
 	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id"}
 
 	dest := filepath.Join(t.TempDir(), "dest")
@@ -247,17 +243,16 @@ func TestApplyDataMountedDevice(t *testing.T) {
 	}
 }
 func TestProcessDumpDataCanceledContext(t *testing.T) {
-	prevLVM := device.SetLVMUUIDFunc(func(context.Context, string) (string, error) { return "", errors.New("no lvm") })
-	defer device.SetLVMUUIDFunc(prevLVM)
-	prevUUID := device.SetUUIDFunc(func(ctx context.Context, _ string) (string, error) {
-		<-ctx.Done()
-		return "", ctx.Err()
-	})
-	defer device.SetUUIDFunc(prevUUID)
-	prevMount := device.SetMountFunc(func(context.Context, string) (bool, error) { return false, nil })
-	defer device.SetMountFunc(prevMount)
-
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	info := device.NewInfoWithDeps(
+		func(ctx context.Context, _ string) (string, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+		func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
 	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "id", DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
 
 	dest := filepath.Join(t.TempDir(), "dest")

--- a/transfer/loop_device_integration_test.go
+++ b/transfer/loop_device_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package transfer
 
 import (

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package transfer
 
 import (

--- a/transfer/manifest_integration_test.go
+++ b/transfer/manifest_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package transfer
 
 import (

--- a/transfer/run_apply.go
+++ b/transfer/run_apply.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/common"
-	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 )
 
@@ -34,7 +33,7 @@ func (t *Transfer) applyData(cfg *config.Config, in io.Reader, destDevice string
 			return fmt.Errorf("destination device uuid %s does not match expected %s", uuid, cfg.DeviceUUID)
 		}
 	}
-	mounted, err := device.IsMountedRW(context.Background(), destDevice)
+	mounted, err := t.Info.IsMountedRW(context.Background(), destDevice)
 	if err != nil {
 		return fmt.Errorf("check mount status: %w", err)
 	}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -272,7 +272,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		t.Logger.Info("destination_validated", zap.String("resource_id", id))
 	}
-	mounted, err := device.IsMountedRW(ctx, destPath)
+	mounted, err := t.Info.IsMountedRW(ctx, destPath)
 	if err != nil {
 		return fmt.Errorf("check mount status: %w", err)
 	}

--- a/transfer/verify_destination_ctx_test.go
+++ b/transfer/verify_destination_ctx_test.go
@@ -29,15 +29,16 @@ func TestVerifyDestinationNilContext(t *testing.T) {
 }
 
 func TestVerifyDestinationCanceledContext(t *testing.T) {
-	prevUUID := device.SetUUIDFunc(func(ctx context.Context, _ string) (string, error) {
-		<-ctx.Done()
-		return "", ctx.Err()
-	})
-	defer device.SetUUIDFunc(prevUUID)
-	prevMount := device.SetMountFunc(func(context.Context, string) (bool, error) { return false, nil })
-	defer device.SetMountFunc(prevMount)
-
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	info := device.NewInfoWithDeps(
+		func(ctx context.Context, _ string) (string, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+		func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
 	cfg := &config.Config{DeviceUUID: "id"}
 	dest := filepath.Join(t.TempDir(), "dest")
 	if err := os.WriteFile(dest, nil, 0600); err != nil {

--- a/transport/negotiation_integration_test.go
+++ b/transport/negotiation_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package transport_test
 
 import (


### PR DESCRIPTION
## Summary
- use DeviceInfoProvider for mount checks in transfer apply flows
- inject custom DeviceInfoProvider in transfer tests to avoid external commands
- mark integration tests with `//go:build integration`

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: expected error without explicit acknowledgment, expected error for invalid compression threshold, expected error for invalid compression level, expected 8 got 5, expected error for missing files, expected parallel 2 got 1, expected parallel 2 got 1, expected deadline exceeded got signal: killed)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a22e19dabc8323b814873670e9425e