### PR TITLE
remote: add ValidRemoteCommand helper

### DIFF
--- a/device/raw.go
+++ b/device/raw.go
@@ -214,7 +214,7 @@ func validateCmd(path string, args []string) error {
 	if strings.ContainsRune(path, '\x00') {
 		return fmt.Errorf("command path contains NUL byte")
 	}
-	if !remote.RemoteCmdRe.MatchString(filepath.Base(path)) {
+	if !remote.ValidRemoteCommand(filepath.Base(path)) {
 		return fmt.Errorf("command path %s contains invalid characters", path)
 	}
 	for _, a := range args {

--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -32,7 +32,7 @@ func StartPrivHelper(ctx context.Context, client *ssh.Client, command string, lo
 		logger = zap.NewNop()
 	}
 	command = strings.TrimSpace(command)
-	if !RemoteCmdRe.MatchString(command) {
+	if !ValidRemoteCommand(command) {
 		return nil, fmt.Errorf("remote command %s contains invalid characters", command)
 	}
 	session, err := client.NewSession()

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -19,8 +19,14 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
-// RemoteCmdRe matches allowable command names for remote execution.
-var RemoteCmdRe = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
+// remoteCmdRe matches allowable command names for remote execution.
+var remoteCmdRe = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
+
+// ValidRemoteCommand reports whether cmd is a valid remote command name.
+// It returns true if cmd matches remoteCmdRe.
+func ValidRemoteCommand(cmd string) bool {
+	return remoteCmdRe.MatchString(cmd)
+}
 
 // SSHClient wraps an ssh.Client and provides structured logging.
 //
@@ -199,7 +205,7 @@ func (c *SSHClient) ValidateRemoteCommand(ctx context.Context, remoteCmd string)
 		return fmt.Errorf("remote command is empty")
 	}
 	cmd := filepath.Base(tokens[0])
-	if !RemoteCmdRe.MatchString(cmd) {
+	if !ValidRemoteCommand(cmd) {
 		return fmt.Errorf("remote command %s contains invalid characters", cmd)
 	}
 	session, err := c.NewSession()

--- a/remote/remote_command_test.go
+++ b/remote/remote_command_test.go
@@ -11,6 +11,21 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+func TestValidRemoteCommand(t *testing.T) {
+	valid := []string{"cmd", "a-b_c.1", "A1"}
+	for _, cmd := range valid {
+		if !ValidRemoteCommand(cmd) {
+			t.Errorf("expected %q to be valid", cmd)
+		}
+	}
+	invalid := []string{"bad+cmd", "cmd with space", "cmd!"}
+	for _, cmd := range invalid {
+		if ValidRemoteCommand(cmd) {
+			t.Errorf("expected %q to be invalid", cmd)
+		}
+	}
+}
+
 func TestValidateRemoteCommand(t *testing.T) {
 	_, rawClient := newSSHServerClient(t, func(cmd string) int {
 		switch cmd {


### PR DESCRIPTION
## Summary
- encapsulate remote command regex behind new `remote.ValidRemoteCommand`
- use helper in priv helper startup and raw device validation
- test valid and invalid remote command names

## Testing
- `go build -v ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2566678688323b31f7a22f1d8216c