### PR TITLE
docs: add operations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ LVMSync is a high-performance incremental data replication tool for LVM snapshot
 - **Flexible Configuration**: Flags, environment variables, or `config.yaml`. See [Configuration](#configuration).
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.
 
+For snapshot workflow, resume modes, verification-only runs, and recovery guidance, see [operations guide](docs/OPERATIONS.md).
+
 ## Supported Platforms
 
 LVMSync supports Linux only. A runtime check in [`main.go`](main.go) aborts

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,53 @@
+# Operations
+
+This guide covers snapshot lifecycle management, resume options, verification modes, and expected exit codes for recovery.
+
+## Snapshot Creation and Cleanup Flow
+
+1. `lvmsync run` validates the source and destination.
+2. A snapshot of the source logical volume is created unless `--skip-snapshot-creation` is used.
+3. Snapshot usage is monitored while blocks are streamed to the destination.
+4. On completion or interruption, the snapshot is removed.
+
+## Resume and Verification Sequences
+
+### `--resume`
+
+```sh
+lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/target
+```
+
+1. Load the resume state and validate settings.
+2. Copy remaining blocks, persisting checkpoints.
+3. Delete the state file when the transfer finishes.
+4. If the command fails, rerun with the same `--resume` file after fixing the issue.
+
+### `--resume=verify`
+
+```sh
+lvmsync run --resume=verify /dev/vg0/snap0 /dev/vg0/target
+```
+
+1. Resume the transfer using the existing state.
+2. After the copy completes, `lvmsync verify` checks the destination against the source or manifest.
+3. A verification failure keeps the resume file for another attempt.
+
+### `--verify-only`
+
+```sh
+lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
+```
+
+Reads both devices and reports mismatches without writing data.
+
+## Exit Codes and Recovery
+
+| Code | Meaning | Recovery Step |
+|------|---------|---------------|
+| `0`  | Success | None |
+| `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
+| `20` | Device error | Verify device paths and snapshot health. |
+| `30` | Unsupported platform | Run on a supported Linux platform. |
+| `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
+| `50` | Runtime failure or verification mismatch | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Transports](transports.md) – transport negotiation and options.
 - [LVM Snapshots](lvm.md) – snapshot creation, extension, discard, and mount checks.
 - [Verification](verify.md) – command usage for integrity checks.
+- [Operations](OPERATIONS.md) – snapshot flow, resume and verify sequences, and exit codes.
 - [Privilege Escalation](privilege_escalation.md) – configuring LVM privilege escalation.
 - [Daemon](daemon.md) – module configuration, ACLs, and listener options.
 - Configuration precedence – flags override environment variables, which in


### PR DESCRIPTION
## Summary
- document snapshot lifecycle, resume modes, verify-only runs, and recovery paths
- link operations guide from README and docs index

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a379f31c4c8323837e9eb9186d4528