### PR TITLE
Release LVM lock on device close

### DIFF
--- a/device/lvm.go
+++ b/device/lvm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
@@ -101,12 +102,26 @@ func (d *LVMDevice) SizeBytes() uint64 { return d.size }
 // BlockSize returns the logical block size in bytes.
 func (d *LVMDevice) BlockSize() uint64 { return d.blockSize }
 
-// Close closes the device.
+// Close closes the device and releases the lock if present.
 func (d *LVMDevice) Close() error {
+	var err error
 	if d.f != nil {
-		return d.f.Close()
+		if cerr := d.f.Close(); cerr != nil {
+			err = multierr.Append(err, cerr)
+			d.logger.Error("lvm_device_close_failed", zap.String("path", d.path), zap.Error(cerr))
+		} else {
+			d.logger.Info("lvm_device_closed", zap.String("path", d.path))
+		}
+		d.f = nil
 	}
-	return nil
+	if d.lock != nil {
+		if rerr := d.lock.Release(); rerr != nil {
+			err = multierr.Append(err, rerr)
+			d.logger.Error("lvm_device_lock_release_failed", zap.String("path", d.path), zap.Error(rerr))
+		}
+		d.lock = nil
+	}
+	return err
 }
 
 var (

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
@@ -93,5 +94,53 @@ func TestRunLVMFailure(t *testing.T) {
 	runner := NewDeviceRunner(cmd)
 	if err := runner.runLVM(ctx, "", "lvremove", "-f", "/dev/vg0/snap"); err == nil {
 		t.Fatalf("expected error from runLVM")
+	}
+}
+
+func TestLVMDeviceCloseReleasesLock(t *testing.T) {
+	restoreDir := lock.SetBaseDir(t.TempDir())
+	t.Cleanup(restoreDir)
+
+	f, err := os.CreateTemp(t.TempDir(), "lvmdev")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	lk, err := lock.Acquire("vg", "lv")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	d := &LVMDevice{f: f, path: f.Name(), lock: lk, logger: zap.NewNop()}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := lock.Acquire("vg", "lv"); err != nil {
+		t.Fatalf("lock not released: %v", err)
+	}
+}
+
+func TestLVMDeviceCloseErrorLogging(t *testing.T) {
+	restoreDir := lock.SetBaseDir(t.TempDir())
+	t.Cleanup(restoreDir)
+
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	f, err := os.CreateTemp(t.TempDir(), "lvmdev")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	lk, err := lock.Acquire("vg", "lv")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("preclose: %v", err)
+	}
+	d := &LVMDevice{f: f, path: f.Name(), lock: lk, logger: logger}
+	if err := d.Close(); err == nil {
+		t.Fatalf("expected error from Close")
+	}
+	if logs.FilterMessage("lvm_device_close_failed").Len() == 0 {
+		t.Fatalf("expected lvm_device_close_failed log")
 	}
 }


### PR DESCRIPTION
## Summary
- release held LVM lock when closing devices
- log close and lock-release failures
- verify lock cleanup even without Cleanup

## Testing
- `go build -v ./...`
- `go test -cover ./...`
- `golangci-lint run` (warnings: Can't process result by diff processor; exclusion path patterns)


------
https://chatgpt.com/codex/tasks/task_e_68a2e422f36c832384d012662da01815