### PR TITLE
refactor escalate root detection and env handling

### DIFF
--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -61,19 +61,22 @@ type Options struct {
 	Sys        syscallFacade // defaults to real unix syscalls
 }
 
-// IsRoot reports whether effective UID is 0 (overridable for tests via Options).
-func IsRoot() bool { return os.Geteuid() == 0 }
+// IsRoot reports whether the effective UID is 0.
+// The check can be overridden for tests via Options.Geteuid.
+func IsRoot(opts Options) bool {
+	geteuid := opts.Geteuid
+	if geteuid == nil {
+		geteuid = os.Geteuid
+	}
+	return geteuid() == 0
+}
 
 // EnsureRootOrReexec ensures the process runs as root.
 // If already root, returns (false, nil).
 // If not root, re-execs the current binary through `sudo -n` and returns (true, err).
 // When (true, nil) is returned, the caller should exit immediately.
 func EnsureRootOrReexec(opts Options) (bool, error) {
-	geteuid := opts.Geteuid
-	if geteuid == nil {
-		geteuid = os.Geteuid
-	}
-	if geteuid() == 0 {
+	if IsRoot(opts) {
 		return false, nil
 	}
 
@@ -103,14 +106,13 @@ func EnsureRootOrReexec(opts Options) (bool, error) {
 	args = append(args, filterAllowed(argv[1:], opts.AllowedPassthrough)...)
 
 	var env []string
-	switch {
-	case opts.SanitizeEnv:
+	if opts.SanitizeEnv {
+		environ := os.Environ
 		if opts.Environ != nil {
-			env = sanitizedChildEnv(opts.Environ())
-		} else {
-			env = sanitizedChildEnv(os.Environ())
+			environ = opts.Environ
 		}
-	case opts.Environ != nil:
+		env = sanitizedChildEnv(environ())
+	} else if opts.Environ != nil {
 		env = opts.Environ()
 	}
 

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -63,6 +64,15 @@ func TestSelfPath(t *testing.T) {
 	p, err := selfPath()
 	if err != nil || p == "" {
 		t.Fatalf("selfPath failed: %v %q", err, p)
+	}
+}
+
+func TestIsRoot(t *testing.T) {
+	if !IsRoot(Options{Geteuid: func() int { return 0 }}) {
+		t.Fatal("expected root")
+	}
+	if IsRoot(Options{Geteuid: func() int { return 1000 }}) {
+		t.Fatal("expected non-root")
 	}
 }
 
@@ -221,6 +231,23 @@ func TestEnsureRootOrReexec_RunnerError(t *testing.T) {
 	}
 }
 
+func TestEnsureRootOrReexec_RunnerExitCode(t *testing.T) {
+	_, err := EnsureRootOrReexec(Options{
+		Geteuid:  func() int { return 1000 },
+		LookPath: func(string) (string, error) { return "/usr/bin/sudo", nil },
+		ExecRunner: func(string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+			return exec.Command("sh", "-c", "exit 42").Run()
+		},
+	})
+	var ee *exec.ExitError
+	if err == nil || !errors.As(err, &ee) {
+		t.Fatalf("expected ExitError, got %v", err)
+	}
+	if code := ee.ExitCode(); code != 42 {
+		t.Fatalf("expected exit code 42, got %d", code)
+	}
+}
+
 func TestEnsureRootOrReexec_DropsDisallowedFlags(t *testing.T) {
 	var got execCall
 	reexeced, err := EnsureRootOrReexec(Options{
@@ -281,6 +308,24 @@ func TestEnsureRootOrReexec_DefaultUnsanitizedEnv(t *testing.T) {
 	}
 	if len(got.env) != 0 {
 		t.Fatalf("expected empty env to inherit unsanitized environment, got %v", got.env)
+	}
+}
+
+func TestEnsureRootOrReexec_EnvPassthrough(t *testing.T) {
+	var got execCall
+	reexeced, err := EnsureRootOrReexec(Options{
+		Geteuid:  func() int { return 1000 },
+		LookPath: func(string) (string, error) { return "/usr/bin/sudo", nil },
+		Environ: func() []string {
+			return []string{"LD_PRELOAD=/x", "LANG=C"}
+		},
+		ExecRunner: fakeRunner(&got, nil),
+	})
+	if err != nil || !reexeced {
+		t.Fatalf("unexpected result: %v %v", reexeced, err)
+	}
+	if len(got.env) != 2 || got.env[0] != "LD_PRELOAD=/x" || got.env[1] != "LANG=C" {
+		t.Fatalf("env not forwarded: %v", got.env)
 	}
 }
 

--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -57,6 +57,7 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 			resumeVerify = true
 			_ = f.Value.Set("")
 			f.Changed = false
+			os.Unsetenv("LVMSYNC_RESUME")
 		}
 	}
 	v, warns, err := buildViper(b.FlagSets)
@@ -70,6 +71,9 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	}
 	if resumeVerify {
 		cfg.ResumeVerify = true
+		if cfg.ResumeState == "" {
+			cfg.ResumeState = defaultResumeState
+		}
 	}
 	if cfg.AllowInsecure {
 		_, envSet := os.LookupEnv("LVMSYNC_ALLOW_INSECURE")


### PR DESCRIPTION
## Summary
- route `IsRoot` through Options dependency injection
- only sanitize reexec environment when requested
- adjust config builder to ignore LVMSYNC_RESUME when verifying resume state
- add tests for root checks, re-exec paths, and sudo exit codes

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a39b5acab483238258e52ef005a70d