### PR TITLE
Deprecate serve command in favor of lvmsyncd

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const deprecationMsg = "serve command deprecated; use lvmsyncd instead"
+
+func newCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Deprecated server command",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return fmt.Errorf(deprecationMsg)
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Fprintln(cmd.OutOrStdout(), deprecationMsg)
+	})
+	return cmd
+}
+
+func run(args []string, w io.Writer) int {
+	cmd := newCommand()
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(w, deprecationMsg)
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stderr))
+}

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestServeCommandDeprecated(t *testing.T) {
+	var buf bytes.Buffer
+	code := run(nil, &buf)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit code")
+	}
+	if !strings.Contains(buf.String(), "lvmsyncd") {
+		t.Fatalf("expected message to mention lvmsyncd, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- replace serve listener with deprecation stub that directs users to `lvmsyncd`
- add unit test validating deprecation notice and non-zero exit code
- verify repository contains no remaining references to standalone `serve` listener

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a31891703c8323b82b8ba08f18d1ff