### PR TITLE
Persist and validate resume metadata

### DIFF
--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -68,7 +68,7 @@ func TestIdentityUUIDMismatch(t *testing.T) {
 			return "id1", nil
 		}
 		return "id2", nil
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return &identityStub{size: 1}, nil
 	})

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -40,6 +40,9 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 	if err != nil {
 		return err
 	}
+	t.Tracker.sizeBytes = size
+	t.Tracker.deviceID = id
+	t.Tracker.epoch = epoch
 
 	var destFile *os.File
 	if cfg.ODirect {

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -335,7 +335,7 @@ func TestVerifyDestinationDigestMismatch(t *testing.T) {
 	}
 	f.Close()
 	cfg := &config.Config{ManifestPath: man}
-	if err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("expected digest mismatch, got %v", err)
 	}
 }

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -55,7 +55,7 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	digest := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{ResumeState: stateFile, Compress: "none", ChecksumAlgorithm: "blake3", DedupMode: "fixed"}
 	chk := resumeChunk{Chunk: digest, Offset: 1024, Length: 2048}
-	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: chk})
+	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: chk}, 0, "", 0)
 
 	val := readResumeState(cfg, logger, 0, cfg.DeviceUUID, 0, [32]byte{}).Fixed
 	if val.Chunk != digest {

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -101,7 +101,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 		CheckpointBytes:   1,
 	}
 	digest0 := blake3.Sum256(srcData0)
-	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
 
 	ctx := context.Background()
 	tr, err := transport.Get("ssh", transport.Config{Logger: zap.NewNop(), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true})
@@ -214,7 +214,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 		CheckpointBytes:   1,
 	}
 	digest0 := blake3.Sum256(srcData0)
-	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
 
 	ctx := context.Background()
 	tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
@@ -355,7 +355,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
 
 			ctx := context.Background()
 			tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
@@ -476,7 +476,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
 
 			ctx := context.Background()
 			tcfg := transport.Config{Logger: zap.NewNop()}
@@ -654,7 +654,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}})
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
 
 			ctx := context.Background()
 			tr, err := transport.Get("ssh", transport.Config{Logger: zap.NewNop(), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true})

--- a/transfer/resume.go
+++ b/transfer/resume.go
@@ -26,6 +26,9 @@ type resumeTracker struct {
 	bytes int64
 	last  time.Time
 	resumeChunks
+	sizeBytes uint64
+	deviceID  string
+	epoch     uint64
 }
 
 func (rt *resumeTracker) chunk(mode string) *resumeChunk {

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -22,7 +22,7 @@ func TestResumeCDCOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: 80, Length: 40}})
+	writeResumeState(cfg, logger, state, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0)
 
 	chk := readResumeState(cfg, logger, 0, cfg.DeviceUUID, 0, [32]byte{})
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -44,7 +44,7 @@ func TestResumeCDCSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
@@ -69,7 +69,7 @@ func TestResumeCDCIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_fixed_test.go
+++ b/transfer/resume_fixed_test.go
@@ -23,7 +23,7 @@ func TestResumeFixedIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -22,7 +22,7 @@ func TestResumeHybridOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: 80, Length: 40}})
+	writeResumeState(cfg, logger, state, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0)
 
 	chk := readResumeState(cfg, logger, 0, cfg.DeviceUUID, 0, [32]byte{})
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -44,7 +44,7 @@ func TestResumeHybridSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
@@ -69,7 +69,7 @@ func TestResumeHybridIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}})
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -34,7 +34,7 @@ type resumeState struct {
 }
 
 // writeResumeState persists resume state; logger must be non-nil.
