### PR TITLE
docs: add operations guide and security updates

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,53 @@
+# Operations
+
+This guide outlines exit codes, resume workflows, and common troubleshooting steps for LVMSync.
+
+## Resume and Verification Sequences
+
+### `--resume`
+
+```sh
+lvmsync run --resume statefile /dev/vg0/snap0 /dev/vg0/target
+```
+
+1. Load the resume state and validate settings.
+2. Copy remaining blocks, persisting checkpoints.
+3. Delete the state file when the transfer finishes.
+4. If the command fails, rerun with the same `--resume` file after fixing the issue.
+
+### `--resume=verify`
+
+```sh
+lvmsync run --resume=verify /dev/vg0/snap0 /dev/vg0/target
+```
+
+1. Resume the transfer using the existing state.
+2. After the copy completes, `lvmsync verify` checks the destination against the source or manifest.
+3. A verification failure keeps the resume file for another attempt.
+
+### `--verify-only`
+
+```sh
+lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
+```
+
+Reads both devices and reports mismatches without writing data.
+
+## Exit Codes and Recovery
+
+| Code | Meaning | Recovery Step |
+|------|---------|---------------|
+| `0`  | Success | None |
+| `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
+| `20` | Device error | Verify device paths and snapshot health. |
+| `30` | Unsupported platform | Run on a supported Linux platform. |
+| `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
+| `50` | Runtime failure or verification mismatch | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
+
+## Troubleshooting
+
+- Compare source and destination identities; the device identity tuple `(device_id, size_bytes, major:minor)` must match the resume file.
+- Confirm the destination is not mounted read-write. Use `--force` only when intentionally overwriting.
+- Rerun with `--resume` after resolving issues to avoid re-copying completed blocks.
+- Review logs for detailed errors and ensure all configuration values follow the expected flag > environment variable > config file precedence.
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ For details on running with minimal privileges and sudoers examples, see [SECURI
 - **Deduplication Strategies**: Detect unchanged blocks using checksum, rolling hash, or a Bloom filter with optional FastCDC content-defined chunking and mmap-backed index.
 - **Hashing**: Hardware-accelerated XXH3 provides fast deduplication hints while BLAKE3 digests are stored in manifests for integrity.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
-- **Resume Support**: Ability to resume interrupted transfers.
+- **Resume Support**: Ability to resume interrupted transfers and verify results with `--resume=verify`.
+- **Device Identity Tuple**: Each run records `(device_id, size_bytes, major:minor)` to prevent writing to the wrong destination.
 - **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
 - **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it.
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to the device's NUMA node.
@@ -38,9 +39,17 @@ For details on running with minimal privileges and sudoers examples, see [SECURI
   - See [LVM snapshot documentation](docs/lvm.md) for snapshot lifecycle and mount checks.
 - **Graceful Shutdown**: Signal handling ensures snapshots are cleaned up on interruption.
 - **Flexible Configuration**: Flags, environment variables, or `config.yaml`. See [Configuration](#configuration).
+  Configuration values follow flag > environment variable > config file precedence.
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.
 
-For snapshot workflow, resume modes, verification-only runs, and recovery guidance, see [operations guide](docs/OPERATIONS.md).
+### Resume and overwrite flows
+
+Transfers store the device identity tuple and compare it against the destination before writing. Mismatches abort the run to avoid accidental overwrites. Use `--force` to bypass this check when intentionally overwriting.
+
+- `--resume statefile` continues an interrupted run.
+- `--resume=verify` resumes the copy and then performs a verification pass.
+
+For snapshot workflow, resume modes, verification-only runs, and recovery guidance, see [operations guide](OPERATIONS.md).
 
 ## Supported Platforms
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,10 +14,13 @@ Tight `sudoers` rules limit what the helper may execute:
 # Allow LVM administration commands
 lvmsync ALL=(root) NOPASSWD: /sbin/lvm, /sbin/lvcreate, /sbin/lvremove, /sbin/lvs, /sbin/pvs, /sbin/vgs
 
-# Permit opening block devices through the helper
-lvmsync ALL=(root) NOPASSWD: /usr/local/bin/lvmsync-helper open, /usr/local/bin/lvmsync-helper write
+# Permit opening devices and issuing writes or discards through the helper
+lvmsync ALL=(root) NOPASSWD: \
+    /usr/local/bin/lvmsync-helper open, \
+    /usr/local/bin/lvmsync-helper write, \
+    /usr/local/bin/lvmsync-helper discard
 
-# Enable discarding unused blocks
+# Enable direct blkdiscard when the helper is unavailable
 lvmsync ALL=(root) NOPASSWD: /usr/sbin/blkdiscard
 ```
 

--- a/perf.md
+++ b/perf.md
@@ -24,6 +24,10 @@ Common options:
 - `--transport` set per test case
 - `--compress` set per test case
 
+## Running Benchmarks
+
+Benchmarks are executed with helper scripts that wrap the `lvmsync run` command and collect timing data.
+
 ### LAN Flags
 
 LAN tests run on a single switch with <1 ms latency.
@@ -77,11 +81,12 @@ make bench-wan SRC=/dev/vg0/snap0 DEST=user@wan:/dev/vg0/vol0 IFACE=eth0
 | ssh       | zstd        | 3.9  | 50 |
 
 ## Reproducing
+Benchmark runs are reproducible when the dataset, hardware, and commit hash are recorded.
 
-Helper scripts iterate through transport and compression combinations:
-
-- `scripts/bench_lan.sh`
-- `scripts/bench_wan.sh`
-
-These scripts output elapsed time and CPU percentage for each run using
-`/usr/bin/time`. Adjust source and destination paths as needed.
+1. Build the binary: `go build ./...`.
+2. Capture the commit: `git rev-parse HEAD`.
+3. Use the helper scripts to iterate through transport and compression combinations:
+   - `scripts/bench_lan.sh`
+   - `scripts/bench_wan.sh`
+4. Each script prints throughput and CPU usage via `/usr/bin/time -f '%e %P'`.
+5. Save the script output together with the commit hash for comparison across runs.


### PR DESCRIPTION
## Summary
- document device identity tuple and resume verification in README
- add standalone operations guide with exit codes and troubleshooting
- expand security sudoers lines and benchmark instructions

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3843820508323908c9d3330dcb281