### PR TITLE
transfer: validate resume metadata tuple

### DIFF
--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -118,10 +118,20 @@ func readResumeState(cfg *config.Config, logger *zap.Logger, size uint64, device
 		rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm {
 		return out
 	}
-	if (rs.DeviceID != "" && deviceID != "" && rs.DeviceID != deviceID) ||
-		(rs.SizeBytes != 0 && size != 0 && rs.SizeBytes != size) ||
-		(rs.Epoch != 0 && epoch != 0 && rs.Epoch != epoch) {
-		return out
+	if deviceID != "" {
+		if rs.DeviceID == "" || rs.DeviceID != deviceID {
+			return out
+		}
+	}
+	if size != 0 {
+		if rs.SizeBytes == 0 || rs.SizeBytes != size {
+			return out
+		}
+	}
+	if epoch != 0 {
+		if rs.Epoch == 0 || rs.Epoch != epoch {
+			return out
+		}
 	}
 	if rs.FirstBlockDigest != "" && digest != ([32]byte{}) {
 		b, err := hex.DecodeString(rs.FirstBlockDigest)

--- a/transfer/resume_state_test.go
+++ b/transfer/resume_state_test.go
@@ -76,6 +76,19 @@ func TestReadResumeStateSizeMismatch(t *testing.T) {
 	}
 }
 
+func TestReadResumeStateDeviceIDMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
+	rt := &resumeTracker{sizeBytes: 100, deviceID: "id", epoch: 1}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cp := readResumeState(cfg, zap.NewNop(), 100, "other", 1, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on device id mismatch")
+	}
+}
+
 func TestReadResumeStateEpochMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "resume.json")

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -306,6 +306,10 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 				if err != nil {
 					return 0, "", 0, fmt.Errorf("read destination size: %w", err)
 				}
+				chk := readResumeState(cfg, t.Logger, size, id, 0, [32]byte{})
+				if chk == (resumeCheckpoint{}) {
+					return 0, "", 0, fmt.Errorf("resume state does not match destination metadata")
+				}
 			}
 			if cfg.DeviceUUID != "" && id != cfg.DeviceUUID {
 				t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", cfg.DeviceUUID), zap.String("resource_id", id))


### PR DESCRIPTION
## Summary
- enforce size, device ID, and epoch checks when loading resume state
- ensure resume metadata matches destination before transfers
- test resume state rejection on device UUID mismatch

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: ResumeState="statefile" want "resume.json" in internal/config TestResumeFlagVerify)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a39b3dd10083238f7084f510967e57