### PR TITLE
feat(lvm): make device root configurable

### DIFF
--- a/internal/blockio/devicewriter_test.go
+++ b/internal/blockio/devicewriter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"lvmsync_go/internal/lvm"
@@ -63,8 +64,9 @@ func (m *mockAgent) IsMounted(ctx context.Context, volume string) (bool, error) 
 
 func TestDeviceWriterOpenSuccess(t *testing.T) {
 	ctx := context.Background()
-	path := "/dev/testvg1/testlv1"
-	if err := os.MkdirAll("/dev/testvg1", 0o755); err != nil {
+	root := t.TempDir()
+	path := filepath.Join(root, "testvg1", "testlv1")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	ftmp, err := os.Create(path)
@@ -72,13 +74,9 @@ func TestDeviceWriterOpenSuccess(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	ftmp.Close()
-	t.Cleanup(func() {
-		os.Remove(path)
-		os.Remove("/dev/testvg1")
-	})
 
 	agent := &mockAgent{volumeExists: true, autoExtend: true, discard: true}
-	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req"}}
+	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
 
 	f, closeFn, err := dw.Open(ctx, "testvg1", "testlv1", false)
 	if err != nil {
@@ -103,8 +101,9 @@ func TestDeviceWriterOpenSuccess(t *testing.T) {
 
 func TestDeviceWriterOpenPreOpenFailure(t *testing.T) {
 	ctx := context.Background()
+	root := t.TempDir()
 	agent := &mockAgent{volumeExists: false}
-	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req"}}
+	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
 	f, closeFn, err := dw.Open(ctx, "vg", "lv", false)
 	if err == nil {
 		t.Fatalf("expected error")
@@ -119,8 +118,9 @@ func TestDeviceWriterOpenPreOpenFailure(t *testing.T) {
 
 func TestDeviceWriterOpenPostCommitFailure(t *testing.T) {
 	ctx := context.Background()
-	path := "/dev/testvg2/testlv2"
-	if err := os.MkdirAll("/dev/testvg2", 0o755); err != nil {
+	root := t.TempDir()
+	path := filepath.Join(root, "testvg2", "testlv2")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	ftmp, err := os.Create(path)
@@ -128,13 +128,9 @@ func TestDeviceWriterOpenPostCommitFailure(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	ftmp.Close()
-	t.Cleanup(func() {
-		os.Remove(path)
-		os.Remove("/dev/testvg2")
-	})
 
 	agent := &mockAgent{volumeExists: true, autoExtend: true, discard: true, unlockErr: errors.New("unlock failed")}
-	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req"}}
+	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
 
 	f, closeFn, err := dw.Open(ctx, "testvg2", "testlv2", false)
 	if err != nil {

--- a/internal/lvm/device.go
+++ b/internal/lvm/device.go
@@ -11,6 +11,7 @@ import (
 type Checker struct {
 	Agent     Agent
 	Requester string
+	DevRoot   string
 }
 
 // PreOpen ensures the logical volume exists and is ready for writes.
@@ -42,7 +43,11 @@ func (c Checker) PreOpen(ctx context.Context, vg, lv string) (string, error) {
 	if err := c.Agent.Lock(ctx, vol, c.Requester); err != nil {
 		return "", err
 	}
-	return filepath.Join("/dev", vg, lv), nil
+	root := c.DevRoot
+	if root == "" {
+		root = "/dev"
+	}
+	return filepath.Join(root, vg, lv), nil
 }
 
 // PostCommit fsyncs the device and releases the lock.

--- a/internal/lvm/device_test.go
+++ b/internal/lvm/device_test.go
@@ -3,6 +3,7 @@ package lvm
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 )
 
@@ -39,6 +40,16 @@ func TestCheckerPreOpen(t *testing.T) {
 	}
 	if path != "/dev/vg/lv" {
 		t.Fatalf("path %s", path)
+	}
+	root := t.TempDir()
+	c.DevRoot = root
+	path, err = c.PreOpen(ctx, "vg", "lv")
+	if err != nil {
+		t.Fatalf("preopen with root: %v", err)
+	}
+	want := filepath.Join(root, "vg", "lv")
+	if path != want {
+		t.Fatalf("path %s want %s", path, want)
 	}
 	mock.exists = false
 	if _, err := c.PreOpen(ctx, "vg", "lv"); err == nil {


### PR DESCRIPTION
## Summary
- allow lvm.Checker to override device root
- use checker.DevRoot when building paths
- inject fake device tree via DevRoot in block device writer tests

## Testing
- `go build ./...`
- `go test -cover ./...` (fails: TestAgentAuthContextError expected context deadline exceeded, got <nil>)
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a2b49633f88323bec293c428523e47