### PR TITLE
escalate: make env sanitization opt-in

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,14 @@ lvmsync ALL=(root) NOPASSWD: /usr/sbin/blkdiscard
 
 Adjust paths to match your distribution.
 
+## Environment sanitization
+
+The helper normally inherits the caller's environment, including `PATH` and
+other variables. Pass the `--sanitize-env` flag or enable the `SanitizeEnv`
+option to run the helper with a minimal, whitelisted environment that drops
+`LD_PRELOAD` and similar variables and enforces a safe `PATH`. Sanitization is
+disabled by default to avoid surprising behavior in mixed environments.
+
 ## Risks of raw-device writes
 
 Granting raw-device access lets the helper overwrite any block on the target. A misconfigured path or bug could destroy unrelated data. LVMSync mitigates this risk by:

--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -44,7 +44,7 @@ type Options struct {
 	AllowedPassthrough map[string]bool
 	// ExtraArgs, if set, are appended after the self path (e.g., a subcommand).
 	ExtraArgs []string
-	// SanitizeEnv (default true) uses a hardened child environment.
+	// SanitizeEnv (default false) uses a hardened child environment.
 	SanitizeEnv bool
 
 	// Dependency seams (optional; default to real OS functions):
@@ -102,7 +102,6 @@ func EnsureRootOrReexec(opts Options) (bool, error) {
 	var env []string
 	switch {
 	case opts.SanitizeEnv:
-		// Default is true unless explicitly false.
 		if opts.Environ != nil {
 			env = sanitizedChildEnv(opts.Environ())
 		} else {
@@ -110,9 +109,6 @@ func EnsureRootOrReexec(opts Options) (bool, error) {
 		}
 	case opts.Environ != nil:
 		env = opts.Environ()
-	default:
-		// SanitizeEnv explicitly false and no custom Environ: inherit the
-		// current environment by leaving env nil.
 	}
 
 	stdin := opts.Stdin // nil by default (no TTY password prompts)

--- a/escalate/escalate_additional_root_test.go
+++ b/escalate/escalate_additional_root_test.go
@@ -14,8 +14,7 @@ func TestEnsureRootOrReexec_SudoMissing(t *testing.T) {
 	}
 	t.Setenv("PATH", "/nonexistent")
 	_, err := EnsureRootOrReexec(Options{
-		Geteuid:     func() int { return 1000 },
-		SanitizeEnv: false,
+		Geteuid: func() int { return 1000 },
 	})
 	if err == nil || !strings.Contains(err.Error(), "sudo not found") {
 		t.Fatalf("expected sudo not found error, got %v", err)

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -249,7 +249,7 @@ func TestEnsureRootOrReexec_DropsDisallowedFlags(t *testing.T) {
 	}
 }
 
-func TestEnsureRootOrReexec_DefaultSanitizedEnv(t *testing.T) {
+func TestEnsureRootOrReexec_SanitizedEnv(t *testing.T) {
 	var got execCall
 	t.Setenv("LD_PRELOAD", "/tmp/x.so")
 	t.Setenv("LANG", "C")
@@ -278,14 +278,13 @@ func TestEnsureRootOrReexec_DefaultSanitizedEnv(t *testing.T) {
 	}
 }
 
-func TestEnsureRootOrReexec_UnsanitizedEnv(t *testing.T) {
+func TestEnsureRootOrReexec_DefaultUnsanitizedEnv(t *testing.T) {
 	var got execCall
 	t.Setenv("LD_PRELOAD", "/tmp/x.so")
 	reexeced, err := EnsureRootOrReexec(Options{
-		Geteuid:     func() int { return 1000 },
-		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
-		SanitizeEnv: false,
-		ExecRunner:  fakeRunner(&got, nil),
+		Geteuid:    func() int { return 1000 },
+		LookPath:   func(string) (string, error) { return "/usr/bin/sudo", nil },
+		ExecRunner: fakeRunner(&got, nil),
 	})
 	if err != nil || !reexeced {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)


### PR DESCRIPTION
## Summary
- default to inheriting environment when escalating
- sanitize only when SanitizeEnv or `--sanitize-env` is set
- document environment sanitization option in security guide

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: Can't process result by diff processor: can't read from patch file path/to/patch/file)*

------
https://chatgpt.com/codex/tasks/task_e_68a38429cea08323b48fdc9c59751145