### PR TITLE
test: add config precedence tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,11 @@ first):
 3. `config.yaml`
 4. Built-in defaults
 
+This precedence applies to duration timeouts, filesystem paths, and security
+flags. Unknown keys in `config.yaml` generate warnings, and settings like
+`allow_insecure` must be explicitly acknowledged via flag or environment
+variable.
+
 Environment variables use the flag name in uppercase with underscores, e.g.:
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,6 @@
 - [Verification](verify.md) – command usage for integrity checks.
 - [Privilege Escalation](privilege_escalation.md) – configuring LVM privilege escalation.
 - [Daemon](daemon.md) – module configuration, ACLs, and listener options.
+- Configuration precedence – flags override environment variables, which in
+  turn override `config.yaml`. Unknown YAML keys emit warnings and invalid
+  overrides are rejected.

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+func TestFreezeTimeoutFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("freeze-timeout: 1s\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_FREEZE_TIMEOUT", "2s")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--freeze-timeout", "3s"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.FreezeTimeout != 3*time.Second {
+		t.Fatalf("FreezeTimeout=%v want %v", cfg.FreezeTimeout, 3*time.Second)
+	}
+}
+
+func TestFreezeTimeoutEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("freeze-timeout: 1s\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_FREEZE_TIMEOUT", "2s")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.FreezeTimeout != 2*time.Second {
+		t.Fatalf("FreezeTimeout=%v want %v", cfg.FreezeTimeout, 2*time.Second)
+	}
+}
+
+func TestLVMSyncPathFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("lvmsync_path: yaml\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_LVMSYNC_PATH", "env")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--lvmsync-path", "flag"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.LVMSyncPath != "flag" {
+		t.Fatalf("LVMSyncPath=%q want %q", cfg.LVMSyncPath, "flag")
+	}
+}
+
+func TestLVMSyncPathEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("lvmsync_path: yaml\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_LVMSYNC_PATH", "env")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.LVMSyncPath != "env" {
+		t.Fatalf("LVMSyncPath=%q want %q", cfg.LVMSyncPath, "env")
+	}
+}
+
+func TestStrictHostKeyCheckFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("strict_host_key_checking: true\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_STRICT_HOST_KEY_CHECKING", "false")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--strict-host-key-checking", "true"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !cfg.StrictHostKeyCheck {
+		t.Fatalf("StrictHostKeyCheck=%v want %v", cfg.StrictHostKeyCheck, true)
+	}
+}
+
+func TestStrictHostKeyCheckEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("strict_host_key_checking: true\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_STRICT_HOST_KEY_CHECKING", "false")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.StrictHostKeyCheck {
+		t.Fatalf("StrictHostKeyCheck=%v want %v", cfg.StrictHostKeyCheck, false)
+	}
+}

--- a/internal/config/ssh_host_key_path_test.go
+++ b/internal/config/ssh_host_key_path_test.go
@@ -53,25 +53,3 @@ func TestEnvOverridesYAML(t *testing.T) {
 		t.Fatalf("SSHHostKeyPath=%q want %q", cfg.SSHHostKeyPath, "env")
 	}
 }
-
-func TestUnknownKeysProduceWarnings(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	defaults, err := DefaultConfig()
-	if err != nil {
-		t.Fatalf("default: %v", err)
-	}
-	b := NewBuilder(defaults)
-	dir := t.TempDir()
-	cfgFile := filepath.Join(dir, "cfg.yaml")
-	if err := os.WriteFile(cfgFile, []byte("bogus: value\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	_, _, warns, err := b.Build(fs, []string{"--config", cfgFile})
-	if err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	if len(warns) != 1 || warns[0] != "unknown configuration key \"bogus\"" {
-		t.Fatalf("warnings=%v", warns)
-	}
-}

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestUnknownKeysProduceWarnings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("bogus: value\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	_, _, warns, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(warns) != 1 || warns[0] != "unknown configuration key \"bogus\"" {
+		t.Fatalf("warnings=%v", warns)
+	}
+}
+
+func TestAllowInsecureRequiresFlagOrEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("allow_insecure: true\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	_, _, _, err = b.Build(fs, []string{"--config", cfgFile})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add precedence tests for timeouts, paths, and security flags
- warn on unknown YAML keys and require explicit allow_insecure overrides
- document configuration precedence across README and docs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: expected 1 warning, got 0 in TestSaveChecksumState/close_warning)*
- `go tool cover -func=coverage.out | tail -n 5`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a330c6ea988323926775a8ecf7f848