-func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunks resumeChunks) {
+func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunks resumeChunks, size uint64, deviceID string, epoch uint64) {
 	toState := func(ch resumeChunk) resumeChunkState {
 		return resumeChunkState{
 			Offset: ch.Offset,
@@ -50,9 +50,9 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunk
 		Fixed:             toState(chunks.Fixed),
 		CDC:               toState(chunks.CDC),
 		Hybrid:            toState(chunks.Hybrid),
-		SizeBytes:         0,
-		DeviceID:          cfg.DeviceUUID,
-		Epoch:             0,
+		SizeBytes:         size,
+		DeviceID:          deviceID,
+		Epoch:             epoch,
 		FirstBlockDigest:  cfg.FirstBlockDigest,
 	}
 	data, err := json.Marshal(rs)
@@ -77,7 +77,7 @@ func saveResumeState(cfg *config.Config, rt *resumeTracker, offset uint64, chunk
 	*rc = resumeChunk{Chunk: chunk, Offset: offset, Length: uint32(size)}
 	if (cfg.CheckpointBytes > 0 && rt.bytes >= int64(cfg.CheckpointBytes)) ||
 		(cfg.CheckpointInterval > 0 && time.Since(rt.last) >= cfg.CheckpointInterval) {
-		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunks{Fixed: rt.Fixed, CDC: rt.CDC, Hybrid: rt.Hybrid})
+		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunks{Fixed: rt.Fixed, CDC: rt.CDC, Hybrid: rt.Hybrid}, rt.sizeBytes, rt.deviceID, rt.epoch)
 		rt.bytes = 0
 		rt.last = time.Now()
 	}
@@ -96,6 +96,9 @@ func finalizeResumeState(cfg *config.Config, rt *resumeTracker, logger *zap.Logg
 	rt.bytes = 0
 	rt.last = time.Time{}
 	rt.resumeChunks = resumeChunks{}
+	rt.sizeBytes = 0
+	rt.deviceID = ""
+	rt.epoch = 0
 }
 
 func readResumeState(cfg *config.Config, logger *zap.Logger, size uint64, deviceID string, epoch uint64, digest [32]byte) resumeCheckpoint {

--- a/transfer/resume_state_test.go
+++ b/transfer/resume_state_test.go
@@ -23,14 +23,14 @@ func TestSaveAndReadResumeState(t *testing.T) {
 		DedupMode:         "fixed",
 		CheckpointBytes:   4,
 	}
-	rt := &resumeTracker{}
+	rt := &resumeTracker{sizeBytes: 100, deviceID: "id", epoch: 1}
 	digest := blake3.Sum256([]byte("data"))
 	cfg.FirstBlockDigest = hex.EncodeToString(digest[:])
 	saveResumeState(cfg, rt, 0, digest, 4, zap.NewNop())
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected resume state file: %v", err)
 	}
-	cp := readResumeState(cfg, zap.NewNop(), 0, cfg.DeviceUUID, 0, digest)
+	cp := readResumeState(cfg, zap.NewNop(), 100, "id", 1, digest)
 	rc := cp.chunk("fixed")
 	if rc.Offset != 0 || rc.Length != 4 || hex.EncodeToString(rc.Chunk[:]) != hex.EncodeToString(digest[:]) {
 		t.Fatalf("unexpected checkpoint: %+v", rc)
@@ -60,5 +60,31 @@ func TestReadResumeStateDigestMismatch(t *testing.T) {
 	cp := readResumeState(cfg, zap.NewNop(), 0, cfg.DeviceUUID, 0, bad)
 	if cp != (resumeCheckpoint{}) {
 		t.Fatalf("expected empty checkpoint on digest mismatch")
+	}
+}
+
+func TestReadResumeStateSizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
+	rt := &resumeTracker{sizeBytes: 100, deviceID: "id", epoch: 1}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cp := readResumeState(cfg, zap.NewNop(), 200, "id", 1, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on size mismatch")
+	}
+}
+
+func TestReadResumeStateEpochMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
+	rt := &resumeTracker{sizeBytes: 100, deviceID: "id", epoch: 1}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cp := readResumeState(cfg, zap.NewNop(), 100, "id", 2, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on epoch mismatch")
 	}
 }

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -40,7 +40,7 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int, algo string)
 		digest = blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
 	}
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: algo, DedupMode: "fixed"}
-	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: 0, Length: uint32(blockSize)}})
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
 	return srcPath, snapshot, resumePath
 }
 
