### PR TITLE
docs: document probe-only and verify-only modes

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -4,6 +4,14 @@ This guide outlines exit codes, resume workflows, and common troubleshooting ste
 
 ## Resume and Verification Sequences
 
+### `--probe-only`
+
+```sh
+lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
+```
+
+Validates device identities and privileges and logs dry-run estimates without writing data.
+
 ### `--resume`
 
 ```sh
@@ -33,6 +41,28 @@ lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
 ```
 
 Reads both devices and reports mismatches without writing data.
+
+## Safe Overwrite Procedure
+
+1. Probe devices and ensure privileges are correct:
+
+   ```sh
+   lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
+   ```
+
+2. Verify existing blocks:
+
+   ```sh
+   lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
+   ```
+
+3. Perform the copy, optionally resuming with verification:
+
+   ```sh
+   lvmsync run --resume=verify /dev/vg0/snap0 /dev/vg0/target
+   ```
+
+Exit code `60` indicates a verification mismatch and leaves the destination untouched.
 
 ## Exit Codes and Recovery
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ For details on running with minimal privileges and sudoers examples, see [SECURI
 - **Hashing**: Hardware-accelerated XXH3 provides fast deduplication hints while BLAKE3 digests are stored in manifests for integrity.
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers and verify results with `--resume=verify`.
+- **Probe and Verification Modes**: `--probe-only` validates devices and privileges without writing, while `--verify-only` scans both sides and reports mismatches.
+- **Dry-run Estimates**: `--dry-run` samples the manifest to project bytes and ETA without transferring data.
 - **Device Identity Tuple**: Each run records `(device_id, size_bytes, major:minor)` to prevent writing to the wrong destination.
 - **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
 - **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it.
@@ -42,14 +44,33 @@ For details on running with minimal privileges and sudoers examples, see [SECURI
   Configuration values follow flag > environment variable > config file precedence.
 - **Configuration Validation**: Checks key parameters (e.g., volume group existence, escalation command) before starting operations.
 
-### Resume and overwrite flows
+### Resume, verification, and safe overwrite flows
 
 Transfers store the device identity tuple and compare it against the destination before writing. Mismatches abort the run to avoid accidental overwrites. Use `--force` to bypass this check when intentionally overwriting.
 
-- `--resume=statefile` continues an interrupted run.
-- `--resume=verify` resumes the copy and then performs a verification pass.
+**Resume after failure**
+```sh
+lvmsync run --resume=statefile /dev/vg0/snap0 /dev/vg0/target
+```
 
-For snapshot workflow, resume modes, verification-only runs, and recovery guidance, see [operations guide](OPERATIONS.md).
+**Resume with verification**
+```sh
+lvmsync run --resume=verify /dev/vg0/snap0 /dev/vg0/target
+```
+
+**Verification only**
+```sh
+lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
+```
+
+**Safe overwrite procedure**
+```sh
+lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
+lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
+lvmsync run /dev/vg0/snap0 /dev/vg0/target
+```
+
+Exit code `60` signals verification mismatches. See [operations guide](OPERATIONS.md) for detailed recovery steps.
 
 ## Supported Platforms
 
@@ -635,6 +656,8 @@ Flags override environment variables, which override `config.yaml` values.
 | `--force` | `LVMSYNC_FORCE` | `force` | Override safety checks and proceed on mounted destination |
 | `--discard` | `LVMSYNC_DISCARD` | `discard` | Issue BLKDISCARD before writing blocks |
 | `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Log estimated transfer bytes without sending data; uses manifest sampling when available |
+| `--verify-only` | `LVMSYNC_VERIFY_ONLY` | `verify_only` | Read source and destination and report mismatches without writing data |
+| `--probe-only` | `LVMSYNC_PROBE_ONLY` | `probe_only` | Validate devices and privileges and log estimates without transferring data |
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | `transport` | Ordered transports to try (e.g., `quic,h2,tcp+tls,ssh`) |
 | `--tcp-port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |
 | `--tcp-parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | `tcp_parallel` | Number of parallel TCP connections |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,13 @@ LVMSync splits privileged and unprivileged responsibilities. The main controller
 
 The controller orchestrates replication, validates parameters, and interacts with remote peers. Operations that require root — such as managing LVM volumes, opening raw block devices or issuing discard commands — are executed through a privileged helper invoked via `sudo` or Linux capabilities. The helper performs only the requested action and exits immediately, minimising the trusted code surface.
 
+## Probe and verify modes
+
+Read-only operations can run without elevated privileges.  
+`--probe-only` checks device metadata, validates privileges, and emits dry-run estimates.  
+`--verify-only` reads source and destination devices and reports mismatches.  
+Both commands exit `0` on success, return `60` for verification failures, and `10` when required capabilities are missing.
+
 ## Example sudoers configuration
 
 Tight `sudoers` rules limit what the helper may execute:

--- a/perf.md
+++ b/perf.md
@@ -23,10 +23,15 @@ Common options:
 - `--parallel 4`
 - `--transport` set per test case
 - `--compress` set per test case
+- `--probe-only` for pre-flight checks and dry-run estimates
+- `--verify-only` when measuring read-only verification costs
 
 ## Running Benchmarks
 
 Benchmarks are executed with helper scripts that wrap the `lvmsync run` command and collect timing data.
+
+Ensure the privilege model is satisfied: run as root or configure `--lvm-escalation`.  
+Non-zero exit codes indicate problems (`10` for privilege failures, `60` for verification mismatches).
 
 ### LAN Flags
 


### PR DESCRIPTION
## Summary
- describe probe-only, verify-only, dry-run estimate, and exit code behaviors across docs
- add resume, verification, and safe overwrite example flows
- clarify privilege model and read-only operations

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestResumeFlagVerify, TestManifestIndexLifecycle)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a39bafb4408323b47924b1f652b4b0