### PR TITLE
feat: add lvmsyncd daemon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ variables, which override configuration files.
 
 ## lvmsync daemon
 
-The `lvmsyncd` binary loads optional modules and listens on one or more URIs. Use `--listen` repeatedly to specify addresses and `--module` to load plugin modules. `--once` exits after initialization.
+The `lvmsyncd` binary loads optional modules and listens on one or more URIs. Use `--listen` repeatedly to specify addresses and `--module` to load plugin modules.
 
 Configuration can come from flags, `LVMSYNC_DAEMON_` environment variables, or a `lvmsyncd.yaml` file. Multi-value environment variables are comma-separated.
 
@@ -144,13 +144,11 @@ Configuration can come from flags, `LVMSYNC_DAEMON_` environment variables, or a
 |------|----------------------|------------|-------------|
 | `--listen` | `LVMSYNC_DAEMON_LISTEN` | `listen` | comma-separated list of listen URIs |
 | `--module` | `LVMSYNC_DAEMON_MODULE` | `module` | comma-separated module paths |
-| `--once` | `LVMSYNC_DAEMON_ONCE` | `once` | run once then exit |
-| `--sudo-helper` | `LVMSYNC_DAEMON_SUDO_HELPER` | `sudo-helper` | optional sudo helper path |
 
 Example:
 
 ```sh
-LVMSYNC_DAEMON_LISTEN=unix:///run/lvmsyncd.sock,tcp://:9000 lvmsyncd --module ./mod.so
+LVMSYNC_DAEMON_LISTEN=unix:///run/lvmsyncd.sock,tcp+tls://:9000 lvmsyncd --module ./mod.so
 ```
 
 See [daemon documentation](docs/daemon.md) for module configuration, ACLs, and
@@ -528,7 +526,7 @@ Running `LVMSYNC_RETRY_DELAY=2s lvmsync run --retry-delay 3s` uses a retry delay
 Environment variables for the lvmsync daemon use the `LVMSYNC_DAEMON_` prefix. Multi-value settings are comma-separated:
 
 ```sh
-LVMSYNC_DAEMON_LISTEN=unix:///run/lvmsyncd.sock,tcp://:9000 lvmsyncd
+LVMSYNC_DAEMON_LISTEN=unix:///run/lvmsyncd.sock,tcp+tls://:9000 lvmsyncd
 ```
 
 Grouped options use dedicated prefixes: `LVMSYNC_DEDUP_`,

