### PR TITLE
Handle exit codes for lvmsyncd

### DIFF
--- a/cmd/lvmsyncd/lvmsyncd.go
+++ b/cmd/lvmsyncd/lvmsyncd.go
@@ -21,6 +21,7 @@ import (
 
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/transport"
 	_ "lvmsync_go/transport/h2"
 	_ "lvmsync_go/transport/quic"
@@ -271,9 +272,23 @@ func handleConn(ctx context.Context, conn net.Conn, tr transport.Interface, modu
 	return nil
 }
 
+func mapExitCode(err error) int {
+	if err == nil {
+		return exitcode.OK
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "parse") || strings.Contains(msg, "missing") || strings.Contains(msg, "required") || strings.Contains(msg, "invalid") {
+		return exitcode.ErrConfig
+	}
+	if strings.Contains(msg, "device") {
+		return exitcode.ErrDevice
+	}
+	return exitcode.ErrRuntime
+}
+
 func main() {
 	logger, _ := zap.NewProduction()
 	if err := run(os.Args[1:], logger); err != nil {
-		os.Exit(1)
+		os.Exit(mapExitCode(err))
 	}
 }

--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"lvmsync_go/common"
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/transport"
 )
 
@@ -122,5 +124,24 @@ func TestListenerSetup(t *testing.T) {
 	}
 	if len(addrs) != 2 || addrs[0] != ":1111" || addrs[1] != ":2222" {
 		t.Fatalf("listener addresses %v", addrs)
+	}
+}
+
+func TestMapExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"success", nil, exitcode.OK},
+		{"config", errors.New("parse listen"), exitcode.ErrConfig},
+		{"runtime", errors.New("listen failed"), exitcode.ErrRuntime},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if c := mapExitCode(tt.err); c != tt.code {
+				t.Fatalf("expected %d, got %d", tt.code, c)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- map lvmsyncd errors to structured exit codes
- add unit tests for exit code mapping

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a34e444f408323b51f35cf9d890916