### PR TITLE
ssh: warn when agent socket unreachable

### DIFF
--- a/transport/ssh/agent_unreachable_test.go
+++ b/transport/ssh/agent_unreachable_test.go
@@ -1,0 +1,36 @@
+package ssh
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/transport"
+)
+
+func TestAgentSocketUnreachableLogsWarning(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "missing.sock"))
+	core, logs := observer.New(zapcore.WarnLevel)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", SSHUseAgent: true, AllowInsecure: true}
+	if _, err := New(context.Background(), cfg); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	entries := logs.FilterMessage("ssh_agent_unreachable").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 ssh_agent_unreachable log, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Fatalf("expected warn level, got %v", entries[0].Level)
+	}
+	ctx := entries[0].ContextMap()
+	if ctx["transport"] != "ssh" {
+		t.Fatalf("expected transport ssh, got %v", ctx["transport"])
+	}
+	if _, ok := ctx["error"]; !ok {
+		t.Fatalf("expected error field in log")
+	}
+}

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -125,7 +125,10 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 		if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
 			agentCtx, cancel := context.WithTimeout(ctx, defaultDialTimeout)
 			defer cancel()
-			if signers, err := agentSigners(agentCtx, sock); err == nil && len(signers) > 0 {
+			signers, err := agentSigners(agentCtx, sock)
+			if err != nil {
+				cfg.Logger.Warn("ssh_agent_unreachable", zap.String("transport", "ssh"), zap.Error(err))
+			} else if len(signers) > 0 {
 				auths = append(auths, ssh.PublicKeys(signers...))
 			}
 		}


### PR DESCRIPTION
## Summary
- warn when SSH agent socket can't be reached during auth setup
- test warning emission when agent socket is missing

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2e40a41708323bafe5e938a354d6c