### PR TITLE
Default checksum logger when nil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module lvmsync_go
 go 1.24.3
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/gokrazy/rsync v0.2.10
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.24.0 h1:H4x4TuulnokZKvHLfzVRTHJfFfnHEeSYJizujEZvmAM=
 github.com/bits-and-blooms/bitset v1.24.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=

--- a/transfer/save_checksum_state_test.go
+++ b/transfer/save_checksum_state_test.go
@@ -1,0 +1,49 @@
+package transfer
+
+import (
+        "errors"
+        "os"
+        "path/filepath"
+        "reflect"
+        "testing"
+
+        "bou.ke/monkey"
+        "go.uber.org/zap"
+        "go.uber.org/zap/zaptest/observer"
+)
+
+func TestSaveChecksumState(t *testing.T) {
+        t.Run("nil logger", func(t *testing.T) {
+                filename := filepath.Join(t.TempDir(), "state")
+                state := &ChecksumState{Checksums: make(map[uint64][]byte), Strategy: "sha256"}
+                if err := SaveChecksumState(filename, state, nil); err != nil {
+                        t.Fatalf("SaveChecksumState returned error: %v", err)
+                }
+        })
+
+        t.Run("close warning", func(t *testing.T) {
+                var f *os.File
+                patchChmod := monkey.PatchInstanceMethod(reflect.TypeOf(f), "Chmod", func(*os.File, os.FileMode) error {
+                        return errors.New("chmod fail")
+                })
+                defer patchChmod.Unpatch()
+                patchClose := monkey.PatchInstanceMethod(reflect.TypeOf(f), "Close", func(*os.File) error {
+                        return errors.New("close fail")
+                })
+                defer patchClose.Unpatch()
+
+                core, observed := observer.New(zap.WarnLevel)
+                logger := zap.New(core)
+
+                filename := filepath.Join(t.TempDir(), "state")
+                state := &ChecksumState{Checksums: make(map[uint64][]byte), Strategy: "sha256"}
+                if err := SaveChecksumState(filename, state, logger); err == nil {
+                        t.Fatalf("expected SaveChecksumState error")
+                }
+                logs := observed.FilterMessage("Failed to close checksum state file").All()
+                if len(logs) != 1 {
+                        t.Fatalf("expected 1 warning, got %d", len(logs))
+                }
+        })
+}
+

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -78,10 +78,13 @@ func LoadChecksumState(filename string) (state *ChecksumState, err error) {
 	return state, nil
 }
 
-// SaveChecksumState persists block checksums; logger must be non-nil.
+// SaveChecksumState persists block checksums. It defaults to a no-op logger when nil.
 //
 //revive:disable-next-line:cognitive-complexity
 func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger) (err error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	var file *os.File
 	file, err = os.Create(filename)
 	if err != nil {


### PR DESCRIPTION
## Summary
- ensure SaveChecksumState uses a no-op logger when none provided
- cover nil logger and close warning handling in SaveChecksumState

## Testing
- `GOFLAGS=-gcflags=all=-l go test ./transfer`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a328bb38408323881fc1b8fc7f4ae6