### PR TITLE
Bind env vars for all root flags

### DIFF
--- a/internal/config/loadconfig_test.go
+++ b/internal/config/loadconfig_test.go
@@ -68,7 +68,7 @@ func TestBuildViperPrecedence(t *testing.T) {
 
 	t.Run("env_overrides_config", func(t *testing.T) {
 		rootFS, args := newFlagSet([]string{"--config", cfgPath})
-		t.Setenv("LVMSYNC-PARALLEL", "2")
+		t.Setenv("LVMSYNC_PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
@@ -89,7 +89,7 @@ func TestBuildViperPrecedence(t *testing.T) {
 
 	t.Run("flags_override_env", func(t *testing.T) {
 		rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
-		t.Setenv("LVMSYNC-PARALLEL", "2")
+		t.Setenv("LVMSYNC_PARALLEL", "2")
 		cfg, err := DefaultConfig()
 		if err != nil {
 			t.Fatalf("DefaultConfig: %v", err)
@@ -105,6 +105,49 @@ func TestBuildViperPrecedence(t *testing.T) {
 		}
 		if got := v.GetInt("parallel"); got != 3 {
 			t.Fatalf("expected parallel 3, got %d", got)
+		}
+	})
+
+	t.Run("env_overrides_default", func(t *testing.T) {
+		rootFS, args := newFlagSet(nil)
+		t.Setenv("LVMSYNC_PARALLEL", "5")
+		cfg, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig: %v", err)
+		}
+		fs := NewFlagSets(cfg)
+		registerFlags(fs, rootFS)
+		if err := rootFS.Parse(args); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		v, _, err := buildViper(fs)
+		if err != nil {
+			t.Fatalf("buildViper: %v", err)
+		}
+		if got := v.GetInt("parallel"); got != 5 {
+			t.Fatalf("expected parallel 5, got %d", got)
+		}
+	})
+
+	t.Run("env_overrides_config_compress_concurrency", func(t *testing.T) {
+		cfgPath := writeTempConfig(t, "compress-concurrency: 1\n")
+		rootFS, args := newFlagSet([]string{"--config", cfgPath})
+		t.Setenv("LVMSYNC_COMPRESS_CONCURRENCY", "4")
+		cfg, err := DefaultConfig()
+		if err != nil {
+			t.Fatalf("DefaultConfig: %v", err)
+		}
+		fs := NewFlagSets(cfg)
+		registerFlags(fs, rootFS)
+		if err := rootFS.Parse(args); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		v, _, err := buildViper(fs)
+		if err != nil {
+			t.Fatalf("buildViper: %v", err)
+		}
+		if got := v.GetInt("compress-concurrency"); got != 4 {
+			t.Fatalf("expected compress-concurrency 4, got %d", got)
 		}
 	})
 }

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -297,24 +297,22 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	v.SetEnvPrefix("LVMSYNC")
 	v.AutomaticEnv()
-	keys := []string{
-		"source-type",
-		"dest-type",
-	}
-	for _, k := range keys {
-		if err := v.BindEnv(k); err != nil {
-			return nil, nil, err
-		}
-	}
+	var envErr error
 	for _, fs := range flagSets.All() {
 		if err := v.BindPFlags(fs); err != nil {
 			return nil, nil, err
 		}
 		fs.VisitAll(func(f *pflag.Flag) {
+			if envErr == nil {
+				envErr = v.BindEnv(f.Name)
+			}
 			if strings.Contains(f.Name, "-") {
 				v.RegisterAlias(strings.ReplaceAll(f.Name, "-", "_"), f.Name)
 			}
 		})
+	}
+	if envErr != nil {
+		return nil, nil, envErr
 	}
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary
- bind all root flags to environment variables
- add tests for LVMSYNC_PARALLEL and LVMSYNC_COMPRESS_CONCURRENCY precedence

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestAllowInsecureRequiresFlagOrEnv, TestBuilderBuildUnsupportedCompression, TestBuilderValidateCompression, TestCompressionLevelValidation, TestCompressConcurrency, TestTLSFileValidation, TestEnvOverridesConfig, TestEnsureDefaultTimeout, TestCommandDefaultTimeout)*
- `golangci-lint run` *(warn: Can't process result by diff processor: can't read from patch file path/to/patch/file)*

------
https://chatgpt.com/codex/tasks/task_e_68a23682565483239c1d6ac8975382ae