### PR TITLE
device: add context to OpenLVM test

### DIFF
--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -58,7 +58,7 @@ func TestOpenLVMChecks(t *testing.T) {
 	cache := lvm.NewDeviceFDCache(zap.NewNop())
 	defer cache.Close()
 	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, defaultIsMountedRW, lock.Acquire, nil)
-	if _, err := runner.OpenLVM("/dev/missing", cache, "", zap.NewNop()); err == nil {
+	if _, err := runner.OpenLVM(context.Background(), "/dev/missing", cache, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error when volume missing")
 	}
 }


### PR DESCRIPTION
## Summary
- use context in `OpenLVM` negative test

## Testing
- `go build ./...` *(fails: t.hostSigner undefined)*
- `go test ./device`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2edb0c6f083238c4d0b947898d364