### PR TITLE
common: optimize SelectBest with map and benchmarks

### DIFF
--- a/common/handshake.go
+++ b/common/handshake.go
@@ -234,17 +234,23 @@ func ReadHandshake(r *bufio.Reader) (Handshake, error) {
 // remote. If no common element exists, the first element of local is returned or
 // an empty string if local is empty.
 func SelectBest(local, remote []string) string {
-	for _, l := range local {
-		for _, r := range remote {
-			if l == r {
-				return l
-			}
-		}
+	if len(local) == 0 {
+		return ""
 	}
-	if len(local) > 0 {
+	if len(remote) == 0 {
 		return local[0]
 	}
-	return ""
+
+	remoteSet := make(map[string]struct{}, len(remote))
+	for _, r := range remote {
+		remoteSet[r] = struct{}{}
+	}
+	for _, l := range local {
+		if _, ok := remoteSet[l]; ok {
+			return l
+		}
+	}
+	return local[0]
 }
 
 func splitNonEmpty(v string) []string {

--- a/common/handshake_benchmark_test.go
+++ b/common/handshake_benchmark_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"strconv"
+	"testing"
+)
+
+// selectBestSlice mirrors the original SelectBest implementation using nested loops.
+func selectBestSlice(local, remote []string) string {
+	for _, l := range local {
+		for _, r := range remote {
+			if l == r {
+				return l
+			}
+		}
+	}
+	if len(local) > 0 {
+		return local[0]
+	}
+	return ""
+}
+
+var (
+	benchLocal  []string
+	benchRemote []string
+)
+
+func init() {
+	const size = 1000
+	benchLocal = make([]string, size)
+	benchRemote = make([]string, size)
+	for i := 0; i < size; i++ {
+		benchLocal[i] = strconv.Itoa(i)
+		benchRemote[i] = "x" + strconv.Itoa(i)
+	}
+	benchRemote[size-1] = benchLocal[size-1]
+}
+
+func BenchmarkSelectBestSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		selectBestSlice(benchLocal, benchRemote)
+	}
+}
+
+func BenchmarkSelectBestMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SelectBest(benchLocal, benchRemote)
+	}
+}


### PR DESCRIPTION
## Summary
- speed up `SelectBest` by replacing nested slice search with map lookups
- add benchmarks comparing slice and map implementations

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`
- `go test -bench=SelectBest -benchmem ./common`


------
https://chatgpt.com/codex/tasks/task_e_68a256a62c4483239172a54143a07c6d