### PR TITLE
config: drop resume verify hook

### DIFF
--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -31,13 +31,6 @@ func (b *builder) Build() (*Config, error) {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
 	}
 
-	if b.resumeVerify {
-		conf.ResumeVerify = true
-		if conf.ResumeState == "" {
-			conf.ResumeState = defaultResumeState
-		}
-	}
-
 	if err := b.applyDefaults(&conf); err != nil {
 		return nil, err
 	}

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
-	"strings"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -154,10 +154,6 @@ func readResumeState(cfg *config.Config, logger *zap.Logger, size uint64, device
 	if strings.ToLower(cfg.VerifyLevel) != "none" {
 		cfg.ResumeVerify = true
 	}
-	if strings.ToLower(cfg.VerifyLevel) != "none" {
-		cfg.ResumeVerify = true
-	}
-	data, err := os.ReadFile(cfg.ResumeState)
 	return resumeCheckpoint{}
 }
 


### PR DESCRIPTION
## Summary
- remove obsolete resumeVerify handling from Viper builder
- tidy resume state reader by dropping duplicate verify logic

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3af39ddac83238510fa2e90960e41