### PR TITLE
refactor: bind flags and env in single pass

### DIFF
--- a/internal/config/allow_insecure_ack_test.go
+++ b/internal/config/allow_insecure_ack_test.go
@@ -27,27 +27,16 @@ func TestAllowInsecureRequiresFlagOrEnv(t *testing.T) {
 
 	t.Setenv("LVMSYNC_ALLOW_INSECURE", "1")
 	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
-	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err != nil {
+	if cfg, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err != nil {
 		t.Fatalf("unexpected error with env ack: %v", err)
+	} else if !cfg.AllowInsecure {
+		t.Fatalf("AllowInsecure not set with env ack")
 	}
 
 	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
-	if _, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow-insecure"}); err != nil {
+	if cfg, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow-insecure"}); err != nil {
 		t.Fatalf("unexpected error with flag ack: %v", err)
-			t.Setenv("LVMSYNC_ALLOW_INSECURE", "1")
-			fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
-			if cfg, _, _, err := builder.Build(fs, []string{"--config", cfgPath}); err != nil {
-				t.Fatalf("unexpected error with env ack: %v", err)
-			} else if !cfg.AllowInsecure {
-				t.Fatalf("AllowInsecure not set with env ack")
-			}
-
-			fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
-			if cfg, _, _, err := builder.Build(fs, []string{"--config", cfgPath, "--allow-insecure"}); err != nil {
-				t.Fatalf("unexpected error with flag ack: %v", err)
-			} else if !cfg.AllowInsecure {
-				t.Fatalf("AllowInsecure not set with flag ack")
-			}
-		})
+	} else if !cfg.AllowInsecure {
+		t.Fatalf("AllowInsecure not set with flag ack")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -253,20 +253,19 @@ func TestBuilderValidateCompression(t *testing.T) {
 		}
 	})
 
-  t.Run("invalidThresholdNonPositive", func(t *testing.T) {
-          conf := &Config{Compress: Zstd, ZstdLevel: 3, CompressThreshold: -0.1}
-          if err := b.validateCompression(conf); err == nil {
-                  t.Fatalf("expected error")
-          }
-  })
-
-	t.Run("thresholdNonPositive", func(t *testing.T) {
-		conf := &Config{Compress: Zstd, ZstdLevel: 3, CompressThreshold: 0}
-		if err := b.validateCompression(conf); err != nil {
-			t.Fatalf("unexpected error: %v", err)
+	t.Run("invalidThresholdNonPositive", func(t *testing.T) {
+		conf := &Config{Compress: Zstd, ZstdLevel: 3, CompressThreshold: -0.1}
+		if err := b.validateCompression(conf); err == nil {
+			t.Fatalf("expected error")
 		}
 	})
 
+	t.Run("thresholdNonPositive", func(t *testing.T) {
+		conf := &Config{Compress: Zstd, ZstdLevel: 3, CompressThreshold: 0}
+		if err := b.validateCompression(conf); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
 
 	t.Run(Auto, func(t *testing.T) {
 		conf := &Config{Compress: Auto, CompressThreshold: 0.9}

--- a/internal/config/fs_freeze_precedence_test.go
+++ b/internal/config/fs_freeze_precedence_test.go
@@ -82,13 +82,8 @@ func TestFSFreezeCommandRejectsRelativePath(t *testing.T) {
 		t.Fatalf("buildViper: %v", err)
 	}
 
-  builder := &builder{v: v, defaults: defaults}
-  if _, err := builder.Build(); err == nil {
-          t.Fatalf("expected error for relative path")
-  }
-
-  builder := &builder{v: v, defaults: defaults}
-	if _, err := builder.Build(); err == nil {
+	b := &builder{v: v, defaults: defaults}
+	if _, err := b.Build(); err == nil {
 		t.Fatalf("expected error for relative path")
 	}
 }
@@ -109,13 +104,8 @@ func TestFSThawCommandRejectsRelativePath(t *testing.T) {
 		t.Fatalf("buildViper: %v", err)
 	}
 
-  builder := &builder{v: v, defaults: defaults}
-  if _, err := builder.Build(); err == nil {
-          t.Fatalf("expected error for relative path")
-  }
-
-	builder := &builder{v: v, defaults: defaults}
-	if _, err := builder.Build(); err == nil {
+	b := &builder{v: v, defaults: defaults}
+	if _, err := b.Build(); err == nil {
 		t.Fatalf("expected error for relative path")
 	}
 }

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -311,21 +311,6 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 	v.SetEnvPrefix("LVMSYNC")
 	v.AutomaticEnv()
 	var envErr error
-
-  for _, fs := range flagSets.All() {
-          if err := v.BindPFlags(fs); err != nil {
-                  return nil, nil, err
-          }
-          fs.VisitAll(func(f *pflag.Flag) {
-                  if envErr == nil {
-                          envErr = v.BindEnv(f.Name)
-                  }
-          })
-  }
-  if envErr != nil {
-          return nil, nil, envErr
-  }
-
 	for _, fs := range flagSets.All() {
 		if err := v.BindPFlags(fs); err != nil {
 			return nil, nil, err
@@ -335,7 +320,8 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 				envErr = v.BindEnv(f.Name)
 			}
 			if strings.Contains(f.Name, "-") && f.Name != "allow-insecure" {
-				v.RegisterAlias(strings.ReplaceAll(f.Name, "-", "_"), f.Name)
+				alias := strings.ReplaceAll(f.Name, "-", "_")
+				v.RegisterAlias(alias, f.Name)
 			}
 		})
 	}
@@ -359,7 +345,7 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 		return nil, nil, err
 	}
 	var warnings []string
-        if cfgFile := v.GetString("config"); cfgFile != "" {
+	if cfgFile := v.GetString("config"); cfgFile != "" {
 		data, err := os.ReadFile(cfgFile)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error reading config file %q: %w", cfgFile, err)
@@ -388,19 +374,8 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, error) {
 				warnings = append(warnings, fmt.Sprintf("unknown configuration key %q", k))
 			}
 		}
-        }
-        for _, fs := range flagSets.All() {
-                fs.VisitAll(func(f *pflag.Flag) {
-                        if strings.Contains(f.Name, "-") {
-                                if f.Name == "allow-insecure" {
-                                        v.RegisterAlias(f.Name, "allow_insecure")
-                                } else {
-                                        v.RegisterAlias(strings.ReplaceAll(f.Name, "-", "_"), f.Name)
-                                }
-                        }
-                })
-        }
-        return v, warnings, nil
+	}
+	return v, warnings, nil
 }
 
 func knownConfigKeys() map[string]struct{} {


### PR DESCRIPTION
## Summary
- streamline viper setup to bind flags, register env vars and add underscore aliases in a single loop
- keep allow-insecure accessible via both `allow-insecure` and `allow_insecure` names
- tidy and fix configuration tests

## Testing
- `go vet ./internal/config`
- `go test ./internal/config`
- `go build ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2438241f0832380eb35b7cb5fd766