### PR TITLE
refactor app runner dependencies

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,24 +21,75 @@ import (
 	"lvmsync_go/proto"
 )
 
-// Wrappers for external dependencies to enable test stubbing.
-var (
-	listen    = net.Listen
-	newServer = func(cfg grpcserver.Config, agent lvmlib.Agent, logger *zap.Logger) (grpcServer, func(), error) {
-		return grpcserver.New(cfg, agent, logger)
+// Runner holds dependencies for application helpers.
+type Runner struct {
+	listen          func(network, addr string) (net.Listener, error)
+	newServer       func(cfg grpcserver.Config, agent lvmlib.Agent, logger *zap.Logger) (grpcServer, func(), error)
+	dial            func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error)
+	handshake       func(ctx context.Context, c proto.ReplicationClient, hs *proto.HandshakeRequest) (*proto.HandshakeResponse, error)
+	createSession   func(ctx context.Context, c proto.ReplicationClient, vol, dev string) (*proto.SessionResponse, error)
+	ackStream       func(ctx context.Context, c proto.ReplicationClient, id string) (ackStreamClient, error)
+	signalsHandler  signalspkg.Handler
+	prepareSnapshot func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error)
+	newTicker       func(time.Duration) *time.Ticker
+}
+
+// NewRunner constructs a Runner with production dependencies.
+func NewRunner() *Runner {
+	return &Runner{
+		listen: net.Listen,
+		newServer: func(cfg grpcserver.Config, agent lvmlib.Agent, logger *zap.Logger) (grpcServer, func(), error) {
+			return grpcserver.New(cfg, agent, logger)
+		},
+		dial: func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
+			return grpcclient.Dial(ctx, addr, conf, logger)
+		},
+		handshake:     grpcclient.Handshake,
+		createSession: grpcclient.CreateSession,
+		ackStream: func(ctx context.Context, c proto.ReplicationClient, id string) (ackStreamClient, error) {
+			return grpcclient.AckStream(ctx, c, id)
+		},
+		signalsHandler:  signalspkg.NewRunner(),
+		prepareSnapshot: clientpkg.PrepareSnapshot,
+		newTicker:       time.NewTicker,
 	}
