### PR TITLE
Skip reading and writing sparse blocks

### DIFF
--- a/transfer/block_generic.go
+++ b/transfer/block_generic.go
@@ -37,3 +37,7 @@ func openFileODirect(path string, flag int) (*os.File, bool, error) {
 	f, err := os.OpenFile(path, flag, 0)
 	return f, false, err
 }
+
+func seekHoleSupported(_ *os.File) bool { return false }
+
+func nextDataOffset(_ *os.File, _ int64) (int64, error) { return -1, nil }

--- a/transfer/block_linux.go
+++ b/transfer/block_linux.go
@@ -100,3 +100,31 @@ func openFileODirect(path string, flag int) (*os.File, bool, error) {
 	}
 	return os.NewFile(uintptr(fd), path), true, nil
 }
+
+func seekHoleSupported(f *os.File) bool {
+	cur, err := unix.Seek(int(f.Fd()), 0, unix.SEEK_CUR)
+	if err != nil {
+		return false
+	}
+	defer unix.Seek(int(f.Fd()), cur, unix.SEEK_SET)
+	if _, err := unix.Seek(int(f.Fd()), 0, unix.SEEK_HOLE); err != nil {
+		return false
+	}
+	return true
+}
+
+func nextDataOffset(f *os.File, offset int64) (int64, error) {
+	cur, err := unix.Seek(int(f.Fd()), 0, unix.SEEK_CUR)
+	if err != nil {
+		return 0, err
+	}
+	defer unix.Seek(int(f.Fd()), cur, unix.SEEK_SET)
+	off, err := unix.Seek(int(f.Fd()), offset, unix.SEEK_DATA)
+	if err != nil {
+		if err == unix.ENXIO {
+			return -1, nil
+		}
+		return 0, err
+	}
+	return off, nil
+}

--- a/transfer/block_sparse_linux_test.go
+++ b/transfer/block_sparse_linux_test.go
@@ -1,0 +1,129 @@
+//go:build linux
+// +build linux
+
+package transfer
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"lvmsync_go/internal/config"
+)
+
+func TestNextDataOffset(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "sparse-src")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	block := int64(4096)
+	if _, err := f.Seek(block*2, 0); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	if _, err := f.Write([]byte("data")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if !seekHoleSupported(f) {
+		t.Skip("SEEK_HOLE not supported")
+	}
+	off, err := nextDataOffset(f, 0)
+	if err != nil {
+		t.Fatalf("nextDataOffset: %v", err)
+	}
+	if off != block*2 {
+		t.Fatalf("expected offset %d, got %d", block*2, off)
+	}
+}
+
+func TestIterateBlocksSkipsSparseRegions(t *testing.T) {
+	bs := 4096
+	src, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(src.Name())
+	defer src.Close()
+
+	data := bytes.Repeat([]byte{1}, bs)
+	if _, err := src.Seek(int64(bs), 0); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	if _, err := src.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg := &config.Config{BlockSize: bs, MaxRetries: 1}
+	ranges := []Range{{Start: 0}, {Start: uint64(bs)}}
+	var buf bytes.Buffer
+	bufOut := bufio.NewWriter(&buf)
+	_, _, _, err = iterateBlocks(context.Background(), cfg, ranges, src, bufOut, nil, [2]int{-1, -1}, zap.NewNop(), &resumeTracker{})
+	if err != nil {
+		t.Fatalf("iterateBlocks: %v", err)
+	}
+	bufOut.Flush()
+
+	expected := 16 + 16 + bs
+	if buf.Len() != expected {
+		t.Fatalf("expected stream size %d, got %d", expected, buf.Len())
+	}
+
+	dest, err := os.CreateTemp(t.TempDir(), "dest")
+	if err != nil {
+		t.Fatalf("CreateTemp dest: %v", err)
+	}
+	defer os.Remove(dest.Name())
+	defer dest.Close()
+
+	rd := bytes.NewReader(buf.Bytes())
+	header := make([]byte, 16)
+	for {
+		if _, err := io.ReadFull(rd, header); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("read header: %v", err)
+		}
+		off := binary.BigEndian.Uint64(header[0:8])
+		size := binary.BigEndian.Uint32(header[8:12])
+		crc := binary.BigEndian.Uint32(header[12:16])
+		var block []byte
+		if size > 0 {
+			block = make([]byte, size)
+			if _, err := io.ReadFull(rd, block); err != nil {
+				t.Fatalf("read block: %v", err)
+			}
+		}
+		if _, err := processBlock(cfg, dest, nil, nil, false, nil, off, crc, nil, block, size, zap.NewNop()); err != nil {
+			t.Fatalf("processBlock: %v", err)
+		}
+	}
+
+	if !seekHoleSupported(dest) {
+		t.Skip("SEEK_HOLE not supported on dest")
+	}
+	off, err := unix.Seek(int(dest.Fd()), 0, unix.SEEK_DATA)
+	if err != nil {
+		t.Fatalf("seek data: %v", err)
+	}
+	if off != int64(bs) {
+		t.Fatalf("expected first data at %d, got %d", bs, off)
+	}
+	buf2 := make([]byte, bs)
+	if _, err := dest.ReadAt(buf2, int64(bs)); err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.Equal(buf2, data) {
+		t.Fatalf("dest block mismatch")
+	}
+}

--- a/transfer/block_stream.go
+++ b/transfer/block_stream.go
@@ -74,6 +74,7 @@ func iterateBlocks(
 	if cfg.IntraDedup {
 		intra = newChunkCache(intraCacheCapacity)
 	}
+	holeSupported := seekHoleSupported(srcFile)
 	for _, r := range ranges {
 		if err := ctx.Err(); err != nil {
 			return totalBytes, skippedBlocks, nil, err
@@ -81,6 +82,30 @@ func iterateBlocks(
 		offset, blockSize, err := validateOffsetAndSize(r.Start, cfg.BlockSize)
 		if err != nil {
 			return totalBytes, skippedBlocks, nil, err
+		}
+		if holeSupported {
+			next, err := nextDataOffset(srcFile, offset)
+			if err != nil {
+				holeSupported = false
+			} else if next == -1 || next >= offset+int64(blockSize) {
+				binary.BigEndian.PutUint64(header[0:8], r.Start)
+				binary.BigEndian.PutUint32(header[8:12], 0)
+				binary.BigEndian.PutUint32(header[12:16], 0)
+				if _, err := bufOut.Write(header[:16]); err != nil {
+					return totalBytes, skippedBlocks, nil, fmt.Errorf("failed to write header: %w", err)
+				}
+				zh := zeroHash(int(blockSize))
+				saveResumeState(cfg, rt, r.Start, zh, int64(blockSize), logger)
+				if idx != nil {
+					zero := zeroBuf(int(blockSize))
+					xx := hashutil.SumXXH3(zero)
+					if err := idx.Set(r.Start, blockSize, 0, xx, zh); err != nil {
+						return totalBytes, skippedBlocks, nil, fmt.Errorf("manifest set: %w", err)
+					}
+				}
+				totalBytes += int64(blockSize)
+				continue
+			}
 		}
 		data, err := ReadBlockWithRetries(ctx, cfg, srcFile, offset, cfg.ZeroCopy, pipeFds, logger)
 		if err != nil {


### PR DESCRIPTION
## Summary
- detect filesystem hole support and locate next data offset on Linux
- skip zero regions in block iteration and punch holes on destination
- add sparse-file unit tests for hole seeking and skipped transfers

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a384266f908323b4f0c30043fe798d