### PR TITLE
lvm: validate volume and LV names

### DIFF
--- a/internal/lvm/device.go
+++ b/internal/lvm/device.go
@@ -13,9 +13,23 @@ type Checker struct {
 	Requester string
 }
 
+// validateName ensures name is a single path element without traversal.
+func validateName(name, label string) error {
+	if name == "" || name != filepath.Base(name) || name == "." || name == ".." {
+		return fmt.Errorf("invalid %s name %q", label, name)
+	}
+	return nil
+}
+
 // PreOpen ensures the logical volume exists and is ready for writes.
 // It locks the volume and returns the device path.
 func (c Checker) PreOpen(ctx context.Context, vg, lv string) (string, error) {
+	if err := validateName(vg, "volume group"); err != nil {
+		return "", err
+	}
+	if err := validateName(lv, "logical volume"); err != nil {
+		return "", err
+	}
 	vol := filepath.Join(vg, lv)
 	ok, err := c.Agent.VolumeExists(ctx, vol)
 	if err != nil {

--- a/internal/lvm/device_test.go
+++ b/internal/lvm/device_test.go
@@ -46,6 +46,25 @@ func TestCheckerPreOpen(t *testing.T) {
 	}
 }
 
+func TestCheckerPreOpenInvalidNames(t *testing.T) {
+	ctx := context.Background()
+	mock := &preMock{exists: true, auto: true, discard: true}
+	c := Checker{Agent: mock, Requester: "req"}
+	cases := []struct{ vg, lv string }{
+		{"vg/foo", "lv"},
+		{"vg", "lv/bar"},
+		{"..", "lv"},
+		{"vg", ".."},
+		{"", "lv"},
+		{"vg", ""},
+	}
+	for _, tc := range cases {
+		if _, err := c.PreOpen(ctx, tc.vg, tc.lv); err == nil {
+			t.Fatalf("expected error for vg %q lv %q", tc.vg, tc.lv)
+		}
+	}
+}
+
 func TestCheckerPostCommit(t *testing.T) {
 	ctx := context.Background()
 	f := &fakeFile{}


### PR DESCRIPTION
## Summary
- validate volume group and logical volume names in PreOpen to prevent path traversal
- add unit tests for invalid VG/LV names

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2b4b2ed248323b63df4a1979c2615