### PR TITLE
tcp_tls: validate ALPN negotiation

### DIFF
--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -136,6 +136,19 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		t.logger.Error("dial_end", fields...)
 		return nil, err
 	}
+	state := conn.ConnectionState()
+	if state.NegotiatedProtocol != alpn {
+		err := fmt.Errorf("alpn mismatch: expected %q, got %q", alpn, state.NegotiatedProtocol)
+		conn.Close()
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		t.logger.Error("dial_end", fields...)
+		return nil, err
+	}
 	if err := conn.SetDeadline(dl); err != nil {
 		conn.Close()
 		fields := []zap.Field{

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -137,6 +137,85 @@ func TestTCPTLSTransportHandshake(t *testing.T) {
 	checkHandshakeFields(t, logs, "negotiate_end", 2)
 }
 
+func TestTCPTLSALPNMatch(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			io.Copy(io.Discard, conn)
+			conn.Close()
+		}
+		close(done)
+	}()
+
+	dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+	conn, err := tr.Dial(dialCtx, ln.Addr().String())
+	cancel()
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		t.Fatalf("expected tls.Conn")
+	}
+	state := tlsConn.ConnectionState()
+	if state.NegotiatedProtocol != alpn {
+		t.Fatalf("expected negotiated protocol %q, got %q", alpn, state.NegotiatedProtocol)
+	}
+	conn.Close()
+	<-done
+}
+
+func TestTCPTLSALPNMismatch(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	core, logs := observer.New(zap.InfoLevel)
+	trIface, err := New(transport.Config{Logger: zap.New(core), Roots: root, ClientCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	tr.serverConf.NextProtos = []string{"other"}
+	ctx := context.Background()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			io.Copy(io.Discard, conn)
+			conn.Close()
+		}
+		close(done)
+	}()
+
+	dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+	_, err = tr.Dial(dialCtx, ln.Addr().String())
+	cancel()
+	if err == nil {
+		t.Fatalf("expected alpn mismatch error")
+	}
+	<-done
+	checkLogFields(t, logs, "dial_start", 1, false, zapcore.InfoLevel)
+	checkLogFields(t, logs, "dial_end", 1, true, zapcore.ErrorLevel)
+}
+
 func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
 	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert})
@@ -154,42 +233,42 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 	defer cancel()
 	defer ln.Close()
 
-        srvCompress := []string{"zstd", "lz4"}
-        cliCompress := []string{"lz4"}
-        srvDigest := []string{"sha256", "blake3"}
-        cliDigest := []string{"blake3"}
+	srvCompress := []string{"zstd", "lz4"}
+	cliCompress := []string{"lz4"}
+	srvDigest := []string{"sha256", "blake3"}
+	cliDigest := []string{"blake3"}
 	srvDedup := []string{"fixed", "cdc"}
 	cliDedup := []string{"cdc"}
 	expCompress := common.SelectBest(srvCompress, cliCompress)
 	expDigest := common.SelectBest(srvDigest, cliDigest)
 	expDedup := common.SelectBest(srvDedup, cliDedup)
 
-        srvHS := common.Handshake{
-                DedupMode:   expDedup,
-                Compressors: srvCompress,
-                Digests:     srvDigest,
-                ResumeToken: "tok",
-                ODirect:     true,
-                MaxInFlight: 8,
-                CDCMin:      64,
-                CDCAvg:      128,
-                CDCMax:      256,
-                CRC32C:      true,
-        }
-        cliHS := common.Handshake{
-                DedupMode:   expDedup,
-                Compressors: cliCompress,
-                Digests:     cliDigest,
-                Compress:    expCompress,
-                Digest:      expDigest,
-                ResumeToken: "tok",
-                ODirect:     true,
-                MaxInFlight: 8,
-                CDCMin:      64,
-                CDCAvg:      128,
-                CDCMax:      256,
-                CRC32C:      true,
-        }
+	srvHS := common.Handshake{
+		DedupMode:   expDedup,
+		Compressors: srvCompress,
+		Digests:     srvDigest,
+		ResumeToken: "tok",
+		ODirect:     true,
+		MaxInFlight: 8,
+		CDCMin:      64,
+		CDCAvg:      128,
+		CDCMax:      256,
+		CRC32C:      true,
+	}
+	cliHS := common.Handshake{
+		DedupMode:   expDedup,
+		Compressors: cliCompress,
+		Digests:     cliDigest,
+		Compress:    expCompress,
+		Digest:      expDigest,
+		ResumeToken: "tok",
+		ODirect:     true,
+		MaxInFlight: 8,
+		CDCMin:      64,
+		CDCAvg:      128,
+		CDCMax:      256,
+		CRC32C:      true,
+	}
 
 	srvErr := make(chan error, 1)
 	go func() {
@@ -209,39 +288,39 @@ func TestTCPTLSTransportSelectBestHandshake(t *testing.T) {
 		}
 		conn.Close()
 	}()
