### PR TITLE
Add WAL resume verification and logging

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -48,6 +48,7 @@ type Config struct {
 	RetryDelay               time.Duration `mapstructure:"retry_delay"`
 	ResumeState              string        `mapstructure:"resume"`
 	ResumeToken              string        `mapstructure:"resume_token"`
+	ResumeVerify             bool          `mapstructure:"-"`
 	DeviceUUID               string        `mapstructure:"device_uuid"`
 	SSHHost                  string        `mapstructure:"ssh_host"`
 	SSHUser                  string        `mapstructure:"ssh_user"`

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -36,7 +36,8 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 
 	reader := bufio.NewReader(decReader)
 
-	if err := t.verifyDestination(ctx, cfg, destPath); err != nil {
+	size, id, epoch, err := t.verifyDestination(ctx, cfg, destPath)
+	if err != nil {
 		return err
 	}
 
@@ -62,13 +63,31 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 	}
 	defer common.CloseWithErr(destFile, &err, "close destination device")
 
+	if cfg.ResumeState != "" {
+		var walRanges []Range
+		t.wal, walRanges, err = OpenWAL(cfg.ResumeState+".wal", size, id, epoch)
+		if err != nil {
+			return err
+		}
+		if cfg.ResumeVerify {
+			if err := verifyWAL(cfg, destFile, walRanges, t.Logger); err != nil {
+				return err
+			}
+		}
+	}
+
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
-	bw, err := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger)
+	bw, err := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger, t.wal)
 	var totalBytes int64
 	totalBytes, err = bw.write(reader)
 	if err != nil {
 		return err
+	}
+	if t.wal != nil {
+		if err := t.wal.Sync(); err != nil {
+			return err
+		}
 	}
 
 	elapsed := time.Since(startTime)

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -27,17 +27,18 @@ type blockWriter struct {
 	sinceSync int64
 	rt        *resumeTracker
 	deps      *Deps
+	wal       *WAL
 }
 
 // newBlockWriter constructs a blockWriter, detecting the destination's physical
 // block size when the configured block size is "auto" (0) and parsing the
 // sync interval when provided as a string. It validates that the configured
 // block size is aligned to the underlying sector size.
-func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger) (*blockWriter, error) {
-	return newBlockWriterWithDeps(cfg, dest, dedup, verify, checksum, logger, DefaultDeps)
+func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, wal *WAL) (*blockWriter, error) {
+	return newBlockWriterWithDeps(cfg, dest, dedup, verify, checksum, logger, wal, DefaultDeps)
 }
 
