### PR TITLE
Add manifest rebuild command and regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,7 +958,8 @@ Resume an interrupted transfer using a checkpointed state file:
 lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/data
 ```
 
-Rebuild a manifest index for an existing device:
+Rebuild a manifest index for an existing device. The command verifies the
+current manifest and rewrites it when digests or device metadata have changed:
 
 ```sh
 lvmsync manifest rebuild /dev/vg0/lv0

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -1,6 +1,7 @@
 package lvmsync
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -33,7 +34,7 @@ type RunOptions struct {
 // Runner holds command behaviors to allow dependency injection in tests.
 type Runner struct {
 	run             func(src, dst string, opts RunOptions, logger *zap.Logger) error
-	manifestRebuild func(device string, dryRun bool, logger *zap.Logger) error
+	manifestRebuild func(device string, cfg *config.Config, logger *zap.Logger) error
 	verify          func(args []string, logger *zap.Logger) error
 }
 
@@ -43,8 +44,8 @@ func (r *Runner) Run(src, dst string, opts RunOptions, logger *zap.Logger) error
 }
 
 // ManifestRebuild regenerates a manifest for the specified device.
-func (r *Runner) ManifestRebuild(device string, dryRun bool, logger *zap.Logger) error {
-	return r.manifestRebuild(device, dryRun, logger)
+func (r *Runner) ManifestRebuild(device string, cfg *config.Config, logger *zap.Logger) error {
+	return r.manifestRebuild(device, cfg, logger)
 }
 
 // Verify compares source and destination devices against a manifest.
@@ -55,16 +56,47 @@ func (r *Runner) Verify(args []string, logger *zap.Logger) error {
 // NewRunner constructs a Runner with default no-op behaviors.
 func NewRunner() *Runner {
 	return &Runner{
-		run:             func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil },
-		manifestRebuild: func(device string, dryRun bool, logger *zap.Logger) error { return nil },
-		verify:          func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) },
+		run: func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil },
+		manifestRebuild: func(device string, cfg *config.Config, logger *zap.Logger) error {
+			if cfg.DryRun {
+				logger.Info("dry run - skipping rebuild")
+				return nil
+			}
+			path := cfg.ManifestPath
+			if path == "" {
+				path = device + ".manifest"
+			}
+			ctx := context.Background()
+			if cfg.ManifestTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, cfg.ManifestTimeout)
+				defer cancel()
+			}
+			hybridFixed := uint32(0)
+			if cfg.DedupMode == "hybrid" {
+				hybridFixed = uint32(cfg.BlockSize)
+			}
+			return manifest.Regenerate(
+				ctx,
+				device,
+				path,
+				logger,
+				cfg.ManifestProgressInterval,
+				cfg.ManifestAllowMounted,
+				uint32(cfg.CDCMin),
+				uint32(cfg.CDCAvg),
+				uint32(cfg.CDCMax),
+				hybridFixed,
+			)
+		},
+		verify: func(args []string, logger *zap.Logger) error { return verifycmd.Run(args, logger) },
 	}
 }
 
 // NewRunnerWithDeps constructs a Runner with custom behaviors, useful for tests.
 func NewRunnerWithDeps(
 	run func(src, dst string, opts RunOptions, logger *zap.Logger) error,
-	rebuild func(device string, dryRun bool, logger *zap.Logger) error,
+	rebuild func(device string, cfg *config.Config, logger *zap.Logger) error,
 	verify func(args []string, logger *zap.Logger) error,
 ) *Runner {
 	r := NewRunner()
@@ -164,7 +196,7 @@ func NewRootCmd(logger *zap.Logger, r *Runner) *cobra.Command {
 				fs.Usage()
 				return fmt.Errorf("usage: lvmsync manifest rebuild [flags] <device>")
 			}
-			return r.ManifestRebuild(remaining[0], cfg.DryRun, logger)
+			return r.ManifestRebuild(remaining[0], cfg, logger)
 		},
 	}
 	manifestCmd.AddCommand(rebuildCmd)

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -100,8 +100,8 @@ func TestRunCommandInvalidConfig(t *testing.T) {
 func TestManifestRebuildRoutes(t *testing.T) {
 	var gotDevice string
 	var dry bool
-	r := NewRunnerWithDeps(nil, func(device string, d bool, logger *zap.Logger) error {
-		gotDevice, dry = device, d
+	r := NewRunnerWithDeps(nil, func(device string, cfg *config.Config, logger *zap.Logger) error {
+		gotDevice, dry = device, cfg.DryRun
 		return nil
 	}, nil)
 	if err := ExecuteWithRunner([]string{"manifest", "rebuild", "--dry-run", "/dev/vg0"}, zap.NewNop(), r); err != nil {
@@ -117,7 +117,7 @@ func TestManifestRebuildRoutes(t *testing.T) {
 
 func TestManifestRebuildInvalidConfig(t *testing.T) {
 	called := false
-	r := NewRunnerWithDeps(nil, func(device string, dryRun bool, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(nil, func(device string, cfg *config.Config, logger *zap.Logger) error {
 		called = true
 		return nil
 	}, nil)

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -8,14 +8,16 @@ copies can be verified.
 
 1. Rebuild a manifest for the source device:
    `lvmsync manifest rebuild <device>`
+   This verifies any existing manifest and rewrites it when digests or device
+   metadata change.
 2. Run a transfer using `lvmsync run`.
 3. Verify that the destination matches the manifest:
    `lvmsync verify <source> <dest>`
 
 ## Usage
 
-- `lvmsync manifest rebuild <device>` regenerates a manifest when one is
-  missing or out of date.
+- `lvmsync manifest rebuild <device>` verifies an existing manifest and
+  regenerates it when digests or metadata are stale.
 - `lvmsync verify <source> <dest>` compares a destination against the manifest
   for the source. Override the manifest path with `--manifest-path` if needed.
 

--- a/manifest/rebuild.go
+++ b/manifest/rebuild.go
@@ -1,0 +1,86 @@
+package manifest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
+)
+
+// Regenerate verifies an existing manifest for the device and rebuilds it when missing or stale.
+// The rebuild respects the same options as Rebuild.
+func Regenerate(
+	ctx context.Context,
+	devicePath, manifestPath string,
+	logger *zap.Logger,
+	interval time.Duration,
+	allowMounted bool,
+	cdcMin, cdcAvg, cdcMax, hybridFixed uint32,
+	opts ...IndexOption,
+) error {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	idx, err := Open(manifestPath)
+	if err == nil {
+		defer idx.Close()
+		info, err := os.Stat(devicePath)
+		if err != nil {
+			return err
+		}
+		if uint64(info.Size()) != idx.hdr.SizeBytes || idx.hdr.BlockSize == 0 {
+			return rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, idx, opts...)
+		}
+		f, err := os.Open(devicePath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		buf := make([]byte, idx.hdr.BlockSize)
+		for i := uint64(0); i < idx.hdr.ChunkCount; i++ {
+			if err = ctx.Err(); err != nil {
+				return err
+			}
+			off, length, _, xx, digest, err := idx.Entry(i)
+			if err != nil {
+				return fmt.Errorf("manifest entry: %w", err)
+			}
+			if int(length) > cap(buf) {
+				buf = make([]byte, int(length))
+			}
+			data := buf[:int(length)]
+			if _, err := f.ReadAt(data, int64(off)); err != nil && err != io.EOF {
+				return fmt.Errorf("read device: %w", err)
+			}
+			if xxh3.Hash(data) != xx || blake3.Sum256(data) != digest {
+				return rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, idx, opts...)
+			}
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+	return Rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, opts...)
+}
+
+func rebuild(
+	ctx context.Context,
+	devicePath, manifestPath string,
+	logger *zap.Logger,
+	interval time.Duration,
+	allowMounted bool,
+	cdcMin, cdcAvg, cdcMax, hybridFixed uint32,
+	idx *Index,
+	opts ...IndexOption,
+) error {
+	if idx != nil {
+		idx.Close()
+	}
+	return Rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, opts...)
+}

--- a/manifest/rebuild_test.go
+++ b/manifest/rebuild_test.go
@@ -1,0 +1,114 @@
+package manifest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/device"
+)
+
+func TestRegenerateMissing(t *testing.T) {
+	dir := t.TempDir()
+	dev := filepath.Join(dir, "dev")
+	data := []byte("aaaabbbb")
+	if err := os.WriteFile(dev, data, 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+	man := filepath.Join(dir, "dev.man")
+	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &mockDevice{path: dev, size: uint64(len(data)), blockSize: 4}, nil
+	}
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil)
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("regenerate: %v", err)
+	}
+	idx, err := Open(man)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer idx.Close()
+	off, length, _, xx, dig, err := idx.Entry(0)
+	if err != nil {
+		t.Fatalf("entry: %v", err)
+	}
+	if off != 0 || length != 4 {
+		t.Fatalf("unexpected entry metadata")
+	}
+	if xx != xxh3.Hash(data[:4]) || dig != blake3.Sum256(data[:4]) {
+		t.Fatalf("manifest not rebuilt correctly")
+	}
+}
+
+func TestRegenerateStale(t *testing.T) {
+	dir := t.TempDir()
+	dev := filepath.Join(dir, "dev")
+	orig := []byte("aaaabbbb")
+	if err := os.WriteFile(dev, orig, 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+	man := filepath.Join(dir, "dev.man")
+	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &mockDevice{path: dev, size: uint64(len(orig)), blockSize: 4}, nil
+	}
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil)
+	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	// modify device so manifest becomes stale
+	updated := []byte("ccccdddd")
+	if err := os.WriteFile(dev, updated, 0o600); err != nil {
+		t.Fatalf("update device: %v", err)
+	}
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("regenerate: %v", err)
+	}
+	idx, err := Open(man)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer idx.Close()
+	_, _, _, xx, dig, err := idx.Entry(0)
+	if err != nil {
+		t.Fatalf("entry: %v", err)
+	}
+	if xx != xxh3.Hash(updated[:4]) || dig != blake3.Sum256(updated[:4]) {
+		t.Fatalf("manifest not updated")
+	}
+}
+
+func TestRegenerateExisting(t *testing.T) {
+	dir := t.TempDir()
+	dev := filepath.Join(dir, "dev")
+	data := []byte("aaaabbbb")
+	if err := os.WriteFile(dev, data, 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+	man := filepath.Join(dir, "dev.man")
+	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &mockDevice{path: dev, size: uint64(len(data)), blockSize: 4}, nil
+	}
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil)
+	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	before, err := os.Stat(man)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("regenerate: %v", err)
+	}
+	after, err := os.Stat(man)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("manifest should not change when up to date")
+	}
+}


### PR DESCRIPTION
## Summary
- add manifest.Regenerate to verify existing manifests and rebuild when stale
- wire `lvmsync manifest rebuild` to call regeneration and respect config
- document manifest rebuild workflow and examples

## Testing
- `go build ./...`
- `GOFLAGS="-gcflags=all=-l" go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a330c010f48323b11fa46e4eb3ca5f