### PR TITLE
Enforce secure transport defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ no additional coordination.
 
 LVMSync negotiates transports in the order provided by `--transport` (default
 `quic,h2,tcp+tls,ssh`). All transports require TLS 1.3 with mutual
-authentication unless `--allow-insecure` is set or the SSH transport is used.
+authentication or SSH host key verification unless `--allow-insecure` is set.
 See [docs/transports.md](docs/transports.md) for details.
 
 | Transport | Security defaults | Notes |
@@ -141,9 +141,9 @@ Transfers rely on a manifest that tracks chunk offsets and digests:
 
 
 authentication. Provide certificate files with `--server-cert`, `--server-key`,
-`--client-cert`, `--client-key`, and `--ca-cert`. Insecure mode can be enabled
-with `--allow-insecure`, but it is disabled by default and should only be used
-for testing.
+`--client-cert`, `--client-key`, and `--ca-cert`. Insecure mode disables
+certificate and host key verification and can be enabled with
+`--allow-insecure`, but it logs a warning and should only be used for testing.
 
 Configuration can be supplied via flags, environment variables prefixed with
 variables, which override configuration files.
@@ -190,7 +190,7 @@ transfer. See [docs/manifest.md](docs/manifest.md) for manifest and verification
 
 - Run `manifest rebuild` and `verify` against quiescent devices.
 - Use `--offline` or freeze/thaw hooks when scanning live filesystems to keep manifests consistent.
-- Network transports default to TLS 1.3; `--allow-insecure` should only be used for testing.
+- Network transports enforce mutual TLS or host key verification; `--allow-insecure` disables these checks, logs a warning, and should only be used for testing.
 - Back up destination data before running transfers; writes are destructive.
 ## Supported Platforms
 

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -52,6 +52,9 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 	if cfg.SSHUser == "" {
 		return nil, fmt.Errorf("ssh user is required")
 	}
+	if cfg.AllowInsecure {
+		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "ssh"), zap.String("security", "host_key_verification_disabled"), zap.String("usage", "development_only"))
+	}
 	var (
 		keySigner  ssh.Signer
 		hostSigner ssh.Signer
@@ -91,6 +94,9 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 			return nil, err
 		}
 	}
+	if hostSigner == nil && !cfg.AllowInsecure {
+		return nil, fmt.Errorf("host key path required unless AllowInsecure is set")
+	}
 
 	serverConf := &ssh.ServerConfig{
 		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
@@ -126,7 +132,6 @@ func New(ctx context.Context, cfg transport.Config) (transport.Interface, error)
 		}
 		hkc = ssh.FixedHostKey(pk)
 	case cfg.AllowInsecure:
-		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "ssh"), zap.String("security", "host_key_verification_disabled"), zap.String("usage", "development_only"))
 		hkc = ssh.InsecureIgnoreHostKey()
 	default:
 		return nil, fmt.Errorf("known hosts or host key required")

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -284,9 +284,29 @@ func TestNewZeroesKeyMaterial(t *testing.T) {
 
 func TestNewHostKeyRequired(t *testing.T) {
 	core, _ := observer.New(zap.InfoLevel)
-	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p"}
+	kh := emptyKnownHosts(t)
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", SSHKnownHosts: kh}
 	if _, err := New(context.Background(), cfg); err == nil || !strings.Contains(err.Error(), "host key path required") {
 		t.Fatalf("expected host key requirement error, got %v", err)
+	}
+}
+
+func TestNewHostKeyVerificationRequired(t *testing.T) {
+	core, _ := observer.New(zap.InfoLevel)
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_rsa")
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	privBytes := x509.MarshalPKCS1PrivateKey(priv)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes})
+	if err := os.WriteFile(keyPath, pemBytes, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg := transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", HostKeyPath: keyPath}
+	if _, err := New(context.Background(), cfg); err == nil || !strings.Contains(err.Error(), "known hosts or host key required") {
+		t.Fatalf("expected host key verification error, got %v", err)
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -46,7 +46,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	clientAuth := tls.RequireAndVerifyClientCert
 	if cfg.AllowInsecure {
 		cfg.Logger.Warn("allow_insecure_enabled", zap.String("transport", "tcp+tls"), zap.String("security", "tls_verification_disabled"), zap.String("usage", "development_only"))
-		clientAuth = tls.RequireAnyClientCert
+		clientAuth = tls.NoClientCert
 	}
 	serverConf := &tls.Config{
 		ClientCAs:    cfg.Roots,

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -680,6 +680,29 @@ func TestTCPTLSTransportRequiresServerCert(t *testing.T) {
 	}
 }
 
+func TestTCPTLSClientAuthDefaults(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert, ServerCert: cert})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	if tr.serverConf.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("expected RequireAndVerifyClientCert, got %v", tr.serverConf.ClientAuth)
+	}
+}
+
+func TestTCPTLSClientAuthInsecure(t *testing.T) {
+	trIface, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new transport: %v", err)
+	}
+	tr := trIface.(*Transport)
+	if tr.serverConf.ClientAuth != tls.NoClientCert {
+		t.Fatalf("expected NoClientCert, got %v", tr.serverConf.ClientAuth)
+	}
+}
+
 func TestTCPTLSListenCloseErrorWarn(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
 	core, obs := observer.New(zap.WarnLevel)


### PR DESCRIPTION
## Summary
- require host key files for SSH transport and warn when insecure mode is used
- disable client auth when TCP+TLS is run with allow_insecure
- document secure transport defaults and add unit tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestResumeFlagVerify)*
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a39b7e7e688323a31267991bc34f63