### PR TITLE
device: require escalator for raw devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Override detection with `--source-type` and `--dest-type` when necessary.
 Internally, `device.Detect` delegates to dedicated helpers:
 
 ```go
-dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, logger, device.NewRunner())
+dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, privilege.New(ctx), logger, device.NewRunner())
 // detectFileDevice, detectLVMDevice, or detectRawDevice is selected based on the path.
 ```
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -19,6 +19,7 @@ import (
 	"lvmsync_go/internal/config"
 	cpufeatures "lvmsync_go/internal/cpufeatures"
 	digestpkg "lvmsync_go/internal/digest"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/internal/rsyncwire"
 	"lvmsync_go/remote"
 	"lvmsync_go/transfer"
@@ -41,7 +42,7 @@ type Runner struct {
 	dumpDedup      func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer, transfer.DeduplicationStrategy) error
 	newSSHClient   func(context.Context, string, string, string, int, string, bool, time.Duration, time.Duration, int, *zap.Logger) (*remote.SSHClient, error)
 	openFile       func(string, int, os.FileMode) (*os.File, error)
-	detectDevice   func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error)
+	detectDevice   func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error)
 	sumFile        func(string, string) ([32]byte, error)
 	streamToRemote func(context.Context, *config.Config, io.WriteCloser, string, string, string, *zap.Logger) error
 }
@@ -243,7 +244,20 @@ func (r *Runner) ExecuteDump(ctx context.Context, cfg *config.Config, snapshotDe
 // Run executes client mode transferring data to dest and returns the destination type.
 func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest string, logger *zap.Logger) (string, error) {
 	defer rootcmd.SyncLogger(logger)
-	dev, err := r.detectDevice(ctx, source, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner())
+	dev, err := r.detectDevice(
+		ctx,
+		source,
+		cfg.Offline,
+		cfg.SourceType,
+		cfg.FSFreezeCommand,
+		cfg.FSThawCommand,
+		cfg.LVMEscalation,
+		cfg.FreezeTimeout,
+		cfg.ThawTimeout,
+		privilege.New(ctx),
+		logger,
+		device.NewRunner(),
+	)
 	if err != nil {
 		return cfg.DestType, err
 	}
@@ -290,7 +304,7 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
 	destType := cfg.DestType
 	if destType == "auto" {
-		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, logger, device.NewRunner()); err == nil {
+		if dev, err := device.Detect(context.Background(), dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(context.Background()), logger, device.NewRunner()); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -13,6 +13,7 @@ import (
 
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/privilege"
 	remotetest "lvmsync_go/remote/testutil"
 	"lvmsync_go/transfer"
 )
@@ -56,7 +57,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()
@@ -110,7 +111,7 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()
@@ -169,7 +170,7 @@ func TestRemotePostScriptContextError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -12,6 +12,7 @@ import (
 
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/transfer"
 )
 
@@ -38,7 +39,7 @@ func TestRunLogsSaveStateError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -11,6 +11,7 @@ import (
 
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/transfer"
 )
 
@@ -43,7 +44,7 @@ func TestRunStdout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *device.Runner) (device.Device, error) {
+	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &fakeDevice{path: "/dev/snap"}, nil
 	}
 	defer func() { detectDevice = origDetect }()

--- a/device/detect.go
+++ b/device/detect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kballard/go-shellquote"
 	"go.uber.org/zap"
 
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/lvm"
 )
 
@@ -46,7 +47,16 @@ func detectLVMDevice(ctx context.Context, path, lvmEscalation string, runner *Ru
 }
 
 // detectRawDevice opens a raw block device.
-func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd, fsThawCmd string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (Device, error) {
+func detectRawDevice(
+	ctx context.Context,
+	path string,
+	offline bool,
+	fsFreezeCmd, fsThawCmd string,
+	freezeTimeout, thawTimeout time.Duration,
+	esc privilege.Escalator,
+	logger *zap.Logger,
+	runner *Runner,
+) (Device, error) {
 	var freezePath, thawPath string
 	var freezeArgs, thawArgs []string
 	if fsFreezeCmd != "" {
@@ -73,7 +83,7 @@ func detectRawDevice(ctx context.Context, path string, offline bool, fsFreezeCmd
 			thawArgs = parts[1:]
 		}
 	}
-	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, logger, runner)
+	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger, runner)
 	if err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err
