### PR TITLE
escalate: allow disabling env sanitization

### DIFF
--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -99,16 +99,20 @@ func EnsureRootOrReexec(opts Options) (bool, error) {
 	}
 	args = append(args, filterAllowed(argv[1:], opts.AllowedPassthrough)...)
 
-	env := ([]string)(nil)
-	if opts.SanitizeEnv || (opts.Environ == nil && opts.SanitizeEnv == false) {
+	var env []string
+	switch {
+	case opts.SanitizeEnv:
 		// Default is true unless explicitly false.
-		if opts.Environ == nil {
-			env = sanitizedChildEnv(os.Environ())
-		} else {
+		if opts.Environ != nil {
 			env = sanitizedChildEnv(opts.Environ())
+		} else {
+			env = sanitizedChildEnv(os.Environ())
 		}
-	} else if opts.Environ != nil {
+	case opts.Environ != nil:
 		env = opts.Environ()
+	default:
+		// SanitizeEnv explicitly false and no custom Environ: inherit the
+		// current environment by leaving env nil.
 	}
 
 	stdin := opts.Stdin // nil by default (no TTY password prompts)

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -249,6 +249,52 @@ func TestEnsureRootOrReexec_DropsDisallowedFlags(t *testing.T) {
 	}
 }
 
+func TestEnsureRootOrReexec_DefaultSanitizedEnv(t *testing.T) {
+	var got execCall
+	t.Setenv("LD_PRELOAD", "/tmp/x.so")
+	t.Setenv("LANG", "C")
+	t.Setenv("TERM", "dumb")
+	reexeced, err := EnsureRootOrReexec(Options{
+		Geteuid:     func() int { return 1000 },
+		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
+		SanitizeEnv: true,
+		ExecRunner:  fakeRunner(&got, nil),
+	})
+	if err != nil || !reexeced {
+		t.Fatalf("unexpected result: %v %v", reexeced, err)
+	}
+	if got.env == nil {
+		t.Fatal("expected sanitized env")
+	}
+	joined := strings.Join(got.env, "\n")
+	if strings.Contains(joined, "LD_PRELOAD=") {
+		t.Fatalf("LD_PRELOAD leaked: %v", got.env)
+	}
+	if !strings.Contains(joined, "LANG=C") || !strings.Contains(joined, "TERM=dumb") {
+		t.Fatalf("whitelisted vars missing: %v", got.env)
+	}
+	if got.env[0] != "PATH=/usr/sbin:/usr/bin:/sbin:/bin" {
+		t.Fatalf("unexpected PATH: %q", got.env[0])
+	}
+}
+
+func TestEnsureRootOrReexec_UnsanitizedEnv(t *testing.T) {
+	var got execCall
+	t.Setenv("LD_PRELOAD", "/tmp/x.so")
+	reexeced, err := EnsureRootOrReexec(Options{
+		Geteuid:     func() int { return 1000 },
+		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
+		SanitizeEnv: false,
+		ExecRunner:  fakeRunner(&got, nil),
+	})
+	if err != nil || !reexeced {
+		t.Fatalf("unexpected result: %v %v", reexeced, err)
+	}
+	if len(got.env) != 0 {
+		t.Fatalf("expected empty env to inherit unsanitized environment, got %v", got.env)
+	}
+}
+
 func TestEnsureRootOrReexec_ErrorLogging(t *testing.T) {
 	var got execCall
 	core, logs := observer.New(zapcore.ErrorLevel)


### PR DESCRIPTION
## Summary
- honor `SanitizeEnv=false` even when no custom environment is supplied
- exercise sanitized and unsanitized re-exec paths in unit tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRunRemoteDumpTimeout, unresolved gaps)*
- `go test -coverprofile=coverage.out $(go list ./... | grep -v reports | grep -v cmd/dump)`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a35a9a47448323b6f47a282f857dac