### PR TITLE
config: check builder for relative freeze/thaw paths

### DIFF
--- a/internal/config/fs_freeze_precedence_test.go
+++ b/internal/config/fs_freeze_precedence_test.go
@@ -82,11 +82,7 @@ func TestFSFreezeCommandRejectsRelativePath(t *testing.T) {
 		t.Fatalf("buildViper: %v", err)
 	}
 	builder := &builder{v: v, defaults: defaults}
-	conf, err := builder.Build()
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	if err := conf.Validate(); err == nil {
+	if _, err := builder.Build(); err == nil {
 		t.Fatalf("expected error for relative path")
 	}
 }
@@ -107,11 +103,7 @@ func TestFSThawCommandRejectsRelativePath(t *testing.T) {
 		t.Fatalf("buildViper: %v", err)
 	}
 	builder := &builder{v: v, defaults: defaults}
-	conf, err := builder.Build()
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	if err := conf.Validate(); err == nil {
+	if _, err := builder.Build(); err == nil {
 		t.Fatalf("expected error for relative path")
 	}
 }


### PR DESCRIPTION
## Summary
- adjust fs freeze/thaw precedence tests to expect builder errors on relative paths

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestAllowInsecureRequiresFlagOrEnv, TestBuilderValidateCompression, TestEnvOverridesConfig)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a23be833448323ad974b0783b3db3e