### PR TITLE
docs: document exit codes and test runner mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1412,14 +1412,14 @@ Invalid configurations will cause the tool to abort with a clear error message.
 ## Exit Codes
 
 
-| Code | Meaning |
-|------|---------|
-| `0`  | Success |
-| `10` | Privilege or capability check failed |
-| `20` | Device error |
-| `30` | Unsupported platform |
-| `40` | Configuration error |
-| `50` | Runtime failure |
+| Constant | Code | Meaning |
+|----------|------|---------|
+| [`exitcode.OK`](internal/exitcode/exitcode.go) | `0`  | Success |
+| [`exitcode.ErrCapability`](internal/exitcode/exitcode.go) | `10` | Privilege or capability check failed |
+| [`exitcode.ErrDevice`](internal/exitcode/exitcode.go) | `20` | Device error |
+| [`exitcode.ErrPlatform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform |
+| [`exitcode.ErrConfig`](internal/exitcode/exitcode.go) | `40` | Configuration error |
+| [`exitcode.ErrRuntime`](internal/exitcode/exitcode.go) | `50` | Runtime failure |
 
 Exit code definitions live in [internal/exitcode](internal/exitcode/exitcode.go), and handling resides in [main.go](main.go).
 

--- a/main_exitcode_test.go
+++ b/main_exitcode_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+
+	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/exitcode"
+)
+
+func TestRunnerExitCodes(t *testing.T) {
+	cases := []struct {
+		name   string
+		goos   string
+		cfgErr error
+		runErr error
+		want   int
+	}{
+		{"platform", "darwin", nil, nil, exitcode.ErrPlatform},
+		{"capability", "linux", errors.New("privilege check failed: missing"), nil, exitcode.ErrCapability},
+		{"config", "linux", errors.New("cfg"), nil, exitcode.ErrConfig},
+		{"device", "linux", nil, errors.New("device gone"), exitcode.ErrDevice},
+		{"runtime", "linux", nil, errors.New("boom"), exitcode.ErrRuntime},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var code int
+			r := NewRunnerWithDeps(
+				func() (*config.Config, []string, *zap.Logger, error) {
+					if tt.cfgErr != nil {
+						return nil, nil, nil, tt.cfgErr
+					}
+					return &config.Config{}, nil, zap.NewNop(), nil
+				},
+				func(_ *config.Config, _ []string, _ *zap.Logger) error { return tt.runErr },
+				rootcmd.SyncLogger,
+				func(c int) { code = c },
+				func() *zap.Logger { return zap.NewNop() },
+				tt.goos,
+			)
+			r.Run()
+			if code != tt.want {
+				t.Fatalf("expected exit code %d, got %d", tt.want, code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- document CLI exit codes in README with links to the `internal/exitcode` constants
- add table-driven test to ensure the runner exits with the correct codes for different error paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a37a0aaafc83238e628d0d49e6f9b9