### PR TITLE
Handle hyphenated gRPC configuration keys

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -329,6 +329,36 @@ func TestBuilderFinalizeConfig(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("missingTLSHyphenated", func(t *testing.T) {
+		b := &builder{defaults: defaults, v: viper.New()}
+		b.v.Set("grpc-listen", ":1")
+		conf := &Config{AllowInsecure: false, ChecksumAlgorithm: "sha256"}
+		if err := b.finalizeConfig(conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("validTLSHyphenated", func(t *testing.T) {
+		dir := t.TempDir()
+		cert := filepath.Join(dir, "cert.pem")
+		key := filepath.Join(dir, "key.pem")
+		if err := os.WriteFile(cert, []byte("cert"), 0o644); err != nil {
+			t.Fatalf("write cert: %v", err)
+		}
+		if err := os.WriteFile(key, []byte("key"), 0o644); err != nil {
+			t.Fatalf("write key: %v", err)
+		}
+		b := &builder{defaults: defaults, v: viper.New()}
+		b.v.Set("grpc-connect", ":1")
+		conf := &Config{AllowInsecure: false, TLSCert: cert, TLSKey: key, ChecksumAlgorithm: "sha256"}
+		if err := b.finalizeConfig(conf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conf.GRPCConnect != ":1" {
+			t.Fatalf("expected GRPCConnect populated from hyphenated key")
+		}
+	})
 }
 
 func TestConfigValidate(t *testing.T) {

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -235,6 +235,15 @@ func (b *builder) finalizeConfig(conf *Config) error {
 		return fmt.Errorf("unsupported checksum algorithm: %s", conf.ChecksumAlgorithm)
 	}
 
+	if b.v != nil {
+		if conf.GRPCListen == "" {
+			conf.GRPCListen = b.v.GetString("grpc-listen")
+		}
+		if conf.GRPCConnect == "" {
+			conf.GRPCConnect = b.v.GetString("grpc-connect")
+		}
+	}
+
 	if !conf.AllowInsecure && (conf.GRPCListen != "" || conf.GRPCConnect != "") {
 		if conf.TLSCert == "" || conf.TLSKey == "" {
 			return fmt.Errorf("tls-cert and tls-key must be specified unless allow-insecure is set")


### PR DESCRIPTION
## Summary
- populate GRPCListen and GRPCConnect from `grpc-listen`/`grpc-connect` before TLS validation
- test TLS validation paths with hyphenated gRPC keys

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: failed to sufficiently increase receive buffer size, accept failed in cmd/serve)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a236afadf08323b949db7053bcfb7e