### PR TITLE
dedup: reuse entropy counts

### DIFF
--- a/dedup/chunker.go
+++ b/dedup/chunker.go
@@ -33,6 +33,9 @@ type Chunker struct {
 	// reusable buffer to avoid per-chunk allocations
 	buf []byte
 
+	// reusable entropy counts window to avoid per-chunk allocations
+	counts [256]int
+
 	// gear table allowing deterministic seeding
 	gear [256]uint64
 }
@@ -112,9 +115,12 @@ func (c *Chunker) NextChunk(r io.Reader) (Chunk, error) {
 	// initialize entropy window
 	copy(c.window[:], buf[size-64:size])
 	c.winPos = 0
-	counts := [256]int{}
+	// reset reusable entropy counts
+	for i := range c.counts {
+		c.counts[i] = 0
+	}
 	for _, b := range c.window {
-		counts[b]++
+		c.counts[b]++
 	}
 
 	for size < c.Max {
@@ -130,7 +136,7 @@ func (c *Chunker) NextChunk(r io.Reader) (Chunk, error) {
 		// update rolling hash
 		h = (h << 1) + c.gear[b[0]]
 		// update entropy window and determine mask
-		e := c.updateEntropy(b[0], &counts)
+		e := c.updateEntropy(b[0], &c.counts)
 		mask := c.selectMask(e)
 
 		if size >= c.Min && h&mask == 0 {

--- a/dedup/chunker_benchmark_test.go
+++ b/dedup/chunker_benchmark_test.go
@@ -1,0 +1,21 @@
+package dedup
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkChunkerNextChunk(b *testing.B) {
+	data := make([]byte, 1024)
+	ch, err := NewChunker(64, 128, 256)
+	if err != nil {
+		b.Fatalf("new chunker: %v", err)
+	}
+	ch.buf = make([]byte, ch.Max)
+	r := bytes.NewReader(data)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		r.Reset(data)
+		_, _ = ch.NextChunk(r)
+	}
+}

--- a/dedup/chunker_test.go
+++ b/dedup/chunker_test.go
@@ -110,3 +110,20 @@ func TestChunkerSeedAffectsBoundaries(t *testing.T) {
 		t.Fatalf("expected different chunk boundaries with different seeds")
 	}
 }
+
+func TestChunkerNextChunkAllocations(t *testing.T) {
+	data := make([]byte, 1024)
+	ch, err := NewChunker(64, 128, 256)
+	if err != nil {
+		t.Fatalf("new chunker: %v", err)
+	}
+	ch.buf = make([]byte, ch.Max)
+	r := bytes.NewReader(nil)
+	allocs := testing.AllocsPerRun(100, func() {
+		r.Reset(data)
+		_, _ = ch.NextChunk(r)
+	})
+	if allocs > 1 {
+		t.Fatalf("expected at most one allocation, got %f", allocs)
+	}
+}


### PR DESCRIPTION
## Summary
- reuse an internal `[256]int]` for entropy counts
- benchmark and test ensure `NextChunk` avoids extra allocations

## Testing
- `go build ./...`
- `go test -cover ./...`
- `go test ./dedup -bench BenchmarkChunkerNextChunk -run ^$ -count=1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a371dd534883238e56aaf8f5ddfb51