### PR TITLE
Allow SSH transport without host key and verify listener requires one

### DIFF
--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -75,8 +75,6 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		return nil, fmt.Errorf("host key path required when allow_insecure is false")
 	}
 
 	serverConf := &ssh.ServerConfig{
@@ -87,7 +85,9 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 			return nil, fmt.Errorf("authentication failed")
 		},
 	}
-	serverConf.AddHostKey(hostSigner)
+	if hostSigner != nil {
+		serverConf.AddHostKey(hostSigner)
+	}
 	if keySigner != nil {
 		serverConf.PublicKeyCallback = func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
 			if c.User() == cfg.SSHUser && bytes.Equal(key.Marshal(), keySigner.PublicKey().Marshal()) {
@@ -259,6 +259,17 @@ func (t *Transport) Listen(ctx context.Context, address string) (net.Listener, e
 		zap.Int64("duration_ms", 0),
 	)
 	start := time.Now()
+	if t.hostSigner == nil {
+		err := fmt.Errorf("host key not configured")
+		fields := []zap.Field{
+			zap.String("address", address),
+			zap.String("role", role),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+			zap.Error(err),
+		}
+		t.logger.Error("listen_end", fields...)
+		return nil, err
+	}
 	lc := net.ListenConfig{}
 	tcpLn, err := lc.Listen(ctx, "tcp", address)
 	fields := []zap.Field{

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -203,11 +203,46 @@ func TestNewWithHostKeyPath(t *testing.T) {
 	}
 }
 
-func TestNewHostKeyRequired(t *testing.T) {
+func TestNewClientOnly(t *testing.T) {
 	core, _ := observer.New(zap.InfoLevel)
-	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p"}
-	if _, err := New(context.Background(), cfg); err == nil || !strings.Contains(err.Error(), "host key path required") {
-		t.Fatalf("expected host key requirement error, got %v", err)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("NewSignerFromKey: %v", err)
+	}
+	hostKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", SSHHostKey: hostKey}
+	trIface, err := New(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tr := trIface.(*Transport)
+	if tr.hostSigner != nil {
+		t.Fatalf("expected nil host signer")
+	}
+}
+
+func TestListenRequiresHostKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("NewSignerFromKey: %v", err)
+	}
+	hostKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))
+	cfg := transport.Config{Logger: zap.NewNop(), SSHUser: "u", SSHPassword: "p", SSHHostKey: hostKey}
+	trIface, err := New(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tr := trIface.(*Transport)
+	if _, err := tr.Listen(context.Background(), "127.0.0.1:0"); err == nil || !strings.Contains(err.Error(), "host key") {
+		t.Fatalf("expected host key error, got %v", err)
 	}
 }
 
@@ -359,7 +394,43 @@ func TestSSHTransportKeyAuth(t *testing.T) {
 	defer cancel()
 	defer ln.Close()
 
-	if peerHS.ResumeToken != "tok" || peerHS.MaxInFlight != 8 || peerHS.CDCMin != 64 || peerHS.CDCAvg != 128 || peerHS.CDCMax != 256 {
+	hs := common.Handshake{ResumeToken: "tok", DedupMode: "cdc", BlockSize: 4096, Compress: "zstd", Digest: "sha256", MaxInFlight: 8, CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		srvCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+		peerHS, err := server.Negotiate(srvCtx, conn, transport.Server, hs)
+		cancel()
+		if err != nil {
+			t.Errorf("server negotiate: %v", err)
+			return
+		}
+		if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
+			t.Errorf("unexpected peer handshake: %+v", peerHS)
+		}
+		buf := make([]byte, 4)
+		io.ReadFull(conn, buf)
+		conn.Write([]byte("pong"))
+		conn.Close()
+		close(done)
+	}()
+	dialCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+	conn, err := client.Dial(dialCtx, ln.Addr().String())
+	cancel()
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	negCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+	peerHS, err := client.Negotiate(negCtx, conn, transport.Client, hs)
+	cancel()
+	if err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	if peerHS.ResumeToken != hs.ResumeToken || peerHS.DedupMode != hs.DedupMode || peerHS.BlockSize != hs.BlockSize || peerHS.Compress != hs.Compress || peerHS.Digest != hs.Digest || peerHS.MaxInFlight != hs.MaxInFlight || peerHS.CDCMin != hs.CDCMin || peerHS.CDCAvg != hs.CDCAvg || peerHS.CDCMax != hs.CDCMax {
 		t.Fatalf("unexpected peer handshake: %+v", peerHS)
 	}
 	if _, err := conn.Write([]byte("ping")); err != nil {


### PR DESCRIPTION
## Summary
- permit SSH transport initialization without a host key when insecure mode is disabled
- ensure `Listen` fails fast if no host key signer is configured
- add tests for client-only setup and missing-host-key listener error

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2e4038b38832388d4c304c3dfd6a7