-        dialCtx, cancel := context.WithTimeout(baseCtx, time.Second)
-        conn, err := tr.Dial(dialCtx, ln.Addr().String())
-        cancel()
-        if err != nil {
-                t.Fatalf("dial: %v", err)
-        }
-        negCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
-        peer, err := tr.Negotiate(negCtx, conn, transport.Client, cliHS)
-        cancel()
-        if err != nil {
-                conn.Close()
-                t.Fatalf("client negotiate: %v", err)
-        }
+	dialCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+	conn, err := tr.Dial(dialCtx, ln.Addr().String())
+	cancel()
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	negCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
+	peer, err := tr.Negotiate(negCtx, conn, transport.Client, cliHS)
+	cancel()
+	if err != nil {
+		conn.Close()
+		t.Fatalf("client negotiate: %v", err)
+	}
 
-        select {
-        case err := <-srvErr:
-                if err != nil {
-                        conn.Close()
-                        t.Fatalf("server negotiate: %v", err)
-                }
-        case <-time.After(time.Second):
-                conn.Close()
-                t.Fatalf("server negotiate timeout")
-        }
+	select {
+	case err := <-srvErr:
+		if err != nil {
+			conn.Close()
+			t.Fatalf("server negotiate: %v", err)
+		}
+	case <-time.After(time.Second):
+		conn.Close()
+		t.Fatalf("server negotiate timeout")
+	}
 
-        if _, err := conn.Write([]byte{1}); err != nil {
-                conn.Close()
-                t.Fatalf("write: %v", err)
-        }
-        conn.Close()
-        if peer.DedupMode != expDedup || peer.Compress != expCompress || peer.Digest != expDigest || peer.ResumeToken != "tok" || !peer.ODirect || peer.CDCMin != 64 || peer.CDCAvg != 128 || peer.CDCMax != 256 {
-                t.Fatalf("unexpected peer handshake: %+v", peer)
-        }
+	if _, err := conn.Write([]byte{1}); err != nil {
+		conn.Close()
+		t.Fatalf("write: %v", err)
+	}
+	conn.Close()
+	if peer.DedupMode != expDedup || peer.Compress != expCompress || peer.Digest != expDigest || peer.ResumeToken != "tok" || !peer.ODirect || peer.CDCMin != 64 || peer.CDCAvg != 128 || peer.CDCMax != 256 {
+		t.Fatalf("unexpected peer handshake: %+v", peer)
+	}
 }
 
 func TestTCPTLSTransportHandshakeError(t *testing.T) {
@@ -432,42 +511,42 @@ func TestTCPTLSUnsupportedCipher(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
-        srvErr := make(chan error, 1)
-        go func() {
-                conn, err := ln.Accept()
-                if err != nil {
-                        srvErr <- err
-                        return
-                }
-                defer conn.Close()
-                tlsConn, ok := conn.(*tls.Conn)
-                if !ok {
-                        srvErr <- errors.New("expected tls.Conn")
-                        return
-                }
-                hsCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-                srvErr <- tlsConn.HandshakeContext(hsCtx)
-                cancel()
-        }()
-        badCfg := &tls.Config{
-                RootCAs:      root,
-                Certificates: []tls.Certificate{cert},
-                MinVersion:   tls.VersionTLS12,
-                MaxVersion:   tls.VersionTLS12,
-                CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
-                NextProtos:   []string{alpn},
-        }
-        if _, err := tls.Dial("tcp", ln.Addr().String(), badCfg); err == nil {
-                t.Fatalf("expected handshake error")
-        }
-        select {
-        case err := <-srvErr:
-                if err == nil {
-                        t.Fatalf("expected server error")
-                }
-        case <-time.After(time.Second):
-                t.Fatalf("server handshake timeout")
-        }
+	srvErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			srvErr <- err
+			return
+		}
+		defer conn.Close()
+		tlsConn, ok := conn.(*tls.Conn)
+		if !ok {
+			srvErr <- errors.New("expected tls.Conn")
+			return
+		}
+		hsCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		srvErr <- tlsConn.HandshakeContext(hsCtx)
+		cancel()
+	}()
+	badCfg := &tls.Config{
+		RootCAs:      root,
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS12,
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+		NextProtos:   []string{alpn},
+	}
+	if _, err := tls.Dial("tcp", ln.Addr().String(), badCfg); err == nil {
+		t.Fatalf("expected handshake error")
+	}
+	select {
+	case err := <-srvErr:
+		if err == nil {
+			t.Fatalf("expected server error")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("server handshake timeout")
+	}
 }
 
 func TestTCPTLSCertValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
- verify ALPN protocol after TLS handshake and close connection on mismatch
- add tests covering successful and failing ALPN negotiation

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: internal/config/allow_insecure_ack_test.go:51:4: expected statement, found ')')*
- `go test -cover ./transport/tcp_tls`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a24398d1b483238b4a81eb2f878df6