### PR TITLE
config: validate compression settings

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -332,27 +332,32 @@ func TestBuilderFinalizeConfig(t *testing.T) {
 }
 
 func TestConfigValidate(t *testing.T) {
+	base := Config{
+		Mode:                 "default",
+		LVMEscalation:        "sudo -n",
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+		CDCMin:               64,
+		CDCAvg:               128,
+		CDCMax:               256,
+		Compress:             Auto,
+		ZstdLevel:            1,
+		LZ4Level:             "fast",
+		CompressThreshold:    0.9,
+	}
 	t.Run("success", func(t *testing.T) {
 		fb := &fakeBackend{free: 100}
 		restore := lvm.SetBackend(fb)
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{
-			Mode:                 "default",
-			VolumeGroup:          "vg0",
-			LVMEscalation:        "sudo -n",
-			SSHKeepAliveInterval: time.Second,
-			LVMTimeout:           time.Second,
-			GRPCDialTimeout:      time.Second,
-			GRPCSetupTimeout:     time.Second,
-			HeartbeatInterval:    time.Second,
-			HeartbeatSendTimeout: time.Second,
-			TCPParallel:          1,
-			CDCMin:               64,
-			CDCAvg:               128,
-			CDCMax:               256,
-		}
+		cfg := base
+		cfg.VolumeGroup = "vg0"
+		cfg.LVMTimeout = time.Second
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -364,49 +369,57 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.VolumeGroup = "vg0"
+		cfg.LVMTimeout = time.Second
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidKeepalive", func(t *testing.T) {
-		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: 0, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.SSHKeepAliveInterval = 0
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatInterval", func(t *testing.T) {
-		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: 0, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.HeartbeatInterval = 0
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidHeartbeatSendTimeout", func(t *testing.T) {
-		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: 0, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.HeartbeatSendTimeout = 0
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidGRPCSetupTimeout", func(t *testing.T) {
-		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: 0, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.GRPCSetupTimeout = 0
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPParallel", func(t *testing.T) {
-		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 5, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.TCPParallel = 5
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 
 	t.Run("invalidTCPLowat", func(t *testing.T) {
-		cfg := &Config{Mode: "default", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, TCPNotSentLowAt: -1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.TCPNotSentLowAt = -1
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -417,7 +430,9 @@ func TestConfigValidate(t *testing.T) {
 		defer restore()
 		restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
 		defer restorePriv()
-		cfg := &Config{Mode: "default", VolumeGroup: "vg0", LVMEscalation: "sudo -n", SSHKeepAliveInterval: time.Second, LVMTimeout: time.Millisecond, GRPCDialTimeout: time.Second, GRPCSetupTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second, TCPParallel: 1, CDCMin: 64, CDCAvg: 128, CDCMax: 256}
+		cfg := base
+		cfg.VolumeGroup = "vg0"
+		cfg.LVMTimeout = time.Millisecond
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected timeout error")
 		}
@@ -434,6 +449,10 @@ func TestConfigValidateCDC(t *testing.T) {
 		HeartbeatSendTimeout: time.Second,
 		TCPParallel:          1,
 		LVMEscalation:        "sudo -n",
+		Compress:             Auto,
+		ZstdLevel:            1,
+		LZ4Level:             "fast",
+		CompressThreshold:    0.9,
 	}
 
 	t.Run("valid", func(t *testing.T) {
@@ -464,6 +483,61 @@ func TestConfigValidateCDC(t *testing.T) {
 		cfg.CDCMax = 3
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestConfigValidateCompression(t *testing.T) {
+	base := Config{
+		Mode:                 "default",
+		LVMEscalation:        "sudo -n",
+		SSHKeepAliveInterval: time.Second,
+		GRPCDialTimeout:      time.Second,
+		GRPCSetupTimeout:     time.Second,
+		HeartbeatInterval:    time.Second,
+		HeartbeatSendTimeout: time.Second,
+		TCPParallel:          1,
+		CDCMin:               64,
+		CDCAvg:               128,
+		CDCMax:               256,
+		Compress:             Auto,
+		ZstdLevel:            1,
+		LZ4Level:             "fast",
+		CompressThreshold:    0.9,
+	}
+	t.Run("unknownAlgorithm", func(t *testing.T) {
+		cfg := base
+		cfg.Compress = "gzip"
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+	t.Run("negativeThreshold", func(t *testing.T) {
+		cfg := base
+		cfg.CompressThreshold = -0.1
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+	t.Run("zstdLevelOutOfRange", func(t *testing.T) {
+		cfg := base
+		cfg.Compress = Zstd
+		cfg.ZstdLevel = 6
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+	t.Run("lz4LevelInvalid", func(t *testing.T) {
+		cfg := base
+		cfg.Compress = "lz4"
+		cfg.LZ4Level = "slow"
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+	t.Run("valid", func(t *testing.T) {
+		if err := base.Validate(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 }
@@ -831,6 +905,36 @@ func TestCompressConcurrency(t *testing.T) {
 			t.Fatalf("expected 8, got %d", cfg.CompressConcurrency)
 		}
 	})
+}
+
+func TestCompressionParsingErrors(t *testing.T) {
+	t.Run("flagNegativeThreshold", func(t *testing.T) {
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		b := NewBuilder(defaults)
+		fs, args := newFlagSet([]string{"--compress-threshold", "-0.5"})
+		if _, _, _, err := b.Build(fs, args); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("envZstdLevelInvalid", func(t *testing.T) {
+		defaults, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig returned error: %v", err)
+		}
+		b := NewBuilder(defaults)
+		t.Setenv("LVMSYNC_COMPRESSION_COMPRESS", "zstd")
+		t.Setenv("LVMSYNC_COMPRESSION_ZSTD_LEVEL", "6")
+		fs, args := newFlagSet(nil)
+		if _, _, _, err := b.Build(fs, args); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	// YAML parsing errors are covered by builder tests elsewhere.
 }
 
 func TestTLSFileValidation(t *testing.T) {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -110,6 +110,42 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 			}
 		}
 	}
+	if err := validateCompressionSettings(c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateCompressionSettings(c *Config) error {
+	if strings.TrimSpace(c.Compress) != "" {
+		algos := strings.Split(c.Compress, ",")
+		for _, a := range algos {
+			a = strings.TrimSpace(strings.ToLower(a))
+			if a == "" {
+				continue
+			}
+			valid := false
+			for _, supported := range SupportedCompression {
+				if a == supported {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return fmt.Errorf("unsupported compression algorithm: %s", a)
+			}
+		}
+	}
+	if c.ZstdLevel != 0 && (c.ZstdLevel < 1 || c.ZstdLevel > 5) {
+		return fmt.Errorf("invalid zstd compression level: %d", c.ZstdLevel)
+	}
+	lz4 := strings.ToLower(c.LZ4Level)
+	if lz4 != "" && lz4 != "fast" && lz4 != "hc" {
+		return fmt.Errorf("invalid lz4 compression level: %s", c.LZ4Level)
+	}
+	if c.CompressThreshold < 0 || c.CompressThreshold > 1 {
+		return fmt.Errorf("invalid compress threshold: %f", c.CompressThreshold)
+	}
 	return nil
 }
 

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -142,7 +142,7 @@ func (b *builder) applyDefaults(conf *Config) error {
 	if conf.CompressConcurrency <= 0 {
 		conf.CompressConcurrency = runtime.GOMAXPROCS(0)
 	}
-	if conf.CompressThreshold <= 0 {
+	if conf.CompressThreshold == 0 {
 		conf.CompressThreshold = b.defaults.CompressThreshold
 	}
 	if conf.ZstdLevel == 0 {
@@ -199,28 +199,29 @@ func (b *builder) applyThroughput(conf *Config) {
 }
 
 func (b *builder) validateCompression(conf *Config) error {
+	if err := validateCompressionSettings(conf); err != nil {
+		return err
+	}
 	resolved := conf.Compress
-	if resolved == Auto {
+	if resolved == "" || resolved == Auto {
 		resolved = compressiondetect.DetectOptimalCompression()
+	}
+	if strings.Contains(resolved, ",") {
+		return nil
 	}
 	switch resolved {
 	case Zstd:
-		if conf.ZstdLevel < 1 || conf.ZstdLevel > 5 {
-			return fmt.Errorf("invalid zstd compression level: %d", conf.ZstdLevel)
-		}
 		conf.CompressLevel = conf.ZstdLevel
 	case "lz4":
-		switch strings.ToLower(conf.LZ4Level) {
-		case "fast":
+		if strings.ToLower(conf.LZ4Level) == "fast" {
 			conf.CompressLevel = int(lz4.Fast)
-		case "hc":
+		} else {
 			conf.CompressLevel = int(lz4.Level9)
-		default:
-			return fmt.Errorf("invalid lz4 compression level: %s", conf.LZ4Level)
 		}
-	}
-	if conf.CompressThreshold <= 0 || conf.CompressThreshold > 1 {
-		return fmt.Errorf("invalid compress threshold: %f", conf.CompressThreshold)
+	case "none":
+		// no compression level for none
+	default:
+		return fmt.Errorf("unsupported compression algorithm: %s", conf.Compress)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- validate compression thresholds and levels in Config.Validate
- surface compression parsing errors during config build
- add tests for compression thresholds and level edge cases

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: cmd/dump build error, multiple config and transfer tests failing)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a22e1b3b9c8323a8c71418a3e170fa