### PR TITLE
Validate Bloom filter fpRate bounds

### DIFF
--- a/dedup/adaptive_test.go
+++ b/dedup/adaptive_test.go
@@ -4,12 +4,18 @@ import "testing"
 
 func TestAdaptiveAvgChunkClamp(t *testing.T) {
 	// clamp to minimum
-	avg, _ := AdaptiveAvgChunk(100, 1<<20, 0.01, 64, 512)
+	avg, _, err := AdaptiveAvgChunk(100, 1<<20, 0.01, 64, 512)
+	if err != nil {
+		t.Fatalf("AdaptiveAvgChunk: %v", err)
+	}
 	if avg != 64 {
 		t.Fatalf("expected avg to clamp to min, got %d", avg)
 	}
 	// clamp to maximum
-	avg, _ = AdaptiveAvgChunk(1<<40, 1, 0.01, 64, 1024)
+	avg, _, err = AdaptiveAvgChunk(1<<40, 1, 0.01, 64, 1024)
+	if err != nil {
+		t.Fatalf("AdaptiveAvgChunk: %v", err)
+	}
 	if avg != 1024 {
 		t.Fatalf("expected avg to clamp to max, got %d", avg)
 	}

--- a/dedup/bloom.go
+++ b/dedup/bloom.go
@@ -1,6 +1,7 @@
 package dedup
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/bits-and-blooms/bloom/v3"
@@ -16,10 +17,15 @@ type Bloom struct {
 
 // NewBloom creates a Bloom filter that can hold n entries with the given
 // false positive rate. Memory usage is derived from these parameters.
-func NewBloom(n uint, fpRate float64) *Bloom {
+//
+// The fpRate must be greater than 0 and less than 1.
+func NewBloom(n uint, fpRate float64) (*Bloom, error) {
+	if err := validateFpRate(fpRate); err != nil {
+		return nil, err
+	}
 	m, k := bloom.EstimateParameters(n, fpRate)
 	f := bloom.New(m, k)
-	return &Bloom{filter: f}
+	return &Bloom{filter: f}, nil
 }
 
 // TestAndAdd returns true if the given byte slice is probably in the set.
@@ -38,15 +44,23 @@ func (b *Bloom) TestAndAdd(digest []byte) bool {
 // rate. The calculation follows the formula given in the PRD:
 //
 //	maxChunks = (RAM * 0.4809) / ln(1/falsePositiveRate)
-func MaxChunks(ramBytes uint64, fpRate float64) uint64 {
-	return uint64((float64(ramBytes) * 0.4809) / math.Log(1.0/fpRate))
+//
+// MaxChunks returns an error if fpRate is not within the (0,1) range.
+func MaxChunks(ramBytes uint64, fpRate float64) (uint64, error) {
+	if err := validateFpRate(fpRate); err != nil {
+		return 0, err
+	}
+	return uint64((float64(ramBytes) * 0.4809) / math.Log(1.0/fpRate)), nil
 }
 
 // AdaptiveAvgChunk computes the average chunk size based on volume size,
 // available RAM and false positive rate. The size is clamped between the
 // provided minimum and maximum values.
-func AdaptiveAvgChunk(volumeSize, ramBytes uint64, fpRate float64, minSize, maxSize uint64) (avg, maxChunks uint64) {
-	maxChunks = MaxChunks(ramBytes, fpRate)
+func AdaptiveAvgChunk(volumeSize, ramBytes uint64, fpRate float64, minSize, maxSize uint64) (avg, maxChunks uint64, err error) {
+	maxChunks, err = MaxChunks(ramBytes, fpRate)
+	if err != nil {
+		return 0, 0, err
+	}
 	if maxChunks == 0 {
 		maxChunks = 1
 	}
@@ -58,4 +72,11 @@ func AdaptiveAvgChunk(volumeSize, ramBytes uint64, fpRate float64, minSize, maxS
 		avg = maxSize
 	}
 	return
+}
+
+func validateFpRate(fpRate float64) error {
+	if fpRate <= 0 || fpRate >= 1 {
+		return fmt.Errorf("fpRate must be > 0 and < 1: %v", fpRate)
+	}
+	return nil
 }

--- a/dedup/doc.go
+++ b/dedup/doc.go
@@ -1,0 +1,5 @@
+// Package dedup provides chunk deduplication helpers.
+//
+// Bloom filter utilities in this package require a false positive rate
+// greater than 0 and less than 1.
+package dedup

--- a/dedup/unit_test.go
+++ b/dedup/unit_test.go
@@ -39,13 +39,25 @@ func TestHasher(t *testing.T) {
 }
 
 func TestBloom(t *testing.T) {
-	b := NewBloom(1000, 0.01)
+	b, err := NewBloom(1000, 0.01)
+	if err != nil {
+		t.Fatalf("new bloom: %v", err)
+	}
 	data := []byte("chunk")
 	if b.TestAndAdd(data) {
 		t.Fatalf("unexpected hit")
 	}
 	if !b.TestAndAdd(data) {
 		t.Fatalf("expected hit on second insert")
+	}
+}
+
+func TestBloomInvalidFpRate(t *testing.T) {
+	cases := []float64{0, 1, -0.5, 1.5}
+	for _, fp := range cases {
+		if _, err := NewBloom(1000, fp); err == nil {
+			t.Fatalf("expected error for fpRate %v", fp)
+		}
 	}
 }
 
@@ -87,13 +99,25 @@ func TestFastCDC(t *testing.T) {
 }
 
 func TestBloomSizing(t *testing.T) {
-	max := MaxChunks(1<<30, 0.01)
+	max, err := MaxChunks(1<<30, 0.01)
+	if err != nil {
+		t.Fatalf("MaxChunks: %v", err)
+	}
 	if max == 0 {
 		t.Fatalf("expected non-zero max chunks")
 	}
-	avg, chunks := AdaptiveAvgChunk(1<<40, 1<<30, 0.01, 64, 1<<20)
+	avg, chunks, err := AdaptiveAvgChunk(1<<40, 1<<30, 0.01, 64, 1<<20)
+	if err != nil {
+		t.Fatalf("AdaptiveAvgChunk: %v", err)
+	}
 	if avg < 64 || chunks == 0 {
 		t.Fatalf("unexpected sizing avg=%d chunks=%d", avg, chunks)
+	}
+	if _, err := MaxChunks(1<<30, 0); err == nil {
+		t.Fatalf("expected error for invalid fpRate in MaxChunks")
+	}
+	if _, _, err := AdaptiveAvgChunk(1<<40, 1<<30, 0, 64, 1<<20); err == nil {
+		t.Fatalf("expected error for invalid fpRate in AdaptiveAvgChunk")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add validation to Bloom filter helpers requiring fpRate in (0,1)
- document Bloom false-positive rate requirements

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a256972650832396940d5be42bf780