### PR TITLE
refactor: inject file and sync dependencies

### DIFF
--- a/transfer/block_generic.go
+++ b/transfer/block_generic.go
@@ -31,7 +31,7 @@ func punchHole(f *os.File, offset uint64, length int) error {
 	return err
 }
 
-var fdatasyncFile = func(f *os.File) error { return f.Sync() }
+func fdatasync(f *os.File) error { return f.Sync() }
 
 func openFileODirect(path string, flag int) (*os.File, bool, error) {
 	f, err := os.OpenFile(path, flag, 0)

--- a/transfer/block_linux.go
+++ b/transfer/block_linux.go
@@ -88,7 +88,7 @@ func punchHole(f *os.File, offset uint64, length int) error {
 	return unix.Fallocate(int(f.Fd()), unix.FALLOC_FL_PUNCH_HOLE|unix.FALLOC_FL_KEEP_SIZE, int64(offset), int64(length))
 }
 
-var fdatasyncFile = func(f *os.File) error {
+func fdatasync(f *os.File) error {
 	return unix.Fdatasync(int(f.Fd()))
 }
 

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -26,6 +26,7 @@ type blockWriter struct {
 	logger    *zap.Logger
 	sinceSync int64
 	rt        *resumeTracker
+	deps      *Deps
 }
 
 // newBlockWriter constructs a blockWriter, detecting the destination's physical
@@ -33,6 +34,10 @@ type blockWriter struct {
 // sync interval when provided as a string. It validates that the configured
 // block size is aligned to the underlying sector size.
 func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger) (*blockWriter, error) {
+	return newBlockWriterWithDeps(cfg, dest, dedup, verify, checksum, logger, DefaultDeps)
+}
+
+func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, deps *Deps) (*blockWriter, error) {
 	if cfg.BlockSize <= 0 || cfg.ODirect {
 		sector, err := DetectSectorSize(dest)
 		if err != nil {
@@ -62,6 +67,7 @@ func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrate
 		verify:   verify,
 		checksum: checksum,
 		logger:   logger,
+		deps:     deps,
 	}
 	if cfg.IntraDedup {
 		bw.intra = newChunkCache(intraCacheCapacity)
@@ -117,7 +123,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 			total += int64(chunkSize)
 			bw.sinceSync += int64(chunkSize)
 			if bw.cfg.SyncIntervalBytes > 0 && bw.sinceSync >= int64(bw.cfg.SyncIntervalBytes) {
-				if err := fdatasyncFile(bw.dest); err != nil {
+				if err := bw.deps.FdatasyncFile(bw.dest); err != nil {
 					return total, err
 				}
 				bw.sinceSync = 0

--- a/transfer/block_writer_apply_test.go
+++ b/transfer/block_writer_apply_test.go
@@ -43,19 +43,16 @@ func TestBlockWriterSyncInterval(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw, err := newBlockWriter(cfg, f, nil, false, checksum, zap.NewNop())
+	calls := 0
+	deps := &Deps{FdatasyncFile: func(*os.File) error {
+		calls++
+		return nil
+	}}
+	bw, err := newBlockWriterWithDeps(cfg, f, nil, false, checksum, zap.NewNop(), deps)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
 	blocks := [][]byte{{1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}}
-
-	calls := 0
-	orig := fdatasyncFile
-	fdatasyncFile = func(*os.File) error {
-		calls++
-		return nil
-	}
-	defer func() { fdatasyncFile = orig }()
 
 	reader := buildBlockStream(t, false, checksum, blocks)
 	total, err := bw.write(reader)

--- a/transfer/block_writer_test.go
+++ b/transfer/block_writer_test.go
@@ -20,7 +20,12 @@ func TestBlockWriterSyncIntervalTriggers(t *testing.T) {
 	defer tmp.Close()
 
 	cfg := &config.Config{BlockSize: 4, SyncIntervalBytes: 8}
-	bw, err := newBlockWriter(cfg, tmp, nil, false, nil, zap.NewNop())
+	calls := 0
+	deps := &Deps{FdatasyncFile: func(f *os.File) error {
+		calls++
+		return nil
+	}}
+	bw, err := newBlockWriterWithDeps(cfg, tmp, nil, false, nil, zap.NewNop(), deps)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
@@ -40,13 +45,7 @@ func TestBlockWriterSyncIntervalTriggers(t *testing.T) {
 	buf.Write(hdr)
 	buf.Write(data2)
 
-	calls := 0
-	orig := fdatasyncFile
-	fdatasyncFile = func(f *os.File) error {
-		calls++
-		return nil
-	}
-	defer func() { fdatasyncFile = orig }()
+	// calls incremented via deps above
 
 	if _, err := bw.write(bufio.NewReader(&buf)); err != nil {
 		t.Fatalf("write: %v", err)

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -19,27 +19,17 @@ import (
 	cpufeatures "lvmsync_go/internal/cpufeatures"
 )
 
-var createStateFile = func(name string) (io.WriteCloser, error) {
-	f, err := os.Create(name)
-	if err != nil {
-		return nil, fmt.Errorf("create state file: %w", err)
-	}
-	if err := f.Chmod(0o600); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("chmod state file: %w", err)
-	}
-	return f, nil
-}
-
-// saveStateFile writes dedup state to the provided path; logger must be non-nil.
-func saveStateFile(logger *zap.Logger, path string, write func(io.Writer) error) error {
-	file, err := createStateFile(path)
+// saveStateFile writes dedup state to the provided path; logger may be nil.
+func saveStateFile(deps *Deps, logger *zap.Logger, path string, write func(io.Writer) error) error {
+	file, err := deps.CreateStateFile(path)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			logger.Warn("failed to close state file", zap.Error(closeErr))
+			if logger != nil {
+				logger.Warn("failed to close state file", zap.Error(closeErr))
+			}
 		}
 	}()
 	return write(file)
@@ -61,6 +51,7 @@ type ChecksumDedup struct {
 	mu        sync.RWMutex
 	strategy  ChecksumStrategy
 	logger    *zap.Logger
+	deps      *Deps
 }
 
 // BloomFilterDedup uses a Bloom filter to track transferred blocks.
@@ -73,6 +64,7 @@ type BloomFilterDedup struct {
 	fpRate    float64
 	strategy  ChecksumStrategy
 	logger    *zap.Logger
+	deps      *Deps
 }
 
 // RollingHashDedup computes a rolling hash for block comparison.
@@ -83,21 +75,11 @@ type RollingHashDedup struct {
 	mu        sync.RWMutex
 	seed      maphash.Seed
 	logger    *zap.Logger
+	deps      *Deps
 }
 
 var rollingHashPool = sync.Pool{
 	New: func() any { return new(maphash.Hash) },
-}
-
-// detectBestStrategy selects the fastest deduplication strategy for the
-// current CPU. Checksum-based deduplication is preferred when SIMD
-// instructions such as AVX or SSE4.2 are available; otherwise a rolling hash
-// is used.
-var detectBestStrategy = func() string {
-	if supportsChecksumAcceleration() {
-		return StrategyChecksum
-	}
-	return StrategyRollingHash
 }
 
 func supportsChecksumAcceleration() bool {
@@ -108,9 +90,13 @@ func supportsChecksumAcceleration() bool {
 // When cfg.DedupStrategy is auto, it selects the best available algorithm
 // and updates cfg accordingly.
 func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) DeduplicationStrategy {
+	return NewDeduplicationStrategyWithDeps(cfg, logger, DefaultDeps)
+}
+
+func NewDeduplicationStrategyWithDeps(cfg *config.Config, logger *zap.Logger, deps *Deps) DeduplicationStrategy {
 	strategy := cfg.DedupStrategy
 	if strategy == StrategyAuto {
-		strategy = detectBestStrategy()
+		strategy = deps.DetectBestStrategy()
 		cfg.DedupStrategy = strategy
 	}
 	switch strategy {
@@ -122,6 +108,7 @@ func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) Deduplicat
 			hashes:    make(map[int64]uint64),
 			seed:      maphash.MakeSeed(),
 			logger:    logger,
+			deps:      deps,
 		}
 		if err := d.loadState(); err != nil {
 			logger.Warn("failed to load dedup state", zap.Error(err))
@@ -140,6 +127,7 @@ func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) Deduplicat
 			fpRate:    cfg.BloomFpRate,
 			strategy:  GetChecksumStrategy(cfg.ChecksumAlgorithm),
 			logger:    logger,
+			deps:      deps,
 		}
 		if err := d.loadState(); err != nil {
 			logger.Warn("failed to load dedup state", zap.Error(err))
@@ -151,6 +139,7 @@ func NewDeduplicationStrategy(cfg *config.Config, logger *zap.Logger) Deduplicat
 			hashes:    make(map[int64][]byte),
 			strategy:  GetChecksumStrategy(cfg.ChecksumAlgorithm),
 			logger:    logger,
+			deps:      deps,
 		}
 		if err := d.loadState(); err != nil {
 			logger.Warn("failed to load dedup state", zap.Error(err))
@@ -179,7 +168,7 @@ func (c *ChecksumDedup) RecordTransfer(offset int64, data []byte) {
 func (c *ChecksumDedup) SaveState() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return saveStateFile(c.logger, c.stateFile, func(file io.Writer) error {
+	return saveStateFile(c.deps, c.logger, c.stateFile, func(file io.Writer) error {
 		size := c.strategy.Size()
 		for offset, hash := range c.hashes {
 			if err := binary.Write(file, binary.LittleEndian, offset); err != nil {
@@ -272,7 +261,7 @@ func (r *RollingHashDedup) RecordTransfer(offset int64, data []byte) {
 func (r *RollingHashDedup) SaveState() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return saveStateFile(r.logger, r.stateFile, func(file io.Writer) error {
+	return saveStateFile(r.deps, r.logger, r.stateFile, func(file io.Writer) error {
 		seedArr := *(*[2]uint64)(unsafe.Pointer(&r.seed))
 		if err := binary.Write(file, binary.LittleEndian, seedArr); err != nil {
 			return err
@@ -356,7 +345,7 @@ func (b *BloomFilterDedup) RecordTransfer(_ int64, data []byte) {
 func (b *BloomFilterDedup) SaveState() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return saveStateFile(b.logger, b.stateFile, func(file io.Writer) error {
+	return saveStateFile(b.deps, b.logger, b.stateFile, func(file io.Writer) error {
 		_, err := b.filter.WriteTo(file)
 		return err
 	})

--- a/transfer/dedup_cdc.go
+++ b/transfer/dedup_cdc.go
@@ -30,12 +30,17 @@ type CDCDedup struct {
 	indexMask uint64
 	stateFile string
 
-	mu  sync.Mutex
-	sha hash.Hash
+	mu   sync.Mutex
+	sha  hash.Hash
+	deps *Deps
 }
 
 // NewCDCDedup constructs a CDCDedup using the tunables provided in cfg.
 func NewCDCDedup(cfg *config.Config) (*CDCDedup, error) {
+	return NewCDCDedupWithDeps(cfg, DefaultDeps)
+}
+
+func NewCDCDedupWithDeps(cfg *config.Config, deps *Deps) (*CDCDedup, error) {
 	bf := bloom.NewWithEstimates(uint(cfg.BloomEntries), cfg.BloomFpRate)
 	ch, err := dedup.NewChunker(cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax, cfg.ChunkSeed)
 	if err != nil {
@@ -46,6 +51,7 @@ func NewCDCDedup(cfg *config.Config) (*CDCDedup, error) {
 		bloom:     bf,
 		stateFile: cfg.DedupStateFile,
 		sha:       sha256.New(),
+		deps:      deps,
 	}
 	if cfg.BloomMBits > 0 {
 		size := 1 << (cfg.BloomMBits - 3)
@@ -118,7 +124,7 @@ func (c *CDCDedup) ChunkAndHash(p []byte) ([]dedup.Chunk, [32]byte, error) {
 func (c *CDCDedup) SaveState() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if err := saveStateFile(nil, c.stateFile, func(w io.Writer) error {
+	if err := saveStateFile(c.deps, nil, c.stateFile, func(w io.Writer) error {
 		_, err := c.bloom.WriteTo(w)
 		return err
 	}); err != nil {

--- a/transfer/dedup_cdc_test.go
+++ b/transfer/dedup_cdc_test.go
@@ -100,14 +100,12 @@ func TestCDCDedupSaveStateWriteFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
-	d, err := NewCDCDedup(cfg)
+	fw := &cdcFailingWriter{failAfter: 0}
+	deps := &Deps{CreateStateFile: func(string) (io.WriteCloser, error) { return fw, nil }}
+	d, err := NewCDCDedupWithDeps(cfg, deps)
 	if err != nil {
 		t.Fatalf("NewCDCDedup: %v", err)
 	}
-	fw := &cdcFailingWriter{failAfter: 0}
-	orig := createStateFile
-	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-	defer func() { createStateFile = orig }()
 	if err := d.SaveState(); err == nil {
 		t.Fatalf("expected error")
 	}

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -20,7 +20,7 @@ import (
 func TestBloomFilterDedupPersistence(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state")
 
-	d1 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01, strategy: &SHA256Checksum{}}
+	d1 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01, strategy: &SHA256Checksum{}, deps: DefaultDeps}
 	data := []byte("hello")
 
 	if !d1.ShouldTransfer(0, data) {
@@ -31,7 +31,7 @@ func TestBloomFilterDedupPersistence(t *testing.T) {
 		t.Fatalf("failed to save state: %v", err)
 	}
 
-	d2 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01, strategy: &SHA256Checksum{}}
+	d2 := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: stateFile, entries: 1000, fpRate: 0.01, strategy: &SHA256Checksum{}, deps: DefaultDeps}
 	if err := d2.loadState(); err != nil {
 		t.Fatalf("failed to load state: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestBloomFilterDedupPersistence(t *testing.T) {
 func TestRollingHashDedupPersistence(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state")
 
-	d1 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64), seed: maphash.MakeSeed()}
+	d1 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64), seed: maphash.MakeSeed(), deps: DefaultDeps}
 	data := []byte("hello")
 
 	if !d1.ShouldTransfer(0, data) {
@@ -55,7 +55,7 @@ func TestRollingHashDedupPersistence(t *testing.T) {
 		t.Fatalf("failed to save state: %v", err)
 	}
 
-	d2 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64), seed: maphash.MakeSeed()}
+	d2 := &RollingHashDedup{stateFile: stateFile, hashes: make(map[int64]uint64), seed: maphash.MakeSeed(), deps: DefaultDeps}
 	if err := d2.loadState(); err != nil {
 		t.Fatalf("failed to load state: %v", err)
 	}

--- a/transfer/dedup_save_state_test.go
+++ b/transfer/dedup_save_state_test.go
@@ -26,11 +26,9 @@ func (fw *failingWriter) Close() error { return nil }
 
 func TestChecksumDedupSaveStateBinaryWriteFailure(t *testing.T) {
 	hash := sha256.Sum256([]byte("data"))
-	c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
 	fw := &failingWriter{failAfter: 0}
-	orig := createStateFile
-	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-	defer func() { createStateFile = orig }()
+	deps := &Deps{CreateStateFile: func(string) (io.WriteCloser, error) { return fw, nil }}
+	c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}, deps: deps}
 	if err := c.SaveState(); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -38,45 +36,37 @@ func TestChecksumDedupSaveStateBinaryWriteFailure(t *testing.T) {
 
 func TestChecksumDedupSaveStateFileWriteFailure(t *testing.T) {
 	hash := sha256.Sum256([]byte("data"))
-	c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}}
 	fw := &failingWriter{failAfter: 1}
-	orig := createStateFile
-	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-	defer func() { createStateFile = orig }()
+	deps := &Deps{CreateStateFile: func(string) (io.WriteCloser, error) { return fw, nil }}
+	c := &ChecksumDedup{stateFile: "ignored", hashes: map[int64][]byte{1: hash[:]}, strategy: &SHA256Checksum{}, deps: deps}
 	if err := c.SaveState(); err == nil {
 		t.Fatalf("expected error")
 	}
 }
 
 func TestRollingHashDedupSaveStateBinaryWriteFailure(t *testing.T) {
-	r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
 	fw := &failingWriter{failAfter: 0}
-	orig := createStateFile
-	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-	defer func() { createStateFile = orig }()
+	deps := &Deps{CreateStateFile: func(string) (io.WriteCloser, error) { return fw, nil }}
+	r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}, deps: deps}
 	if err := r.SaveState(); err == nil {
 		t.Fatalf("expected error")
 	}
 }
 
 func TestRollingHashDedupSaveStateFileWriteFailure(t *testing.T) {
-	r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}}
 	fw := &failingWriter{failAfter: 1}
-	orig := createStateFile
-	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-	defer func() { createStateFile = orig }()
+	deps := &Deps{CreateStateFile: func(string) (io.WriteCloser, error) { return fw, nil }}
+	r := &RollingHashDedup{stateFile: "ignored", hashes: map[int64]uint64{1: 1}, deps: deps}
 	if err := r.SaveState(); err == nil {
 		t.Fatalf("expected error")
 	}
 }
 
 func TestBloomFilterDedupSaveStateWriteFailure(t *testing.T) {
-	b := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: "ignored", strategy: &SHA256Checksum{}}
-	b.RecordTransfer(0, []byte("data"))
 	fw := &failingWriter{failAfter: 0}
-	orig := createStateFile
-	createStateFile = func(string) (io.WriteCloser, error) { return fw, nil }
-	defer func() { createStateFile = orig }()
+	deps := &Deps{CreateStateFile: func(string) (io.WriteCloser, error) { return fw, nil }}
+	b := &BloomFilterDedup{filter: bloom.NewWithEstimates(1000, 0.01), stateFile: "ignored", strategy: &SHA256Checksum{}, deps: deps}
+	b.RecordTransfer(0, []byte("data"))
 	if err := b.SaveState(); err == nil {
 		t.Fatalf("expected error")
 	}

--- a/transfer/deps.go
+++ b/transfer/deps.go
@@ -1,0 +1,40 @@
+package transfer
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Deps bundles external interactions for transfer package components.
+type Deps struct {
+	CreateStateFile    func(string) (io.WriteCloser, error)
+	DetectBestStrategy func() string
+	FdatasyncFile      func(*os.File) error
+}
+
+func defaultCreateStateFile(name string) (io.WriteCloser, error) {
+	f, err := os.Create(name)
+	if err != nil {
+		return nil, fmt.Errorf("create state file: %w", err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("chmod state file: %w", err)
+	}
+	return f, nil
+}
+
+func detectBestStrategy() string {
+	if supportsChecksumAcceleration() {
+		return StrategyChecksum
+	}
+	return StrategyRollingHash
+}
+
+// DefaultDeps provides real implementations for production use.
+var DefaultDeps = &Deps{
+	CreateStateFile:    defaultCreateStateFile,
+	DetectBestStrategy: detectBestStrategy,
+	FdatasyncFile:      fdatasync,
+}

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -50,18 +50,13 @@ func TestNewDeduplicationStrategy(t *testing.T) {
 		t.Fatal("expected checksum strategy")
 	}
 
-	origDetect := detectBestStrategy
-	defer func() { detectBestStrategy = origDetect }()
-
 	cfg.DedupStrategy = "auto"
-	detectBestStrategy = func() string { return "rolling_hash" }
-	if _, ok := NewDeduplicationStrategy(cfg, zap.NewNop()).(*RollingHashDedup); !ok {
+	if _, ok := NewDeduplicationStrategyWithDeps(cfg, zap.NewNop(), &Deps{DetectBestStrategy: func() string { return "rolling_hash" }}).(*RollingHashDedup); !ok {
 		t.Fatal("expected rolling hash strategy for auto")
 	}
 
 	cfg.DedupStrategy = "auto"
-	detectBestStrategy = func() string { return "checksum" }
-	if _, ok := NewDeduplicationStrategy(cfg, zap.NewNop()).(*ChecksumDedup); !ok {
+	if _, ok := NewDeduplicationStrategyWithDeps(cfg, zap.NewNop(), &Deps{DetectBestStrategy: func() string { return "checksum" }}).(*ChecksumDedup); !ok {
 		t.Fatal("expected checksum strategy for auto")
 	}
 }


### PR DESCRIPTION
## Summary
- add `Deps` struct to carry file creation, strategy detection, and fdatasync hooks
- refactor transfer components to use injected deps instead of global functions
- update tests to supply mock deps

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a24eed43b08323aaad887710e5a7fd