### PR TITLE
Use channel to cancel lvmsyncd listeners

### DIFF
--- a/cmd/lvmsyncd/cobra_test.go
+++ b/cmd/lvmsyncd/cobra_test.go
@@ -3,13 +3,12 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
-	"net"
 	"reflect"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -87,6 +86,7 @@ func writeTempConfig(t *testing.T, content string) string {
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
 
 type trackingListener struct {
 	net.Listener
@@ -128,6 +128,7 @@ func TestStartContextCancelStopsListeners(t *testing.T) {
 	defer cancel()
 
 	var tl *trackingListener
+	started := make(chan struct{})
 	get := func(string, transport.Config) (transport.Interface, error) {
 		ft := fakeTransport{listen: func(ctx context.Context, addr string) (net.Listener, error) {
 			ln, err := net.Listen("tcp", addr)
@@ -135,6 +136,7 @@ func TestStartContextCancelStopsListeners(t *testing.T) {
 				return nil, err
 			}
 			tl = &trackingListener{Listener: ln}
+			close(started)
 			go func() {
 				<-ctx.Done()
 				tl.Close()
@@ -146,7 +148,7 @@ func TestStartContextCancelStopsListeners(t *testing.T) {
 
 	opts := Options{Listen: []string{"grpc://127.0.0.1:0", "fake://127.0.0.1:0"}}
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		<-started
 		cancel()
 	}()
 	err := start(ctx, opts, zap.NewNop(), get)


### PR DESCRIPTION
## Summary
- Replace time-based cancel in lvmsyncd test with channel signaling when listener starts

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`
- `go test ./cmd/lvmsyncd`


------
https://chatgpt.com/codex/tasks/task_e_68a2dd348ed483239e7495b10a5a8266