### PR TITLE
lvm: parse escalation commands with shell quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - transfer: sample 8 KiB per chunk and log compression decisions.
 
 ### Fixed
+- lvm: parse `--lvm-escalation` using shell-style quoting and reject unsafe formats
 - tests: accept net.Error timeouts in h2 handshake timeout
 - manifest: log configuration warnings with structured fields
 - lock: reject VG/LV names with invalid characters via regex validation

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--skip-snapshot-creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
 | `--skip-disk-check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot-size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
-| `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; validated at startup |
+| `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; parsed with shell-style quoting and validated at startup |
 | `--lvm-timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations and privilege checks |
 | `--sig-cache-ttl` | `LVMSYNC_LVM_SIG_CACHE_TTL` | `sig-cache-ttl` | TTL for cached LVM signatures |
 | `--sig-cache-max` | `LVMSYNC_LVM_SIG_CACHE_MAX` | `sig-cache-max` | Maximum cached LVM signatures |
@@ -1190,10 +1190,18 @@ timeouts or cancellations are reported separately.
 | `--volume-group` | Source volume group. Derived from the source device path when empty | "" |
 | `--target-volume-group` | Volume group name of the target LVM volume | "" |
 | `--target-vgs` | Candidate target volume groups for auto-selection | [] |