@@ -151,7 +151,7 @@ func TestResumeModeTransitions(t *testing.T) {
 			default:
 				chunks.Fixed = rc
 			}
-			writeResumeState(cfgStart, zap.NewNop(), resume, chunks)
+			writeResumeState(cfgStart, zap.NewNop(), resume, chunks, 0, "", 0)
 
 			cfgResume := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.to}
 

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -274,7 +274,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 		if err != nil {
-			return fmt.Errorf("read destination digest: %w", err)
+			return 0, "", 0, fmt.Errorf("read destination digest: %w", err)
 		}
 		if dig != hdr.FirstBlockDigest {
 			t.Logger.Error(
@@ -282,7 +282,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 				zap.String("expected_digest", hex.EncodeToString(hdr.FirstBlockDigest[:])),
 				zap.String("first_block_digest", hex.EncodeToString(dig[:])),
 			)
-			return fmt.Errorf("destination device digest mismatch")
+			return 0, "", 0, fmt.Errorf("destination device digest mismatch")
 		}
 		if cfg.ResumeState != "" {
 			if _, err := os.Stat(cfg.ResumeState); err == nil {
@@ -316,11 +316,11 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		if cfg.FirstBlockDigest != "" {
 			dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 			if err != nil {
-				return fmt.Errorf("read destination digest: %w", err)
+				return 0, "", 0, fmt.Errorf("read destination digest: %w", err)
 			}
 			if hex.EncodeToString(dig[:]) != cfg.FirstBlockDigest {
 				t.Logger.Error("first_block_digest_mismatch", zap.String("expected_digest", cfg.FirstBlockDigest), zap.String("first_block_digest", hex.EncodeToString(dig[:])))
-				return fmt.Errorf("destination device digest mismatch")
+				return 0, "", 0, fmt.Errorf("destination device digest mismatch")
 			}
 		}
 		t.Logger.Info("destination_validated", zap.String("resource_id", id))

--- a/transfer/verify_destination_ctx_test.go
+++ b/transfer/verify_destination_ctx_test.go
@@ -24,7 +24,7 @@ func TestVerifyDestinationNilContext(t *testing.T) {
 		t.Fatalf("write dest: %v", err)
 	}
 	//lint:ignore SA1012 testing nil context handling
-	if err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
+	if _, _, _, err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
 		t.Fatalf("expected nil context error, got %v", err)
 	}
 }

--- a/transfer/wal_resume_test.go
+++ b/transfer/wal_resume_test.go
@@ -58,7 +58,7 @@ func TestResumeValidation(t *testing.T) {
 		t.Fatalf("write resume: %v", err)
 	}
 	cfg := &config.Config{ResumeState: path, DedupMode: "fixed", Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3"}
-	chk := readResumeState(cfg, zap.NewNop(), 2, "dest", 2)
+	chk := readResumeState(cfg, zap.NewNop(), 2, "dest", 2, [32]byte{})
 	if rc := chk.chunk("fixed"); rc != (resumeChunk{}) {
 		t.Fatalf("expected empty checkpoint, got %#v", rc)
 	}

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -31,7 +31,7 @@ func buildManifest(t *testing.T, devPath, manPath, uuid string, size uint64) {
 	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
 		return &mockDevice{path: devPath, size: size, blockSize: 4}, nil
 	}
-	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil)
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil, nil)
 	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}


### PR DESCRIPTION
## Summary
- record device size, UUID, and epoch when writing resume state
- capture destination metadata in the transfer tracker and validate on read
- test resume state handling for matching and mismatched size/epoch

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3938d41408323b6b1c3e1ae99839f