-	dial = func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
-		return grpcclient.Dial(ctx, addr, conf, logger)
+}
+
+// NewRunnerWithDeps constructs a Runner overriding default dependencies.
+func NewRunnerWithDeps(deps *Runner) *Runner {
+	r := NewRunner()
+	if deps == nil {
+		return r
 	}
-	handshake     = grpcclient.Handshake
-	createSession = grpcclient.CreateSession
-	ackStream     = func(ctx context.Context, c proto.ReplicationClient, id string) (ackStreamClient, error) {
-		return grpcclient.AckStream(ctx, c, id)
+	if deps.listen != nil {
+		r.listen = deps.listen
 	}
-	signalsHandler  signalspkg.Handler = signalspkg.NewRunner()
-	prepareSnapshot                    = clientpkg.PrepareSnapshot
-	newTicker                          = time.NewTicker
-)
+	if deps.newServer != nil {
+		r.newServer = deps.newServer
+	}
+	if deps.dial != nil {
+		r.dial = deps.dial
+	}
+	if deps.handshake != nil {
+		r.handshake = deps.handshake
+	}
+	if deps.createSession != nil {
+		r.createSession = deps.createSession
+	}
+	if deps.ackStream != nil {
+		r.ackStream = deps.ackStream
+	}
+	if deps.signalsHandler != nil {
+		r.signalsHandler = deps.signalsHandler
+	}
+	if deps.prepareSnapshot != nil {
+		r.prepareSnapshot = deps.prepareSnapshot
+	}
+	if deps.newTicker != nil {
+		r.newTicker = deps.newTicker
+	}
+	return r
+}
 
 type grpcServer interface {
 	Serve(net.Listener) error
@@ -56,7 +107,7 @@ type ackStreamClient interface {
 }
 
 // StartGRPCServer starts the gRPC server if configured and returns a cleanup function and error channel.
-func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), <-chan error, error) {
+func (r *Runner) StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), <-chan error, error) {
 	errCh := make(chan error, 1)
 	if cfg.GRPCListen == "" {
 		close(errCh)
@@ -64,11 +115,11 @@ func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger
 	}
 
 	srvCfg := grpcserver.Config{TLSCert: cfg.TLSCert, TLSKey: cfg.TLSKey, CACert: cfg.CACert, AllowInsecure: cfg.AllowInsecure}
-	ln, err := listen("tcp", cfg.GRPCListen)
+	ln, err := r.listen("tcp", cfg.GRPCListen)
 	if err != nil {
 		return nil, nil, fmt.Errorf("gRPC listen: %w", err)
 	}
-	srv, srvCleanup, err := newServer(srvCfg, nil, logger)
+	srv, srvCleanup, err := r.newServer(srvCfg, nil, logger)
 	if err != nil {
 		ln.Close()
 		return nil, nil, fmt.Errorf("gRPC server: %w", err)
@@ -96,12 +147,12 @@ func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger
 }
 
 // ClientHandshake performs the gRPC client handshake and returns a cleanup function and heartbeat error channel.
-func ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), chan error, error) {
+func (r *Runner) ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), chan error, error) {
 	if cfg.GRPCConnect == "" {
 		return func() {}, nil, nil
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	conn, err := dial(ctx, cfg.GRPCConnect, grpcclient.Config{
+	conn, err := r.dial(ctx, cfg.GRPCConnect, grpcclient.Config{
 		TLSCert:       cfg.TLSCert,
 		TLSKey:        cfg.TLSKey,
 		CACert:        cfg.CACert,
@@ -115,20 +166,20 @@ func ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger
 	c := proto.NewReplicationClient(conn)
 	hs := &proto.HandshakeRequest{SectorSize: 512, Alignment: 512, MaxConcurrency: uint32(cfg.Parallel), DedupSupported: true, CompressionSupported: true}
 	hsCtx, hsCancel := context.WithTimeout(ctx, 10*time.Second)
-	if _, err := handshake(hsCtx, c, hs); err != nil {
+	if _, err := r.handshake(hsCtx, c, hs); err != nil {
 		hsCancel()
 		cancel()
 		conn.Close()
 		return nil, nil, fmt.Errorf("handshake failed: %w", err)
 	}
-	sess, err := createSession(hsCtx, c, "vol", "dev")
+	sess, err := r.createSession(hsCtx, c, "vol", "dev")
 	hsCancel()
 	if err != nil {
 		cancel()
 		conn.Close()
 		return nil, nil, fmt.Errorf("create session: %w", err)
 	}
-	stream, err := ackStream(ctx, c, sess.GetSessionId())
+	stream, err := r.ackStream(ctx, c, sess.GetSessionId())
 	if err != nil {
 		cancel()
 		conn.Close()
@@ -136,7 +187,7 @@ func ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger
 	}
 	hbErrCh := make(chan error, 1)
 	go func(id string) {
-		ticker := newTicker(cfg.HeartbeatInterval)
+		ticker := r.newTicker(cfg.HeartbeatInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -177,15 +228,35 @@ func ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger
 }
 
 // SetupSignalHandling configures signal handling and returns the signal and error channels.
-func SetupSignalHandling(ctx context.Context, cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
+func (r *Runner) SetupSignalHandling(ctx context.Context, cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	sigErrCh := make(chan error, 1)
-	go signalsHandler.Handle(ctx, cfg, logger, signals, snapshotPath, sigErrCh)
+	go r.signalsHandler.Handle(ctx, cfg, logger, signals, snapshotPath, sigErrCh)
 	return signals, sigErrCh
 }
 
 // PrepareSnapshot wraps the snapshot preparation logic.
+func (r *Runner) PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+	return r.prepareSnapshot(ctx, cfg, originalVolume, logger)
+}
+
+// StartGRPCServer starts the gRPC server with default dependencies.
+func StartGRPCServer(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), <-chan error, error) {
+	return NewRunner().StartGRPCServer(ctx, cfg, logger)
+}
+
+// ClientHandshake performs the handshake with default dependencies.
+func ClientHandshake(ctx context.Context, cfg *config.Config, logger *zap.Logger) (func(), chan error, error) {
+	return NewRunner().ClientHandshake(ctx, cfg, logger)
+}
+
+// SetupSignalHandling configures signal handling with default dependencies.
+func SetupSignalHandling(ctx context.Context, cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
+	return NewRunner().SetupSignalHandling(ctx, cfg, snapshotPath, logger)
+}
+
+// PrepareSnapshot wraps snapshot preparation with default dependencies.
 func PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
-	return prepareSnapshot(ctx, cfg, originalVolume, logger)
+	return NewRunner().PrepareSnapshot(ctx, cfg, originalVolume, logger)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -40,17 +40,16 @@ func (f *fakeServer) GracefulStop()            { f.stopped.Store(true) }
 func TestStartGRPCServerSuccess(t *testing.T) {
 	cfg := &config.Config{GRPCListen: "127.0.0.1:0"}
 	logger := zap.NewNop()
-	origListen := listen
-	origNewServer := newServer
-	defer func() { listen = origListen; newServer = origNewServer }()
-	listen = func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil }
 	srv := &fakeServer{}
-	newServer = func(conf grpcserver.Config, agent lvmlib.Agent, _ *zap.Logger) (grpcServer, func(), error) {
-		return srv, func() {}, nil
-	}
+	r := NewRunnerWithDeps(&Runner{
+		listen: func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil },
+		newServer: func(conf grpcserver.Config, agent lvmlib.Agent, _ *zap.Logger) (grpcServer, func(), error) {
+			return srv, func() {}, nil
+		},
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cleanup, errCh, err := StartGRPCServer(ctx, cfg, logger)
+	cleanup, errCh, err := r.StartGRPCServer(ctx, cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,11 +70,11 @@ func TestStartGRPCServerSuccess(t *testing.T) {
 func TestStartGRPCServerListenError(t *testing.T) {
 	cfg := &config.Config{GRPCListen: "bad"}
 	logger := zap.NewNop()
-	origListen := listen
-	defer func() { listen = origListen }()
-	listen = func(network, addr string) (net.Listener, error) { return nil, errors.New("boom") }
+	r := NewRunnerWithDeps(&Runner{
+		listen: func(network, addr string) (net.Listener, error) { return nil, errors.New("boom") },
+	})
 
-	if _, _, err := StartGRPCServer(context.Background(), cfg, logger); err == nil {
+	if _, _, err := r.StartGRPCServer(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -83,15 +82,14 @@ func TestStartGRPCServerListenError(t *testing.T) {
 func TestStartGRPCServerServeError(t *testing.T) {
 	cfg := &config.Config{GRPCListen: "127.0.0.1:0"}
 	logger := zap.NewNop()
-	origListen := listen
-	origNewServer := newServer
-	defer func() { listen = origListen; newServer = origNewServer }()
-	listen = func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil }
 	srvErr := errors.New("serve boom")
-	newServer = func(conf grpcserver.Config, agent lvmlib.Agent, _ *zap.Logger) (grpcServer, func(), error) {
-		return &failingServer{err: srvErr}, func() {}, nil
-	}
-	cleanup, errCh, err := StartGRPCServer(context.Background(), cfg, logger)
+	r := NewRunnerWithDeps(&Runner{
+		listen: func(network, addr string) (net.Listener, error) { return &fakeListener{}, nil },
+		newServer: func(conf grpcserver.Config, agent lvmlib.Agent, _ *zap.Logger) (grpcServer, func(), error) {
+			return &failingServer{err: srvErr}, func() {}, nil
+		},
+	})
+	cleanup, errCh, err := r.StartGRPCServer(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -132,26 +130,18 @@ func TestClientHandshakeSuccess(t *testing.T) {
 
 	fc := &fakeConn{}
 	fs := &fakeStream{}
-	origDial := dial
-	origHandshake := handshake
-	origCreateSession := createSession
-	origAckStream := ackStream
-	defer func() {
-		dial = origDial
-		handshake = origHandshake
-		createSession = origCreateSession
-		ackStream = origAckStream
-	}()
-	dial = func(context.Context, string, grpcclient.Config, *zap.Logger) (closeableConn, error) { return fc, nil }
-	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
-		return &proto.HandshakeResponse{}, nil
-	}
-	createSession = func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
-		return &proto.SessionResponse{SessionId: "id"}, nil
-	}
-	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
+	r := NewRunnerWithDeps(&Runner{
+		dial: func(context.Context, string, grpcclient.Config, *zap.Logger) (closeableConn, error) { return fc, nil },
+		handshake: func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+			return &proto.HandshakeResponse{}, nil
+		},
+		createSession: func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
+			return &proto.SessionResponse{SessionId: "id"}, nil
+		},
+		ackStream: func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil },
+	})
 
-	cleanup, hbErrCh, err := ClientHandshake(context.Background(), cfg, logger)
+	cleanup, hbErrCh, err := r.ClientHandshake(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -167,13 +157,13 @@ func TestClientHandshakeSuccess(t *testing.T) {
 func TestClientHandshakeDialError(t *testing.T) {
 	cfg := &config.Config{GRPCConnect: "addr", GRPCDialTimeout: time.Second, HeartbeatInterval: time.Second, HeartbeatSendTimeout: time.Second}
 	logger := zap.NewNop()
-	origDial := dial
-	defer func() { dial = origDial }()
-	dial = func(context.Context, string, grpcclient.Config, *zap.Logger) (closeableConn, error) {
-		return nil, errors.New("dial fail")
-	}
+	r := NewRunnerWithDeps(&Runner{
+		dial: func(context.Context, string, grpcclient.Config, *zap.Logger) (closeableConn, error) {
+			return nil, errors.New("dial fail")
+		},
+	})
 
-	if _, _, err := ClientHandshake(context.Background(), cfg, logger); err == nil {
+	if _, _, err := r.ClientHandshake(context.Background(), cfg, logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -184,28 +174,20 @@ func TestClientHandshakeHeartbeatFailure(t *testing.T) {
 
 	fc := &fakeConn{}
 	fs := &failingStream{}
-	origDial := dial
-	origHandshake := handshake
-	origCreateSession := createSession
-	origAckStream := ackStream
-	defer func() {
-		dial = origDial
-		handshake = origHandshake
-		createSession = origCreateSession
-		ackStream = origAckStream
-	}()
-	dial = func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
-		return fc, nil
-	}
-	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
-		return &proto.HandshakeResponse{}, nil
-	}
-	createSession = func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
-		return &proto.SessionResponse{SessionId: "id"}, nil
-	}
-	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
+	r := NewRunnerWithDeps(&Runner{
+		dial: func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
+			return fc, nil
+		},
+		handshake: func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+			return &proto.HandshakeResponse{}, nil
+		},
+		createSession: func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
+			return &proto.SessionResponse{SessionId: "id"}, nil
+		},
+		ackStream: func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil },
+	})
 
-	cleanup, hbErrCh, err := ClientHandshake(context.Background(), cfg, logger)
+	cleanup, hbErrCh, err := r.ClientHandshake(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -227,28 +209,20 @@ func TestClientHandshakeHeartbeatTimeout(t *testing.T) {
 	fc := &fakeConn{}
 	block := make(chan struct{})
 	fs := &blockingStream{block: block}
-	origDial := dial
-	origHandshake := handshake
-	origCreateSession := createSession
-	origAckStream := ackStream
-	defer func() {
-		dial = origDial
-		handshake = origHandshake
-		createSession = origCreateSession
-		ackStream = origAckStream
-	}()
-	dial = func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
-		return fc, nil
-	}
-	handshake = func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
-		return &proto.HandshakeResponse{}, nil
-	}
-	createSession = func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
-		return &proto.SessionResponse{SessionId: "id"}, nil
-	}
-	ackStream = func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil }
+	r := NewRunnerWithDeps(&Runner{
+		dial: func(ctx context.Context, addr string, conf grpcclient.Config, logger *zap.Logger) (closeableConn, error) {
+			return fc, nil
+		},
+		handshake: func(context.Context, proto.ReplicationClient, *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+			return &proto.HandshakeResponse{}, nil
+		},
+		createSession: func(context.Context, proto.ReplicationClient, string, string) (*proto.SessionResponse, error) {
+			return &proto.SessionResponse{SessionId: "id"}, nil
+		},
+		ackStream: func(context.Context, proto.ReplicationClient, string) (ackStreamClient, error) { return fs, nil },
+	})
 
-	cleanup, hbErrCh, err := ClientHandshake(context.Background(), cfg, logger)
+	cleanup, hbErrCh, err := r.ClientHandshake(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -283,15 +257,13 @@ func TestSetupSignalHandling(t *testing.T) {
 	cfg := &config.Config{}
 	var path string
 	called := make(chan struct{})
-	origHandle := signalsHandler
-	defer func() { signalsHandler = origHandle }()
-	signalsHandler = signalspkg.HandlerFunc(func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	r := NewRunnerWithDeps(&Runner{signalsHandler: signalspkg.HandlerFunc(func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		<-sigs
 		*p = "set"
 		close(called)
-	})
+	})})
 	logger := zap.NewNop()
-	signals, sigErrCh := SetupSignalHandling(context.Background(), cfg, &path, logger)
+	signals, sigErrCh := r.SetupSignalHandling(context.Background(), cfg, &path, logger)
 	signals <- os.Interrupt
 	select {
 	case <-called:
@@ -314,13 +286,11 @@ func TestSetupSignalHandling(t *testing.T) {
 func TestSetupSignalHandlingError(t *testing.T) {
 	cfg := &config.Config{}
 	var path string
-	origHandle := signalsHandler
-	defer func() { signalsHandler = origHandle }()
-	signalsHandler = signalspkg.HandlerFunc(func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
+	r := NewRunnerWithDeps(&Runner{signalsHandler: signalspkg.HandlerFunc(func(ctx context.Context, cfg *config.Config, _ *zap.Logger, sigs <-chan os.Signal, p *string, errCh chan<- error) {
 		errCh <- errors.New("boom")
-	})
+	})})
 	logger := zap.NewNop()
-	_, sigErrCh := SetupSignalHandling(context.Background(), cfg, &path, logger)
+	_, sigErrCh := r.SetupSignalHandling(context.Background(), cfg, &path, logger)
 	if err := <-sigErrCh; err == nil {
 		t.Fatalf("expected error")
 	}
@@ -331,12 +301,10 @@ func TestSetupSignalHandlingError(t *testing.T) {
 func TestPrepareSnapshot(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
-	orig := prepareSnapshot
-	defer func() { prepareSnapshot = orig }()
-	prepareSnapshot = func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+	r := NewRunnerWithDeps(&Runner{prepareSnapshot: func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
 		return "snap", nil, func() {}, nil
-	}
-	snap, ch, cleanup, err := PrepareSnapshot(context.Background(), cfg, "vol", logger)
+	}})
+	snap, ch, cleanup, err := r.PrepareSnapshot(context.Background(), cfg, "vol", logger)
 	if err != nil || snap != "snap" || ch != nil || cleanup == nil {
 		t.Fatalf("unexpected result")
 	}
@@ -345,12 +313,10 @@ func TestPrepareSnapshot(t *testing.T) {
 func TestPrepareSnapshotError(t *testing.T) {
 	cfg := &config.Config{}
 	logger := zap.NewNop()
-	orig := prepareSnapshot
-	defer func() { prepareSnapshot = orig }()
-	prepareSnapshot = func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
+	r := NewRunnerWithDeps(&Runner{prepareSnapshot: func(ctx context.Context, c *config.Config, v string, l *zap.Logger) (string, chan error, func(), error) {
 		return "", nil, nil, errors.New("fail")
-	}
-	if _, _, _, err := PrepareSnapshot(context.Background(), cfg, "vol", logger); err == nil {
+	}})
+	if _, _, _, err := r.PrepareSnapshot(context.Background(), cfg, "vol", logger); err == nil {
 		t.Fatalf("expected error")
 	}
 }


### PR DESCRIPTION
## Summary
- replace global dependency vars in app with Runner struct and constructors
- provide default and injectable overrides through `NewRunner`/`NewRunnerWithDeps`
- update app tests to use `NewRunnerWithDeps`

## Testing
- `go build ./...`
- `go test -cover ./app`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2e4495d188323aa9671b6d9037133