### PR TITLE
docs: replace serve with lvmsyncd

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,78 +650,26 @@ SSH transport negotiation also derives read and write deadlines from the caller'
   lvmsync run --mode throughput /dev/vg0/source /dev/vg1/target
   ```
 
-## Serve Subcommand
+## lvmsyncd Examples
 
-Run a standalone QUIC listener:
+`lvmsyncd` exposes replication endpoints with the `--listen` flag. Each URI
+scheme selects a transport and optional parameters configure authentication.
 
-```sh
-lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
-```
-
-TLS is required by default. The server rejects plaintext clients unless
-`--allow-insecure` or `LVMSYNC_SERVE_ALLOW_INSECURE` is set, which disables
-encryption and authentication and should only be used in trusted development
-environments.
-
-| Flag | Environment | Description |
-|------|-------------|-------------|
-| `--transport` | `LVMSYNC_SERVE_TRANSPORT` | Transport to serve |
-| `--quic-listen` | `LVMSYNC_SERVE_QUIC_LISTEN` | QUIC listen address |
-| `--tls-cert` | `LVMSYNC_SERVE_TLS_CERT` | TLS certificate file |
-| `--tls-key` | `LVMSYNC_SERVE_TLS_KEY` | TLS key file |
-| `--ca-cert` | `LVMSYNC_SERVE_CA_CERT` | CA certificate file |
-| `--allow-insecure` | `LVMSYNC_SERVE_ALLOW_INSECURE` | Permit insecure (no TLS) connections (disabled by default) |
-
-
-
-TLS mode requires explicit certificates. Provide `--tls-cert`, `--tls-key`, and `--ca-cert`; the daemon fails to start if any are missing and does not generate self-signed certificates.
-
-To detect stalled clients, the daemon sends periodic keepalive pings governed by
-`--keepalive-time` (default `2m`). If an acknowledgement is not received within
-`--keepalive-timeout` (default `20s`), the connection is closed. Unary RPCs are
-wrapped with a deadline controlled by `--request-timeout` (default `15s`).
-
-
-1. **Handshake** – clients advertise `sector_size`, `alignment`, `max_concurrency`, and whether deduplication and compression are supported.
-2. **Session Creation** – the client sends an ephemeral certificate and receives a session ID, server certificate, and pre-shared key.
-3. **Resume Bitmap** – dirty block bitmaps are streamed with the session ID to resume interrupted transfers, and final manifests carrying SHA-256 digests validate completion.
-4. **Ack/Ping Stream** – a bidirectional stream of `Ack` messages per session provides keep-alives and progress confirmation.
-5. **Finalization** – the client requests completion using the session ID when replication is done.
-
-
-Run the daemon with TLS:
+Start a TLS/TCP listener:
 
 ```sh
+lvmsyncd --listen tcp+tls://:9443 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
 
-Disabling TLS with `--allow-insecure` is supported for development but is unsafe for production deployments.
-
-
-Environment variables provide the same settings:
+Activate an SSH listener:
 
 ```sh
+lvmsyncd --listen ssh://:2222 --ssh-host-key-path host_key
 ```
 
-Misconfiguration logs an error and exits with code `1`:
-
-```sh
-echo $?
-1
-```
-
-
-```yaml
-tls-cert: cert.pem
-tls-key: key.pem
-ca-cert: ca.pem
-```
-
-
-```sh
-```
-
-```sh
-```
+Both transports require explicit keys; the daemon exits if any are missing and
+never generates self-signed certificates. Use `--allow-insecure` only for
+development.
 
 ### `config.yaml` example
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -14,10 +14,12 @@ LVMSync runs on Linux only and is validated on the `amd64` and `arm64` architect
 - Resume and deduplicate transfers to minimize bandwidth usage.
 - Easy to operate locally or over SSH with configurable options.
 
-## Serve Command and Logging
+## lvmsyncd Architecture
 
-The planned `serve` subcommand will expose a QUIC listener for incoming replication requests. It follows an argument simplification philosophy, surfacing only essential flags while relying on configuration binding for advanced tuning. All logging for this command must use the structured `zap` logger.
-
+The `lvmsyncd` daemon loads modules and listens on URIs specified by `--listen`.
+Each scheme selects a transport and configuration is sourced from flags,
+`LVMSYNC_DAEMON_*` environment variables, or a `lvmsyncd.yaml` file. The flag
+surface remains minimal and all logging uses the structured `zap` logger.
 
 
 ## Identified Gaps
@@ -57,19 +59,8 @@ The planned `serve` subcommand will expose a QUIC listener for incoming replicat
    - Document package architecture and developer guidelines.
    - Explain how to run tests and CI locally.
 
-6. **Implement QUIC Serve Command**
-   - Build the `serve` subcommand with a minimal flag surface.
-   - Enforce `zap` for structured logging.
-
-7. **Audit Flag Surface**
-   - Review existing CLI flags for redundancy and simplification.
-   - Keep documentation and configuration options consistent.
-
-8. **Update Serve Documentation**
-   - Document `serve` usage in `README` and configuration examples.
-
-9. **Add Serve Tests**
-   - Provide unit tests covering command behavior and flag parsing.
+6. **Document lvmsyncd Architecture**
+   - Describe module loading, listen URIs, and configuration precedence.
 
 Contributors tackling these tasks must run:
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -2,9 +2,10 @@
 
 ## Usage
 
-LVMSync supports multiple transports selectable with the `--transport` flag.
-Transports are tried in order until a connection is established. The default
-order is `quic,h2,tcp+tls,ssh`. Flags override `LVMSYNC_TRANSPORT_*`
+`lvmsyncd` exposes transports by listening on URIs passed to `--listen`. Each
+scheme selects a transport such as `quic`, `tcp+tls`, or `ssh`. Clients choose
+their preferred order with the `--transport` flag; transports are tried in order
+until a connection is established. Flags override `LVMSYNC_TRANSPORT_*`
 environment variables, which override `transport` keys in `config.yaml`.
 
 Each transport constructor accepts a configuration with an optional `zap.Logger`.
@@ -61,12 +62,15 @@ used only in development.
 
 ## Examples
 
+Expose multiple transports with `lvmsyncd`:
+
 ```sh
-lvmsync --transport quic,h2,tcp+tls,ssh --tcp-port 9443
+lvmsyncd --listen tcp+tls://:9443 --listen ssh://:2222 \
+  --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem \
+  --ssh-host-key-path host_key
 ```
 
-
-clients. Defaults:
+Listeners enforce these defaults:
 
 - `--keepalive-time` (2m): interval between server pings.
 - `--keepalive-timeout` (20s): wait for a ping acknowledgement before closing.
@@ -85,13 +89,7 @@ clients. Defaults:
 Example:
 
 ```sh
-lvmsync --transport quic --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
-```
-
-Run a listener with the `serve` subcommand:
-
-```sh
-lvmsync serve --transport quic --quic-listen :12000 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
+lvmsyncd --listen quic://:12000 --tls-cert cert.pem --tls-key key.pem --ca-cert ca.pem
 ```
 
 ## HTTP/2 (h2)


### PR DESCRIPTION
## Summary
- replace Serve Subcommand with lvmsyncd TLS/TCP and SSH listener examples
- document transport exposure through lvmsyncd and update QUIC example
- pivot PRD to lvmsyncd architecture and tasks

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a313ea3bb0832395f7d5379557da19