### PR TITLE
Rename rsync packages

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -19,7 +19,7 @@ import (
 	"lvmsync_go/internal/config"
 	cpufeatures "lvmsync_go/internal/cpufeatures"
 	digestpkg "lvmsync_go/internal/digest"
-	"lvmsync_go/internal/rsynkwire"
+	"lvmsync_go/internal/rsyncwire"
 	"lvmsync_go/remote"
 	"lvmsync_go/transfer"
 	"lvmsync_go/transport"
@@ -381,7 +381,7 @@ func (r *Runner) StreamToRemote(ctx context.Context, cfg *config.Config, remoteS
 	}
 
 	rw := writeOnlyReadWriter{remoteStdin}
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(rw, maxFrame))
+	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, maxFrame))
 	if err := cl.SendDigest(alg, sum); err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("send digest: %w", err)

--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -1,4 +1,4 @@
-package rsynkserver
+package rsyncserver
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/internal/digest"
-	"lvmsync_go/internal/rsynkwire"
+	"lvmsync_go/internal/rsyncwire"
 	"lvmsync_go/internal/signaturecache"
 )
 
@@ -29,13 +29,13 @@ type Device interface {
 
 // Server applies incoming deltas to the Device.
 //
-// Frames are expected to be sent using rsynkwire.Stream and consist of a leading
+// Frames are expected to be sent using rsyncwire.Stream and consist of a leading
 // byte indicating the frame type:
 //
 //	'S' - signature frame used to reconstruct source signatures
 //	'D' - delta frame containing an 8 byte big endian offset followed by data
 //
-// CRC32C integrity of each frame is verified by rsynkwire.Stream.
+// CRC32C integrity of each frame is verified by rsyncwire.Stream.
 type Server struct {
 	dev     Device
 	alg     string
@@ -59,7 +59,7 @@ func New(dev Device, logger *zap.Logger, cache *signaturecache.Cache, vg, lv str
 
 // Handle consumes frames from the Stream until EOF, applying any delta frames to
 // the Device. On graceful EOF the Device is fsynced.
-func (s *Server) Handle(ctx context.Context, stream *rsynkwire.Stream) error {
+func (s *Server) Handle(ctx context.Context, stream *rsyncwire.Stream) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return err

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -1,4 +1,4 @@
-package rsynkserver
+package rsyncserver
 
 import (
 	"bytes"
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/internal/digest"
-	"lvmsync_go/internal/rsynkwire"
+	"lvmsync_go/internal/rsyncwire"
 	"lvmsync_go/internal/signaturecache"
 )
 
@@ -79,9 +79,9 @@ func TestHandleApplyDelta(t *testing.T) {
 	srv := newServer(t, dev, data)
 	ctx := context.Background()
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
+	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
 	if err := cl.SendDelta(0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
@@ -106,9 +106,9 @@ func TestHandleShortWrite(t *testing.T) {
 	srv := newServer(t, dev, []byte("hi"))
 	ctx := context.Background()
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
-	cl := rsynkwire.NewClient(rsynkwire.NewStream(c1, maxFrame))
+	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
 	if err := cl.SendDelta(0, []byte("hi")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestHandleRejectsOversizedSignatures(t *testing.T) {
 	srv := New(dev, zap.NewNop(), nil, "", "")
 	ctx := context.Background()
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	var buf bytes.Buffer
 	buf.WriteByte('S')
@@ -140,7 +140,7 @@ func TestHandleRejectsOversizedSignatures(t *testing.T) {
 	buf.WriteByte(0)
 	binary.Write(&buf, binary.LittleEndian, int32(0))
 	buf.WriteByte(0)
-	if err := rsynkwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+	if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -168,14 +168,14 @@ func TestHandleCacheHit(t *testing.T) {
 	defer c2.Close()
 	ctx := context.Background()
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	var buf bytes.Buffer
 	buf.WriteByte('G')
 	buf.WriteByte(byte(len(digest.SHA256)))
 	buf.WriteString(digest.SHA256)
 	buf.Write(dgst[:])
-	if err := rsynkwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+	if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -202,8 +202,8 @@ func TestHandleCacheMissUpdates(t *testing.T) {
 	defer c2.Close()
 	ctx := context.Background()
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
-	stream := rsynkwire.NewStream(c1, maxFrame)
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
+	stream := rsyncwire.NewStream(c1, maxFrame)
 
 	var gbuf bytes.Buffer
 	gbuf.WriteByte('G')
@@ -213,7 +213,7 @@ func TestHandleCacheMissUpdates(t *testing.T) {
 	if err := stream.Send(gbuf.Bytes()); err != nil {
 		t.Fatalf("Send digest: %v", err)
 	}
-	if err := rsynkwire.NewClient(stream).SendDelta(0, data); err != nil {
+	if err := rsyncwire.NewClient(stream).SendDelta(0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	c1.Close()
@@ -250,13 +250,13 @@ func TestHandleCacheTTLExpiry(t *testing.T) {
 	defer c2.Close()
 	ctx := context.Background()
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 	var buf bytes.Buffer
 	buf.WriteByte('G')
 	buf.WriteByte(byte(len(digest.SHA256)))
 	buf.WriteString(digest.SHA256)
 	buf.Write(dgst[:])
-	if err := rsynkwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+	if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -282,13 +282,13 @@ func TestHandleCacheLRUEviction(t *testing.T) {
 		c1, c2 := net.Pipe()
 		ctx := context.Background()
 		errCh := make(chan error, 1)
-		go func() { errCh <- srv.Handle(ctx, rsynkwire.NewStream(c2, maxFrame)) }()
+		go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 		var buf bytes.Buffer
 		buf.WriteByte('G')
 		buf.WriteByte(byte(len(digest.SHA256)))
 		buf.WriteString(digest.SHA256)
 		buf.Write(dgst[:])
-		if err := rsynkwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+		if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
 			t.Fatalf("Send: %v", err)
 		}
 		c1.Close()

--- a/internal/rsyncwire/client_test.go
+++ b/internal/rsyncwire/client_test.go
@@ -1,4 +1,4 @@
-package rsynkwire
+package rsyncwire
 
 import (
 	"bytes"

--- a/internal/rsyncwire/stream_test.go
+++ b/internal/rsyncwire/stream_test.go
@@ -1,4 +1,4 @@
-package rsynkwire
+package rsyncwire
 
 import (
 	"bytes"

--- a/internal/rsyncwire/wire.go
+++ b/internal/rsyncwire/wire.go
@@ -1,7 +1,7 @@
-// Package rsynkwire implements a length-prefixed framing protocol with CRC32C
+// Package rsyncwire implements a length-prefixed framing protocol with CRC32C
 // for streaming rsync data. Frames larger than the configured maximum cause
 // Send and Recv to return an error.
-package rsynkwire
+package rsyncwire
 
 import (
 	"bytes"


### PR DESCRIPTION
## Summary
- rename internal rsynkserver/rsynkwire packages to rsyncserver/rsyncwire
- update imports and references to use new package names

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68a2b4a6b09c8323bf2561972f2c369e