### PR TITLE
Fix missing closing brace in lvmsyncd test helper

### DIFF
--- a/cmd/lvmsyncd/cobra_test.go
+++ b/cmd/lvmsyncd/cobra_test.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
-	"net"
 	"reflect"
 	"sync"
 	"testing"
@@ -87,6 +87,7 @@ func writeTempConfig(t *testing.T, content string) string {
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
 
 type trackingListener struct {
 	net.Listener


### PR DESCRIPTION
## Summary
- close writeTempConfig helper function in `cmd/lvmsyncd/cobra_test.go`

## Testing
- `go test ./cmd/lvmsyncd`


------
https://chatgpt.com/codex/tasks/task_e_68a2dd27ade08323884d56fb30f3f8f8