### PR TITLE
Run gRPC and data planes concurrently

### DIFF
--- a/cmd/lvmsyncd/cobra.go
+++ b/cmd/lvmsyncd/cobra.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"plugin"
 	"strings"
 
@@ -10,6 +13,10 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+
+	"lvmsync_go/transport"
 )
 
 // Options holds configuration for lvmsyncd.
@@ -35,7 +42,7 @@ func loadModules(mods []string, logger *zap.Logger) error {
 	return nil
 }
 
-func start(ctx context.Context, opts Options, logger *zap.Logger) error {
+func start(ctx context.Context, opts Options, logger *zap.Logger, getTransport func(string, transport.Config) (transport.Interface, error)) error {
 	if err := loadModules(opts.Modules, logger); err != nil {
 		return err
 	}
@@ -48,21 +55,107 @@ func start(ctx context.Context, opts Options, logger *zap.Logger) error {
 	if opts.Once {
 		return nil
 	}
-	<-ctx.Done()
-	return ctx.Err()
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, uri := range opts.Listen {
+		u, err := url.Parse(uri)
+		if err != nil {
+			return fmt.Errorf("parse listen uri %q: %w", uri, err)
+		}
+		scheme := u.Scheme
+		addr := u.Host
+		switch scheme {
+		case "grpc":
+			g.Go(func() error {
+				ln, err := net.Listen("tcp", addr)
+				if err != nil {
+					return fmt.Errorf("grpc listen %q: %w", addr, err)
+				}
+				srv := grpc.NewServer()
+				serveErr := make(chan error, 1)
+				go func() { serveErr <- srv.Serve(ln) }()
+				select {
+				case err := <-serveErr:
+					if errors.Is(err, grpc.ErrServerStopped) || errors.Is(err, net.ErrClosed) {
+						return ctx.Err()
+					}
+					return fmt.Errorf("grpc serve: %w", err)
+				case <-ctx.Done():
+					srv.GracefulStop()
+					ln.Close()
+					err := <-serveErr
+					if errors.Is(err, grpc.ErrServerStopped) || errors.Is(err, net.ErrClosed) {
+						return ctx.Err()
+					}
+					if err != nil {
+						return fmt.Errorf("grpc serve: %w", err)
+					}
+					return ctx.Err()
+				}
+			})
+		default:
+			schemeCopy := scheme
+			addrCopy := addr
+			uriCopy := uri
+			g.Go(func() error {
+				tr, err := getTransport(schemeCopy, transport.Config{Logger: logger})
+				if err != nil {
+					return fmt.Errorf("get transport %q: %w", schemeCopy, err)
+				}
+				ln, err := tr.Listen(ctx, addrCopy)
+				if err != nil {
+					return fmt.Errorf("listen %q: %w", uriCopy, err)
+				}
+				defer ln.Close()
+				go func() {
+					<-ctx.Done()
+					ln.Close()
+				}()
+				for {
+					if _, err := ln.Accept(); err != nil {
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						default:
+							return err
+						}
+					}
+				}
+			})
+		}
+	}
+
+	return g.Wait()
 }
 
 // Runner holds dependencies for lvmsyncd execution.
 type Runner struct {
-	Start func(ctx context.Context, opts Options, logger *zap.Logger) error
+	Start        func(ctx context.Context, opts Options, logger *zap.Logger, getTransport func(string, transport.Config) (transport.Interface, error)) error
+	GetTransport func(string, transport.Config) (transport.Interface, error)
 }
 
 // NewRunner returns a Runner with production dependencies.
-func NewRunner() *Runner { return &Runner{Start: start} }
+func NewRunner() *Runner {
+	return &Runner{
+		Start:        start,
+		GetTransport: transport.Get,
+	}
+}
 
-// NewRunnerWithDeps creates a Runner with custom start function for tests.
-func NewRunnerWithDeps(start func(ctx context.Context, opts Options, logger *zap.Logger) error) *Runner {
-	return &Runner{Start: start}
+// NewRunnerWithDeps creates a Runner with custom dependencies for tests.
+func NewRunnerWithDeps(
+	startFn func(ctx context.Context, opts Options, logger *zap.Logger, getTransport func(string, transport.Config) (transport.Interface, error)) error,
+	get func(string, transport.Config) (transport.Interface, error),
+) *Runner {
+	r := NewRunner()
+	if startFn != nil {
+		r.Start = startFn
+	}
+	if get != nil {
+		r.GetTransport = get
+	}
+	return r
 }
 
 type flagBinder interface {
@@ -138,7 +231,7 @@ func (r *Runner) NewCmd(logger *zap.Logger, v flagBinder) (*cobra.Command, error
 			if ctx == nil {
 				ctx = context.Background()
 			}
-			return r.Start(ctx, opts, logger)
+			return r.Start(ctx, opts, logger, r.GetTransport)
 		},
 	}
 	if err := bindFlagSets(cmd, v); err != nil {

--- a/cmd/lvmsyncd/cobra_test.go
+++ b/cmd/lvmsyncd/cobra_test.go
@@ -3,21 +3,27 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
 )
 
 func TestFlagParsing(t *testing.T) {
 	logger := zap.NewNop()
 	var got Options
-	r := NewRunnerWithDeps(func(ctx context.Context, opts Options, _ *zap.Logger) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, opts Options, _ *zap.Logger, _ func(string, transport.Config) (transport.Interface, error)) error {
 		got = opts
 		return nil
-	})
+	}, nil)
 	args := []string{
 		"--listen", "tcp://:8080",
 		"--listen", "unix:///tmp/sock",
@@ -51,5 +57,89 @@ func TestNewCmdBindError(t *testing.T) {
 	r := NewRunner()
 	if _, err := r.NewCmd(zap.NewNop(), &bindErrViper{Viper: viper.New()}); err == nil || err.Error() != "bind fail" {
 		t.Fatalf("expected bind fail, got %v", err)
+	}
+}
+
+type trackingListener struct {
+	net.Listener
+	mu     sync.Mutex
+	closed bool
+}
+
+func (l *trackingListener) Close() error {
+	l.mu.Lock()
+	l.closed = true
+	l.mu.Unlock()
+	return l.Listener.Close()
+}
+
+func (l *trackingListener) Closed() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.closed
+}
+
+type fakeTransport struct {
+	listen func(context.Context, string) (net.Listener, error)
+}
+
+func (f fakeTransport) Name() string                                   { return "fake" }
+func (f fakeTransport) Dial(context.Context, string) (net.Conn, error) { return nil, nil }
+func (f fakeTransport) Listen(ctx context.Context, addr string) (net.Listener, error) {
+	if f.listen != nil {
+		return f.listen(ctx, addr)
+	}
+	return nil, nil
+}
+func (f fakeTransport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (common.Handshake, error) {
+	return hs, nil
+}
+
+func TestStartContextCancelStopsListeners(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var tl *trackingListener
+	get := func(string, transport.Config) (transport.Interface, error) {
+		ft := fakeTransport{listen: func(ctx context.Context, addr string) (net.Listener, error) {
+			ln, err := net.Listen("tcp", addr)
+			if err != nil {
+				return nil, err
+			}
+			tl = &trackingListener{Listener: ln}
+			go func() {
+				<-ctx.Done()
+				tl.Close()
+			}()
+			return tl, nil
+		}}
+		return ft, nil
+	}
+
+	opts := Options{Listen: []string{"grpc://127.0.0.1:0", "fake://127.0.0.1:0"}}
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	err := start(ctx, opts, zap.NewNop(), get)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if tl == nil || !tl.Closed() {
+		t.Fatalf("listener not closed")
+	}
+}
+
+func TestStartTransportError(t *testing.T) {
+	get := func(string, transport.Config) (transport.Interface, error) {
+		ft := fakeTransport{listen: func(context.Context, string) (net.Listener, error) {
+			return nil, errors.New("listen fail")
+		}}
+		return ft, nil
+	}
+	opts := Options{Listen: []string{"fake://127.0.0.1:0"}}
+	err := start(context.Background(), opts, zap.NewNop(), get)
+	if err == nil || err.Error() != "listen \"fake://127.0.0.1:0\": listen fail" {
+		t.Fatalf("expected listen error, got %v", err)
 	}
 }

--- a/cmd/lvmsyncd/main_test.go
+++ b/cmd/lvmsyncd/main_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/internal/exitcode"
+	"lvmsync_go/transport"
 )
 
 func TestRunLoggerError(t *testing.T) {
@@ -18,7 +19,9 @@ func TestRunLoggerError(t *testing.T) {
 }
 
 func TestRunExecuteError(t *testing.T) {
-	r := NewRunnerWithDeps(func(context.Context, Options, *zap.Logger) error { return errors.New("boom") })
+	r := NewRunnerWithDeps(func(context.Context, Options, *zap.Logger, func(string, transport.Config) (transport.Interface, error)) error {
+		return errors.New("boom")
+	}, nil)
 	code := run(func() (*zap.Logger, error) { return zap.NewNop(), nil }, r)
 	if code != exitcode.ErrRuntime {
 		t.Fatalf("expected %d got %d", exitcode.ErrRuntime, code)


### PR DESCRIPTION
## Summary
- run gRPC control plane and rsync-style data plane concurrently with errgroup
- allow dependency injection of transport registry for listener setup
- add tests ensuring both planes start and stop cleanly

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2b864643c8323a59a1838d7daf9f8