### PR TITLE
digest: expose CPU feature helpers for Select

### DIFF
--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -57,9 +57,12 @@ func TestRunRemoteDump(t *testing.T) {
 
 	origDump := dumpChangesSequential
 	origSum := sumFile
-	origSelect := digestpkg.Select
+	origAVX2, origAVX512, origNEON, origAESNI := digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI
 	origStream := streamToRemote
-	digestpkg.Select = func() string { return digestpkg.SHA256 }
+	digestpkg.HasAVX2 = func() bool { return false }
+	digestpkg.HasAVX512 = func() bool { return false }
+	digestpkg.HasNEON = func() bool { return false }
+	digestpkg.HasAESNI = func() bool { return false }
 	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
 	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
 		if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
@@ -76,7 +79,7 @@ func TestRunRemoteDump(t *testing.T) {
 	defer func() {
 		dumpChangesSequential = origDump
 		sumFile = origSum
-		digestpkg.Select = origSelect
+		digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI = origAVX2, origAVX512, origNEON, origAESNI
 		streamToRemote = origStream
 	}()
 
@@ -132,9 +135,12 @@ func TestRunRemoteDumpError(t *testing.T) {
 
 	origDump := dumpChangesSequential
 	origSum := sumFile
-	origSelect := digestpkg.Select
+	origAVX2, origAVX512, origNEON, origAESNI := digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI
 	origStream := streamToRemote
-	digestpkg.Select = func() string { return digestpkg.SHA256 }
+	digestpkg.HasAVX2 = func() bool { return false }
+	digestpkg.HasAVX512 = func() bool { return false }
+	digestpkg.HasNEON = func() bool { return false }
+	digestpkg.HasAESNI = func() bool { return false }
 	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
 	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
 		if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
@@ -148,7 +154,7 @@ func TestRunRemoteDumpError(t *testing.T) {
 	defer func() {
 		dumpChangesSequential = origDump
 		sumFile = origSum
-		digestpkg.Select = origSelect
+		digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI = origAVX2, origAVX512, origNEON, origAESNI
 		streamToRemote = origStream
 	}()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -724,28 +724,34 @@ func TestValidateChecksumAuto(t *testing.T) {
 
 	t.Run("simd", func(t *testing.T) {
 		cfg := base
-		orig := digest.Select
-		digest.Select = func() string { return digest.BLAKE3 }
-		defer func() { digest.Select = orig }()
+		origAVX2, origAVX512, origNEON, origAESNI := digest.HasAVX2, digest.HasAVX512, digest.HasNEON, digest.HasAESNI
+		digest.HasAVX2 = func() bool { return true }
+		digest.HasAVX512 = func() bool { return false }
+		digest.HasNEON = func() bool { return false }
+		digest.HasAESNI = func() bool { return false }
 		if err := cfg.ValidateWith(geteuid); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.ChecksumAlgorithm != digest.BLAKE3 {
 			t.Fatalf("expected %s, got %s", digest.BLAKE3, cfg.ChecksumAlgorithm)
 		}
+		digest.HasAVX2, digest.HasAVX512, digest.HasNEON, digest.HasAESNI = origAVX2, origAVX512, origNEON, origAESNI
 	})
 
 	t.Run("fallback", func(t *testing.T) {
 		cfg := base
-		orig := digest.Select
-		digest.Select = func() string { return digest.SHA256 }
-		defer func() { digest.Select = orig }()
+		origAVX2, origAVX512, origNEON, origAESNI := digest.HasAVX2, digest.HasAVX512, digest.HasNEON, digest.HasAESNI
+		digest.HasAVX2 = func() bool { return false }
+		digest.HasAVX512 = func() bool { return false }
+		digest.HasNEON = func() bool { return false }
+		digest.HasAESNI = func() bool { return false }
 		if err := cfg.ValidateWith(geteuid); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.ChecksumAlgorithm != digest.SHA256 {
 			t.Fatalf("expected %s, got %s", digest.SHA256, cfg.ChecksumAlgorithm)
 		}
+		digest.HasAVX2, digest.HasAVX512, digest.HasNEON, digest.HasAESNI = origAVX2, origAVX512, origNEON, origAESNI
 	})
 }
 

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -10,21 +10,26 @@ const (
 )
 
 var (
-	hasAVX2   = cpufeatures.HasAVX2
-	hasAVX512 = cpufeatures.HasAVX512
-	hasNEON   = cpufeatures.HasNEON
-	hasAESNI  = cpufeatures.HasAESNI
+	// HasAVX2 reports AVX2 support. Tests may override this variable.
+	HasAVX2 = cpufeatures.HasAVX2
+	// HasAVX512 reports AVX-512 support. Tests may override this variable.
+	HasAVX512 = cpufeatures.HasAVX512
+	// HasNEON reports NEON/ASIMD support. Tests may override this variable.
+	HasNEON = cpufeatures.HasNEON
+	// HasAESNI reports AES-NI support. Tests may override this variable.
+	HasAESNI = cpufeatures.HasAESNI
 )
 
 func detect() string {
-	if hasAVX512() || hasAVX2() || hasNEON() || hasAESNI() {
+	if HasAVX512() || HasAVX2() || HasNEON() || HasAESNI() {
 		return BLAKE3
 	}
 	return SHA256
 }
 
 // Select returns the preferred digest algorithm based on CPU capabilities.
-// It chooses BLAKE3 when AVX2, AVX-512, or NEON are available, falling back
-// to SHA-256 otherwise. The function variable allows tests to override the
-// detection logic.
-var Select = detect
+// It chooses BLAKE3 when AVX2, AVX-512, NEON, or AES-NI are available,
+// falling back to SHA-256 otherwise.
+func Select() string {
+	return detect()
+}

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -3,8 +3,8 @@ package digest
 import "testing"
 
 func TestDetect(t *testing.T) {
-	origAVX2, origAVX512, origNEON, origAESNI := hasAVX2, hasAVX512, hasNEON, hasAESNI
-	t.Cleanup(func() { hasAVX2, hasAVX512, hasNEON, hasAESNI = origAVX2, origAVX512, origNEON, origAESNI })
+	origAVX2, origAVX512, origNEON, origAESNI := HasAVX2, HasAVX512, HasNEON, HasAESNI
+	t.Cleanup(func() { HasAVX2, HasAVX512, HasNEON, HasAESNI = origAVX2, origAVX512, origNEON, origAESNI })
 
 	tests := []struct {
 		name                      string
@@ -19,10 +19,10 @@ func TestDetect(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hasAVX2 = func() bool { return tt.avx2 }
-			hasAVX512 = func() bool { return tt.avx512 }
-			hasNEON = func() bool { return tt.neon }
-			hasAESNI = func() bool { return tt.aesni }
+			HasAVX2 = func() bool { return tt.avx2 }
+			HasAVX512 = func() bool { return tt.avx512 }
+			HasNEON = func() bool { return tt.neon }
+			HasAESNI = func() bool { return tt.aesni }
 			if got := detect(); got != tt.want {
 				t.Fatalf("detect() = %s, want %s", got, tt.want)
 			}

--- a/transfer/block_stream_test.go
+++ b/transfer/block_stream_test.go
@@ -42,13 +42,19 @@ func TestPrepareResultHeader(t *testing.T) {
 
 func TestNewDigestHasherAuto(t *testing.T) {
 	data := []byte("data")
-	orig := digest.Select
-	digest.Select = func() string { return digest.BLAKE3 }
+	origAVX2, origAVX512, origNEON, origAESNI := digest.HasAVX2, digest.HasAVX512, digest.HasNEON, digest.HasAESNI
+	digest.HasAVX2 = func() bool { return true }
+	digest.HasAVX512 = func() bool { return false }
+	digest.HasNEON = func() bool { return false }
+	digest.HasAESNI = func() bool { return false }
 	h := newDigestHasher(config.Auto)
 	if _, ok := h.(*blake3.Hasher); !ok {
 		t.Fatalf("expected BLAKE3 hasher")
 	}
-	digest.Select = func() string { return digest.SHA256 }
+	digest.HasAVX2 = func() bool { return false }
+	digest.HasAVX512 = func() bool { return false }
+	digest.HasNEON = func() bool { return false }
+	digest.HasAESNI = func() bool { return false }
 	h = newDigestHasher(config.Auto)
 	h.Write(data)
 	sum := h.Sum(nil)
@@ -56,5 +62,5 @@ func TestNewDigestHasherAuto(t *testing.T) {
 	if !bytes.Equal(sum, exp[:]) {
 		t.Fatalf("expected SHA-256 sum, got %x", sum)
 	}
-	digest.Select = orig
+	digest.HasAVX2, digest.HasAVX512, digest.HasNEON, digest.HasAESNI = origAVX2, origAVX512, origNEON, origAESNI
 }


### PR DESCRIPTION
## Summary
- make `Select` a pure function that calls internal `detect`
- export CPU feature helper vars so tests can override them
- update tests to stub CPU features instead of swapping `Select`

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2e43ee9048323b9a33f754091ce56