### PR TITLE
feat: inject privilege escalator in configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ command-line use, environment variables, and `config.yaml` files.
   `NewRunnerWithDeps` constructors so tests can inject mocks.
 - Callers and subcommands should invoke methods on a `Runner` instance rather than
   modifying global variables.
+- Privilege checks rely on a `privilege.Escalator` interface. `cmd/root.ConfigureWithEscalator`
+  accepts an `Escalator` so tests can stub privilege escalation without invoking
+  real `sudo`.
 
 ## Device Detection
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -108,8 +108,10 @@ func SyncLogger(logger *zap.Logger) {
 	}
 }
 
-// Configure loads configuration, ensures privileges, validates, and sets up logging.
-func Configure() (*config.Config, []string, *zap.Logger, error) {
+// ConfigureWithEscalator loads configuration, ensures privileges via the provided
+// privilege.Escalator, validates, and sets up logging. A nil escalator defaults
+// to the production implementation.
+func ConfigureWithEscalator(esc privilege.Escalator) (*config.Config, []string, *zap.Logger, error) {
 	defaults, err := config.DefaultConfig()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("configuration error: %w", err)
@@ -122,7 +124,9 @@ func Configure() (*config.Config, []string, *zap.Logger, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.LVMTimeout)
 	defer cancel()
-	esc := privilege.New(ctx)
+	if esc == nil {
+		esc = privilege.New(ctx)
+	}
 	if err = esc.Ensure(ctx); err != nil {
 		return nil, nil, nil, fmt.Errorf("privilege check failed: %w", err)
 	}
@@ -154,6 +158,12 @@ func Configure() (*config.Config, []string, *zap.Logger, error) {
 		zap.String("lvmsync_path", cfg.LVMSyncPath),
 	)
 	return cfg, args, logger, nil
+}
+
+// Configure loads configuration, ensures privileges, validates, and sets up
+// logging using the default privilege escalator.
+func Configure() (*config.Config, []string, *zap.Logger, error) {
+	return ConfigureWithEscalator(nil)
 }
 
 // PrepareSnapshot wraps snapshot preparation.

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -4,13 +4,25 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"testing"
 
 	"go.uber.org/zap"
 
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/transport"
 )
+
+type stubEscalator struct{ err error }
+
+func (s stubEscalator) Ensure(context.Context) error { return s.err }
+
+func (s stubEscalator) Command(context.Context, string, ...string) *exec.Cmd {
+	return exec.Command("true")
+}
+
+var _ privilege.Escalator = (*stubEscalator)(nil)
 
 func TestPrepareClientCreatesSnapshotAndCleanup(t *testing.T) {
 	cfg, err := config.DefaultConfig()
@@ -221,21 +233,32 @@ func TestRunExecuteClientError(t *testing.T) {
 func TestConfigure(t *testing.T) {
 	orig := os.Args
 	defer func() { os.Args = orig }()
-	os.Args = []string{"cmd", "/src", "/dst"}
-	cfg, args, logger, err := Configure()
-	if err != nil {
-		t.Fatalf("Configure error: %v", err)
-	}
-	if cfg == nil || logger == nil || len(args) != 2 {
-		t.Fatalf("invalid configure results")
-	}
+
+	t.Run("success", func(t *testing.T) {
+		os.Args = []string{"cmd", "/src", "/dst"}
+		cfg, args, logger, err := ConfigureWithEscalator(stubEscalator{})
+		if err != nil {
+			t.Fatalf("Configure error: %v", err)
+		}
+		if cfg == nil || logger == nil || len(args) != 2 {
+			t.Fatalf("invalid configure results")
+		}
+	})
+
+	t.Run("escalation failure", func(t *testing.T) {
+		os.Args = []string{"cmd", "/src", "/dst"}
+		_, _, _, err := ConfigureWithEscalator(stubEscalator{err: errors.New("boom")})
+		if err == nil {
+			t.Fatalf("expected configure error")
+		}
+	})
 }
 
-func TestConfigureError(t *testing.T) {
+func TestConfigureConfigError(t *testing.T) {
 	orig := os.Args
 	defer func() { os.Args = orig }()
 	os.Args = []string{"cmd", "--compress-threshold", "2", "/src", "/dst"}
-	if _, _, _, err := Configure(); err == nil {
+	if _, _, _, err := ConfigureWithEscalator(stubEscalator{}); err == nil {
 		t.Fatalf("expected configure error")
 	}
 }


### PR DESCRIPTION
## Summary
- add `ConfigureWithEscalator` to inject a `privilege.Escalator`
- provide stub escalator for tests and cover success and failure cases
- document escalation interface usage for dependency injection

## Testing
- `go build ./...`
- `go test ./cmd/root ./internal/privilege`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a34e48d27483239d8b983c08047130