### PR TITLE
escalate: inject syscall facade via options

### DIFF
--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -16,13 +16,15 @@
 //
 // Typical usage:
 //
-//	reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{})
-//	if err != nil { log.Fatal(err) }
-//	if reexeced { return } // parent should exit after delegating to sudo
+//			reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{})
+//			if err != nil { log.Fatal(err) }
+//			if reexeced { return } // parent should exit after delegating to sudo
 //
-//	// ... privileged work ...
-//	if err := escalate.DropToInvokerIfSudo(); err != nil { log.Fatal(err) }
-//	// ... continue unprivileged work ...
+//			// ... privileged work ...
+//	             if err := escalate.DropToInvokerIfSudo(escalate.Options{}); err != nil {
+//	                     log.Fatal(err)
+//	             }
+//	             // ... continue unprivileged work ...
 package escalate
 
 import (
@@ -53,9 +55,10 @@ type Options struct {
 	Geteuid    func() int                        // defaults to os.Geteuid
 	LookPath   func(file string) (string, error) // defaults to exec.LookPath
 	ExecRunner func(name string, args, env []string, stdin io.Reader, stdout, stderr io.Writer) error
-	Stdin      io.Reader // defaults to nil (no prompting)
-	Stdout     io.Writer // defaults to os.Stdout
-	Stderr     io.Writer // defaults to os.Stderr
+	Stdin      io.Reader     // defaults to nil (no prompting)
+	Stdout     io.Writer     // defaults to os.Stdout
+	Stderr     io.Writer     // defaults to os.Stderr
+	Sys        syscallFacade // defaults to real unix syscalls
 }
 
 // IsRoot reports whether effective UID is 0 (overridable for tests via Options).
@@ -138,7 +141,8 @@ func EnsureRootOrReexec(opts Options) (bool, error) {
 
 // DropToInvokerIfSudo drops privileges back to the invoking user if launched
 // via sudo (SUDO_UID/SUDO_GID). No-op if those env vars are absent.
-func DropToInvokerIfSudo() error {
+// Dependency seams are provided via opts.
+func DropToInvokerIfSudo(opts Options) error {
 	suid := os.Getenv("SUDO_UID")
 	sgid := os.Getenv("SUDO_GID")
 	if suid == "" || sgid == "" {
@@ -151,6 +155,10 @@ func DropToInvokerIfSudo() error {
 	gid, err := parseInt(sgid)
 	if err != nil {
 		return fmt.Errorf("parse SUDO_GID (%q): %w", sgid, err)
+	}
+	sys := opts.Sys
+	if sys == nil {
+		sys = unixFacade{}
 	}
 	if err := sys.Setgroups([]int{gid}); err != nil {
 		return fmt.Errorf("setgroups: %w", err)
@@ -248,8 +256,6 @@ type unixFacade struct{}
 func (unixFacade) Setgroups(gids []int) error  { return unix.Setgroups(gids) }
 func (unixFacade) Setresgid(r, e, s int) error { return unix.Setresgid(r, e, s) }
 func (unixFacade) Setresuid(r, e, s int) error { return unix.Setresuid(r, e, s) }
-
-var sys syscallFacade = unixFacade{}
 
 func defaultExecRunner(name string, args, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	cmd := exec.Command(name, args...)

--- a/escalate/escalate_additional_root_test.go
+++ b/escalate/escalate_additional_root_test.go
@@ -28,7 +28,7 @@ func TestDropToInvokerIfSudo_InvalidEnv(t *testing.T) {
 	}
 	t.Setenv("SUDO_UID", "notnum")
 	t.Setenv("SUDO_GID", "100")
-	if err := DropToInvokerIfSudo(); err == nil {
+	if err := DropToInvokerIfSudo(Options{}); err == nil {
 		t.Fatal("expected error for invalid SUDO_UID")
 	}
 }

--- a/escalate/escalate_root_test.go
+++ b/escalate/escalate_root_test.go
@@ -57,7 +57,7 @@ func TestHelperEscalateAndDrop(t *testing.T) {
 
 	os.Setenv("SUDO_UID", "1")
 	os.Setenv("SUDO_GID", "1")
-	if err := DropToInvokerIfSudo(); err != nil {
+	if err := DropToInvokerIfSudo(Options{}); err != nil {
 		logger.Error("deescalation_failed", zap.Error(err))
 		os.Exit(2)
 	}

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -91,27 +91,21 @@ func (m *mockSys) Setresuid(r, e, s int) error {
 }
 
 func TestDropToInvokerIfSudo_NoEnv(t *testing.T) {
-	old := sys
-	sys = &mockSys{}
-	t.Cleanup(func() { sys = old })
+	m := &mockSys{}
 	os.Unsetenv("SUDO_UID")
 	os.Unsetenv("SUDO_GID")
 
-	if err := DropToInvokerIfSudo(); err != nil {
+	if err := DropToInvokerIfSudo(Options{Sys: m}); err != nil {
 		t.Fatalf("expected no-op nil err, got %v", err)
 	}
 }
 
 func TestDropToInvokerIfSudo_Success(t *testing.T) {
 	m := &mockSys{}
-	old := sys
-	sys = m
-	t.Cleanup(func() { sys = old })
-
 	t.Setenv("SUDO_UID", "1000")
 	t.Setenv("SUDO_GID", "100")
 
-	if err := DropToInvokerIfSudo(); err != nil {
+	if err := DropToInvokerIfSudo(Options{Sys: m}); err != nil {
 		t.Fatalf("DropToInvokerIfSudo error: %v", err)
 	}
 	if len(m.groups) != 1 || m.groups[0] != 100 {
@@ -127,13 +121,9 @@ func TestDropToInvokerIfSudo_Success(t *testing.T) {
 
 func TestDropToInvokerIfSudo_ParseError(t *testing.T) {
 	m := &mockSys{}
-	old := sys
-	sys = m
-	t.Cleanup(func() { sys = old })
-
 	t.Setenv("SUDO_UID", "notnum")
 	t.Setenv("SUDO_GID", "100")
-	if err := DropToInvokerIfSudo(); err == nil {
+	if err := DropToInvokerIfSudo(Options{Sys: m}); err == nil {
 		t.Fatal("expected parse error")
 	}
 }


### PR DESCRIPTION
## Summary
- inject syscall facade into `escalate.Options` and drop global
- update privilege drop to use provided facade
- adjust tests to pass facades explicitly

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3842b73f08323ace08f0917e30baa