### PR TITLE
Track and release mmaped block buffers

### DIFF
--- a/internal/blockio/buffer_pool.go
+++ b/internal/blockio/buffer_pool.go
@@ -2,11 +2,15 @@ package blockio
 
 import (
 	"sync"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
-var bufferPools sync.Map
+var (
+	bufferPools    sync.Map
+	mmappedBuffers sync.Map // key uintptr -> []byte
+)
 
 func getAlignedBlockBuffer(size int) []byte {
 	if p, ok := bufferPools.Load(size); ok {
@@ -23,6 +27,10 @@ func getAlignedBlockBuffer(size int) []byte {
 		if err != nil {
 			buf := make([]byte, size)
 			return &buf
+		}
+		if len(b) > 0 {
+			ptr := uintptr(unsafe.Pointer(&b[0]))
+			mmappedBuffers.Store(ptr, b)
 		}
 		return &b
 	}}
@@ -42,6 +50,27 @@ func putAlignedBlockBuffer(buf []byte) {
 	if p, ok := bufferPools.Load(len(buf)); ok {
 		if pool, ok := p.(*sync.Pool); ok {
 			pool.Put(&buf)
+			return
 		}
 	}
+	if len(buf) > 0 {
+		ptr := uintptr(unsafe.Pointer(&buf[0]))
+		if bAny, ok := mmappedBuffers.LoadAndDelete(ptr); ok {
+			unix.Munmap(bAny.([]byte))
+		}
+	}
+}
+
+func purgeAlignedBlockBufferPools() {
+	bufferPools.Range(func(k, v any) bool {
+		bufferPools.Delete(k)
+		return true
+	})
+	mmappedBuffers.Range(func(k, v any) bool {
+		if b, ok := v.([]byte); ok {
+			unix.Munmap(b)
+		}
+		mmappedBuffers.Delete(k)
+		return true
+	})
 }

--- a/internal/blockio/buffer_pool_test.go
+++ b/internal/blockio/buffer_pool_test.go
@@ -1,0 +1,39 @@
+package blockio
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+)
+
+func TestPutUnmapsWhenPoolMissing(t *testing.T) {
+	size := os.Getpagesize()
+	t.Cleanup(purgeAlignedBlockBufferPools)
+	buf := getAlignedBlockBuffer(size)
+	ptr := uintptr(unsafe.Pointer(&buf[0]))
+	if _, ok := mmappedBuffers.Load(ptr); !ok {
+		t.Fatalf("expected buffer to be mmapped")
+	}
+	bufferPools.Delete(size)
+	putAlignedBlockBuffer(buf)
+	if _, ok := mmappedBuffers.Load(ptr); ok {
+		t.Fatalf("expected buffer to be unmapped when pool missing")
+	}
+}
+
+func TestPurgeAlignedBlockBufferPools(t *testing.T) {
+	size := os.Getpagesize()
+	buf := getAlignedBlockBuffer(size)
+	ptr := uintptr(unsafe.Pointer(&buf[0]))
+	if _, ok := mmappedBuffers.Load(ptr); !ok {
+		t.Fatalf("expected buffer to be mmapped")
+	}
+	putAlignedBlockBuffer(buf)
+	purgeAlignedBlockBufferPools()
+	if _, ok := mmappedBuffers.Load(ptr); ok {
+		t.Fatalf("expected buffer to be unmapped after purge")
+	}
+	if _, ok := bufferPools.Load(size); ok {
+		t.Fatalf("expected buffer pool to be purged")
+	}
+}


### PR DESCRIPTION
## Summary
- track whether block buffers come from unix.Mmap
- unmap buffers when not reused and provide purge
- add tests covering buffer reuse and release paths

## Testing
- `go build -v ./...`
- `go test -cover ./...` *(fails: internal/config/allow_insecure_ack_test.go:51:4: expected statement, found ')')*
- `go test -cover ./internal/blockio`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a24383f8a08323aa5911d6a1d2c907