### PR TITLE
docs: document sudoers entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 LVMSync is a high-performance incremental data replication tool for LVM snapshots. It efficiently transfers only changed blocks using metadata from snapshot COW (Copy-On-Write) devices and communicates with LVM through native Go bindings rather than shell commands.
 
-For details on running with minimal privileges and sudoers examples, see [SECURITY.md](SECURITY.md).
+For details on running with minimal privileges and sudoers examples, see [SECURITY.md](SECURITY.md) and [docs/sudoers.md](docs/sudoers.md).
 
 ## Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ The controller orchestrates replication, validates parameters, and interacts wit
 
 ## Example sudoers configuration
 
-Tight `sudoers` rules limit what the helper may execute:
+Tight `sudoers` rules limit what the helper may execute. See [docs/sudoers.md](docs/sudoers.md) for command-specific entries:
 
 ```sudoers
 # Allow LVM administration commands

--- a/docs/sudoers.md
+++ b/docs/sudoers.md
@@ -1,0 +1,43 @@
+# sudoers Entries
+
+LVMSync requires elevated privileges for a small set of operations. The
+following examples show least-privilege `sudoers` rules for each command.
+Adjust paths to match your distribution and test on non-production systems
+before enabling them in production.
+
+## LVM administration
+
+Permit only the LVM utilities needed by LVMSync:
+
+```sudoers
+# Allow LVMSync to run LVM commands without a password
+lvmsync ALL=(root) NOPASSWD: \
+    /sbin/lvm, \
+    /sbin/lvcreate, \
+    /sbin/lvremove, \
+    /sbin/lvs, \
+    /sbin/pvs, \
+    /sbin/vgs
+```
+
+## Device helper
+
+The helper performs privileged device operations such as opening block
+devices, writing data and issuing discards:
+
+```sudoers
+lvmsync ALL=(root) NOPASSWD: \
+    /usr/local/bin/lvmsync-helper open, \
+    /usr/local/bin/lvmsync-helper write, \
+    /usr/local/bin/lvmsync-helper discard
+```
+
+## blkdiscard fallback
+
+Enable direct `blkdiscard` when the helper is unavailable:
+
+```sudoers
+lvmsync ALL=(root) NOPASSWD: /usr/sbin/blkdiscard
+```
+
+Test each entry carefully to ensure no additional privileges are granted.


### PR DESCRIPTION
## Summary
- document least-privilege sudoers entries for privileged commands
- cross-link sudoers guidance from README and SECURITY

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestResumeFlagVerify)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a39b6414788323b05e3f406cd09f98