### PR TITLE
fix(config): handle alias config warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - config: remove duplicate prefixes in LVMSYNC_DEDUP_* environment bindings.
 - device: require --offline or freeze/thaw hooks for raw devices
 - device, transfer: require non-nil loggers and remove conditional logging
+- config: avoid warnings for alias keys in YAML (e.g., allow-insecure vs. allow_insecure)
 - tests: fix O_DIRECT match and transport mismatch handshake validation tests
 - quic: remove redundant deadline methods and use Role.String for dial/listen
 - device: remove logger nil guards and default to `zap.NewNop()`

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -360,9 +360,20 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 		if err := yaml.Unmarshal(data, &raw); err == nil {
 			valid := knownConfigKeys()
 			for k := range raw {
-				if _, ok := valid[k]; !ok {
-					warnings = append(warnings, fmt.Sprintf("unknown configuration key %q", k))
+				if _, ok := valid[k]; ok {
+					continue
 				}
+				switch {
+				case strings.Contains(k, "-"):
+					if _, ok := valid[strings.ReplaceAll(k, "-", "_")]; ok {
+						continue
+					}
+				case strings.Contains(k, "_"):
+					if _, ok := valid[strings.ReplaceAll(k, "_", "-")]; ok {
+						continue
+					}
+				}
+				warnings = append(warnings, fmt.Sprintf("unknown configuration key %q", k))
 			}
 		}
 	}

--- a/internal/config/viper_builder_alias_keys_test.go
+++ b/internal/config/viper_builder_alias_keys_test.go
@@ -1,0 +1,38 @@
+package config
+
+import "testing"
+
+func TestConfigBuilderAliasKeysNoWarnings(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "hyphen_alias",
+			content: "numa-pin: true\n",
+		},
+		{
+			name:    "underscore_alias",
+			content: "fs_freeze_command: /bin/true\nfs_thaw_command: /bin/true\n",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgPath := writeTempConfig(t, tt.content)
+			defaults, err := DefaultConfig()
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			builder := NewBuilder(defaults)
+			fs, args := newFlagSet([]string{"--config", cfgPath})
+			_, _, warns, err := builder.Build(fs, args)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			if len(warns) != 0 {
+				t.Fatalf("expected no warnings, got %v", warns)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- avoid warnings for underscored/hyphenated alias keys in YAML config
- test that alias keys do not emit warnings

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: context deadline, grpc/server took too long)*
- `go test ./internal/config -run AliasKeys -cover`
- `go tool cover -func=coverage.out | tail -n 5`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a23beeff988323ba55c37abc99c0ed