### PR TITLE
feat: add verification and partial exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1424,6 +1424,8 @@ Invalid configurations will cause the tool to abort with a clear error message.
 | [`exitcode.ErrPlatform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform |
 | [`exitcode.ErrConfig`](internal/exitcode/exitcode.go) | `40` | Configuration error |
 | [`exitcode.ErrRuntime`](internal/exitcode/exitcode.go) | `50` | Runtime failure |
+| [`exitcode.ErrVerify`](internal/exitcode/exitcode.go) | `60` | Verification mismatch |
+| [`exitcode.ErrPartial`](internal/exitcode/exitcode.go) | `70` | Partial transfer |
 
 Exit code definitions live in [internal/exitcode](internal/exitcode/exitcode.go), and handling resides in [main.go](main.go).
 

--- a/cmd/lvmsyncd/lvmsyncd.go
+++ b/cmd/lvmsyncd/lvmsyncd.go
@@ -283,6 +283,12 @@ func mapExitCode(err error) int {
 	if strings.Contains(msg, "device") {
 		return exitcode.ErrDevice
 	}
+	if strings.Contains(msg, "mismatch") || strings.Contains(msg, "blocks differ") {
+		return exitcode.ErrVerify
+	}
+	if strings.Contains(msg, "signal") || strings.Contains(msg, "canceled") {
+		return exitcode.ErrPartial
+	}
 	return exitcode.ErrRuntime
 }
 

--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -136,6 +136,8 @@ func TestMapExitCode(t *testing.T) {
 		{"success", nil, exitcode.OK},
 		{"config", errors.New("parse listen"), exitcode.ErrConfig},
 		{"runtime", errors.New("listen failed"), exitcode.ErrRuntime},
+		{"verify", errors.New("digest mismatch"), exitcode.ErrVerify},
+		{"partial", errors.New("received signal: interrupt"), exitcode.ErrPartial},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -49,5 +49,7 @@ Reads both devices and reports mismatches without writing data.
 | `20` | Device error | Verify device paths and snapshot health. |
 | `30` | Unsupported platform | Run on a supported Linux platform. |
 | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
-| `50` | Runtime failure or verification mismatch | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
+| `50` | Runtime failure | Inspect logs and fix the issue. |
+| `60` | Verification mismatch | Investigate mismatched data before retrying. |
+| `70` | Partial transfer | Address the error and resume with `--resume`. |
 

--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -13,4 +13,8 @@ const (
 	ErrConfig = 40
 	// ErrRuntime represents errors during command execution.
 	ErrRuntime = 50
+	// ErrVerify indicates checksum or digest verification failures.
+	ErrVerify = 60
+	// ErrPartial indicates a resumable transfer was aborted before completion.
+	ErrPartial = 70
 )

--- a/internal/exitcode/exitcode_test.go
+++ b/internal/exitcode/exitcode_test.go
@@ -14,6 +14,8 @@ func TestExitCodeValues(t *testing.T) {
 		{"ErrPlatform", ErrPlatform, 30},
 		{"ErrConfig", ErrConfig, 40},
 		{"ErrRuntime", ErrRuntime, 50},
+		{"ErrVerify", ErrVerify, 60},
+		{"ErrPartial", ErrPartial, 70},
 	}
 	for _, c := range cases {
 		if c.code != c.want {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"os"
 	"runtime"
 	"strings"
@@ -86,9 +88,15 @@ func (r *Runner) Run() {
 	if err := r.RunFunc(cfg, args, logger); err != nil {
 		logger.Error("run failed", zap.Error(err))
 		r.SyncLogger(logger)
-		if strings.Contains(err.Error(), "device") {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "device"):
 			r.Exit(exitcode.ErrDevice)
-		} else {
+		case strings.Contains(msg, "mismatch") || strings.Contains(msg, "blocks differ"):
+			r.Exit(exitcode.ErrVerify)
+		case strings.Contains(msg, "signal") || errors.Is(err, context.Canceled):
+			r.Exit(exitcode.ErrPartial)
+		default:
 			r.Exit(exitcode.ErrRuntime)
 		}
 		return

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -181,3 +181,39 @@ func TestMainDeviceErrorExitCode(t *testing.T) {
 		t.Fatalf("expected exit code %d, got %d", exitcode.ErrDevice, code)
 	}
 }
+
+func TestMainVerifyExitCode(t *testing.T) {
+	var code int
+	logger := zap.NewNop()
+	runner := NewRunnerWithDeps(
+		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("digest mismatch") },
+		rootcmd.SyncLogger,
+		func(c int) { code = c },
+		func() *zap.Logger { return zap.NewNop() },
+		"linux",
+	)
+	runner.Run()
+	if code != exitcode.ErrVerify {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrVerify, code)
+	}
+}
+
+func TestMainPartialExitCode(t *testing.T) {
+	var code int
+	logger := zap.NewNop()
+	runner := NewRunnerWithDeps(
+		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error {
+			return errors.New("received signal: interrupt")
+		},
+		rootcmd.SyncLogger,
+		func(c int) { code = c },
+		func() *zap.Logger { return zap.NewNop() },
+		"linux",
+	)
+	runner.Run()
+	if code != exitcode.ErrPartial {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrPartial, code)
+	}
+}

--- a/main_exitcode_test.go
+++ b/main_exitcode_test.go
@@ -24,6 +24,8 @@ func TestRunnerExitCodes(t *testing.T) {
 		{"config", "linux", errors.New("cfg"), nil, exitcode.ErrConfig},
 		{"device", "linux", nil, errors.New("device gone"), exitcode.ErrDevice},
 		{"runtime", "linux", nil, errors.New("boom"), exitcode.ErrRuntime},
+		{"verify", "linux", nil, errors.New("digest mismatch"), exitcode.ErrVerify},
+		{"partial", "linux", nil, errors.New("received signal: interrupt"), exitcode.ErrPartial},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add ErrVerify and ErrPartial codes
- map checksum mismatches and resumable aborts to new codes
- document expanded exit codes in operations guide and help text

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a3842d9b4c8323b92213bb6f078cf9