### PR TITLE
Add alias mapping for hyphenated config keys

### DIFF
--- a/internal/config/allow_insecure_ack_test.go
+++ b/internal/config/allow_insecure_ack_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,28 +14,30 @@ func TestAllowInsecureRequiresFlagOrEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	builder := NewBuilder(defaults)
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(cfgPath, []byte("allow_insecure: true\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	for _, key := range []string{"allow_insecure", "allow-insecure"} {
+		t.Run(key, func(t *testing.T) {
+			builder := NewBuilder(defaults)
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(cfgPath, []byte(fmt.Sprintf("%s: true\n", key)), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			os.Unsetenv("LVMSYNC_ALLOW_INSECURE")
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err == nil {
+				t.Fatalf("expected error without explicit acknowledgment")
+			}
 
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err == nil {
-		t.Fatalf("expected error without explicit acknowledgment")
-	}
+			t.Setenv("LVMSYNC_ALLOW_INSECURE", "1")
+			fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
+			if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err != nil {
+				t.Fatalf("unexpected error with env ack: %v", err)
+			}
 
-	os.Setenv("LVMSYNC_ALLOW_INSECURE", "1")
-	defer os.Unsetenv("LVMSYNC_ALLOW_INSECURE")
-	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
-	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err != nil {
-		t.Fatalf("unexpected error with env ack: %v", err)
-	}
-
-	os.Unsetenv("LVMSYNC_ALLOW_INSECURE")
-	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
-	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow-insecure"}); err != nil {
-		t.Fatalf("unexpected error with flag ack: %v", err)
+			fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
+			if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow-insecure"}); err != nil {
+				t.Fatalf("unexpected error with flag ack: %v", err)
+			}
+		})
 	}
 }

