### PR TITLE
transfer: add byte units to offset log fields

### DIFF
--- a/transfer/block_common.go
+++ b/transfer/block_common.go
@@ -92,7 +92,7 @@ func readWithZeroCopy(cfg *config.Config, src *os.File, offset int64, pipeFds [2
 		}
 
 		logger.Warn("Zero-copy transfer failed",
-			zap.Int64("offset", offset),
+			zap.Int64("offset_bytes", offset),
 			zap.Int("size_bytes", blockSize),
 			zap.Int("attempt", attempt+1),
 			zap.Error(err))
@@ -141,7 +141,7 @@ func retryRead(cfg *config.Config, src *os.File, offset int64, logger *zap.Logge
 		}
 
 		logger.Warn("Failed to read block",
-			zap.Int64("offset", offset),
+			zap.Int64("offset_bytes", offset),
 			zap.Int("size_bytes", blockSize),
 			zap.Int("attempt", attempt+1),
 			zap.Error(err))

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -54,7 +54,8 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	stateFile := filepath.Join(tmp, "resume")
 	digest := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{ResumeState: stateFile, Compress: "none", ChecksumAlgorithm: "blake3", DedupMode: "fixed"}
-	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: resumeChunk{Chunk: digest}})
+	chk := resumeChunk{Chunk: digest, Offset: 1024, Length: 2048}
+	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: chk})
 
 	val := readResumeState(cfg, logger).Fixed
 	if val.Chunk != digest {
@@ -67,5 +68,11 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	}
 	if v, ok := entries[0].ContextMap()["resume_chunk"].(string); !ok || v != hex.EncodeToString(digest[:]) {
 		t.Fatalf("unexpected resume_chunk %v", entries[0].ContextMap()["resume_chunk"])
+	}
+	if v, ok := entries[0].ContextMap()["resume_offset_bytes"].(uint64); !ok || v != chk.Offset {
+		t.Fatalf("unexpected resume_offset_bytes %v", entries[0].ContextMap()["resume_offset_bytes"])
+	}
+	if v, ok := entries[0].ContextMap()["resume_length_bytes"].(uint32); !ok || v != chk.Length {
+		t.Fatalf("unexpected resume_length_bytes %v", entries[0].ContextMap()["resume_length_bytes"])
 	}
 }

--- a/transfer/resume_cdc.go
+++ b/transfer/resume_cdc.go
@@ -15,7 +15,7 @@ func findResumeIndexCDC(cfg *config.Config, ranges []Range, chk resumeChunk, log
 		}
 		if next <= ranges[i].End {
 			ranges[i].Start = next
-			logger.Info("Resuming after offset", zap.Uint64("resume_offset", next))
+			logger.Info("Resuming after offset", zap.Uint64("resume_offset_bytes", next))
 			return i
 		}
 	}

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -130,8 +130,8 @@ func readResumeState(cfg *config.Config, logger *zap.Logger) resumeCheckpoint {
 	if rc != (resumeChunk{}) {
 		logger.Info("Resuming from chunk",
 			zap.String("resume_chunk", hex.EncodeToString(rc.Chunk[:])),
-			zap.Uint64("resume_offset", rc.Offset),
-			zap.Uint32("resume_length", rc.Length))
+			zap.Uint64("resume_offset_bytes", rc.Offset),
+			zap.Uint32("resume_length_bytes", rc.Length))
 	}
 	return out
 }

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -112,7 +112,7 @@ func writeData(destFile *os.File, offset uint64, data []byte, logger *zap.Logger
 		return fmt.Errorf("offset %d overflows int64", offset)
 	}
 	if _, err := destFile.Seek(int64(offset), io.SeekStart); err != nil {
-		logger.Warn("Seek error", zap.Uint64("offset", offset), zap.Error(err))
+		logger.Warn("Seek error", zap.Uint64("offset_bytes", offset), zap.Error(err))
 		return fmt.Errorf("failed to seek to offset %d: %w", offset, err)
 	}
 	if _, err := destFile.Write(data); err != nil {


### PR DESCRIPTION
## Summary
- rename block read offset log field to `offset_bytes`
- audit transfer logging to use byte units for offsets and lengths
- update resume log field tests

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2566dd27c8323b73e639eaea1851a