### PR TITLE
propagate context through OpenLVM

### DIFF
--- a/device/detect.go
+++ b/device/detect.go
@@ -29,14 +29,14 @@ func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
 }
 
 // detectLVMDevice opens an LVM logical volume.
-func detectLVMDevice(path, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
+func detectLVMDevice(ctx context.Context, path, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
 	if err := lvm.VerifyEscalationCommand(lvmEscalation); err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
 	}
 	cache := lvm.NewDeviceFDCache(logger)
 	defer cache.Close()
-	dev, err := runner.OpenLVM(path, cache, lvmEscalation, logger)
+	dev, err := runner.OpenLVM(ctx, path, cache, lvmEscalation, logger)
 	if err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
@@ -124,7 +124,7 @@ func Detect(
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type lvm: %s", resolved)
 			}
-			return detectLVMDevice(resolved, lvmEscalation, runner, logger)
+			return detectLVMDevice(ctx, resolved, lvmEscalation, runner, logger)
 		case TypeRaw:
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
@@ -141,7 +141,7 @@ func Detect(
 		out, err := runner.command.CommandContext(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
 		fsType := strings.TrimSpace(string(out))
 		if err == nil && fsType == "LVM2_member" {
-			return detectLVMDevice(resolved, lvmEscalation, runner, logger)
+			return detectLVMDevice(ctx, resolved, lvmEscalation, runner, logger)
 		}
 		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger, runner)
 	}

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -55,10 +55,10 @@ func TestDetectLVMDeviceSuccess(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 	runner := NewRunner()
-	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
-	dev, err := detectLVMDevice("/dev/test", "", runner, logger)
+	dev, err := detectLVMDevice(context.Background(), "/dev/test", "", runner, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -82,10 +82,10 @@ func TestDetectLVMDeviceError(t *testing.T) {
 	restore := lvm.SetEscalationChecker(func(string) error { return nil })
 	defer restore()
 	runner := NewRunner()
-	runner.openLVMOverride = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 		return nil, errors.New("fail")
 	}
-	if _, err := detectLVMDevice("/dev/test", "", runner, zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice(context.Background(), "/dev/test", "", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -95,11 +95,11 @@ func TestDetectLVMDeviceEscalationError(t *testing.T) {
 	defer restore()
 	runner := NewRunner()
 	called := false
-	runner.openLVMOverride = func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 		called = true
 		return &LVMDevice{path: "/dev/test", logger: zap.NewNop(), runner: runner}, nil
 	}
-	if _, err := detectLVMDevice("/dev/test", "sudo -n", runner, zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice(context.Background(), "/dev/test", "sudo -n", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 	if called {

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -184,7 +184,7 @@ func TestDetectLVM(t *testing.T) {
 		return exec.CommandContext(ctx, name, args...)
 	})
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
 	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, zap.NewNop(), runner)

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -31,11 +31,10 @@ type LVMDevice struct {
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
 // Size information is obtained through the lvm package helpers.
-func (r *Runner) OpenLVM(path string, cache *lvm.FDCache, escalation string, logger *zap.Logger) (*LVMDevice, error) {
+func (r *Runner) OpenLVM(ctx context.Context, path string, cache *lvm.FDCache, escalation string, logger *zap.Logger) (*LVMDevice, error) {
 	if r.openLVMOverride != nil {
-		return r.openLVMOverride(path, cache, escalation, logger)
+		return r.openLVMOverride(ctx, path, cache, escalation, logger)
 	}
-	ctx := context.Background()
 	exists, err := r.volumeExists(ctx, path)
 	if err != nil {
 		return nil, err
@@ -152,7 +151,7 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 	}
 	cache := lvm.NewDeviceFDCache(d.logger)
 	defer cache.Close()
-	snapDev, err := d.runner.OpenLVM(snapPath, cache, d.escalation, d.logger)
+	snapDev, err := d.runner.OpenLVM(ctx, snapPath, cache, d.escalation, d.logger)
 	if err != nil {
 		_ = d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -27,7 +27,7 @@ func NewRunnerWithDeps(func(context.Context, string) (bool, error), func(context
 type LVMDevice struct{}
 
 // OpenLVM returns an error on non-Linux systems.
-func (r *Runner) OpenLVM(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+func (r *Runner) OpenLVM(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
 	return nil, fmt.Errorf("LVM devices are only supported on Linux")
 }
 

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -26,7 +26,7 @@ func TestOpenLVM(t *testing.T) {
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
 	runner := NewRunner()
-	dev, err := runner.OpenLVM(loop, cache, "", zap.NewNop())
+	dev, err := runner.OpenLVM(context.Background(), loop, cache, "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestOpenLVMNonBlockDevice(t *testing.T) {
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
 	runner := NewRunner()
-	if _, err := runner.OpenLVM(f.Name(), cache, "", zap.NewNop()); err == nil {
+	if _, err := runner.OpenLVM(context.Background(), f.Name(), cache, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error for non-block device")
 	}
 }
@@ -57,7 +57,7 @@ func TestOpenLVMChecks(t *testing.T) {
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
 	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, IsMountedRW, lock.Acquire, nil)
-	if _, err := runner.OpenLVM("/dev/missing", cache, "", zap.NewNop()); err == nil {
+	if _, err := runner.OpenLVM(context.Background(), "/dev/missing", cache, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error when volume missing")
 	}
 }

--- a/device/runner.go
+++ b/device/runner.go
@@ -29,7 +29,7 @@ type Runner struct {
 	discardEnabled    func(context.Context, string) (bool, error)
 	isMountedRW       func(context.Context, string) (bool, error)
 	lockAcquire       func(string, string) (*lock.Lock, error)
-	openLVMOverride   func(string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error)
+	openLVMOverride   func(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error)
 }
 
 // NewDeviceRunner returns a Runner using production dependencies and the provided Commander.

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -65,7 +65,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop(), runner: runner}, nil
 	}
 


### PR DESCRIPTION
## Summary
- accept a context.Context in `OpenLVM`
- forward context to LVM checks and snapshot logic
- adjust device detection and tests for new signature

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2e41e68dc83238a6b2b93a65afc75