### PR TITLE
Ensure verifyDestination returns full tuple on error

### DIFF
--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -68,7 +68,7 @@ func TestIdentityUUIDMismatch(t *testing.T) {
 			return "id1", nil
 		}
 		return "id2", nil
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return &identityStub{size: 1}, nil
 	})

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -335,7 +335,7 @@ func TestVerifyDestinationDigestMismatch(t *testing.T) {
 	}
 	f.Close()
 	cfg := &config.Config{ManifestPath: man}
-	if err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("expected digest mismatch, got %v", err)
 	}
 }

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -274,7 +274,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 		if err != nil {
-			return fmt.Errorf("read destination digest: %w", err)
+			return 0, "", 0, fmt.Errorf("read destination digest: %w", err)
 		}
 		if dig != hdr.FirstBlockDigest {
 			t.Logger.Error(
@@ -282,7 +282,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 				zap.String("expected_digest", hex.EncodeToString(hdr.FirstBlockDigest[:])),
 				zap.String("first_block_digest", hex.EncodeToString(dig[:])),
 			)
-			return fmt.Errorf("destination device digest mismatch")
+			return 0, "", 0, fmt.Errorf("destination device digest mismatch")
 		}
 		if cfg.ResumeState != "" {
 			if _, err := os.Stat(cfg.ResumeState); err == nil {
@@ -316,11 +316,11 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		if cfg.FirstBlockDigest != "" {
 			dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 			if err != nil {
-				return fmt.Errorf("read destination digest: %w", err)
+				return 0, "", 0, fmt.Errorf("read destination digest: %w", err)
 			}
 			if hex.EncodeToString(dig[:]) != cfg.FirstBlockDigest {
 				t.Logger.Error("first_block_digest_mismatch", zap.String("expected_digest", cfg.FirstBlockDigest), zap.String("first_block_digest", hex.EncodeToString(dig[:])))
-				return fmt.Errorf("destination device digest mismatch")
+				return 0, "", 0, fmt.Errorf("destination device digest mismatch")
 			}
 		}
 		t.Logger.Info("destination_validated", zap.String("resource_id", id))

--- a/transfer/verify_destination_ctx_test.go
+++ b/transfer/verify_destination_ctx_test.go
@@ -24,7 +24,7 @@ func TestVerifyDestinationNilContext(t *testing.T) {
 		t.Fatalf("write dest: %v", err)
 	}
 	//lint:ignore SA1012 testing nil context handling
-	if err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
+	if _, _, _, err := tr.verifyDestination(nil, cfg, dest); err == nil || !strings.Contains(err.Error(), "nil context") {
 		t.Fatalf("expected nil context error, got %v", err)
 	}
 }

--- a/transfer/verify_destination_validation_test.go
+++ b/transfer/verify_destination_validation_test.go
@@ -1,0 +1,76 @@
+package transfer
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/device"
+	"lvmsync_go/internal/config"
+	manifestpkg "lvmsync_go/manifest"
+)
+
+func TestVerifyDestinationManifestDigestError(t *testing.T) {
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "id", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(context.Context, string, uint64) ([32]byte, error) { return [32]byte{}, errors.New("boom") },
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, make([]byte, 1024), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	man := filepath.Join(t.TempDir(), "man")
+	var hdr manifestpkg.Header
+	hdr.Version = manifestpkg.Version
+	hdr.BlockSize = 512
+	hdr.SizeBytes = 1024
+	hdr.ChunkCount = 2
+	copy(hdr.DeviceID[:], []byte("id"))
+	hdr.MAC = manifestHeaderMAC(&hdr)
+	f, err := os.Create(man)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	f.Close()
+	cfg := &config.Config{ManifestPath: man}
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "read destination digest") {
+		t.Fatalf("expected digest read error, got %v", err)
+	}
+}
+
+func TestVerifyDestinationFirstBlockDigestMismatch(t *testing.T) {
+	info := device.NewInfoWithDeps(
+		nil,
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(context.Context, string, uint64) ([32]byte, error) {
+			var d [32]byte
+			d[0] = 1
+			return d, nil
+		},
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, make([]byte, 512), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	cfg := &config.Config{FirstBlockDigest: strings.Repeat("00", 32)}
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("expected digest mismatch, got %v", err)
+	}
+}

--- a/transfer/wal_resume_test.go
+++ b/transfer/wal_resume_test.go
@@ -58,7 +58,7 @@ func TestResumeValidation(t *testing.T) {
 		t.Fatalf("write resume: %v", err)
 	}
 	cfg := &config.Config{ResumeState: path, DedupMode: "fixed", Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3"}
-	chk := readResumeState(cfg, zap.NewNop(), 2, "dest", 2)
+	chk := readResumeState(cfg, zap.NewNop(), 2, "dest", 2, [32]byte{})
 	if rc := chk.chunk("fixed"); rc != (resumeChunk{}) {
 		t.Fatalf("expected empty checkpoint, got %#v", rc)
 	}

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -31,7 +31,7 @@ func buildManifest(t *testing.T, devPath, manPath, uuid string, size uint64) {
 	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
 		return &mockDevice{path: devPath, size: size, blockSize: 4}, nil
 	}
-	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil)
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil, nil)
 	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}


### PR DESCRIPTION
## Summary
- return zero-value tuple alongside errors from `verifyDestination`
- add tests for manifest digest read failures and first-block digest mismatches
- update existing tests to use the expanded return signature

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_68a3938b8bc48323b84bdfc14cdfe117