### PR TITLE
remove closed ssh sessions from multiplexer

### DIFF
--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -17,6 +17,7 @@ import (
 type SSHSession struct {
 	Client  *SSHClient
 	Session *ssh.Session
+	host    string
 }
 
 type SSHMultiplexer struct {
@@ -41,6 +42,7 @@ func GetMultiplexedSession(client *SSHClient, host string) (*SSHSession, error) 
 		return nil, err
 	}
 
+	session.host = host
 	multiplexer.sessions[host] = session
 	return session, nil
 }
@@ -68,6 +70,16 @@ func (s *SSHSession) Close() {
 	if err := s.Session.Close(); err != nil && !errors.Is(err, io.EOF) {
 		s.Client.Logger.Warn("session close error", zap.Error(err))
 	}
+	if s.host != "" {
+		RemoveSession(s.host)
+	}
+}
+
+// RemoveSession deletes the cached session for the given host.
+func RemoveSession(host string) {
+	multiplexer.mu.Lock()
+	defer multiplexer.mu.Unlock()
+	delete(multiplexer.sessions, host)
 }
 
 // RunSSHCommand executes a command on a remote host over SSH and logs using logger.

--- a/remote/ssh_session_cache_test.go
+++ b/remote/ssh_session_cache_test.go
@@ -1,0 +1,49 @@
+package remote
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestSessionCloseRemovesFromCache(t *testing.T) {
+	multiplexer.mu.Lock()
+	multiplexer.sessions = make(map[string]*SSHSession)
+	multiplexer.mu.Unlock()
+
+	_, rawClient := newSSHServerClient(t, func(string) int { return 0 })
+	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
+
+	const host = "cachehost"
+
+	s1, err := GetMultiplexedSession(client, host)
+	if err != nil {
+		t.Fatalf("GetMultiplexedSession first: %v", err)
+	}
+
+	s2, err := GetMultiplexedSession(client, host)
+	if err != nil {
+		t.Fatalf("GetMultiplexedSession second: %v", err)
+	}
+	if s1 != s2 {
+		t.Fatalf("expected cached session reuse")
+	}
+
+	s1.Close()
+
+	multiplexer.mu.Lock()
+	_, ok := multiplexer.sessions[host]
+	multiplexer.mu.Unlock()
+	if ok {
+		t.Fatalf("session not removed from cache")
+	}
+
+	s3, err := GetMultiplexedSession(client, host)
+	if err != nil {
+		t.Fatalf("GetMultiplexedSession after close: %v", err)
+	}
+	if s3 == s1 {
+		t.Fatalf("expected new session after close")
+	}
+	s3.Close()
+}


### PR DESCRIPTION
## Summary
- track host for each SSH session and remove it from multiplexer on close
- add RemoveSession helper for cache deletion
- test session caching and removal

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a371d336008323af52a8a6968d6378