### PR TITLE
test: cover root command

### DIFF
--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -78,3 +78,182 @@ func TestPrepareClientSnapshotError(t *testing.T) {
 		t.Fatalf("expected nil cleanup on error")
 	}
 }
+
+func TestDispatchSubcommand(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	logger := zap.NewNop()
+
+	manifestCalled := false
+	verifyCalled := false
+	r := NewRunnerWithDeps(&Runner{
+		runManifestFn: func(c *config.Config, args []string, _ *zap.Logger) error {
+			manifestCalled = true
+			if args[0] != "arg1" || args[1] != "arg2" {
+				t.Fatalf("unexpected manifest args: %v", args)
+			}
+			return nil
+		},
+		runVerifyFn: func(args []string, _ *zap.Logger) error {
+			verifyCalled = true
+			if args[0] != "varg" {
+				t.Fatalf("unexpected verify args: %v", args)
+			}
+			return nil
+		},
+	})
+
+	handled, err := r.dispatchSubcommand(cfg, []string{"manifest", "arg1", "arg2"}, logger)
+	if err != nil || !handled || !manifestCalled {
+		t.Fatalf("manifest not handled: handled=%v err=%v called=%v", handled, err, manifestCalled)
+	}
+
+	handled, err = r.dispatchSubcommand(cfg, []string{"verify", "varg"}, logger)
+	if err != nil || !handled || !verifyCalled {
+		t.Fatalf("verify not handled: handled=%v err=%v called=%v", handled, err, verifyCalled)
+	}
+
+	if handled, err = r.dispatchSubcommand(cfg, []string{"other"}, logger); handled || err != nil {
+		t.Fatalf("unexpected handling for unknown subcommand: handled=%v err=%v", handled, err)
+	}
+}
+
+func TestDispatchSubcommandError(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		runManifestFn: func(*config.Config, []string, *zap.Logger) error { return errors.New("boom") },
+	})
+	handled, err := r.dispatchSubcommand(cfg, []string{"manifest"}, zap.NewNop())
+	if !handled || err == nil {
+		t.Fatalf("expected manifest error")
+	}
+}
+
+func TestRunSubcommandHandled(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	called := false
+	r := NewRunnerWithDeps(&Runner{
+		runManifestFn: func(*config.Config, []string, *zap.Logger) error { called = true; return nil },
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			t.Fatalf("prepareSnapshot should not be called")
+			return "", nil, nil, nil
+		},
+	})
+	if err := r.Run(cfg, []string{"manifest"}, zap.NewNop()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if !called {
+		t.Fatalf("manifest handler not invoked")
+	}
+}
+
+func TestRunSuccess(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(ctx context.Context, cfg *config.Config, snap *string, _ *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			return "snap", make(chan error), func() {}, nil
+		},
+		executeClientFn: func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
+			return nil
+		},
+	})
+	if err := r.Run(cfg, []string{"/src", "/dst"}, zap.NewNop()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+}
+
+func TestRunPrepareSnapshotError(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(ctx context.Context, cfg *config.Config, snap *string, _ *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			return "", nil, nil, errors.New("snap fail")
+		},
+	})
+	if err := r.Run(cfg, []string{"/src", "/dst"}, zap.NewNop()); err == nil {
+		t.Fatalf("expected snapshot error")
+	}
+}
+
+func TestRunExecuteClientError(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(ctx context.Context, cfg *config.Config, snap *string, _ *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			return "snap", make(chan error), func() {}, nil
+		},
+		executeClientFn: func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
+			return errors.New("exec fail")
+		},
+	})
+	if err := r.Run(cfg, []string{"/src", "/dst"}, zap.NewNop()); err == nil {
+		t.Fatalf("expected execute error")
+	}
+}
+
+func TestConfigure(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"cmd", "/src", "/dst"}
+	cfg, args, logger, err := Configure()
+	if err != nil {
+		t.Fatalf("Configure error: %v", err)
+	}
+	if cfg == nil || logger == nil || len(args) != 2 {
+		t.Fatalf("invalid configure results")
+	}
+}
+
+func TestConfigureError(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"cmd", "--compress-threshold", "2", "/src", "/dst"}
+	if _, _, _, err := Configure(); err == nil {
+		t.Fatalf("expected configure error")
+	}
+}
+
+func TestExecuteRunError(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"cmd", "/src", "/dst"}
+	if err := Execute(); err == nil {
+		t.Fatalf("expected execute error")
+	}
+}
+
+func TestExecuteConfigureError(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"cmd", "--compress-threshold", "2", "/src", "/dst"}
+	if err := Execute(); err == nil {
+		t.Fatalf("expected configure error")
+	}
+}


### PR DESCRIPTION
## Summary
- add root dispatch and run tests for manifest, snapshot, and client execution paths
- verify configuration loading and execution failure handling

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `go test -cover ./cmd/root`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a328bd89908323814b19c2a544f674