### PR TITLE
Ensure allow_insecure YAML key is recognized by viper

### DIFF
--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -312,7 +312,11 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 		}
 		fs.VisitAll(func(f *pflag.Flag) {
 			if strings.Contains(f.Name, "-") {
-				v.RegisterAlias(strings.ReplaceAll(f.Name, "-", "_"), f.Name)
+				if f.Name == "allow-insecure" {
+					v.RegisterAlias(f.Name, "allow_insecure")
+				} else {
+					v.RegisterAlias(strings.ReplaceAll(f.Name, "-", "_"), f.Name)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- register `allow_insecure` alias in viper so `v.IsSet("allow-insecure")` captures YAML configuration

## Testing
- `go build ./...`
- `go test -run TestAllowInsecureRequiresFlagOrEnv ./internal/config`
- `go test -cover ./...` *(fails: builder_build_test.go:40 expected error; escalate_test.go:201 expected deadline exceeded)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a23694cc2c8323a7da5ccee689478f