### PR TITLE
manifest: sync header on creation

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -234,6 +234,14 @@ func Create(path, deviceID string, size uint64, blockSize, cdcMin, cdcAvg, cdcMa
 	idx.hdr.MAC = headerMAC(&idx.hdr)
 	idx.writeHeader()
 	idx.initTables()
+	if err := unix.Msync(idx.data[:HeaderSize], unix.MS_SYNC); err != nil {
+		idx.Close()
+		return nil, err
+	}
+	if err := f.Sync(); err != nil {
+		idx.Close()
+		return nil, err
+	}
 	return idx, nil
 }
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -182,6 +182,32 @@ func TestReadHeaderMACMismatch(t *testing.T) {
 	}
 }
 
+func TestCreateSyncsHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "crash.man")
+	idx, err := Create(path, "dev", 4096, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Simulate crash by closing without fsync.
+	if err := unix.Munmap(idx.data); err != nil {
+		t.Fatalf("munmap: %v", err)
+	}
+	if err := idx.f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	idx2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if idx2.hdr.Version != Version || idx2.hdr.ChunkCount != 1 {
+		t.Fatalf("header mismatch: %+v", idx2.hdr)
+	}
+	if err := idx2.Close(); err != nil {
+		t.Fatalf("close2: %v", err)
+	}
+}
+
 func TestUpgrade(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "old.man")


### PR DESCRIPTION
## Summary
- flush header to disk in manifest.Create to ensure persistence on crash
- add test verifying header survives close without fsync

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a371e286c88323b79854b38c020d7d