### PR TITLE
Add resume verify configuration and tests

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -22,8 +22,9 @@ lvmsync run --resume=verify /dev/vg0/snap0 /dev/vg0/target
 ```
 
 1. Resume the transfer using the existing state.
-2. After the copy completes, `lvmsync verify` checks the destination against the source or manifest.
-3. A verification failure keeps the resume file for another attempt.
+2. Validate previously written blocks against the manifest before applying new data.
+3. After the copy completes, `lvmsync verify` checks the destination against the source or manifest.
+4. Any verification mismatch aborts the run and leaves the resume file for another attempt.
 
 ### `--verify-only`
 

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -68,7 +68,7 @@ func TestIdentityUUIDMismatch(t *testing.T) {
 			return "id1", nil
 		}
 		return "id2", nil
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return &identityStub{size: 1}, nil
 	})

--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 )
@@ -49,6 +50,15 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	if err := fs.Parse(args); err != nil {
 		return nil, nil, nil, err
 	}
+
+	resumeVerify := false
+	if f := fs.Lookup("resume"); f != nil && f.Changed {
+		if strings.EqualFold(f.Value.String(), "verify") {
+			resumeVerify = true
+			_ = f.Value.Set("")
+			f.Changed = false
+		}
+	}
 	v, warns, err := buildViper(b.FlagSets)
 	if err != nil {
 		return nil, nil, warns, err
@@ -57,6 +67,9 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	cfg, err := vb.Build()
 	if err != nil {
 		return nil, nil, warns, err
+	}
+	if resumeVerify {
+		cfg.ResumeVerify = true
 	}
 	if cfg.AllowInsecure {
 		_, envSet := os.LookupEnv("LVMSYNC_ALLOW_INSECURE")

--- a/internal/config/resume_verify_test.go
+++ b/internal/config/resume_verify_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestResumeVerifyFlag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LVMSYNC_RESUME", "statefile")
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--resume=verify"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !cfg.ResumeVerify {
+		t.Fatalf("expected ResumeVerify true")
+	}
+	if cfg.ResumeState != "statefile" {
+		t.Fatalf("ResumeState=%q want %q", cfg.ResumeState, "statefile")
+	}
+}

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -335,7 +335,7 @@ func TestVerifyDestinationDigestMismatch(t *testing.T) {
 	}
 	f.Close()
 	cfg := &config.Config{ManifestPath: man}
-	if err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("expected digest mismatch, got %v", err)
 	}
 }

--- a/transfer/resume_verify_integration_test.go
+++ b/transfer/resume_verify_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/device"
+	"lvmsync_go/internal/config"
+	privilege "lvmsync_go/internal/privilege"
+)
+
+func TestResumeVerifyMismatch(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 4096
+	first := bytes.Repeat([]byte{1}, blockSize)
+	second := bytes.Repeat([]byte{2}, blockSize)
+	data := append(first, second...)
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(dest, data, 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	man := filepath.Join(dir, "dest.man")
+	buildManifest(t, dest, man, "uuid", uint64(len(data)))
+	resume := filepath.Join(dir, "resume.state")
+	w, _, err := OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Append(Range{Start: 0, End: uint64(len(data))}); err != nil {
+		t.Fatalf("append wal: %v", err)
+	}
+	w.Close()
+	// Corrupt second block
+	corrupt := bytes.Repeat([]byte{3}, blockSize)
+	f, err := os.OpenFile(dest, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open dest: %v", err)
+	}
+	if _, err := f.WriteAt(corrupt, int64(blockSize)); err != nil {
+		t.Fatalf("corrupt dest: %v", err)
+	}
+	f.Close()
+	firstDigest := blake3.Sum256(first)
+	detect := func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		return &mockDevice{path: dest, size: uint64(len(data)), blockSize: uint64(blockSize)}, nil
+	}
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "uuid", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(context.Context, string, uint64) ([32]byte, error) { return firstDigest, nil },
+		detect,
+	)
+	tr := NewTransfer(zap.NewNop(), nil, info)
+	cfg := &config.Config{
+		BlockSize:         blockSize,
+		ManifestPath:      man,
+		ResumeState:       resume,
+		ResumeVerify:      true,
+		Compress:          "none",
+		ChecksumAlgorithm: "sha256",
+		MaxRetries:        1,
+	}
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest)
+	if err == nil {
+		t.Fatalf("expected verification failure")
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -274,7 +274,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 		if err != nil {
-			return fmt.Errorf("read destination digest: %w", err)
+			return 0, "", 0, fmt.Errorf("read destination digest: %w", err)
 		}
 		if dig != hdr.FirstBlockDigest {
 			t.Logger.Error(
@@ -282,7 +282,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 				zap.String("expected_digest", hex.EncodeToString(hdr.FirstBlockDigest[:])),
 				zap.String("first_block_digest", hex.EncodeToString(dig[:])),
 			)
-			return fmt.Errorf("destination device digest mismatch")
+			return 0, "", 0, fmt.Errorf("destination device digest mismatch")
 		}
 		if cfg.ResumeState != "" {
 			if _, err := os.Stat(cfg.ResumeState); err == nil {
@@ -316,11 +316,11 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		if cfg.FirstBlockDigest != "" {
 			dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 			if err != nil {
-				return fmt.Errorf("read destination digest: %w", err)
+				return 0, "", 0, fmt.Errorf("read destination digest: %w", err)
 			}
 			if hex.EncodeToString(dig[:]) != cfg.FirstBlockDigest {
 				t.Logger.Error("first_block_digest_mismatch", zap.String("expected_digest", cfg.FirstBlockDigest), zap.String("first_block_digest", hex.EncodeToString(dig[:])))
-				return fmt.Errorf("destination device digest mismatch")
+				return 0, "", 0, fmt.Errorf("destination device digest mismatch")
 			}
 		}
 		t.Logger.Info("destination_validated", zap.String("resource_id", id))

--- a/transfer/verify_destination_ctx_test.go
+++ b/transfer/verify_destination_ctx_test.go
@@ -24,7 +24,7 @@ func TestVerifyDestinationNilContext(t *testing.T) {
 		t.Fatalf("write dest: %v", err)
 	}
 	//lint:ignore SA1012 testing nil context handling
-	if err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
+	if _, _, _, err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
 		t.Fatalf("expected nil context error, got %v", err)
 	}
 }

--- a/transfer/wal_resume_test.go
+++ b/transfer/wal_resume_test.go
@@ -58,7 +58,7 @@ func TestResumeValidation(t *testing.T) {
 		t.Fatalf("write resume: %v", err)
 	}
 	cfg := &config.Config{ResumeState: path, DedupMode: "fixed", Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3"}
-	chk := readResumeState(cfg, zap.NewNop(), 2, "dest", 2)
+	chk := readResumeState(cfg, zap.NewNop(), 2, "dest", 2, [32]byte{})
 	if rc := chk.chunk("fixed"); rc != (resumeChunk{}) {
 		t.Fatalf("expected empty checkpoint, got %#v", rc)
 	}

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -31,7 +31,7 @@ func buildManifest(t *testing.T, devPath, manPath, uuid string, size uint64) {
 	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
 		return &mockDevice{path: devPath, size: size, blockSize: 4}, nil
 	}
-	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil)
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil, nil)
 	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Map `--resume=verify` to `ResumeVerify` in configuration parsing
- Fail resume verification when WAL ranges differ from manifest
- Document verification path in operations guide

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`
- `go test -tags integration ./transfer -run TestResumeVerifyMismatch -count=1` *(failed: undefined: device.SetUUIDFunc)*


------
https://chatgpt.com/codex/tasks/task_e_68a393923460832394e84e224bd81d0a