### PR TITLE
Respect LVMSYNC_RESUME with --resume=verify

### DIFF
--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -57,7 +57,6 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 			resumeVerify = true
 			_ = f.Value.Set("")
 			f.Changed = false
-			os.Unsetenv("LVMSYNC_RESUME")
 		}
 	}
 	v, warns, err := buildViper(b.FlagSets)

--- a/internal/config/resume_verify_test.go
+++ b/internal/config/resume_verify_test.go
@@ -27,7 +27,6 @@ func TestResumeFlagPath(t *testing.T) {
 }
 
 func TestResumeFlagVerify(t *testing.T) {
-	t.Skip("resume verify precedence not verified")
 	t.Setenv("HOME", t.TempDir())
 	envState := "statefile"
 	t.Setenv("LVMSYNC_RESUME", envState)
@@ -44,9 +43,13 @@ func TestResumeFlagVerify(t *testing.T) {
 	if !cfg.ResumeVerify {
 		t.Fatalf("ResumeVerify=%v want true", cfg.ResumeVerify)
 	}
-	if cfg.ResumeState != "statefile" {
-		t.Fatalf("ResumeState=%q want %q", cfg.ResumeState, "statefile")
-	if cfg.ResumeState != defaultResumeState {
-		t.Fatalf("ResumeState=%q want %q", cfg.ResumeState, defaultResumeState)
+	if cfg.ResumeState != envState {
+		t.Fatalf("ResumeState=%q want %q", cfg.ResumeState, envState)
+	}
+	if defaults.ResumeVerify {
+		t.Fatalf("defaults ResumeVerify=%v want false", defaults.ResumeVerify)
+	}
+	if defaults.ResumeState != "" {
+		t.Fatalf("defaults ResumeState=%q want %q", defaults.ResumeState, "")
 	}
 }

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -34,7 +34,9 @@ func (b *builder) Build() (*Config, error) {
 
 	if b.resumeVerify {
 		conf.ResumeVerify = true
-		conf.ResumeState = defaultResumeState
+		if conf.ResumeState == "" {
+			conf.ResumeState = defaultResumeState
+		}
 	}
 
 	if err := b.applyDefaults(&conf); err != nil {


### PR DESCRIPTION
## Summary
- preserve LVMSYNC_RESUME when `--resume=verify` is used
- default resume state to `resume.json` only when no state path provided
- add test verifying resume verification respects env var

## Testing
- `go build ./...` *(fails: transfer/transfer.go:180:83: syntax error: unexpected { at end of statement)*
- `go test ./internal/config`
- `go test -coverprofile=coverage.out ./...` *(fails: transfer/transfer.go:180:83: syntax error: unexpected { at end of statement)*
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3a38909a483239a3d162cb9db5cd5