--- a/cmd/lvmsyncd/lvmsyncd.go
+++ b/cmd/lvmsyncd/lvmsyncd.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -27,9 +28,8 @@ import (
 )
 
 type options struct {
-	modules       map[string]string
-	transports    []string
-	tcpPort       int
+	modules       map[string]struct{}
+	listens       []string
 	stdio         bool
 	inetd         bool
 	tlsCert       string
@@ -38,12 +38,11 @@ type options struct {
 	allowInsecure bool
 }
 
-func parseModules(vals []string) map[string]string {
-	m := make(map[string]string)
+func parseModules(vals []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(vals))
 	for _, v := range vals {
-		parts := strings.SplitN(v, "=", 2)
-		if len(parts) == 2 {
-			m[parts[0]] = parts[1]
+		if v != "" {
+			m[v] = struct{}{}
 		}
 	}
 	return m
@@ -52,8 +51,7 @@ func parseModules(vals []string) map[string]string {
 func parseOptions(v *viper.Viper) options {
 	return options{
 		modules:       parseModules(v.GetStringSlice("module")),
-		transports:    splitTransports(v.GetString("transport")),
-		tcpPort:       v.GetInt("tcp-port"),
+		listens:       v.GetStringSlice("listen"),
 		stdio:         v.GetBool("stdio"),
 		inetd:         v.GetBool("inetd"),
 		tlsCert:       v.GetString("tls-cert"),
@@ -63,27 +61,11 @@ func parseOptions(v *viper.Viper) options {
 	}
 }
 
-func splitTransports(s string) []string {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
 func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	fs := pflag.NewFlagSet("lvmsyncd", pflag.ExitOnError)
-	fs.StringSlice("module", nil, "module mapping name=path")
-	fs.String("transport", "tcp+tls", "comma-separated transports")
-	fs.Int("tcp-port", 8730, "TCP port to listen on")
-	fs.Bool("stdio", false, "use stdio for a single connection")
+	fs.StringSlice("module", nil, "module path")
+	fs.StringSlice("listen", nil, "transport listen URI")
+	fs.Bool("stdio", false, "serve a single connection over stdio")
 	fs.Bool("inetd", false, "use stdio under inetd activation")
 	fs.String("tls-cert", "", "TLS certificate file")
 	fs.String("tls-key", "", "TLS key file")
@@ -93,7 +75,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	if err := v.BindPFlags(fs); err != nil {
 		return err
 	}
-	v.SetEnvPrefix("LVMSYNCD")
+	v.SetEnvPrefix("LVMSYNC_DAEMON")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 	return nil
@@ -139,6 +121,33 @@ type dummyAddr string
 func (d dummyAddr) Network() string { return string(d) }
 func (d dummyAddr) String() string  { return string(d) }
 
+type listenSpec struct {
+	scheme string
+	addr   string
+}
+
+func parseListen(listens []string) ([]listenSpec, error) {
+	specs := make([]listenSpec, 0, len(listens))
+	for _, l := range listens {
+		if l == "" {
+			continue
+		}
+		u, err := url.Parse(l)
+		if err != nil {
+			return nil, fmt.Errorf("parse listen URI %q: %w", l, err)
+		}
+		if u.Scheme == "" {
+			return nil, fmt.Errorf("missing scheme in %q", l)
+		}
+		addr := u.Host
+		if addr == "" {
+			addr = u.Path
+		}
+		specs = append(specs, listenSpec{scheme: u.Scheme, addr: addr})
+	}
+	return specs, nil
+}
+
 func start(ctx context.Context, opts options, logger *zap.Logger) error {
 	cfg := transport.Config{Logger: logger, AllowInsecure: opts.allowInsecure}
 	if !opts.allowInsecure {
@@ -167,22 +176,36 @@ func start(ctx context.Context, opts options, logger *zap.Logger) error {
 		}
 		cfg.Roots = roots
 	}
-	trs, err := transport.GetOrdered(opts.transports, cfg)
+	specs, err := parseListen(opts.listens)
 	if err != nil {
-		return fmt.Errorf("get transport: %w", err)
+		return err
 	}
 	if opts.stdio || opts.inetd {
-		if len(trs) == 0 {
-			return fmt.Errorf("no transport specified")
+		scheme := "tcp+tls"
+		if len(specs) > 0 {
+			scheme = specs[0].scheme
+		}
+		tr, err := transport.Get(scheme, cfg)
+		if err != nil {
+			return fmt.Errorf("get transport: %w", err)
 		}
 		conn := &stdioConn{}
-		return handleConn(ctx, conn, trs[0], opts.modules, logger)
+		return handleConn(ctx, conn, tr, opts.modules, logger)
 	}
-	addr := fmt.Sprintf(":%d", opts.tcpPort)
-	errCh := make(chan error, len(trs))
+	if len(specs) == 0 {
+		return fmt.Errorf("no listeners provided")
+	}
+	errCh := make(chan error, len(specs))
 	var wg sync.WaitGroup
-	for _, tr := range trs {
-		ln, err := tr.Listen(ctx, addr)
+	for _, sp := range specs {
+		tr, err := transport.Get(sp.scheme, cfg)
+		if err != nil {
+			return fmt.Errorf("get transport: %w", err)
+		}
+		if sp.addr == "" {
+			return fmt.Errorf("missing address for %s", sp.scheme)
+		}
+		ln, err := tr.Listen(ctx, sp.addr)
 		if err != nil {
 			return fmt.Errorf("listen: %w", err)
 		}
@@ -211,7 +234,7 @@ func start(ctx context.Context, opts options, logger *zap.Logger) error {
 	}
 }
 
-func handleConn(ctx context.Context, conn net.Conn, tr transport.Interface, modules map[string]string, logger *zap.Logger) error {
+func handleConn(ctx context.Context, conn net.Conn, tr transport.Interface, modules map[string]struct{}, logger *zap.Logger) error {
 	remote := conn.RemoteAddr().String()
 	logger.Info("conn_accepted", zap.String("remote_addr", remote))
 	defer func() {

--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"net"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -14,15 +17,38 @@ import (
 )
 
 // mockTransport implements transport.Interface for testing negotiation.
-type mockTransport struct{ negotiated bool }
+type mockTransport struct {
+	negotiated bool
+	listened   *[]string
+	mu         sync.Mutex
+}
 
-func (m *mockTransport) Name() string                                         { return "mock" }
-func (m *mockTransport) Dial(context.Context, string) (net.Conn, error)       { return nil, nil }
-func (m *mockTransport) Listen(context.Context, string) (net.Listener, error) { return nil, nil }
+func (m *mockTransport) Name() string                                   { return "mock" }
+func (m *mockTransport) Dial(context.Context, string) (net.Conn, error) { return nil, nil }
+func (m *mockTransport) Listen(ctx context.Context, addr string) (net.Listener, error) {
+	if m.listened != nil {
+		m.mu.Lock()
+		*m.listened = append(*m.listened, addr)
+		m.mu.Unlock()
+	}
+	return &dummyListener{ctx: ctx, addr: dummyAddr(addr)}, nil
+}
 func (m *mockTransport) Negotiate(context.Context, net.Conn, transport.Role, common.Handshake) (common.Handshake, error) {
 	m.negotiated = true
 	return common.Handshake{}, nil
 }
+
+type dummyListener struct {
+	ctx  context.Context
+	addr net.Addr
+}
+
+func (d *dummyListener) Accept() (net.Conn, error) {
+	<-d.ctx.Done()
+	return nil, d.ctx.Err()
+}
+func (d *dummyListener) Close() error   { return nil }
+func (d *dummyListener) Addr() net.Addr { return d.addr }
 
 func TestFlagParsing(t *testing.T) {
 	v := viper.New()
@@ -30,19 +56,13 @@ func TestFlagParsing(t *testing.T) {
 	if err := bindFlags(cmd, v); err != nil {
 		t.Fatalf("bindFlags: %v", err)
 	}
-	args := []string{"--module", "foo=/dev/null", "--module", "bar=/dev/zero", "--transport", "h2,tcp+tls", "--tcp-port", "9000"}
+	args := []string{"--module", "/dev/null", "--module", "/dev/zero", "--listen", "h2://:9000", "--listen", "tcp+tls://:9443"}
 	if err := cmd.ParseFlags(args); err != nil {
 		t.Fatalf("ParseFlags: %v", err)
 	}
 	opts := parseOptions(v)
-	if len(opts.modules) != 2 || opts.modules["foo"] != "/dev/null" || opts.modules["bar"] != "/dev/zero" {
-		t.Fatalf("modules parsed incorrectly: %+v", opts.modules)
-	}
-	if len(opts.transports) != 2 || opts.transports[0] != "h2" || opts.transports[1] != "tcp+tls" {
-		t.Fatalf("transports parsed incorrectly: %+v", opts.transports)
-	}
-	if opts.tcpPort != 9000 {
-		t.Fatalf("tcpPort parsed incorrectly: %d", opts.tcpPort)
+	if len(opts.modules) != 2 || opts.listens[0] != "h2://:9000" || opts.listens[1] != "tcp+tls://:9443" {
+		t.Fatalf("options parsed incorrectly: %+v", opts)
 	}
 }
 
@@ -51,7 +71,7 @@ func TestModuleACL(t *testing.T) {
 	server, client := net.Pipe()
 	done := make(chan error, 1)
 	go func() {
-		done <- handleConn(context.Background(), server, tr, map[string]string{"foo": "/dev/null"}, zap.NewNop())
+		done <- handleConn(context.Background(), server, tr, map[string]struct{}{"/dev/null": {}}, zap.NewNop())
 	}()
 	if _, err := client.Write([]byte("bar\n")); err != nil {
 		t.Fatalf("write: %v", err)
@@ -66,9 +86,9 @@ func TestTransportNegotiation(t *testing.T) {
 	server, client := net.Pipe()
 	done := make(chan error, 1)
 	go func() {
-		done <- handleConn(context.Background(), server, tr, map[string]string{"foo": "/dev/null"}, zap.NewNop())
+		done <- handleConn(context.Background(), server, tr, map[string]struct{}{"/dev/null": {}}, zap.NewNop())
 	}()
-	if _, err := client.Write([]byte("foo\n")); err != nil {
+	if _, err := client.Write([]byte("/dev/null\n")); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	if err := <-done; err != nil {
@@ -76,5 +96,31 @@ func TestTransportNegotiation(t *testing.T) {
 	}
 	if !tr.negotiated {
 		t.Fatalf("expected negotiation to occur")
+	}
+}
+
+func TestListenerSetup(t *testing.T) {
+	var addrs []string
+	if err := transport.Register("mocklisten", func(cfg transport.Config) (transport.Interface, error) {
+		return &mockTransport{listened: &addrs}, nil
+	}); err != nil && !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("register: %v", err)
+	}
+	opts := options{
+		modules:       map[string]struct{}{"/dev/null": {}},
+		listens:       []string{"mocklisten://:1111", "mocklisten://:2222"},
+		allowInsecure: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- start(ctx, opts, zap.NewNop()) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	err := <-done
+	if err != context.Canceled {
+		t.Fatalf("start returned %v", err)
+	}
+	if len(addrs) != 2 || addrs[0] != ":1111" || addrs[1] != ":2222" {
+		t.Fatalf("listener addresses %v", addrs)
 	}
 }

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -42,12 +42,12 @@ Example listeners:
 
 ```sh
 # Multiple network listeners
-lvmsyncd --listen unix:///run/lvmsyncd.sock --listen tcp://:9443
+lvmsyncd --listen unix:///run/lvmsyncd.sock --listen tcp+tls://:9443
 
-# Systemd socket activation
+# Systemd socket activation (defaults to tcp+tls)
 lvmsyncd --inetd
 
-# Standard input/output
+# Standard input/output (defaults to tcp+tls)
 lvmsyncd --stdio
 ```
 
@@ -66,7 +66,7 @@ Example mTLS invocation:
 
 ```sh
 lvmsyncd \
-  --listen tcp://:9443 \
+  --listen tcp+tls://:9443 \
   --tls-cert server.pem --tls-key server.key \
   --ca-cert ca.pem --module /usr/lib/lvmsync/modules/snapshot.so
 ```


### PR DESCRIPTION
## Summary
- add lvmsyncd command with URI listeners, stdio/inetd modes, and mTLS defaults
- cover module ACLs and listener setup in tests
- document daemon usage and flags

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3188ba188832381bf803c2cbda0e3