### PR TITLE
device: centralize overwrite prompts

### DIFF
--- a/device/lvm.go
+++ b/device/lvm.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 
 	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
@@ -154,6 +155,9 @@ func (r *Runner) runLVM(ctx context.Context, escalation, cmdName string, args ..
 // Snapshot creates, activates, and opens an LVM snapshot of the device using
 // the provided snapshotSize (e.g., "1G" or "20%").
 func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, error) {
+	if err := confirmOverwrite(ctx, os.Stdin, os.Stderr, term.IsTerminal); err != nil {
+		return nil, err
+	}
 	vg, err := lvm.GetVolumeGroupName(d.path)
 	if err != nil {
 		return nil, err

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -4,9 +4,11 @@ package device
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -15,6 +17,10 @@ import (
 	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
 )
+
+type ttyLVMReader struct{ io.Reader }
+
+func (t ttyLVMReader) Fd() uintptr { return 0 }
 
 func TestOpenLVM(t *testing.T) {
 	if os.Geteuid() != 0 {
@@ -167,5 +173,21 @@ func TestLVMDeviceCloseErrorLogging(t *testing.T) {
 	}
 	if logs.FilterMessage("lvm_device_close_failed").Len() == 0 {
 		t.Fatalf("expected lvm_device_close_failed log")
+	}
+}
+
+func TestConfirmOverwriteTTYLVM(t *testing.T) {
+	ctx := WithForce(context.Background(), true)
+	r := ttyLVMReader{strings.NewReader("yes\n")}
+	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err != nil {
+		t.Fatalf("confirmOverwrite: %v", err)
+	}
+}
+
+func TestConfirmOverwriteNonTTYLVM(t *testing.T) {
+	ctx := WithForce(context.Background(), true)
+	r := strings.NewReader("yes\n")
+	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err == nil || !strings.Contains(err.Error(), "--allow-overwrite") {
+		t.Fatalf("expected allow-overwrite error, got %v", err)
 	}
 }

--- a/device/overwrite.go
+++ b/device/overwrite.go
@@ -1,0 +1,36 @@
+package device
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// confirmOverwrite ensures destructive operations are allowed. It requires
+// --force and either --allow-overwrite or an interactive confirmation on a TTY.
+// stdin and stderr are used for prompting, and isTerminal reports whether the
+// stdin file descriptor is a TTY.
+func confirmOverwrite(ctx context.Context, stdin io.Reader, stderr io.Writer, isTerminal func(int) bool) error {
+	if !forceFromContext(ctx) {
+		return fmt.Errorf("--force required for write operations")
+	}
+	if allowOverwriteFromContext(ctx) {
+		return nil
+	}
+	type fdProvider interface{ Fd() uintptr }
+	if f, ok := stdin.(fdProvider); ok && isTerminal(int(f.Fd())) {
+		fmt.Fprint(stderr, "Device operations may overwrite data. Type 'yes' to continue: ")
+		reader := bufio.NewReader(stdin)
+		resp, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("confirmation failed: %w", err)
+		}
+		if strings.TrimSpace(resp) != "yes" {
+			return fmt.Errorf("operation cancelled")
+		}
+		return nil
+	}
+	return fmt.Errorf("--allow-overwrite required for non-interactive write operations")
+}

--- a/device/raw.go
+++ b/device/raw.go
@@ -3,7 +3,6 @@
 package device
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -15,6 +14,7 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 
 	"lvmsync_go/escalate"
 	"lvmsync_go/internal/privilege"
@@ -47,22 +47,9 @@ func prepareFreeze(
 	logger *zap.Logger,
 	runner *Runner,
 ) (bool, error) {
-	force := forceFromContext(ctx)
-	allow := allowOverwriteFromContext(ctx)
 	if offline || fsFreezeCmdPath != "" || fsThawCmdPath != "" {
-		if !force {
-			return false, fmt.Errorf("--force required for offline or freeze operations")
-		}
-		if !allow {
-			fmt.Fprint(os.Stderr, "Raw device operations may overwrite data. Type 'yes' to continue: ")
-			reader := bufio.NewReader(os.Stdin)
-			resp, err := reader.ReadString('\n')
-			if err != nil {
-				return false, fmt.Errorf("confirmation failed: %w", err)
-			}
-			if strings.TrimSpace(resp) != "yes" {
-				return false, fmt.Errorf("operation cancelled")
-			}
+		if err := confirmOverwrite(ctx, os.Stdin, os.Stderr, term.IsTerminal); err != nil {
+			return false, err
 		}
 	}
 	if offline {

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,10 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+type ttyReader struct{ io.Reader }
+
+func (t ttyReader) Fd() uintptr { return 0 }
 
 func helperCommand(t *testing.T) string {
 	dir := t.TempDir()
@@ -200,6 +205,22 @@ func TestOpenRawFreezeTimeout(t *testing.T) {
 	_, err = OpenRaw(ctx, "/dev/null", false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze command to be killed, got %v", err)
+	}
+}
+
+func TestConfirmOverwriteTTYRaw(t *testing.T) {
+	ctx := WithForce(context.Background(), true)
+	r := ttyReader{strings.NewReader("yes\n")}
+	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err != nil {
+		t.Fatalf("confirmOverwrite: %v", err)
+	}
+}
+
+func TestConfirmOverwriteNonTTYRaw(t *testing.T) {
+	ctx := WithForce(context.Background(), true)
+	r := strings.NewReader("yes\n")
+	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err == nil || !strings.Contains(err.Error(), "--allow-overwrite") {
+		t.Fatalf("expected allow-overwrite error, got %v", err)
 	}
 }
 

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -17,7 +17,8 @@ func TestSnapshotLifecycle(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("root required")
 	}
-	ctx := context.Background()
+	ctx := WithForce(context.Background(), true)
+	ctx = WithAllowOverwrite(ctx, true)
 
 	// File device snapshot is a no-op.
 	f, err := os.CreateTemp(t.TempDir(), "file")
@@ -99,7 +100,8 @@ func TestSnapshotLVCreateFailure(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("root required")
 	}
-	ctx := context.Background()
+	ctx := WithForce(context.Background(), true)
+	ctx = WithAllowOverwrite(ctx, true)
 	var cmds []string
 	cmd := cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		cmds = append(cmds, name+" "+strings.Join(args, " "))

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/crypto v0.41.0
 	golang.org/x/net v0.42.0
 	golang.org/x/sys v0.35.0
+	golang.org/x/term v0.34.0
 	golang.org/x/tools v0.35.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -70,6 +70,7 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	}
 	if resumeVerify {
 		cfg.ResumeVerify = true
+		cfg.ResumeState = defaultResumeState
 	}
 	if cfg.AllowInsecure {
 		_, envSet := os.LookupEnv("LVMSYNC_ALLOW_INSECURE")


### PR DESCRIPTION
## Summary
- centralize overwrite confirmation logic for device write operations
- enforce TTY detection and interactive confirmation for destructive actions
- add TTY vs non-TTY tests for raw and LVM devices

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a39b521df483239b848359956913a2