### PR TITLE
require explicit logger parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ command-line use, environment variables, and `config.yaml` files.
 - Transport constructors must accept a `*zap.Logger`; avoid package-level loggers.
 - Pass loggers explicitly to commands and helpers; do not use `zap.L()` or other globals.
 - Use `zap.NewNop()` instead of `nil` when no logging is needed.
+- Constructors and other exported functions must require a non-nil logger; callers
+  must always supply one (use `zap.NewNop()` to disable logging).
 - Log connection lifecycle events and errors with `snake_case` fields including units (e.g., `bytes_transferred`, `duration_ms`).
 - Do not log secrets or authentication tokens; scrub sensitive values before emitting them.
 - Callers using transports should `defer rootcmd.SyncLogger(logger)` to ensure logs are flushed.

--- a/device/detect.go
+++ b/device/detect.go
@@ -97,9 +97,6 @@ func Detect(
 	logger *zap.Logger,
 	runner *Runner,
 ) (Device, error) {
-	if logger == nil {
-		return nil, fmt.Errorf("logger is nil")
-	}
 	if runner == nil {
 		runner = NewRunner()
 	}

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -65,12 +65,6 @@ func TestDetectFile(t *testing.T) {
 	}
 }
 
-func TestDetectNilLogger(t *testing.T) {
-	if _, err := Detect(context.Background(), "", true, "", "", "", "", 0, 0, nil, NewRunner()); err == nil {
-		t.Fatalf("expected error when logger is nil")
-	}
-}
-
 func TestDetectFileSymlink(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "file")
 	if err != nil {

--- a/device/file.go
+++ b/device/file.go
@@ -20,9 +20,6 @@ type FileDevice struct {
 // OpenFile opens a regular file and reports its size and filesystem block size.
 // logger must be non-nil.
 func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
-	if logger == nil {
-		return nil, fmt.Errorf("logger is nil")
-	}
 	info, err := os.Stat(path)
 	if err != nil {
 		logger.Error("file_device_open_failed", zap.String("path", path), zap.Error(err))

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -65,17 +65,6 @@ func TestOpenFileRejectsNonRegular(t *testing.T) {
 	}
 }
 
-func TestOpenFileNilLogger(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "file")
-	if err != nil {
-		t.Fatalf("temp file: %v", err)
-	}
-	f.Close()
-	if _, err := OpenFile(f.Name(), nil); err == nil {
-		t.Fatalf("expected error when logger is nil")
-	}
-}
-
 func fdCount(t *testing.T) int {
 	t.Helper()
 	entries, err := os.ReadDir("/proc/self/fd")

--- a/device/raw.go
+++ b/device/raw.go
@@ -118,9 +118,6 @@ func OpenRaw(
 	logger *zap.Logger,
 	runner *Runner,
 ) (_ *RawDevice, err error) {
-	if logger == nil {
-		return nil, fmt.Errorf("logger is nil")
-	}
 	if runner == nil {
 		runner = NewRunner()
 	}

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -55,12 +55,6 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	}
 }
 
-func TestOpenRawNilLogger(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "", true, "", nil, "", nil, 0, 0, nil, NewRunner()); err == nil {
-		t.Fatalf("expected error when logger is nil")
-	}
-}
-
 func TestRawDeviceCloseErrorLogging(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root")

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -433,8 +433,9 @@ func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 // Rebuild creates a manifest index for device at output path.
 // DeviceID is determined via the configured DeviceInfoProvider. The device is read sequentially using blockSize-sized chunks.
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.
-// The operation respects cancellation via ctx.
-// When allowMounted is false, Rebuild aborts if the device is mounted read-write.
+// The operation respects cancellation via ctx. When allowMounted is false,
+// Rebuild aborts if the device is mounted read-write. logger must be non-nil;
+// pass zap.NewNop() to disable logging.
 func Rebuild(
 	ctx context.Context,
 	devicePath, output string,
@@ -445,9 +446,6 @@ func Rebuild(
 	opts ...IndexOption,
 ) (err error) {
 	cfg := applyOptions(opts)
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	if err = ctx.Err(); err != nil {
 		return err
 	}

--- a/manifest/rebuild.go
+++ b/manifest/rebuild.go
@@ -13,7 +13,8 @@ import (
 )
 
 // Regenerate verifies an existing manifest for the device and rebuilds it when missing or stale.
-// The rebuild respects the same options as Rebuild.
+// The rebuild respects the same options as Rebuild. logger must be non-nil;
+// pass zap.NewNop() to disable logging.
 func Regenerate(
 	ctx context.Context,
 	devicePath, manifestPath string,
@@ -23,9 +24,6 @@ func Regenerate(
 	cdcMin, cdcAvg, cdcMax, hybridFixed uint32,
 	opts ...IndexOption,
 ) error {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	idx, err := Open(manifestPath)
 	if err == nil {
 		defer idx.Close()

--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -26,11 +26,9 @@ type PrivHelperClient struct {
 // StartPrivHelper starts the remote privileged helper using the provided SSH client.
 // The helper reads (index, payload, hash) messages and performs pwrite operations.
 // The provided context controls the lifetime of the startup; if it is canceled
-// before the remote command begins executing, an error is returned.
+// before the remote command begins executing, an error is returned. logger must
+// be non-nil; use zap.NewNop() to disable logging.
 func StartPrivHelper(ctx context.Context, client *ssh.Client, command string, logger *zap.Logger) (*PrivHelperClient, error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	command = strings.TrimSpace(command)
 	if !ValidRemoteCommand(command) {
 		return nil, fmt.Errorf("remote command %s contains invalid characters", command)

--- a/remote/ssh_manager.go
+++ b/remote/ssh_manager.go
@@ -53,12 +53,9 @@ func WithPrivateKeyParser(p func([]byte) (ssh.Signer, error)) SSHManagerOption {
 // knownHostsPath. The timeout applies to establishing new connections.
 //
 // The provided ctx controls cancellation for initialization steps such as
-// retrieving authentication methods. It should include a deadline.
+// retrieving authentication methods. It should include a deadline. logger must
+// be non-nil; pass zap.NewNop() to disable logging.
 func NewSSHManager(ctx context.Context, user, keyPath string, timeout time.Duration, knownHostsPath string, logger *zap.Logger, opts ...SSHManagerOption) (*SSHManager, error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-
 	mgr := &SSHManager{
 		clients:         make(map[string]*sshClientEntry),
 		timeout:         timeout,

--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -70,10 +70,9 @@ func (s *SSHSession) Close() {
 	}
 }
 
+// RunSSHCommand executes a command on a remote host over SSH and logs using logger.
+// logger must be non-nil; pass zap.NewNop() to disable logging.
 func RunSSHCommand(ctx context.Context, logger *zap.Logger, host, user, keyPath, hostKeyPath string, port int, command string, timeout time.Duration) error {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	publicKey, err := readHostPublicKey(hostKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to load host public key: %w", err)

--- a/transfer/compression.go
+++ b/transfer/compression.go
@@ -145,11 +145,8 @@ func estimateRatio(data []byte, algo string, level, concurrency int) (float64, e
 // settings. Compression is skipped when the estimated ratio exceeds the
 // threshold. The returned string indicates the algorithm used; "none" means no
 // compression was applied. Decisions are logged using the provided logger.
+// logger must be non-nil; use zap.NewNop() to disable logging.
 func CompressChunk(data []byte, compress string, lz4Level, zstdLevel, concurrency int, threshold float64, logger *zap.Logger) ([]byte, string, error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-
 	algo, lvl := selectAlgorithm(len(data), compress, lz4Level, zstdLevel)
 	if algo == "none" {
 		logger.Debug("compression_disabled")

--- a/transfer/save_checksum_state_test.go
+++ b/transfer/save_checksum_state_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func TestSaveChecksumState(t *testing.T) {
-	t.Run("nil logger", func(t *testing.T) {
+	t.Run("no logging", func(t *testing.T) {
 		filename := filepath.Join(t.TempDir(), "state")
 		state := &ChecksumState{Checksums: make(map[uint64][]byte), Strategy: "sha256"}
-		if err := SaveChecksumState(filename, state, nil); err != nil {
+		if err := SaveChecksumState(filename, state, zap.NewNop()); err != nil {
 			t.Fatalf("SaveChecksumState returned error: %v", err)
 		}
 	})

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -31,12 +31,9 @@ type Transfer struct {
 }
 
 // NewTransfer creates a Transfer with the provided logger and wait group.
-// When wg is nil, a new instance is allocated. A nil logger is replaced with
-// zap.NewNop().
+// When wg is nil, a new instance is allocated. logger must be non-nil; callers
+// wanting no logs should pass zap.NewNop().
 func NewTransfer(logger *zap.Logger, wg *sync.WaitGroup, info device.DeviceInfoProvider) *Transfer {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	if wg == nil {
 		wg = &sync.WaitGroup{}
 	}
@@ -78,13 +75,11 @@ func LoadChecksumState(filename string) (state *ChecksumState, err error) {
 	return state, nil
 }
 
-// SaveChecksumState persists block checksums. It defaults to a no-op logger when nil.
+// SaveChecksumState persists block checksums. logger must be non-nil; use
+// zap.NewNop() to disable logging.
 //
 //revive:disable-next-line:cognitive-complexity
 func SaveChecksumState(filename string, state *ChecksumState, logger *zap.Logger) (err error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	var file *os.File
 	file, err = os.Create(filename)
 	if err != nil {

--- a/transfer/transfer_basic_test.go
+++ b/transfer/transfer_basic_test.go
@@ -68,8 +68,8 @@ func TestNewDeduplicationStrategyInvalidBloomEntries(t *testing.T) {
 	}
 }
 
-func TestNewTransferNilLogger(t *testing.T) {
-	tr := NewTransfer(nil, nil, nil)
+func TestNewTransfer(t *testing.T) {
+	tr := NewTransfer(zap.NewNop(), nil, nil)
 	if tr.Logger == nil {
 		t.Fatal("expected non-nil logger")
 	}


### PR DESCRIPTION
## Summary
- remove nil logger fallbacks from constructors in remote, transfer, device, and manifest packages
- update callers and tests to pass `zap.NewNop()` when logging is disabled
- document non-nil logger requirement for constructors in `AGENTS.md`

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a34e4aefc48323ae46bb6acf4d44cc