### PR TITLE
Add context-aware block read retries with configurable backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--odirect` | `LVMSYNC_ODIRECT` | `odirect` | Use O_DIRECT for device I/O when possible |
 | `--numa-pin` | `LVMSYNC_NUMA_PIN` | `numa_pin` | Pin worker goroutines to device NUMA node |
 | `--max-retries` | `LVMSYNC_MAX_RETRIES` | `max_retries` | Maximum number of retries per block |
+| `--retry-delay` | `LVMSYNC_RETRY_DELAY` | `retry_delay` | Initial delay between retries |
 | `--resume` | `LVMSYNC_RESUME` | `resume` | Path to resume state file (records dedup mode and last chunk boundary) |
 | `--speed` | `LVMSYNC_SPEED` | `speed` | Transfer speed limit |
 | `--sync-interval` | `LVMSYNC_SYNC_INTERVAL` | `sync_interval` | Bytes between fdatasync calls (accepts size suffixes like `64KB`; invalid values error) |
@@ -1089,6 +1090,8 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--parallel`        | Number of concurrent workers                                                                            | `4`       |
 | `--zerocopy`        | Enable zero-copy transfers (only used in sequential mode)                                               | `false`   |
 | `--max-retries`     | Maximum number of retries per block                                                                     | `3`       |
