### PR TITLE
remote: require explicit logger

### DIFF
--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -24,7 +24,7 @@ func TestSetupSSHClient(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		dummy := &remote.SSHClient{}
+		dummy := &remote.SSHClient{Logger: zap.NewNop()}
 		called := false
 		newSSHClient = func(ctx context.Context, host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
 			called = true

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -24,9 +24,8 @@ var RemoteCmdRe = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
 
 // SSHClient wraps an ssh.Client and provides structured logging.
 //
-// The embedded *zap.Logger defaults to a no-op logger when nil to avoid
-// nil-pointer dereferences while still allowing callers to inject their own
-// logger for observability.
+// The embedded *zap.Logger must be non-nil; callers can pass
+// zap.NewNop() to disable logging.
 type SSHClient struct {
 	*ssh.Client
 	*zap.Logger
@@ -35,7 +34,8 @@ type SSHClient struct {
 // NewSSHClient establishes an SSH connection to the given host using either a
 // private key or the local SSH agent for authentication. The connection is
 // configured with a keep-alive mechanism and host key verification based on the
-// provided known_hosts file.
+// provided known_hosts file. The logger must not be nil; use zap.NewNop() when
+// logging is undesired.
 func NewSSHClient(
 	ctx context.Context,
 	host, user, keyPath string,
@@ -46,9 +46,6 @@ func NewSSHClient(
 	retries int,
 	logger *zap.Logger,
 ) (*SSHClient, error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 
 	authMethods, err := selectAuthMethods(ctx, logger, keyPath, timeout)
 	if err != nil {


### PR DESCRIPTION
## Summary
- require callers to provide a non-nil `*zap.Logger` in `remote.NewSSHClient`
- document logger requirement and ensure tests pass explicit loggers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a25671fd088323bb0a7d2822d2e8f6