### PR TITLE
quic: surface connection close errors

### DIFF
--- a/transport/quic/close_test.go
+++ b/transport/quic/close_test.go
@@ -1,0 +1,104 @@
+package quic
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	quic "github.com/quic-go/quic-go"
+)
+
+// stubQConn implements quic.Connection for testing Conn.Close.
+type stubQConn struct {
+	closeErr   error
+	localAddr  net.Addr
+	remoteAddr net.Addr
+}
+
+func (s *stubQConn) AcceptStream(context.Context) (quic.Stream, error)           { return nil, nil }
+func (s *stubQConn) AcceptUniStream(context.Context) (quic.ReceiveStream, error) { return nil, nil }
+func (s *stubQConn) OpenStream() (quic.Stream, error)                            { return nil, nil }
+func (s *stubQConn) OpenStreamSync(context.Context) (quic.Stream, error)         { return nil, nil }
+func (s *stubQConn) OpenUniStream() (quic.SendStream, error)                     { return nil, nil }
+func (s *stubQConn) OpenUniStreamSync(context.Context) (quic.SendStream, error)  { return nil, nil }
+func (s *stubQConn) LocalAddr() net.Addr                                         { return s.localAddr }
+func (s *stubQConn) RemoteAddr() net.Addr                                        { return s.remoteAddr }
+func (s *stubQConn) CloseWithError(quic.ApplicationErrorCode, string) error      { return s.closeErr }
+func (s *stubQConn) Context() context.Context                                    { return context.Background() }
+func (s *stubQConn) ConnectionState() quic.ConnectionState                       { return quic.ConnectionState{} }
+func (s *stubQConn) SendDatagram([]byte) error                                   { return nil }
+func (s *stubQConn) ReceiveDatagram(context.Context) ([]byte, error)             { return nil, nil }
+
+// stubStream implements quic.Stream for testing.
+type stubStream struct{ closeErr error }
+
+func (s *stubStream) StreamID() quic.StreamID          { return 0 }
+func (s *stubStream) Read([]byte) (int, error)         { return 0, io.EOF }
+func (s *stubStream) Write(p []byte) (int, error)      { return len(p), nil }
+func (s *stubStream) Close() error                     { return s.closeErr }
+func (s *stubStream) CancelRead(quic.StreamErrorCode)  {}
+func (s *stubStream) CancelWrite(quic.StreamErrorCode) {}
+func (s *stubStream) Context() context.Context         { return context.Background() }
+func (s *stubStream) SetDeadline(time.Time) error      { return nil }
+func (s *stubStream) SetReadDeadline(time.Time) error  { return nil }
+func (s *stubStream) SetWriteDeadline(time.Time) error { return nil }
+
+func TestConnClose(t *testing.T) {
+	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1}
+	qerr := errors.New("qconn close")
+	serr := errors.New("stream close")
+
+	tests := []struct {
+		name     string
+		qcErr    error
+		stErr    error
+		wantErrs []error
+		wantLogs bool
+	}{
+		{"success", nil, nil, nil, false},
+		{"qconn_error", qerr, nil, []error{qerr}, true},
+		{"stream_error", nil, serr, []error{serr}, true},
+		{"both_error", qerr, serr, []error{qerr, serr}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, obs := observer.New(zap.DebugLevel)
+			c := &Conn{
+				qconn:  &stubQConn{closeErr: tt.qcErr, localAddr: addr, remoteAddr: addr},
+				stream: &stubStream{closeErr: tt.stErr},
+				logger: zap.New(core),
+			}
+			err := c.Close()
+			if len(tt.wantErrs) == 0 {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				if obs.Len() != 0 {
+					t.Fatalf("expected no logs, got %d", obs.Len())
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			for _, we := range tt.wantErrs {
+				if !errors.Is(err, we) {
+					t.Fatalf("expected error %v, got %v", we, err)
+				}
+			}
+			if obs.Len() != 1 {
+				t.Fatalf("expected 1 log entry, got %d", obs.Len())
+			}
+			if obs.All()[0].Message != "close_failed" {
+				t.Fatalf("unexpected log message %q", obs.All()[0].Message)
+			}
+		})
+	}
+}

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	quic "github.com/quic-go/quic-go"
@@ -35,13 +36,15 @@ type Conn struct {
 	qconn        quic.Connection
 	stream       quic.Stream
 	readDeadline time.Time
+	logger       *zap.Logger
 }
 
 // listener adapts a quic.Listener to net.Listener by accepting a stream for
 // each connection.
 type listener struct {
-	ql  *quic.Listener
-	ctx context.Context
+	ql     *quic.Listener
+	ctx    context.Context
+	logger *zap.Logger
 }
 
 // New constructs a Transport using the provided TLS roots and client cert.
@@ -130,7 +133,7 @@ func (t *Transport) Dial(ctx context.Context, address string) (net.Conn, error) 
 		return nil, err
 	}
 	t.logger.Info("dial_end", fields...)
-	return &Conn{qconn: qconn, stream: stream}, nil
+	return &Conn{qconn: qconn, stream: stream, logger: t.logger}, nil
 }
 
 // Listen starts a QUIC listener.
@@ -154,7 +157,7 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		return nil, err
 	}
 	t.logger.Info("listen_end", fields...)
-	return &listener{ql: ql, ctx: ctx}, nil
+	return &listener{ql: ql, ctx: ctx, logger: t.logger}, nil
 }
 
 // Accept waits for the next connection and returns its first stream.
@@ -171,7 +174,7 @@ func (l *listener) Accept() (net.Conn, error) {
 		qconn.CloseWithError(0, err.Error())
 		return nil, err
 	}
-	return &Conn{qconn: qconn, stream: stream}, nil
+	return &Conn{qconn: qconn, stream: stream, logger: l.logger}, nil
 }
 
 func (l *listener) Close() error { return l.ql.Close() }
@@ -309,8 +312,17 @@ func (c *Conn) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 func (c *Conn) Read(p []byte) (int, error)  { return c.stream.Read(p) }
 func (c *Conn) Write(p []byte) (int, error) { return c.stream.Write(p) }
 func (c *Conn) Close() error {
-	_ = c.qconn.CloseWithError(0, "")
-	return c.stream.Close()
+	err1 := c.qconn.CloseWithError(0, "")
+	err2 := c.stream.Close()
+	err := multierr.Append(err1, err2)
+	if err != nil {
+		c.logger.Error("close_failed",
+			zap.String("remote_addr", c.qconn.RemoteAddr().String()),
+			zap.String("local_addr", c.qconn.LocalAddr().String()),
+			zap.Error(err),
+		)
+	}
+	return err
 }
 func (c *Conn) LocalAddr() net.Addr  { return c.qconn.LocalAddr() }
 func (c *Conn) RemoteAddr() net.Addr { return c.qconn.RemoteAddr() }


### PR DESCRIPTION
## Summary
- capture errors from both QUIC connection and stream closing
- log close failures with connection addresses
- add unit tests for Conn.Close success and error scenarios

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a256901b9883238061d19075492749