-func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, deps *Deps) (*blockWriter, error) {
+func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, wal *WAL, deps *Deps) (*blockWriter, error) {
 	if cfg.BlockSize <= 0 || cfg.ODirect {
 		sector, err := DetectSectorSize(dest)
 		if err != nil {
@@ -68,6 +69,7 @@ func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup Deduplicati
 		checksum: checksum,
 		logger:   logger,
 		deps:     deps,
+		wal:      wal,
 	}
 	if cfg.IntraDedup {
 		bw.intra = newChunkCache(intraCacheCapacity)
@@ -119,6 +121,11 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 			return total, err
 		}
 		saveResumeState(bw.cfg, bw.rt, offset, chunkID, int64(chunkSize), bw.logger)
+		if bw.wal != nil && written {
+			if err := bw.wal.Append(Range{Start: offset, End: offset + uint64(chunkSize)}); err != nil {
+				return total, err
+			}
+		}
 		if written {
 			total += int64(chunkSize)
 			bw.sinceSync += int64(chunkSize)

--- a/transfer/block_writer_apply_test.go
+++ b/transfer/block_writer_apply_test.go
@@ -48,7 +48,7 @@ func TestBlockWriterSyncInterval(t *testing.T) {
 		calls++
 		return nil
 	}}
-	bw, err := newBlockWriterWithDeps(cfg, f, nil, false, checksum, zap.NewNop(), deps)
+	bw, err := newBlockWriterWithDeps(cfg, f, nil, false, checksum, zap.NewNop(), nil, deps)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestBlockWriterMACVerification(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw, err := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop())
+	bw, err := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestBlockWriterCRCValidation(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw, err := newBlockWriter(cfg, f, nil, false, nil, zap.NewNop())
+	bw, err := newBlockWriter(cfg, f, nil, false, nil, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}

--- a/transfer/block_writer_test.go
+++ b/transfer/block_writer_test.go
@@ -25,7 +25,7 @@ func TestBlockWriterSyncIntervalTriggers(t *testing.T) {
 		calls++
 		return nil
 	}}
-	bw, err := newBlockWriterWithDeps(cfg, tmp, nil, false, nil, zap.NewNop(), deps)
+	bw, err := newBlockWriterWithDeps(cfg, tmp, nil, false, nil, zap.NewNop(), nil, deps)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestBlockWriterInvalidSyncInterval(t *testing.T) {
 	cases := []string{"bogus", "10%"}
 	for _, interval := range cases {
 		cfg := &config.Config{BlockSize: 4, SyncInterval: interval}
-		if _, err := newBlockWriter(cfg, tmp, nil, false, nil, zap.NewNop()); err == nil {
+		if _, err := newBlockWriter(cfg, tmp, nil, false, nil, zap.NewNop(), nil); err == nil {
 			t.Fatalf("newBlockWriter(%q) expected error", interval)
 		}
 	}

--- a/transfer/run_apply.go
+++ b/transfer/run_apply.go
@@ -62,5 +62,14 @@ func (t *Transfer) RunApply(cfg *config.Config, applyFile, destDevice string) (e
 	defer common.CloseWithErr(rc, &err, "close apply file")
 	err = t.applyData(cfg, rc, destDevice)
 	finalizeResumeState(cfg, t.Tracker, t.Logger)
+	if t.wal != nil {
+		if syncErr := t.wal.Sync(); syncErr != nil && err == nil {
+			err = syncErr
+		}
+		if closeErr := t.wal.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		t.wal = nil
+	}
 	return err
 }

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -18,6 +18,7 @@ import (
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/device"
+	hashutil "lvmsync_go/hash"
 	"lvmsync_go/internal/config"
 	manifestpkg "lvmsync_go/manifest"
 )
@@ -28,6 +29,7 @@ type Transfer struct {
 	workerWG *sync.WaitGroup
 	Tracker  *resumeTracker
 	Info     device.DeviceInfoProvider
+	wal      *WAL
 }
 
 // NewTransfer creates a Transfer with the provided logger and wait group.
@@ -233,59 +235,100 @@ func readManifestHeader(ctx context.Context, path string, timeout time.Duration)
 	return &hdr, nil
 }
 
-func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, destPath string) error {
+func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, destPath string) (uint64, string, uint64, error) {
 	if ctx == nil {
-		return fmt.Errorf("nil context")
+		return 0, "", 0, fmt.Errorf("nil context")
 	}
+	var size uint64
+	var id string
+	var epoch uint64
 	if cfg.ManifestPath != "" {
 		hdr, err := readManifestHeader(ctx, cfg.ManifestPath, 0)
 		if err != nil {
-			return err
+			return 0, "", 0, err
 		}
-		id, err := t.Info.GetDeviceID(ctx, destPath)
+		id, err = t.Info.GetDeviceID(ctx, destPath)
 		if err != nil {
-			return fmt.Errorf("read destination id: %w", err)
+			return 0, "", 0, fmt.Errorf("read destination id: %w", err)
 		}
 		manID := strings.TrimRight(string(hdr.DeviceID[:]), "\x00")
 		if id != manID {
 			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", manID), zap.String("resource_id", id))
-			return fmt.Errorf("destination device id %s does not match manifest %s", id, manID)
+			return 0, "", 0, fmt.Errorf("destination device id %s does not match manifest %s", id, manID)
 		}
-		size, err := t.Info.SizeBytes(ctx, destPath)
+		size, err = t.Info.SizeBytes(ctx, destPath)
 		if err != nil {
-			return fmt.Errorf("read destination size: %w", err)
+			return 0, "", 0, fmt.Errorf("read destination size: %w", err)
 		}
 		if size != hdr.SizeBytes {
 			t.Logger.Error("device_size_mismatch", zap.Uint64("expected_size_bytes", hdr.SizeBytes), zap.Uint64("size_bytes", size))
-			return fmt.Errorf("destination device size %d does not match manifest %d", size, hdr.SizeBytes)
+			return 0, "", 0, fmt.Errorf("destination device size %d does not match manifest %d", size, hdr.SizeBytes)
 		}
 		if cfg.ResumeState != "" {
 			if _, err := os.Stat(cfg.ResumeState); err == nil {
 				chk := readResumeState(cfg, t.Logger, hdr.SizeBytes, manID, hdr.Epoch)
 				if chk == (resumeCheckpoint{}) {
-					return fmt.Errorf("resume state does not match destination metadata")
+					return 0, "", 0, fmt.Errorf("resume state does not match destination metadata")
 				}
 			}
 		}
+		epoch = hdr.Epoch
 		t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
-	} else if cfg.DeviceUUID != "" {
-		id, err := t.Info.GetDeviceID(ctx, destPath)
-		if err != nil {
-			return fmt.Errorf("read destination uuid: %w", err)
+	} else {
+		if cfg.ResumeState != "" || cfg.DeviceUUID != "" {
+			var err error
+			id, err = t.Info.GetDeviceID(ctx, destPath)
+			if err != nil {
+				return 0, "", 0, fmt.Errorf("read destination id: %w", err)
+			}
+			if cfg.ResumeState != "" {
+				size, err = t.Info.SizeBytes(ctx, destPath)
+				if err != nil {
+					return 0, "", 0, fmt.Errorf("read destination size: %w", err)
+				}
+			}
+			if cfg.DeviceUUID != "" && id != cfg.DeviceUUID {
+				t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", cfg.DeviceUUID), zap.String("resource_id", id))
+				return 0, "", 0, fmt.Errorf("destination device uuid %s does not match expected %s", id, cfg.DeviceUUID)
+			}
+			t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
 		}
-		if id != cfg.DeviceUUID {
-			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", cfg.DeviceUUID), zap.String("resource_id", id))
-			return fmt.Errorf("destination device uuid %s does not match expected %s", id, cfg.DeviceUUID)
-		}
-		t.Logger.Info("destination_validated", zap.String("resource_id", id))
 	}
 	mounted, err := t.Info.IsMountedRW(ctx, destPath)
 	if err != nil {
-		return fmt.Errorf("check mount status: %w", err)
+		return 0, "", 0, fmt.Errorf("check mount status: %w", err)
 	}
 	if mounted && !cfg.Force {
 		t.Logger.Error("destination_mounted_rw", zap.String("path", destPath))
-		return fmt.Errorf("destination device %s is mounted read-write", destPath)
+		return 0, "", 0, fmt.Errorf("destination device %s is mounted read-write", destPath)
+	}
+	return size, id, epoch, nil
+}
+
+func verifyWAL(cfg *config.Config, dest *os.File, ranges []Range, logger *zap.Logger) error {
+	if cfg.ManifestPath == "" {
+		return fmt.Errorf("manifest required for resume verify")
+	}
+	idx, err := manifestpkg.Open(cfg.ManifestPath)
+	if err != nil {
+		return fmt.Errorf("open manifest: %w", err)
+	}
+	defer idx.Close()
+	buf := make([]byte, cfg.BlockSize)
+	for _, r := range ranges {
+		size := r.End - r.Start
+		if int(size) > len(buf) {
+			buf = make([]byte, size)
+		}
+		if _, err := dest.ReadAt(buf[:size], int64(r.Start)); err != nil {
+			return fmt.Errorf("read wal range: %w", err)
+		}
+		xx := hashutil.SumXXH3(buf[:size])
+		sum := blake3.Sum256(buf[:size])
+		if !idx.Match(r.Start, uint32(size), 0, xx, func() [32]byte { return sum }) {
+			logger.Error("wal_verify_mismatch", zap.Uint64("offset_bytes", r.Start))
+			return fmt.Errorf("wal verification failed at offset %d", r.Start)
+		}
 	}
 	return nil
 }

--- a/transfer/verify_destination_ctx_test.go
+++ b/transfer/verify_destination_ctx_test.go
@@ -23,7 +23,7 @@ func TestVerifyDestinationNilContext(t *testing.T) {
 	if err := os.WriteFile(dest, []byte("data"), 0600); err != nil {
 		t.Fatalf("write dest: %v", err)
 	}
-	if err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
+	if _, _, _, err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
 		t.Fatalf("expected nil context error, got %v", err)
 	}
 }
@@ -46,7 +46,7 @@ func TestVerifyDestinationCanceledContext(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
-	go func() { errCh <- tr.verifyDestination(ctx, cfg, dest) }()
+	go func() { _, _, _, err := tr.verifyDestination(ctx, cfg, dest); errCh <- err }()
 	time.Sleep(10 * time.Millisecond)
 	cancel()
 	select {

--- a/transfer/wal.go
+++ b/transfer/wal.go
@@ -108,6 +108,13 @@ func (w *WAL) Append(r Range) error {
 	return w.f.Sync()
 }
 
+func (w *WAL) Sync() error {
+	if w.f != nil {
+		return w.f.Sync()
+	}
+	return nil
+}
+
 func (w *WAL) Close() error {
 	if w.f != nil {
 		return w.f.Close()

--- a/transfer/wal_test.go
+++ b/transfer/wal_test.go
@@ -25,7 +25,7 @@ func TestWALMismatch(t *testing.T) {
 	}
 }
 
-func TestWALDurability(t *testing.T) {
+func TestWALRecovery(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	w, _, err := OpenWAL(path, 100, "dev", 1)

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -1,0 +1,100 @@
+package transfer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/device"
+	"lvmsync_go/internal/config"
+	manifestpkg "lvmsync_go/manifest"
+)
+
+type mockDevice struct {
+	path      string
+	size      uint64
+	blockSize uint64
+}
+
+func (m *mockDevice) Path() string                                            { return m.path }
+func (m *mockDevice) SizeBytes() uint64                                       { return m.size }
+func (m *mockDevice) BlockSize() uint64                                       { return m.blockSize }
+func (m *mockDevice) Close() error                                            { return nil }
+func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
+func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
+
+func buildManifest(t *testing.T, devPath, manPath, uuid string, size uint64) {
+	t.Helper()
+	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &mockDevice{path: devPath, size: size, blockSize: 4}, nil
+	}
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil)
+	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+}
+
+func TestWALVerifySuccess(t *testing.T) {
+	dir := t.TempDir()
+	dev := filepath.Join(dir, "dev")
+	data := []byte("abcd")
+	if err := os.WriteFile(dev, data, 0o600); err != nil {
+		t.Fatalf("write dev: %v", err)
+	}
+	man := filepath.Join(dir, "man")
+	buildManifest(t, dev, man, "uuid", uint64(len(data)))
+	walPath := filepath.Join(dir, "wal")
+	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Append(Range{Start: 0, End: uint64(len(data))}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	w.Close()
+	cfg := &config.Config{BlockSize: len(data), ManifestPath: man}
+	f, err := os.Open(dev)
+	if err != nil {
+		t.Fatalf("open dev: %v", err)
+	}
+	defer f.Close()
+	if err := verifyWAL(cfg, f, []Range{{Start: 0, End: uint64(len(data))}}, zap.NewNop()); err != nil {
+		t.Fatalf("verifyWAL: %v", err)
+	}
+}
+
+func TestWALVerifyMismatch(t *testing.T) {
+	dir := t.TempDir()
+	dev := filepath.Join(dir, "dev")
+	data := []byte("abcd")
+	if err := os.WriteFile(dev, data, 0o600); err != nil {
+		t.Fatalf("write dev: %v", err)
+	}
+	man := filepath.Join(dir, "man")
+	buildManifest(t, dev, man, "uuid", uint64(len(data)))
+	walPath := filepath.Join(dir, "wal")
+	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Append(Range{Start: 0, End: uint64(len(data))}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	w.Close()
+	// Corrupt device
+	if err := os.WriteFile(dev, []byte("wxyz"), 0o600); err != nil {
+		t.Fatalf("corrupt dev: %v", err)
+	}
+	cfg := &config.Config{BlockSize: len(data), ManifestPath: man}
+	f, err := os.Open(dev)
+	if err != nil {
+		t.Fatalf("open dev: %v", err)
+	}
+	defer f.Close()
+	if err := verifyWAL(cfg, f, []Range{{Start: 0, End: uint64(len(data))}}, zap.NewNop()); err == nil {
+		t.Fatalf("expected verifyWAL error")
+	}
+}


### PR DESCRIPTION
## Summary
- add `ResumeVerify` option and WAL integration for transfer apply
- fsync WAL after each range and after final checkpoint
- support resume verification against manifest digests with tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: Can't process result by diff processor: can't read from patch file path/to/patch/file)*

------
https://chatgpt.com/codex/tasks/task_e_68a384201af483239e7af3ab8a8e4935