+| `--retry-delay`     | Initial delay between retries
+| `100ms`   |
 | `--resume`          | Path to resume state file                                                                               | `""`      |
 | `--speed`           | Transfer speed limit (e.g., `"100MB"`)                                                                  | `"100MB"` |
 | `-v, --verbose`     | Verbosity level (e.g., `-v`, `-vv`, `-vvv`)                                                             | `0`       |

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -46,6 +46,7 @@ type Config struct {
 	ODirect                  bool          `mapstructure:"odirect"`
 	NumaPin                  bool          `mapstructure:"numa_pin"`
 	MaxRetries               int           `mapstructure:"max_retries"`
+	RetryDelay               time.Duration `mapstructure:"retry_delay"`
 	ResumeState              string        `mapstructure:"resume"`
 	ResumeToken              string        `mapstructure:"resume_token"`
 	DeviceUUID               string        `mapstructure:"device_uuid"`
@@ -184,6 +185,7 @@ func DefaultConfig() (*Config, error) {
 		ODirect:                  false,
 		NumaPin:                  false,
 		MaxRetries:               3,
+		RetryDelay:               100 * time.Millisecond,
 		ResumeState:              "",
 		ResumeToken:              "",
 		DeviceUUID:               "",

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -72,6 +72,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("odirect", cfg.ODirect, "Use O_DIRECT for device I/O when possible")
 	fs.Bool("numa-pin", cfg.NumaPin, "Pin worker goroutines to device NUMA node")
 	fs.Int("max-retries", cfg.MaxRetries, "Maximum number of retries per block")
+	fs.Duration("retry-delay", cfg.RetryDelay, "Initial delay between retries")
 	fs.String("resume", cfg.ResumeState, "Path to resume state file")
 	fs.String("speed", cfg.Speed, "Transfer speed limit")
 	fs.String("sync-interval", cfg.SyncInterval, "Bytes between fdatasync calls")

--- a/internal/config/flagsets_test.go
+++ b/internal/config/flagsets_test.go
@@ -33,6 +33,7 @@ func TestInitGeneralFlags(t *testing.T) {
 		{"odirect", strconv.FormatBool(cfg.ODirect)},
 		{"numa-pin", strconv.FormatBool(cfg.NumaPin)},
 		{"max-retries", strconv.Itoa(cfg.MaxRetries)},
+		{"retry-delay", cfg.RetryDelay.String()},
 		{"resume", cfg.ResumeState},
 		{"speed", cfg.Speed},
 		{"sync-interval", cfg.SyncInterval},

--- a/transfer/block_benchmark_test.go
+++ b/transfer/block_benchmark_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"context"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -47,7 +48,7 @@ func BenchmarkReadBlockWithRetriesEphemeral(b *testing.B) {
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
 	for i := 0; i < b.N; i++ {
-		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, [2]int{-1, -1}, zap.NewNop()); err != nil {
+		if _, err := ReadBlockWithRetries(context.Background(), cfg, f, int64(i*cfg.BlockSize), true, [2]int{-1, -1}, zap.NewNop()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -84,7 +85,7 @@ func BenchmarkReadBlockWithRetriesPersistent(b *testing.B) {
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
 	for i := 0; i < b.N; i++ {
-		if _, err := ReadBlockWithRetries(cfg, f, int64(i*cfg.BlockSize), true, pipeFds, zap.NewNop()); err != nil {
+		if _, err := ReadBlockWithRetries(context.Background(), cfg, f, int64(i*cfg.BlockSize), true, pipeFds, zap.NewNop()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/transfer/block_common.go
+++ b/transfer/block_common.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -44,19 +45,23 @@ func ReadBlock(src *os.File, offset int64, size int) ([]byte, error) {
 // ReadBlockWithRetries reads a block with retries; logger must be non-nil.
 //
 //nolint:revive // high complexity is acceptable for this low-level function
-func ReadBlockWithRetries(cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
+func ReadBlockWithRetries(ctx context.Context, cfg *config.Config, src *os.File, offset int64, useZeroCopy bool, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
 	if useZeroCopy {
-		return readWithZeroCopy(cfg, src, offset, pipeFds, logger)
+		return readWithZeroCopy(ctx, cfg, src, offset, pipeFds, logger)
 	}
-	return retryRead(cfg, src, offset, logger)
+	return retryRead(ctx, cfg, src, offset, logger)
 }
 
 // readWithZeroCopy uses zero-copy transfers; logger must be non-nil.
 //
 //revive:disable-next-line:cognitive-complexity
-func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
+func readWithZeroCopy(ctx context.Context, cfg *config.Config, src *os.File, offset int64, pipeFds [2]int, logger *zap.Logger) ([]byte, error) {
 	blockSize := cfg.BlockSize
 	maxRetries := cfg.MaxRetries
+	baseDelay := cfg.RetryDelay
+	if baseDelay <= 0 {
+		baseDelay = 100 * time.Millisecond
+	}
 
 	if pipeFds[0] == -1 && pipeFds[1] == -1 {
 		if err := syscall.Pipe(pipeFds[:]); err != nil {
@@ -97,7 +102,15 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 			zap.Int("attempt", attempt+1),
 			zap.Error(err))
 
-		time.Sleep(100 * time.Millisecond)
+		delay := baseDelay * time.Duration(1<<attempt)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			if errClose := w.Close(); errClose != nil {
+				logger.Warn("pipe write close", zap.Error(errClose))
+			}
+			return nil, ctx.Err()
+		}
 	}
 	if errClose := w.Close(); errClose != nil {
 		return nil, errClose
@@ -124,9 +137,13 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 	return data, nil
 }
 
-func retryRead(cfg *config.Config, src *os.File, offset int64, logger *zap.Logger) ([]byte, error) {
+func retryRead(ctx context.Context, cfg *config.Config, src *os.File, offset int64, logger *zap.Logger) ([]byte, error) {
 	blockSize := cfg.BlockSize
 	maxRetries := cfg.MaxRetries
+	baseDelay := cfg.RetryDelay
+	if baseDelay <= 0 {
+		baseDelay = 100 * time.Millisecond
+	}
 
 	var buf []byte
 	if cfg.ODirect {
@@ -146,7 +163,17 @@ func retryRead(cfg *config.Config, src *os.File, offset int64, logger *zap.Logge
 			zap.Int("attempt", attempt+1),
 			zap.Error(err))
 
-		time.Sleep(100 * time.Millisecond)
+		delay := baseDelay * time.Duration(1<<attempt)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			if cfg.ODirect {
+				putAlignedBlockBuffer(buf)
+			} else {
+				putBlockBuffer(buf)
+			}
+			return nil, ctx.Err()
+		}
 	}
 
 	if cfg.ODirect {

--- a/transfer/block_stream.go
+++ b/transfer/block_stream.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash"
 	"math"
@@ -81,8 +82,11 @@ func iterateBlocks(
 		if err != nil {
 			return totalBytes, skippedBlocks, nil, err
 		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, pipeFds, logger)
+		data, err := ReadBlockWithRetries(ctx, cfg, srcFile, offset, cfg.ZeroCopy, pipeFds, logger)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return totalBytes, skippedBlocks, nil, err
+			}
 			return totalBytes, skippedBlocks, nil, fmt.Errorf("error reading block at offset %d: %w", r.Start, err)
 		}
 		xx := hashutil.SumXXH3(data)
@@ -282,8 +286,15 @@ func worker(ctx context.Context, cfg *config.Config, srcFile *os.File, tasks <-c
 				results <- &BlockResult{Index: task.Index, Err: err}
 				continue
 			}
-			data, err := ReadBlockWithRetries(cfg, srcFile, offset, false, [2]int{-1, -1}, logger)
-			zero := err == nil && isAllZero(data)
+			data, err := ReadBlockWithRetries(ctx, cfg, srcFile, offset, false, [2]int{-1, -1}, logger)
+			if err != nil {
+				results <- &BlockResult{Index: task.Index, Err: err}
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				continue
+			}
+			zero := isAllZero(data)
 			var resData []byte
 			size := blockSize
 			var chunkID [32]byte
@@ -302,7 +313,6 @@ func worker(ctx context.Context, cfg *config.Config, srcFile *os.File, tasks <-c
 				Size:    size,
 				Data:    resData,
 				ChunkID: chunkID,
-				Err:     err,
 			}
 		}
 	}

--- a/transfer/block_test.go
+++ b/transfer/block_test.go
@@ -2,6 +2,8 @@ package transfer
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -30,7 +32,7 @@ func TestReadBlockWithRetriesTransientFailure(t *testing.T) {
 	}()
 
 	start := time.Now()
-	buf, err := ReadBlockWithRetries(cfg, tmp, 0, false, [2]int{-1, -1}, logger)
+	buf, err := ReadBlockWithRetries(context.Background(), cfg, tmp, 0, false, [2]int{-1, -1}, logger)
 	if err != nil {
 		t.Fatalf("ReadBlockWithRetries returned error: %v", err)
 	}
@@ -57,7 +59,7 @@ func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
 	}
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
-	buf, err := ReadBlockWithRetries(cfg, tmp, 0, true, [2]int{-1, -1}, logger)
+	buf, err := ReadBlockWithRetries(context.Background(), cfg, tmp, 0, true, [2]int{-1, -1}, logger)
 	if err != nil {
 		t.Fatalf("ReadBlockWithRetries error: %v", err)
 	}
@@ -85,7 +87,7 @@ func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
 	}()
 
 	atomic.StoreInt64(&PipeCreationCount, 0)
-	buf, err = ReadBlockWithRetries(cfg, tmp, 0, true, fds, logger)
+	buf, err = ReadBlockWithRetries(context.Background(), cfg, tmp, 0, true, fds, logger)
 	if err != nil {
 		t.Fatalf("ReadBlockWithRetries error: %v", err)
 	}
@@ -96,4 +98,27 @@ func TestReadBlockWithRetriesPipeHandling(t *testing.T) {
 		t.Fatalf("expected PipeCreationCount 0, got %d", c)
 	}
 	putBlockBuffer(buf)
+}
+
+func TestReadBlockWithRetriesContextCancel(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := &config.Config{BlockSize: 4, MaxRetries: 3}
+
+	tmp := newTempFile(t, "block")
+	defer tmp.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := ReadBlockWithRetries(ctx, cfg, tmp, 0, false, [2]int{-1, -1}, logger)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if time.Since(start) >= 100*time.Millisecond {
+		t.Fatalf("expected cancellation before backoff elapsed")
+	}
 }

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -261,7 +261,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 		t.Fatalf("open src: %v", err)
 	}
 	checkpoint := readResumeState(cfg, tt.Logger)
-	startIdx := findResumeIndex(cfg, srcFile, ranges, checkpoint, tt.Logger)
+	startIdx := findResumeIndex(context.Background(), cfg, srcFile, ranges, checkpoint, tt.Logger)
 	if startIdx > 0 {
 		ranges = ranges[startIdx:]
 	}
@@ -531,7 +531,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 				t.Fatalf("open src: %v", err)
 			}
 			checkpoint := readResumeState(cfg, tt.Logger)
-			startIdx := findResumeIndex(cfg, srcFile, ranges, checkpoint, tt.Logger)
+			startIdx := findResumeIndex(context.Background(), cfg, srcFile, ranges, checkpoint, tt.Logger)
 			if startIdx > 0 {
 				ranges = ranges[startIdx:]
 			}
@@ -705,7 +705,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 				t.Fatalf("open src: %v", err)
 			}
 			checkpoint := readResumeState(cfg, tt.Logger)
-			startIdx := findResumeIndex(cfg, srcFile, ranges, checkpoint, tt.Logger)
+			startIdx := findResumeIndex(context.Background(), cfg, srcFile, ranges, checkpoint, tt.Logger)
 			if startIdx > 0 {
 				ranges = ranges[startIdx:]
 			}

--- a/transfer/pool_test.go
+++ b/transfer/pool_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -30,7 +31,7 @@ func BenchmarkReadBlockWithPool(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		buf, err := ReadBlockWithRetries(cfg, f, 0, false, [2]int{-1, -1}, zap.NewNop())
+		buf, err := ReadBlockWithRetries(context.Background(), cfg, f, 0, false, [2]int{-1, -1}, zap.NewNop())
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -26,7 +26,7 @@ func TestResumeCDCOffset(t *testing.T) {
 
 	chk := readResumeState(cfg, logger)
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
-	idx := findResumeIndex(cfg, nil, ranges, chk, logger)
+	idx := findResumeIndex(context.Background(), cfg, nil, ranges, chk, logger)
 	if idx != 1 {
 		t.Fatalf("expected index 1, got %d", idx)
 	}

--- a/transfer/resume_checksum_test.go
+++ b/transfer/resume_checksum_test.go
@@ -29,7 +29,7 @@ func TestResumeFinalChecksum(t *testing.T) {
 	}
 	defer srcFile.Close()
 	checkpoint := readResumeState(cfg, logger)
-	start := findResumeIndex(cfg, srcFile, ranges, checkpoint, logger)
+	start := findResumeIndex(context.Background(), cfg, srcFile, ranges, checkpoint, logger)
 	w := bufio.NewWriter(io.Discard)
 	_, _, digest, err := iterateBlocks(context.Background(), cfg, ranges[start:], srcFile, w, nil, [2]int{-1, -1}, logger, nil)
 	if err != nil {

--- a/transfer/resume_fixed.go
+++ b/transfer/resume_fixed.go
@@ -1,7 +1,9 @@
 package transfer
 
 import (
+	"context"
 	"crypto/sha256"
+	"errors"
 	"os"
 
 	"github.com/zeebo/blake3"
@@ -11,7 +13,7 @@ import (
 )
 
 // findResumeIndex determines the starting range index based on the checkpoint and dedup mode.
-func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
+func findResumeIndex(ctx context.Context, cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeCheckpoint, logger *zap.Logger) int {
 	if cfg.ResumeState == "" {
 		return 0
 	}
@@ -21,12 +23,12 @@ func findResumeIndex(cfg *config.Config, srcFile *os.File, ranges []Range, chk r
 	case "hybrid":
 		return findResumeIndexHybrid(cfg, ranges, chk.Hybrid, logger)
 	default:
-		return findResumeIndexFixed(cfg, srcFile, ranges, chk.Fixed, logger)
+		return findResumeIndexFixed(ctx, cfg, srcFile, ranges, chk.Fixed, logger)
 	}
 }
 
 // findResumeIndexFixed finds resume index using fixed-size blocks; logger must be non-nil.
-func findResumeIndexFixed(cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeChunk, logger *zap.Logger) int {
+func findResumeIndexFixed(ctx context.Context, cfg *config.Config, srcFile *os.File, ranges []Range, chk resumeChunk, logger *zap.Logger) int {
 	if chk.Chunk == [32]byte{} {
 		return 0
 	}
@@ -35,8 +37,11 @@ func findResumeIndexFixed(cfg *config.Config, srcFile *os.File, ranges []Range, 
 		if err != nil {
 			return 0
 		}
-		data, err := ReadBlockWithRetries(cfg, srcFile, offset, cfg.ZeroCopy, [2]int{-1, -1}, logger)
+		data, err := ReadBlockWithRetries(ctx, cfg, srcFile, offset, cfg.ZeroCopy, [2]int{-1, -1}, logger)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return 0
+			}
 			continue
 		}
 		var sum [32]byte

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -26,7 +26,7 @@ func TestResumeHybridOffset(t *testing.T) {
 
 	chk := readResumeState(cfg, logger)
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
-	idx := findResumeIndex(cfg, nil, ranges, chk, logger)
+	idx := findResumeIndex(context.Background(), cfg, nil, ranges, chk, logger)
 	if idx != 1 {
 		t.Fatalf("expected index 1, got %d", idx)
 	}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -131,7 +131,7 @@ func (t *Transfer) dumpChangesCore(ctx context.Context, cfg *config.Config, snap
 	defer cleanupPipe()
 
 	checkpoint := readResumeState(cfg, t.Logger)
-	startIdx := findResumeIndex(cfg, srcFile, ranges, checkpoint, t.Logger)
+	startIdx := findResumeIndex(ctx, cfg, srcFile, ranges, checkpoint, t.Logger)
 	if startIdx > 0 {
 		ranges = ranges[startIdx:]
 	}

--- a/transfer/worker.go
+++ b/transfer/worker.go
@@ -178,7 +178,7 @@ func (t *Transfer) DumpChangesParallel(ctx context.Context, cfg *config.Config, 
 	defer common.CloseWithErr(srcFile, &err, "close source file")
 
 	checkpoint := readResumeState(cfg, t.Logger)
-	resumeStart := findResumeIndex(cfg, srcFile, ranges, checkpoint, t.Logger)
+	resumeStart := findResumeIndex(ctx, cfg, srcFile, ranges, checkpoint, t.Logger)
 	results := t.startParallelWorkers(ctx, cfg, srcFile, ranges, resumeStart, t.Logger)
 
 	startTime := time.Now()


### PR DESCRIPTION
## Summary
- add RetryDelay config and flag for controlling exponential backoff
- make block reads context-aware and replace sleeps with context-based waits
- propagate context through block stream and resume scanning

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2566ab9288323a1751f1c6fcffcf1