### PR TITLE
docs: warn on unknown YAML config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document manifest usage, transport security defaults, and resume/verify workflows.
 - compressiondetect: choose zstd when AVX2 or NEON is available.
 - transfer: sample 8 KiB per chunk and log compression decisions.
+- config: warn on unused or unknown keys in YAML config files.
 
 ### Fixed
 - lvm: parse `--lvm-escalation` using shell-style quoting and reject unsafe formats

--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,12 @@ LVMSync binds its command line flags to [Viper](https://github.com/spf13/viper),
 
 Environment variables use the `LVMSYNC_` prefix and match flag names converted to upper case with hyphens replaced by underscores. The `--config` flag can point to an alternative YAML file.
 
+Unused or unknown keys in the YAML file produce runtime warnings to surface typos. For example, a `config.yaml` containing an unrecognized `unused_key` triggers:
+
+```json
+{"level":"warn","msg":"unknown configuration key \"unused_key\""}
+```
+
 ### Examples by Option Group
 
 #### General

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -21,6 +21,7 @@ copies can be verified.
 
 Manifest commands group flags with pflag and bind them to Viper while logging progress with zap.
 Flags override environment variables, which override `config.yaml` values.
+Unused or unknown keys in the YAML file trigger runtime warnings.
 
 | Flag | Environment variable | Config key | Description |
 |------|----------------------|------------|-------------|


### PR DESCRIPTION
## Summary
- document that unknown or unused YAML config keys log warnings
- mention the warning behavior in manifest docs
- note the runtime warnings in the changelog

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a328f5ddac832393ae60e300af26cc