### PR TITLE
test: use underscore in env var

### DIFF
--- a/internal/config/precedence_binding_test.go
+++ b/internal/config/precedence_binding_test.go
@@ -10,7 +10,7 @@ import (
 func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	rootFS, args := newFlagSet([]string{"--config", cfgPath, "--parallel", "3"})
-	t.Setenv("LVMSYNC-PARALLEL", "2")
+	t.Setenv("LVMSYNC_PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -39,7 +39,7 @@ func TestCLIFlagsOverrideEnvAndConfig(t *testing.T) {
 func TestEnvOverridesConfig(t *testing.T) {
 	cfgPath := writeTempConfig(t, "parallel: 1\n")
 	rootFS, args := newFlagSet([]string{"--config", cfgPath})
-	t.Setenv("LVMSYNC-PARALLEL", "2")
+	t.Setenv("LVMSYNC_PARALLEL", "2")
 
 	defaults, err := DefaultConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary
- replace `LVMSYNC-PARALLEL` with `LVMSYNC_PARALLEL` in config precedence tests

## Testing
- `go test ./internal/config -run TestEnvOverridesConfig -count=1 -v`
- `go build ./...`
- `go test -cover ./...` *(fails: TestAllowInsecureRequiresFlagOrEnv, TestBuilderValidateCompression, TestFSFreezeCommandRejectsRelativePath, TestFSThawCommandRejectsRelativePath)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a23be5c1f88323bf054f2925c478a8