### PR TITLE
transport: return error from MustRegister

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -102,7 +102,8 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	transport.MustRegister("h2", func(cfg transport.Config) (transport.Interface, error) {
+	logger := zap.NewNop()
+	if err := transport.MustRegister("h2", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(cfg)
 		if err != nil {
 			return nil, err
@@ -111,7 +112,10 @@ func init() {
 			return nil, fmt.Errorf("h2: nil transport")
 		}
 		return tr, nil
-	}, zap.NewNop(), rootcmd.SyncLogger)
+	}); err != nil {
+		logger.Error("register_failed", zap.String("transport", "h2"), zap.Error(err))
+		rootcmd.SyncLogger(logger)
+	}
 }
 
 func (t *Transport) Name() string { return "h2" }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -86,7 +86,8 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	transport.MustRegister("quic", func(cfg transport.Config) (transport.Interface, error) {
+	logger := zap.NewNop()
+	if err := transport.MustRegister("quic", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(cfg)
 		if err != nil {
 			return nil, err
@@ -95,7 +96,10 @@ func init() {
 			return nil, fmt.Errorf("quic: nil transport")
 		}
 		return tr, nil
-	}, zap.NewNop(), rootcmd.SyncLogger)
+	}); err != nil {
+		logger.Error("register_failed", zap.String("transport", "quic"), zap.Error(err))
+		rootcmd.SyncLogger(logger)
+	}
 }
 
 func (t *Transport) Name() string { return "quic" }

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -28,24 +28,11 @@ func Register(name string, f Factory) error {
 	return nil
 }
 
-// MustRegister adds a transport factory to the registry and panics on error.
+// MustRegister adds a transport factory to the registry.
 //
-// A log entry is emitted before panicking to aid debugging when duplicate
-// registrations occur. The provided logger is used for logging and flushed
-// using syncLogger if registration fails.
-func MustRegister(name string, f Factory, logger *zap.Logger, syncLogger func(*zap.Logger)) {
-	if err := Register(name, f); err != nil {
-		if logger == nil {
-			logger = zap.NewNop()
-		}
-		logger.Error("register_failed", zap.String("transport", name), zap.Error(err))
-		if syncLogger != nil {
-			syncLogger(logger)
-		} else {
-			_ = logger.Sync()
-		}
-		panic(fmt.Sprintf("register transport %q: %v", name, err))
-	}
+// It returns an error if the transport is already registered.
+func MustRegister(name string, f Factory) error {
+	return Register(name, f)
 }
 
 // Get returns a transport from the registry by name.

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -127,7 +127,7 @@ func TestGetOrdered(t *testing.T) {
 	}
 }
 
-func TestMustRegisterPanics(t *testing.T) {
+func TestMustRegisterDuplicate(t *testing.T) {
 	regMu.Lock()
 	original := registry
 	registry = map[string]Factory{}
@@ -138,20 +138,22 @@ func TestMustRegisterPanics(t *testing.T) {
 		regMu.Unlock()
 	}()
 
-	syncLogger := func(l *zap.Logger) { _ = l.Sync() }
-	MustRegister("dup", func(Config) (Interface, error) { return nil, nil }, zap.NewNop(), syncLogger)
+	if err := MustRegister("dup", func(Config) (Interface, error) { return nil, nil }); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
 
+	syncLogger := func(l *zap.Logger) { _ = l.Sync() }
 	core, obs := observer.New(zapcore.ErrorLevel)
 	logger := zap.New(core)
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic")
-		}
-		if obs.FilterMessage("register_failed").Len() != 1 {
-			t.Fatalf("expected register_failed log")
-		}
-	}()
+	if err := MustRegister("dup", func(Config) (Interface, error) { return nil, nil }); err != nil {
+		logger.Error("register_failed", zap.String("transport", "dup"), zap.Error(err))
+		syncLogger(logger)
+	} else {
+		t.Fatalf("expected duplicate registration error")
+	}
 
-	MustRegister("dup", func(Config) (Interface, error) { return nil, nil }, logger, syncLogger)
+	if obs.FilterMessage("register_failed").Len() != 1 {
+		t.Fatalf("expected register_failed log")
+	}
 }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -176,7 +176,8 @@ func agentSigners(ctx context.Context, sock string) ([]ssh.Signer, error) {
 }
 
 func init() {
-	transport.MustRegister("ssh", func(cfg transport.Config) (transport.Interface, error) {
+	logger := zap.NewNop()
+	if err := transport.MustRegister("ssh", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(context.Background(), cfg)
 		if err != nil {
 			return nil, err
@@ -185,7 +186,10 @@ func init() {
 			return nil, fmt.Errorf("ssh: nil transport")
 		}
 		return tr, nil
-	}, zap.NewNop(), rootcmd.SyncLogger)
+	}); err != nil {
+		logger.Error("register_failed", zap.String("transport", "ssh"), zap.Error(err))
+		rootcmd.SyncLogger(logger)
+	}
 }
 
 func (t *Transport) Name() string { return "ssh" }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -68,7 +68,8 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	transport.MustRegister("tcp+tls", func(cfg transport.Config) (transport.Interface, error) {
+	logger := zap.NewNop()
+	if err := transport.MustRegister("tcp+tls", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(cfg)
 		if err != nil {
 			return nil, err
@@ -77,7 +78,10 @@ func init() {
 			return nil, fmt.Errorf("tcp+tls: nil transport")
 		}
 		return tr, nil
-	}, zap.NewNop(), rootcmd.SyncLogger)
+	}); err != nil {
+		logger.Error("register_failed", zap.String("transport", "tcp+tls"), zap.Error(err))
+		rootcmd.SyncLogger(logger)
+	}
 }
 
 func (t *Transport) Name() string { return "tcp+tls" }


### PR DESCRIPTION
## Summary
- return errors from transport registry MustRegister instead of panicking
- log and sync registration errors in h2, quic, ssh and tcp+tls init functions
- add unit test covering duplicate registration without panic

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a2f9a885608323bd37e733d29ced7a