### PR TITLE
refactor transport registry logging

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/internal/logging"
 	"lvmsync_go/transport"
@@ -110,7 +111,7 @@ func init() {
 			return nil, fmt.Errorf("h2: nil transport")
 		}
 		return tr, nil
-	})
+	}, zap.NewNop(), rootcmd.SyncLogger)
 }
 
 func (t *Transport) Name() string { return "h2" }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -12,6 +12,7 @@ import (
 
 	quic "github.com/quic-go/quic-go"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/internal/logging"
 	"lvmsync_go/transport"
@@ -91,7 +92,7 @@ func init() {
 			return nil, fmt.Errorf("quic: nil transport")
 		}
 		return tr, nil
-	})
+	}, zap.NewNop(), rootcmd.SyncLogger)
 }
 
 func (t *Transport) Name() string { return "quic" }

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -31,12 +31,19 @@ func Register(name string, f Factory) error {
 // MustRegister adds a transport factory to the registry and panics on error.
 //
 // A log entry is emitted before panicking to aid debugging when duplicate
-// registrations occur.
-func MustRegister(name string, f Factory) {
+// registrations occur. The provided logger is used for logging and flushed
+// using syncLogger if registration fails.
+func MustRegister(name string, f Factory, logger *zap.Logger, syncLogger func(*zap.Logger)) {
 	if err := Register(name, f); err != nil {
-		logger := zap.L()
+		if logger == nil {
+			logger = zap.NewNop()
+		}
 		logger.Error("register_failed", zap.String("transport", name), zap.Error(err))
-		_ = logger.Sync()
+		if syncLogger != nil {
+			syncLogger(logger)
+		} else {
+			_ = logger.Sync()
+		}
 		panic(fmt.Sprintf("register transport %q: %v", name, err))
 	}
 }

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -58,7 +58,7 @@ func TestConcurrentRegister(t *testing.T) {
 			t.Errorf("expected error for %s", name)
 		}
 	}
-	logger.Sync()
+	_ = logger.Sync()
 }
 
 func TestDuplicateRegister(t *testing.T) {
@@ -138,13 +138,11 @@ func TestMustRegisterPanics(t *testing.T) {
 		regMu.Unlock()
 	}()
 
-	MustRegister("dup", func(Config) (Interface, error) { return nil, nil })
+	syncLogger := func(l *zap.Logger) { _ = l.Sync() }
+	MustRegister("dup", func(Config) (Interface, error) { return nil, nil }, zap.NewNop(), syncLogger)
 
 	core, obs := observer.New(zapcore.ErrorLevel)
 	logger := zap.New(core)
-	orig := zap.L()
-	zap.ReplaceGlobals(logger)
-	defer zap.ReplaceGlobals(orig)
 
 	defer func() {
 		if r := recover(); r == nil {
@@ -155,5 +153,5 @@ func TestMustRegisterPanics(t *testing.T) {
 		}
 	}()
 
-	MustRegister("dup", func(Config) (Interface, error) { return nil, nil })
+	MustRegister("dup", func(Config) (Interface, error) { return nil, nil }, logger, syncLogger)
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
@@ -165,7 +166,7 @@ func init() {
 			return nil, fmt.Errorf("ssh: nil transport")
 		}
 		return tr, nil
-	})
+	}, zap.NewNop(), rootcmd.SyncLogger)
 }
 
 func (t *Transport) Name() string { return "ssh" }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/internal/logging"
 	"lvmsync_go/transport"
@@ -76,7 +77,7 @@ func init() {
 			return nil, fmt.Errorf("tcp+tls: nil transport")
 		}
 		return tr, nil
-	})
+	}, zap.NewNop(), rootcmd.SyncLogger)
 }
 
 func (t *Transport) Name() string { return "tcp+tls" }


### PR DESCRIPTION
## Summary
- inject logger and sync function into `transport.MustRegister`
- use injected logger and flush with `rootcmd.SyncLogger` in transport registrations
- adapt transport registry tests to pass loggers directly

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a24eea6acc8323b186eed037fd6bee