@@ -94,6 +104,7 @@ func Detect(
 	offline bool,
 	explicitType, fsFreezeCmd, fsThawCmd, lvmEscalation string,
 	freezeTimeout, thawTimeout time.Duration,
+	esc privilege.Escalator,
 	logger *zap.Logger,
 	runner *Runner,
 ) (Device, error) {
@@ -126,7 +137,7 @@ func Detect(
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
 			}
-			return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger, runner)
+			return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, esc, logger, runner)
 		default:
 			return nil, fmt.Errorf("unknown device type %q", explicitType)
 		}
@@ -140,7 +151,7 @@ func Detect(
 		if err == nil && fsType == "LVM2_member" {
 			return detectLVMDevice(ctx, resolved, lvmEscalation, runner, logger)
 		}
-		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, logger, runner)
+		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, esc, logger, runner)
 	}
 	err = fmt.Errorf("unsupported path type: %s", resolved)
 	logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/lvm"
 )
 
@@ -109,7 +110,7 @@ func TestDetectLVMDeviceEscalationError(t *testing.T) {
 
 func TestDetectRawDeviceSuccess(t *testing.T) {
 	orig := openRawFunc
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
+	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
 		f, err := os.CreateTemp(t.TempDir(), "raw")
 		if err != nil {
 			return nil, err
@@ -119,7 +120,7 @@ func TestDetectRawDeviceSuccess(t *testing.T) {
 	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := detectRawDevice(context.Background(), "/dev/test", true, "", "", 0, 0, logger, NewRunner())
+	dev, err := detectRawDevice(context.Background(), "/dev/test", true, "", "", 0, 0, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -140,7 +141,7 @@ func TestDetectRawDeviceSuccess(t *testing.T) {
 }
 
 func TestDetectRawDeviceError(t *testing.T) {
-	if _, err := detectRawDevice(context.Background(), "/dev/null", true, "", "", 0, 0, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := detectRawDevice(context.Background(), "/dev/null", true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -148,14 +149,14 @@ func TestDetectRawDeviceError(t *testing.T) {
 func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 	orig := openRawFunc
 	called := false
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
+	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
 	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
-	_, err := detectRawDevice(context.Background(), "/dev/test", true, "/bin/echo \"unterminated", "", 0, 0, logger, NewRunner())
+	_, err := detectRawDevice(context.Background(), "/dev/test", true, "/bin/echo \"unterminated", "", 0, 0, fakeEsc{}, logger, NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "invalid freeze command") {
 		t.Fatalf("expected freeze parse error, got %v", err)
 	}
@@ -174,14 +175,14 @@ func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 func TestDetectRawDeviceThawParseError(t *testing.T) {
 	orig := openRawFunc
 	called := false
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
+	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
 	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
-	_, err := detectRawDevice(context.Background(), "/dev/test", true, "", "/bin/echo \"unterminated", 0, 0, logger, NewRunner())
+	_, err := detectRawDevice(context.Background(), "/dev/test", true, "", "/bin/echo \"unterminated", 0, 0, fakeEsc{}, logger, NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "invalid thaw command") {
 		t.Fatalf("expected thaw parse error, got %v", err)
 	}

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -44,7 +44,7 @@ func TestDetectFile(t *testing.T) {
 	f.Close()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), f.Name(), true, "", "", "", "", 0, 0, logger, NewRunner())
+	dev, err := Detect(context.Background(), f.Name(), true, "", "", "", "", 0, 0, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestDetectRaw(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, logger, NewRunner())
+	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	if err := os.Symlink(loop, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
+	dev, err := Detect(context.Background(), link, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	defer os.Remove(lvPath)
 	defer os.Remove(vgDir)
 
-	dev, err := Detect(context.Background(), lvPath, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
+	dev, err := Detect(context.Background(), lvPath, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestDetectLVM(t *testing.T) {
 	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
-	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, zap.NewNop(), runner)
+	dev, err := Detect(context.Background(), loop, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), runner)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestDetectRawCommandQuoting(t *testing.T) {
 	})
 	freeze := "/bin/echo 'freeze path with spaces'"
 	thaw := "/bin/echo 'thaw path with spaces'"
-	dev, err := Detect(context.Background(), loop, false, "raw", freeze, thaw, "", 0, 0, zap.NewNop(), NewDeviceRunner(cmd))
+	dev, err := Detect(context.Background(), loop, false, "raw", freeze, thaw, "", 0, 0, fakeEsc{}, zap.NewNop(), NewDeviceRunner(cmd))
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}

--- a/device/discard_linux.go
+++ b/device/discard_linux.go
@@ -3,13 +3,21 @@
 package device
 
 import (
+	"fmt"
 	"os"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
+
+	"lvmsync_go/escalate"
 )
 
 func blkdiscard(f *os.File, offset, length uint64) error {
+	if reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{}); err != nil {
+		return err
+	} else if reexeced {
+		return fmt.Errorf("re-exec requested for root")
+	}
 	data := [2]uint64{offset, length}
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.BLKDISCARD, uintptr(unsafe.Pointer(&data)))
 	if errno != 0 {

--- a/device/fake_escalator_test.go
+++ b/device/fake_escalator_test.go
@@ -1,0 +1,18 @@
+package device
+
+import (
+	"context"
+	"os/exec"
+
+	"lvmsync_go/internal/privilege"
+)
+
+type fakeEsc struct{ err error }
+
+var _ privilege.Escalator = (*fakeEsc)(nil)
+
+func (f fakeEsc) Ensure(context.Context) error { return f.err }
+
+func (f fakeEsc) Command(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, args...)
+}

--- a/device/info.go
+++ b/device/info.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/moby/sys/mountinfo"
 	"go.uber.org/zap"
+
+	"lvmsync_go/internal/privilege"
 )
 
 const (
@@ -32,7 +34,7 @@ type Info struct {
 	uuidFunc    func(context.Context, string) (string, error)
 	lvmUUIDFunc func(context.Context, string) (string, error)
 	mountFunc   func(context.Context, string) (bool, error)
-	detectFunc  func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error)
+	detectFunc  func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error)
 }
 
 // NewInfo returns an Info using production dependencies.
@@ -51,7 +53,7 @@ func NewInfoWithDeps(
 	uuid func(context.Context, string) (string, error),
 	lvmUUID func(context.Context, string) (string, error),
 	mount func(context.Context, string) (bool, error),
-	detect func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error),
+	detect func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error),
 ) *Info {
 	if uuid == nil {
 		uuid = defaultUUIDFunc
@@ -78,8 +80,8 @@ func (i *Info) SetMountFunc(f func(context.Context, string) (bool, error)) func(
 
 // SetDetectFunc allows tests to override the device detector. It returns the previous function for restoration.
 func (i *Info) SetDetectFunc(
-	f func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error),
-) func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error) {
+	f func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error),
+) func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 	prev := i.detectFunc
 	i.detectFunc = f
 	return prev
@@ -174,7 +176,7 @@ func (i *Info) SizeBytes(ctx context.Context, path string) (size uint64, err err
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	dev, err := i.detectFunc(ctx, path, true, "", "", "", "", 0, 0, zap.NewNop(), NewRunner())
+	dev, err := i.detectFunc(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx), zap.NewNop(), NewRunner())
 	if err != nil {
 		return 0, err
 	}

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/moby/sys/mountinfo"
 	"go.uber.org/zap"
+
+	"lvmsync_go/internal/privilege"
 )
 
 func TestGetUUIDCanceledContext(t *testing.T) {
@@ -450,7 +452,7 @@ func TestDefaultLVMUUIDFunc(t *testing.T) {
 func TestSizeBytes(t *testing.T) {
 	dev := &stubDevice{size: 123}
 	info := NewInfo()
-	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return dev, nil
 	})
 	defer info.SetDetectFunc(prev)
@@ -469,7 +471,7 @@ func TestSizeBytesCloseError(t *testing.T) {
 	want := errors.New("close boom")
 	dev := &stubDevice{size: 456, closeErr: want}
 	info := NewInfo()
-	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, *zap.Logger, *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return dev, nil
 	})
 	defer info.SetDetectFunc(prev)

--- a/device/raw.go
+++ b/device/raw.go
@@ -15,6 +15,8 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
+	"lvmsync_go/escalate"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/remote"
 )
 
@@ -75,6 +77,11 @@ func prepareFreeze(
 
 // openDevice ensures the path is a block device and opens it for reading and writing.
 func openDevice(path string) (*os.File, error) {
+	if reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{}); err != nil {
+		return nil, err
+	} else if reexeced {
+		return nil, fmt.Errorf("re-exec requested for root")
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -115,9 +122,16 @@ func OpenRaw(
 	fsThawCmdArgs []string,
 	freezeTimeout time.Duration,
 	thawTimeout time.Duration,
+	esc privilege.Escalator,
 	logger *zap.Logger,
 	runner *Runner,
 ) (_ *RawDevice, err error) {
+	if esc == nil {
+		esc = privilege.New(ctx)
+	}
+	if err := esc.Ensure(ctx); err != nil {
+		return nil, err
+	}
 	if runner == nil {
 		runner = NewRunner()
 	}

--- a/device/raw_nonlinux.go
+++ b/device/raw_nonlinux.go
@@ -8,13 +8,15 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"lvmsync_go/internal/privilege"
 )
 
 // RawDevice is unsupported on non-Linux platforms.
 type RawDevice struct{}
 
 // OpenRaw returns an error on non-Linux systems.
-func OpenRaw(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, *zap.Logger, *Runner) (*RawDevice, error) {
+func OpenRaw(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (*RawDevice, error) {
 	return nil, fmt.Errorf("raw devices are only supported on Linux")
 }
 

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,7 +32,7 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger, NewRunner())
+	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -63,7 +64,7 @@ func TestRawDeviceCloseErrorLogging(t *testing.T) {
 	defer cleanup()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, logger, NewRunner())
+	d, err := OpenRaw(context.Background(), loop, true, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -84,14 +85,14 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, 0, 0, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := OpenRaw(context.Background(), f.Name(), true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
 
 func TestOpenRawRejectsCharDevice(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err == nil {
-		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, zap.NewNop(), NewRunner()); err == nil {
+		if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -100,8 +101,14 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected offline or freeze command error")
+	}
+}
+
+func TestOpenRawEscalatorError(t *testing.T) {
+	if _, err := OpenRaw(context.Background(), "/dev/null", true, "", nil, "", nil, 0, 0, fakeEsc{err: errors.New("boom")}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected escalator error, got %v", err)
 	}
 }
 
@@ -114,7 +121,7 @@ func TestOpenRawFreezeCommandFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing true binary: %v", err)
 	}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, falsePath, nil, truePath, nil, time.Second, time.Second, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, falsePath, nil, truePath, nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -128,7 +135,7 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 	}
 	freezeArgs := []string{freezeTmp}
 	thawArgs := []string{thawTmp}
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, touchPath, freezeArgs, touchPath, thawArgs, time.Second, time.Second, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, touchPath, freezeArgs, touchPath, thawArgs, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {
@@ -174,7 +181,7 @@ func TestOpenRawFreezeTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing true binary: %v", err)
 	}
-	_, err = OpenRaw(context.Background(), "/dev/null", false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, zap.NewNop(), NewRunner())
+	_, err = OpenRaw(context.Background(), "/dev/null", false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze command to be killed, got %v", err)
 	}
@@ -206,7 +213,7 @@ func TestOpenRawStoresThawConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing touch binary: %v", err)
 	}
-	d, err := OpenRaw(context.Background(), loop, false, truePath, nil, touchPath, []string{thawTmp}, time.Second, time.Second, zap.NewNop(), NewRunner())
+	d, err := OpenRaw(context.Background(), loop, false, truePath, nil, touchPath, []string{thawTmp}, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -227,7 +234,7 @@ func TestOpenRawFreezeThawLogs(t *testing.T) {
 	logger := zap.New(core)
 	helper := helperCommand(t)
 	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
-	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-success"}, time.Second, time.Second, logger, runner)
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-success"}, time.Second, time.Second, fakeEsc{}, logger, runner)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -244,7 +251,7 @@ func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 	logger := zap.New(core)
 	helper := helperCommand(t)
 	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
-	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, logger, runner)
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, fakeEsc{}, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze timeout, got %v", err)
 	}
@@ -264,7 +271,7 @@ func TestOpenRawThawFailure(t *testing.T) {
 	logger := zap.New(core)
 	helper := helperCommand(t)
 	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
-	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-fail"}, time.Second, time.Second, logger, runner)
+	_, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-fail"}, time.Second, time.Second, fakeEsc{}, logger, runner)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -291,7 +298,7 @@ func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 		t.Fatalf("missing true binary: %v", err)
 	}
 	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, logger, runner); err == nil || !strings.Contains(err.Error(), "freeze output") {
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, fakeEsc{}, logger, runner); err == nil || !strings.Contains(err.Error(), "freeze output") {
 		t.Fatalf("expected freeze output in error, got %v", err)
 	}
 	entries := logs.FilterMessage("fs_freeze_failed").All()

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"lvmsync_go/device"
+	"lvmsync_go/internal/privilege"
 )
 
 const (
@@ -79,7 +80,7 @@ type IndexOption func(*indexOptions)
 func defaultIndexOptions() indexOptions {
 	return indexOptions{
 		detectDevice: func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, logger, device.NewRunner())
+			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx), logger, device.NewRunner())
 		},
 		closeHook: func() error { return nil },
 		info:      device.NewInfo(),


### PR DESCRIPTION
## Summary
- require a privilege.Escalator when opening raw devices and during raw detection
- ensure root before opening devices or issuing blkdiscard
- wire cmd/dump to provide an escalator to device detection
- test raw device paths with a fake escalator

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a379d5bfac83239de41371c0f47d82