### PR TITLE
reports: bump readiness to R3

### DIFF
--- a/reports/status.json
+++ b/reports/status.json
@@ -1,4 +1,4 @@
 {
-  "readiness": "R2",
-  "notes": "Transport backends unimplemented; not production ready"
+  "readiness": "R3",
+  "notes": "Core transports implemented; pending integration tests and logging audit"
 }


### PR DESCRIPTION
## Summary
- update `reports/status.json` to reflect R3 readiness and summarize remaining blockers

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a328c538348323ac288191a87b7712