### PR TITLE
remote: improve RunSSHCommand handling

### DIFF
--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -71,8 +71,9 @@ func (s *SSHSession) Close() {
 }
 
 // RunSSHCommand executes a command on a remote host over SSH and logs using logger.
+// stdout and stderr direct command output; nil values are replaced with io.Discard.
 // logger must be non-nil; pass zap.NewNop() to disable logging.
-func RunSSHCommand(ctx context.Context, logger *zap.Logger, host, user, keyPath, hostKeyPath string, port int, command string, timeout time.Duration) error {
+func RunSSHCommand(ctx context.Context, logger *zap.Logger, host, user, keyPath, hostKeyPath string, port int, command string, timeout time.Duration, stdout, stderr io.Writer) error {
 	publicKey, err := readHostPublicKey(hostKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to load host public key: %w", err)
@@ -103,15 +104,30 @@ func RunSSHCommand(ctx context.Context, logger *zap.Logger, host, user, keyPath,
 	}
 	defer session.Close()
 
-	var stdoutBuf, stderrBuf io.Writer
-	cmdErr := session.Start(command, nil, stdoutBuf, stderrBuf)
-	if cmdErr != nil {
-		return fmt.Errorf("failed to start command: %w", cmdErr)
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
 	}
 
-	err = session.Wait()
-	if err != nil {
-		return fmt.Errorf("SSH command failed: %w", err)
+	errCh := make(chan error, 1)
+	if err := session.Start(command, nil, stdout, stderr); err != nil {
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+	go func() { errCh <- session.Wait() }()
+
+	select {
+	case <-ctx.Done():
+		if sigErr := session.Session.Signal(ssh.SIGKILL); sigErr != nil && !errors.Is(sigErr, io.EOF) {
+			logger.Warn("session signal error", zap.Error(sigErr))
+		}
+		<-errCh
+		return ctx.Err()
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("SSH command failed: %w", err)
+		}
 	}
 
 	logger.Info("SSH command completed", zap.String("host", host), zap.String("command", command))

--- a/remote/ssh_session_test.go
+++ b/remote/ssh_session_test.go
@@ -2,14 +2,20 @@ package remote
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	remotetest "lvmsync_go/remote/testutil"
 
+	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -45,5 +51,91 @@ func TestLoadHostPublicKey(t *testing.T) {
 	}
 	if _, err := readHostPublicKey(filepath.Join(t.TempDir(), "missing")); err == nil {
 		t.Fatalf("expected error for missing host key")
+	}
+}
+
+func TestRunSSHCommandSuccess(t *testing.T) {
+	srv := remotetest.NewMockSSHServerWithChannel(t, func(cmd string, ch ssh.Channel) int {
+		ch.Write([]byte("out"))          //nolint:errcheck
+		ch.Stderr().Write([]byte("err")) //nolint:errcheck
+		return 0
+	})
+	defer srv.Close()
+
+	keyFile := remotetest.CreateTempKey(t)
+	hostKey := filepath.Join(t.TempDir(), "host_key.pub")
+	if err := os.WriteFile(hostKey, srv.PublicKey.Marshal(), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	host, portStr, err := net.SplitHostPort(srv.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := RunSSHCommand(context.Background(), zap.NewNop(), host, "test", keyFile, hostKey, port, "cmd", time.Second, &stdout, &stderr); err != nil {
+		t.Fatalf("RunSSHCommand: %v", err)
+	}
+	if stdout.String() != "out" {
+		t.Fatalf("unexpected stdout %q", stdout.String())
+	}
+	if stderr.String() != "err" {
+		t.Fatalf("unexpected stderr %q", stderr.String())
+	}
+}
+
+func TestRunSSHCommandFailure(t *testing.T) {
+	srv := remotetest.NewMockSSHServer(t, func(cmd string) int { return 1 })
+	defer srv.Close()
+
+	keyFile := remotetest.CreateTempKey(t)
+	hostKey := filepath.Join(t.TempDir(), "host_key.pub")
+	if err := os.WriteFile(hostKey, srv.PublicKey.Marshal(), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	host, portStr, err := net.SplitHostPort(srv.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+
+	if err := RunSSHCommand(context.Background(), zap.NewNop(), host, "test", keyFile, hostKey, port, "cmd", time.Second, nil, nil); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRunSSHCommandTimeout(t *testing.T) {
+	srv := remotetest.NewMockSSHServer(t, func(cmd string) int {
+		time.Sleep(200 * time.Millisecond)
+		return 0
+	})
+	defer srv.Close()
+
+	keyFile := remotetest.CreateTempKey(t)
+	hostKey := filepath.Join(t.TempDir(), "host_key.pub")
+	if err := os.WriteFile(hostKey, srv.PublicKey.Marshal(), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	host, portStr, err := net.SplitHostPort(srv.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if err := RunSSHCommand(ctx, zap.NewNop(), host, "test", keyFile, hostKey, port, "cmd", time.Second, nil, nil); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- allow `RunSSHCommand` to stream stdout/stderr to provided writers or discard by default
- respect context cancellation by killing the remote process
- add tests for success, failure, and timeout scenarios

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a371d2090883239df2d44d934795d3