### PR TITLE
Ensure snapshots are prepared and cleaned up before sync

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -192,9 +192,9 @@ func (r *Runner) dispatchSubcommand(cfg *config.Config, args []string, logger *z
 	return false, nil
 }
 
-func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (context.Context, func(), string, string, chan error, error) {
+func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (context.Context, func(), string, string, chan error, chan error, error) {
 	if _, err := r.selectTransportFn(cfg, logger); err != nil {
-		return nil, nil, "", "", nil, fmt.Errorf("select transport: %w", err)
+		return nil, nil, "", "", nil, nil, fmt.Errorf("select transport: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -206,24 +206,38 @@ func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Lo
 		pflag.Usage()
 		cancel()
 		signal.Stop(signals)
-		return nil, nil, "", "", nil, fmt.Errorf("invalid arguments")
+		return nil, nil, "", "", nil, nil, fmt.Errorf("invalid arguments")
 	}
+
 	originalVolume := args[0]
 	destPath := ""
 	if !cfg.StdoutMode {
 		destPath = args[1]
 	}
-	snapshotPath = originalVolume
+
+	snapPath, monitorErrCh, snapCleanup, err := r.prepareSnapshotFn(ctx, cfg, originalVolume, logger)
+	if err != nil {
+		cancel()
+		signal.Stop(signals)
+		if snapCleanup != nil {
+			snapCleanup()
+		}
+		return nil, nil, "", "", nil, nil, fmt.Errorf("prepare snapshot: %w", err)
+	}
+	snapshotPath = snapPath
 
 	cleanup := func() {
+		if snapCleanup != nil {
+			snapCleanup()
+		}
 		signal.Stop(signals)
 		cancel()
 	}
-	return ctx, cleanup, snapshotPath, destPath, sigErrCh, nil
+	return ctx, cleanup, snapshotPath, destPath, sigErrCh, monitorErrCh, nil
 }
 
-func (r *Runner) executeSync(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh chan error, logger *zap.Logger) error {
-	return r.ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, nil, logger)
+func (r *Runner) executeSync(ctx context.Context, cfg *config.Config, snapshotPath, destPath string, sigErrCh, monitorErrCh chan error, logger *zap.Logger) error {
+	return r.ExecuteClient(ctx, cfg, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
 }
 
 func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) error {
@@ -232,13 +246,13 @@ func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) erro
 		return err
 	}
 
-	ctx, cleanup, snapshotPath, destPath, sigErrCh, err := r.prepareClient(cfg, args, logger)
+	ctx, cleanup, snapshotPath, destPath, sigErrCh, monitorErrCh, err := r.prepareClient(cfg, args, logger)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	return r.executeSync(ctx, cfg, snapshotPath, destPath, sigErrCh, logger)
+	return r.executeSync(ctx, cfg, snapshotPath, destPath, sigErrCh, monitorErrCh, logger)
 }
 
 // Run invokes the default runner's Run method.

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -1,0 +1,80 @@
+package root
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/config"
+	"lvmsync_go/transport"
+)
+
+func TestPrepareClientCreatesSnapshotAndCleanup(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+
+	snapCleanupCalled := false
+	var snapshotPtr *string
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(ctx context.Context, cfg *config.Config, snap *string, _ *zap.Logger) (chan os.Signal, chan error) {
+			snapshotPtr = snap
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			return "snap-path", make(chan error), func() { snapCleanupCalled = true }, nil
+		},
+	})
+
+	logger := zap.NewNop()
+	ctx, cleanup, snapPath, destPath, sigCh, monitorCh, err := r.prepareClient(cfg, []string{"/dev/vg/orig", "/dest"}, logger)
+	if err != nil {
+		t.Fatalf("prepareClient error: %v", err)
+	}
+	if ctx == nil || cleanup == nil || sigCh == nil || monitorCh == nil {
+		t.Fatalf("expected non-nil results")
+	}
+	if snapPath != "snap-path" {
+		t.Fatalf("unexpected snapshot path: %s", snapPath)
+	}
+	if destPath != "/dest" {
+		t.Fatalf("unexpected dest path: %s", destPath)
+	}
+	if snapshotPtr == nil || *snapshotPtr != snapPath {
+		t.Fatalf("snapshot path pointer not updated")
+	}
+
+	cleanup()
+	if !snapCleanupCalled {
+		t.Fatalf("snapshot cleanup not invoked")
+	}
+}
+
+func TestPrepareClientSnapshotError(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(ctx context.Context, cfg *config.Config, snap *string, _ *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			return "", nil, nil, errors.New("snap error")
+		},
+	})
+
+	logger := zap.NewNop()
+	if _, cleanup, _, _, _, _, err := r.prepareClient(cfg, []string{"/dev/vg/orig", "/dest"}, logger); err == nil {
+		t.Fatalf("expected snapshot error")
+	} else if cleanup != nil {
+		t.Fatalf("expected nil cleanup on error")
+	}
+}

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -154,3 +154,31 @@ func TestCreateSnapshotCleanupNoPanic(t *testing.T) {
 		t.Fatalf("expected closed monitor channel")
 	}
 }
+
+func TestPrepareSnapshotCreateSnapshotError(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.SkipDiskCheck = true
+	cfg.VolumeGroup = "vg"
+	cfg.TargetVolumeGroup = "vg2"
+
+	r := client.NewRunnerWithDeps(
+		func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 1024, nil },
+		nil,
+		nil,
+		nil,
+		nil,
+		func(context.Context, string, string, string, *zap.Logger) error { return errors.New("create error") },
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	logger := zap.NewNop()
+	if _, _, _, err := r.PrepareSnapshot(context.Background(), cfg, "/dev/vg/orig", logger); err == nil {
+		t.Fatalf("expected create error")
+	}
+}


### PR DESCRIPTION
## Summary
- prepare snapshot during client setup and defer removal
- wire snapshot monitor channel into client execution
- add unit tests for snapshot preparation and root client setup

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a31896822483238d962fdaca90e06f