### PR TITLE
docs: expand exit code table

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -42,7 +42,9 @@ Reads both devices and reports mismatches without writing data.
 | `20` | Device error | Verify device paths and snapshot health. |
 | `30` | Unsupported platform | Run on a supported Linux platform. |
 | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
-| `50` | Runtime failure or verification mismatch | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
+| `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
+| `60` | Verification mismatch | Investigate mismatched data before retrying. |
+| `70` | Partial transfer | Address the error and resume with `--resume`. |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- document exit codes 60 (verification mismatch) and 70 (partial transfer) in operations guide
- clarify that code 50 represents runtime failures

## Testing
- `go build ./...` *(fails: transfer/transfer.go not enough return values)*
- `go test -cover ./...` *(fails: transfer/transfer.go not enough return values)*
- `golangci-lint run`
- `go tool cover -func=coverage.out` *(fails: coverage.out missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a393d2d7248323831309e20af6623a