### PR TITLE
fix missing brace in dumpChangesCore

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -110,6 +110,7 @@ func (t *Transfer) dumpChangesCore(ctx context.Context, cfg *config.Config, snap
 
 	if cfg.Delta == "rsync" {
 		return t.streamRsyncDelta(ctx, cfg, snapshot, source, out)
+	}
 	if cfg.DryRun {
 		size, err := t.Info.SizeBytes(ctx, snapshot)
 		if err != nil {


### PR DESCRIPTION
## Summary
- close rsync delta branch in Transfer.dumpChangesCore so dry-run logic runs

## Testing
- `go test ./transfer ./cmd/root ./cmd/dump ./cmd/verify ./cmd/lvmsync` *(fails: lvmsync_go/transfer build failure: transfer/resume_state.go:160:2: declared and not used: data)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a389cacc832399bd221f243b8541