### PR TITLE
Use multierr for comprehensive index Close errors

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
@@ -167,24 +168,21 @@ func (i *Index) readHeader() error {
 func (i *Index) Close() error {
 	var err error
 	if i.data != nil {
-		if err = unix.Msync(i.data, unix.MS_SYNC); err != nil {
-			_ = unix.Munmap(i.data)
-			_ = i.f.Close()
-			if i.closeHook != nil {
-				_ = i.closeHook()
-			}
-			return err
+		if syncErr := unix.Msync(i.data, unix.MS_SYNC); syncErr != nil {
+			err = multierr.Append(err, syncErr)
 		}
-		_ = unix.Munmap(i.data)
+		if unmapErr := unix.Munmap(i.data); unmapErr != nil {
+			err = multierr.Append(err, unmapErr)
+		}
 	}
 	if i.f != nil {
 		if ferr := i.f.Close(); ferr != nil {
-			err = ferr
+			err = multierr.Append(err, ferr)
 		}
 	}
 	if i.closeHook != nil {
-		if hookErr := i.closeHook(); err == nil && hookErr != nil {
-			err = hookErr
+		if hookErr := i.closeHook(); hookErr != nil {
+			err = multierr.Append(err, hookErr)
 		}
 	}
 	return err

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zeebo/xxh3"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sys/unix"
 
 	"lvmsync_go/device"
 )
@@ -281,6 +282,36 @@ func TestUpgradeCloseHook(t *testing.T) {
 	}
 	if called != 1 {
 		t.Fatalf("expected close hook called once, got %d", called)
+	}
+}
+
+func TestIndexCloseAggregatesErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "aggregate.man")
+	idx, err := Create(path, "dev", 4096, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Force msync error by unmapping data early.
+	_ = unix.Munmap(idx.data)
+	// Force file close error by closing the file before Index.Close.
+	_ = idx.f.Close()
+	hookErr := errors.New("hook fail")
+	idx.closeHook = func() error { return hookErr }
+
+	err = idx.Close()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid argument") {
+		t.Fatalf("missing msync error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "file already closed") {
+		t.Fatalf("missing file close error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "hook fail") {
+		t.Fatalf("missing hook error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- accumulate Msync, file close, and hook failures with `multierr.Append`
- add test covering multiple simultaneous close failures

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a25d1df2b48323879689538da54de5