### PR TITLE
Document security model and sudoers examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 LVMSync is a high-performance incremental data replication tool for LVM snapshots. It efficiently transfers only changed blocks using metadata from snapshot COW (Copy-On-Write) devices and communicates with LVM through native Go bindings rather than shell commands.
 
+For details on running with minimal privileges and sudoers examples, see [SECURITY.md](SECURITY.md).
+
 ## Features
 
 - **Incremental Block-Level Synchronization**: Transfers only changed blocks.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Model
+
+LVMSync splits privileged and unprivileged responsibilities. The main controller runs as a regular user and delegates any operation that requires elevated permissions to a small, audited helper.
+
+## Non-root controller and helper
+
+The controller orchestrates replication, validates parameters, and interacts with remote peers. Operations that require root — such as managing LVM volumes, opening raw block devices or issuing discard commands — are executed through a privileged helper invoked via `sudo` or Linux capabilities. The helper performs only the requested action and exits immediately, minimising the trusted code surface.
+
+## Example sudoers configuration
+
+Tight `sudoers` rules limit what the helper may execute:
+
+```sudoers
+# Allow LVM administration commands
+lvmsync ALL=(root) NOPASSWD: /sbin/lvm, /sbin/lvcreate, /sbin/lvremove, /sbin/lvs, /sbin/pvs, /sbin/vgs
+
+# Permit opening block devices through the helper
+lvmsync ALL=(root) NOPASSWD: /usr/local/bin/lvmsync-helper open, /usr/local/bin/lvmsync-helper write
+
+# Enable discarding unused blocks
+lvmsync ALL=(root) NOPASSWD: /usr/sbin/blkdiscard
+```
+
+Adjust paths to match your distribution.
+
+## Risks of raw-device writes
+
+Granting raw-device access lets the helper overwrite any block on the target. A misconfigured path or bug could destroy unrelated data. LVMSync mitigates this risk by:
+
+* Requiring explicit device paths; globbing and symlinks are rejected.
+* Verifying device size and LVM signatures before writing.
+* Dropping privileges immediately after completing the privileged section.
+
+Review `sudoers` entries carefully and test on non-production systems before granting wide access.

--- a/docs/privilege_escalation.md
+++ b/docs/privilege_escalation.md
@@ -2,6 +2,8 @@
 
 LVMSync operates on block devices and prefers Linux capabilities over sudo.
 
+For security design and sudoers examples, see [SECURITY.md](../SECURITY.md).
+
 ## Capabilities
 
 Grant required capabilities to the binary:


### PR DESCRIPTION
## Summary
- add SECURITY.md describing non-root controller, privileged helper, sudoers examples, and raw-device safeguards
- reference SECURITY.md from README and privilege escalation docs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 5`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a379e98ec483239c2c3fa1124efd84