--- a/internal/config/builder_build_test.go
+++ b/internal/config/builder_build_test.go
@@ -9,34 +9,42 @@ import (
 // TestBuilderBuildSuccess verifies that Build returns a config using defaults
 // when no explicit settings are provided.
 func TestBuilderBuildSuccess(t *testing.T) {
-	v := viper.New()
-	v.Set("allow-insecure", true)
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	b := &builder{v: v, defaults: defaults}
-	cfg, err := b.Build()
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	if cfg.Transport == "" {
-		t.Fatalf("expected Transport to be set")
+	for _, k := range []string{"allow-insecure", "allow_insecure"} {
+		t.Run(k, func(t *testing.T) {
+			v := viper.New()
+			v.Set(k, true)
+			b := &builder{v: v, defaults: defaults}
+			cfg, err := b.Build()
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			if cfg.Transport == "" {
+				t.Fatalf("expected Transport to be set")
+			}
+		})
 	}
 }
 
 // TestBuilderBuildUnsupportedCompression verifies that Build fails when an
 // unsupported compression algorithm is specified.
 func TestBuilderBuildUnsupportedCompression(t *testing.T) {
-	v := viper.New()
-	v.Set("allow-insecure", true)
-	v.Set("compress-threshold", 2.0)
 	defaults, err := DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	b := &builder{v: v, defaults: defaults}
-	if _, err := b.Build(); err == nil {
-		t.Fatalf("expected error for invalid compression threshold")
+	for _, k := range []string{"compress-threshold", "compress_threshold"} {
+		t.Run(k, func(t *testing.T) {
+			v := viper.New()
+			v.Set("allow-insecure", true)
+			v.Set(k, 2.0)
+			b := &builder{v: v, defaults: defaults}
+			if _, err := b.Build(); err == nil {
+				t.Fatalf("expected error for invalid compression threshold")
+			}
+		})
 	}
 }

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -25,6 +25,7 @@ type builder struct {
 }
 
 func (b *builder) Build() (*Config, error) {
+	registerKeyAliases(b.v)
 	var conf Config
 	if err := b.v.Unmarshal(&conf); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
@@ -47,10 +48,10 @@ func (b *builder) applyDefaults(conf *Config) error {
 	if conf.Mode == "" {
 		conf.Mode = b.defaults.Mode
 	}
-	if !b.v.IsSet("allow-insecure") {
+	if !isSet(b.v, "allow-insecure") {
 		conf.AllowInsecure = b.defaults.AllowInsecure
 	}
-	if !b.v.IsSet("numa-pin") {
+	if !isSet(b.v, "numa-pin") {
 		conf.NumaPin = b.defaults.NumaPin
 	}
 	if conf.GRPCPort == 0 {
@@ -65,7 +66,7 @@ func (b *builder) applyDefaults(conf *Config) error {
 	if conf.ManifestProgressInterval == 0 {
 		conf.ManifestProgressInterval = b.defaults.ManifestProgressInterval
 	}
-	if !b.v.IsSet("manifest-allow-mounted") {
+	if !isSet(b.v, "manifest-allow-mounted") {
 		conf.ManifestAllowMounted = b.defaults.ManifestAllowMounted
 	}
 
@@ -158,42 +159,42 @@ func (b *builder) applyDefaults(conf *Config) error {
 }
 
 func (b *builder) applyThroughput(conf *Config) {
-	if !b.v.IsSet("transport") {
+	if !isSet(b.v, "transport") {
 		conf.Transport = "tcp+tls"
 	}
-	if !b.v.IsSet("parallel") {
+	if !isSet(b.v, "parallel") {
 		conf.Parallel = 8
 	}
-	if !b.v.IsSet("concurrency") {
+	if !isSet(b.v, "concurrency") {
 		conf.Concurrency = 8
 	}
-	if !b.v.IsSet("dedup") {
+	if !isSet(b.v, "dedup") {
 		conf.DedupMode = "hybrid"
 	}
-	if !b.v.IsSet("block-size") {
+	if !isSet(b.v, "block-size") {
 		conf.BlockSize = 2 * 1024 * 1024
 		conf.BlockSizeRaw = "2097152"
 	}
-	if !b.v.IsSet("cdc-min") {
+	if !isSet(b.v, "cdc-min") {
 		conf.CDCMin = 256 * 1024
 	}
-	if !b.v.IsSet("cdc-avg") {
+	if !isSet(b.v, "cdc-avg") {
 		conf.CDCAvg = 2 * 1024 * 1024
 	}
-	if !b.v.IsSet("cdc-max") {
+	if !isSet(b.v, "cdc-max") {
 		conf.CDCMax = 8 * 1024 * 1024
 	}
-	if !b.v.IsSet("compress") {
+	if !isSet(b.v, "compress") {
 		conf.Compress = Auto
 	}
-	if !b.v.IsSet("odirect") {
+	if !isSet(b.v, "odirect") {
 		conf.ODirect = true
 	}
-	if !b.v.IsSet("sync_interval") {
+	if !isSet(b.v, "sync_interval") {
 		conf.SyncInterval = "1GB"
 		conf.SyncIntervalBytes = 1000000000
 	}
-	if !b.v.IsSet("checkpoint-interval") && conf.CheckpointInterval == 0 {
+	if !isSet(b.v, "checkpoint-interval") && conf.CheckpointInterval == 0 {
 		conf.CheckpointInterval = 10 * time.Second
 	}
 }
@@ -364,4 +365,28 @@ func knownConfigKeys() map[string]struct{} {
 		}
 	}
 	return keys
+}
+
+func registerKeyAliases(v *viper.Viper) {
+	for k := range knownConfigKeys() {
+		switch {
+		case strings.Contains(k, "-"):
+			v.RegisterAlias(strings.ReplaceAll(k, "-", "_"), k)
+		case strings.Contains(k, "_"):
+			v.RegisterAlias(strings.ReplaceAll(k, "_", "-"), k)
+		}
+	}
+}
+
+func isSet(v *viper.Viper, key string) bool {
+	if v.IsSet(key) {
+		return true
+	}
+	if strings.Contains(key, "-") {
+		return v.IsSet(strings.ReplaceAll(key, "-", "_"))
+	}
+	if strings.Contains(key, "_") {
+		return v.IsSet(strings.ReplaceAll(key, "_", "-"))
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- map hyphenated config keys to underscore variants before unmarshalling
- ensure default detection checks both key styles
- cover underscore and hyphen forms in config builder tests

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestAllowInsecureRequiresFlagOrEnv/allow_insecure, TestBuilderValidateCompression/invalidThresholdNonPositive, TestBuildViperPrecedence/env_overrides_config, TestEnvOverridesConfig, TestEnsureDefaultTimeout, TestCommandDefaultTimeout)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2368ca6f883239dc66706898f8eb5