-| `--lvm-escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., "sudo -n"); validated at startup | "sudo -n" |
+| `--lvm-escalation` | Command used to re-execute the program with elevated privileges when not running as root (e.g., `sudo -p "my prompt" -n`); parsed with shell-style quoting and validated at startup | "sudo -n" |
 | `--lvm-timeout` | Timeout for LVM operations and privilege checks | 10s |
 | `--sig-cache-ttl` | TTL for cached LVM signatures | 24h |
 | `--sig-cache-max` | Maximum cached LVM signatures | 128 |
+
+The `--lvm-escalation` value must be a single executable and its arguments; pipes,
+redirects, and other shell operators are rejected. Quote any paths or argument
+values containing spaces, for example:
+
+```sh
+--lvm-escalation "/usr/bin/sudo wrapper" -p "no password" -n
+```
 
 `lvm_timeout` also bounds the startup privilege check to avoid hanging when
 escalation commands stall.

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -119,7 +119,10 @@ func (r *Runner) runLVM(ctx context.Context, escalation, cmdName string, args ..
 		return err
 	}
 	if geteuid() != 0 {
-		parts := strings.Fields(escalation)
+		parts, err := lvm.ParseEscalation(escalation)
+		if err != nil {
+			return err
+		}
 		if len(parts) > 0 {
 			lvmCmd := cmdName
 			cmdName = parts[0]

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -85,6 +85,31 @@ func TestRunLVMPrivilegeEscalation(t *testing.T) {
 	}
 }
 
+func TestRunLVMPrivilegeEscalationQuoted(t *testing.T) {
+	ctx := context.Background()
+	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	defer restore()
+	var gotName string
+	var gotArgs []string
+	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return exec.CommandContext(ctx, "true")
+	})
+	runner := NewDeviceRunner(cmd)
+	origEuid := geteuid
+	geteuid = func() int { return 1 }
+	t.Cleanup(func() { geteuid = origEuid })
+	esc := "\"/usr/bin/sudo wrapper\" -p 'my prompt' -n"
+	if err := runner.runLVM(ctx, esc, "lvremove", "-f", "/dev/vg0/snap"); err != nil {
+		t.Fatalf("runLVM: %v", err)
+	}
+	want := []string{"-p", "my prompt", "-n", "lvremove", "-f", "/dev/vg0/snap"}
+	if gotName != "/usr/bin/sudo wrapper" || !reflect.DeepEqual(gotArgs, want) {
+		t.Fatalf("unexpected command: %s %v", gotName, gotArgs)
+	}
+}
+
 func TestRunLVMFailure(t *testing.T) {
 	ctx := context.Background()
 	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -90,9 +90,9 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 		}
 	}
 	if geteuid() != 0 {
-		parts := strings.Fields(c.LVMEscalation)
-		if len(parts) == 0 {
-			return fmt.Errorf("lvm escalation command is empty")
+		parts, err := lvm.ParseEscalation(c.LVMEscalation)
+		if err != nil {
+			return err
 		}
 		if _, err := findInPath(parts[0]); err != nil {
 			return fmt.Errorf("lvm escalation command %q not found: %w", parts[0], err)

--- a/lvm/escalation.go
+++ b/lvm/escalation.go
@@ -5,19 +5,44 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/kballard/go-shellquote"
 )
 
 // execCommand is used for running external commands and can be overridden in tests.
 var execCommand = exec.Command
 
+// geteuid returns the effective user ID; overridable for tests.
+var geteuid = os.Geteuid
+
+// ParseEscalation splits the escalation command using shell-style quoting and
+// rejects unsafe characters. It returns an error if the command is empty or
+// contains unsupported tokens like pipes or redirects.
+func ParseEscalation(escalation string) ([]string, error) {
+	if strings.TrimSpace(escalation) == "" {
+		return nil, fmt.Errorf("lvm escalation command is empty")
+	}
+	if strings.ContainsAny(escalation, "|&;<>") {
+		return nil, fmt.Errorf("unsupported characters in lvm escalation command")
+	}
+	parts, err := shellquote.Split(escalation)
+	if err != nil {
+		return nil, fmt.Errorf("invalid lvm escalation command: %w", err)
+	}
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("lvm escalation command is empty")
+	}
+	return parts, nil
+}
+
 // verifyEscalation checks that the escalation command succeeds when not running as root.
 func verifyEscalation(escalation string) error {
-	if os.Geteuid() == 0 {
+	if geteuid() == 0 {
 		return nil
 	}
-	parts := strings.Fields(escalation)
-	if len(parts) == 0 {
-		return fmt.Errorf("insufficient privileges: LVM operations require root privileges")
+	parts, err := ParseEscalation(escalation)
+	if err != nil {
+		return fmt.Errorf("insufficient privileges: %w", err)
 	}
 	cmd := execCommand(parts[0], append(parts[1:], "true")...)
 	out, err := cmd.CombinedOutput()

--- a/lvm/escalation_test.go
+++ b/lvm/escalation_test.go
@@ -1,0 +1,55 @@
+package lvm
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestParseEscalation(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"sudo -n", []string{"sudo", "-n"}},
+		{"\"/usr/bin/sudo wrapper\" -p 'my prompt' -n", []string{"/usr/bin/sudo wrapper", "-p", "my prompt", "-n"}},
+	}
+	for _, tc := range cases {
+		got, err := ParseEscalation(tc.in)
+		if err != nil {
+			t.Fatalf("ParseEscalation(%q): %v", tc.in, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("ParseEscalation(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+	bad := []string{"", "sudo -n | rm -rf /", "'unterminated"}
+	for _, in := range bad {
+		if _, err := ParseEscalation(in); err == nil {
+			t.Fatalf("ParseEscalation(%q) expected error", in)
+		}
+	}
+}
+
+func TestVerifyEscalationCommandSplit(t *testing.T) {
+	var name string
+	var args []string
+	origExec := execCommand
+	execCommand = func(n string, a ...string) *exec.Cmd {
+		name = n
+		args = append([]string(nil), a...)
+		return exec.Command("true")
+	}
+	defer func() { execCommand = origExec }()
+	origUID := geteuid
+	geteuid = func() int { return 1 }
+	defer func() { geteuid = origUID }()
+	esc := "\"/usr/bin/sudo wrapper\" -p 'my prompt' -n"
+	if err := VerifyEscalationCommand(esc); err != nil {
+		t.Fatalf("VerifyEscalationCommand: %v", err)
+	}
+	wantArgs := []string{"-p", "my prompt", "-n", "true"}
+	if name != "/usr/bin/sudo wrapper" || !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("got %q %v, want %q %v", name, args, "/usr/bin/sudo wrapper", wantArgs)
+	}
+}


### PR DESCRIPTION
## Summary
- parse LVM escalation commands with shell-style quoting and reject unsafe tokens
- validate shell-quoted escalation in config and LVM runner
- document acceptable escalation format and add tests for quoted paths and args

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2e42838b0832381bafdd14c3cf3c6