### PR TITLE
test: cover retry delay precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,14 @@ parallel: 4
 running `LVMSYNC_PARALLEL=8 lvmsync run --parallel 16` results in `parallel=16`
 because flags override environment variables, which override the config file.
 
+A similar hierarchy applies to duration values:
+
+```yaml
+retry_delay: 1s
+```
+
+Running `LVMSYNC_RETRY_DELAY=2s lvmsync run --retry-delay 3s` uses a retry delay of `3s`.
+
 Environment variables for the gRPC daemon use the `LVMSYNC_GRPC_` prefix with dashes converted to underscores, for example:
 
 ```sh

--- a/internal/config/retry_delay_precedence_test.go
+++ b/internal/config/retry_delay_precedence_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+        "testing"
+        "time"
+)
+
+func TestRetryDelayCLIOverridesEnvAndConfig(t *testing.T) {
+        cfgPath := writeTempConfig(t, "retry_delay: 1s\n")
+        rootFS, args := newFlagSet([]string{"--config", cfgPath, "--retry-delay", "3s"})
+        t.Setenv("LVMSYNC_RETRY_DELAY", "2s")
+
+        defaults, err := DefaultConfig()
+        if err != nil {
+                t.Fatalf("DefaultConfig: %v", err)
+        }
+        fs := NewFlagSets(defaults)
+        registerFlags(fs, rootFS)
+        if err := rootFS.Parse(args); err != nil {
+                t.Fatalf("parse: %v", err)
+        }
+        v, _, err := buildViper(fs)
+        if err != nil {
+                t.Fatalf("buildViper: %v", err)
+        }
+        builder := &builder{v: v, defaults: defaults}
+        conf, err := builder.Build()
+        if err != nil {
+                t.Fatalf("Build: %v", err)
+        }
+        if conf.RetryDelay != 3*time.Second {
+                t.Fatalf("expected retry_delay 3s, got %v", conf.RetryDelay)
+        }
+}
+
+func TestRetryDelayEnvOverridesConfig(t *testing.T) {
+        cfgPath := writeTempConfig(t, "retry_delay: 1s\n")
+        rootFS, args := newFlagSet([]string{"--config", cfgPath})
+        t.Setenv("LVMSYNC_RETRY_DELAY", "2s")
+
+        defaults, err := DefaultConfig()
+        if err != nil {
+                t.Fatalf("DefaultConfig: %v", err)
+        }
+        fs := NewFlagSets(defaults)
+        registerFlags(fs, rootFS)
+        if err := rootFS.Parse(args); err != nil {
+                t.Fatalf("parse: %v", err)
+        }
+        v, _, err := buildViper(fs)
+        if err != nil {
+                t.Fatalf("buildViper: %v", err)
+        }
+        builder := &builder{v: v, defaults: defaults}
+        conf, err := builder.Build()
+        if err != nil {
+                t.Fatalf("Build: %v", err)
+        }
+        if conf.RetryDelay != 2*time.Second {
+                t.Fatalf("expected retry_delay 2s, got %v", conf.RetryDelay)
+        }
+}
+


### PR DESCRIPTION
## Summary
- add config precedence tests for retry_delay across flags, env vars, and YAML
- document precedence order for retry_delay in README

## Testing
- `go build -v ./...`
- `go test -run RetryDelay -cover ./internal/config`
- `golangci-lint run` *(fails: Can't process result by diff processor: can't read from patch file path/to/patch/file: open path/to/patch/file: no such file or directory; linter still completed with warnings)*
- `go test -cover ./...` *(timeout: test run did not finish within the allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b87baeec8323a4a8fe2e15f4057b