### PR TITLE
Add device identity and WAL recovery

### DIFF
--- a/cmd/dump/fake_device_test.go
+++ b/cmd/dump/fake_device_test.go
@@ -14,3 +14,6 @@ func (f *fakeDevice) BlockSize() uint64                                       { 
 func (f *fakeDevice) Snapshot(context.Context, string) (device.Device, error) { return f, nil }
 func (f *fakeDevice) Cleanup(context.Context) error                           { return nil }
 func (f *fakeDevice) Close() error                                            { return nil }
+func (f *fakeDevice) Identity() (device.DeviceIdentity, error)                { return device.DeviceIdentity{}, nil }
+func (f *fakeDevice) AppendWAL(r device.Range) error                          { return nil }
+func (f *fakeDevice) RecoverWAL(fn func(device.Range) error) error            { return nil }

--- a/device/device.go
+++ b/device/device.go
@@ -18,6 +18,12 @@ type Device interface {
 	Cleanup(ctx context.Context) error
 	// Close releases any resources associated with the device.
 	Close() error
+	// Identity gathers metadata describing the device.
+	Identity() (DeviceIdentity, error)
+	// AppendWAL records an applied range in the device's WAL.
+	AppendWAL(r Range) error
+	// RecoverWAL replays ranges from the WAL using fn.
+	RecoverWAL(fn func(Range) error) error
 }
 
 // Device type identifiers for Detect and CLI hints.

--- a/device/file.go
+++ b/device/file.go
@@ -62,6 +62,17 @@ func (d *FileDevice) SizeBytes() uint64 { return d.size }
 // BlockSize returns the filesystem block size.
 func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 
+// Identity returns size information for the file.
+func (d *FileDevice) Identity() (DeviceIdentity, error) {
+	return DeviceIdentity{SizeBytes: d.SizeBytes()}, nil
+}
+
+// AppendWAL is a no-op for file devices.
+func (d *FileDevice) AppendWAL(r Range) error { return nil }
+
+// RecoverWAL is a no-op for file devices.
+func (d *FileDevice) RecoverWAL(fn func(Range) error) error { return nil }
+
 // Close closes the underlying file descriptor.
 func (d *FileDevice) Close() error {
 	err := d.f.Close()

--- a/device/identity.go
+++ b/device/identity.go
@@ -1,0 +1,14 @@
+package device
+
+// DeviceIdentity describes metadata uniquely identifying a block device.
+type DeviceIdentity struct {
+	SizeBytes  uint64
+	KernelUUID string
+	GPTUUID    string
+}
+
+// Range represents a byte range on a device.
+type Range struct {
+	Start uint64
+	End   uint64
+}

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -43,6 +43,11 @@ func (s *identityStub) BlockSize() uint64                                { retur
 func (s *identityStub) Snapshot(context.Context, string) (Device, error) { return s, nil }
 func (s *identityStub) Cleanup(context.Context) error                    { return nil }
 func (s *identityStub) Close() error                                     { return nil }
+func (s *identityStub) Identity() (DeviceIdentity, error) {
+	return DeviceIdentity{SizeBytes: s.size}, nil
+}
+func (s *identityStub) AppendWAL(r Range) error               { return nil }
+func (s *identityStub) RecoverWAL(fn func(Range) error) error { return nil }
 
 func TestIdentitySizeMismatchFailsEarly(t *testing.T) {
 	info := NewInfo()

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -528,3 +528,8 @@ func (s *stubDevice) BlockSize() uint64                                { return 
 func (s *stubDevice) Snapshot(context.Context, string) (Device, error) { return nil, nil }
 func (s *stubDevice) Cleanup(context.Context) error                    { return nil }
 func (s *stubDevice) Close() error                                     { return s.closeErr }
+func (s *stubDevice) Identity() (DeviceIdentity, error) {
+	return DeviceIdentity{SizeBytes: s.size}, nil
+}
+func (s *stubDevice) AppendWAL(r Range) error               { return nil }
+func (s *stubDevice) RecoverWAL(fn func(Range) error) error { return nil }

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ type LVMDevice struct {
 	logger      *zap.Logger
 	lock        *lock.Lock
 	runner      *Runner
+	wal         *WAL
 }
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
@@ -101,6 +103,44 @@ func (d *LVMDevice) SizeBytes() uint64 { return d.size }
 
 // BlockSize returns the logical block size in bytes.
 func (d *LVMDevice) BlockSize() uint64 { return d.blockSize }
+
+// Identity gathers size, kernel uuid and GPT info for the logical volume.
+func (d *LVMDevice) Identity() (DeviceIdentity, error) {
+	id := DeviceIdentity{SizeBytes: d.SizeBytes()}
+	out, err := exec.Command("lvs", "--noheadings", "-o", "lv_uuid", d.Path()).Output()
+	if err != nil {
+		return DeviceIdentity{}, err
+	}
+	id.KernelUUID = strings.TrimSpace(string(out))
+	if out, err = exec.Command("blkid", "-o", "value", "-s", "PTUUID", d.Path()).Output(); err == nil {
+		id.GPTUUID = strings.TrimSpace(string(out))
+	}
+	return id, nil
+}
+
+// SetWAL attaches a WAL to the device.
+func (d *LVMDevice) SetWAL(w *WAL) { d.wal = w }
+
+// AppendWAL records an applied range in the attached WAL.
+func (d *LVMDevice) AppendWAL(r Range) error {
+	if d.wal == nil {
+		return nil
+	}
+	return d.wal.Append(r)
+}
+
+// RecoverWAL replays recorded ranges using fn.
+func (d *LVMDevice) RecoverWAL(fn func(Range) error) error {
+	if d.wal == nil {
+		return nil
+	}
+	for _, r := range d.wal.Ranges() {
+		if err := fn(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // Close closes the device and releases the lock if present.
 func (d *LVMDevice) Close() error {

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -34,7 +34,12 @@ func (r *Runner) OpenLVM(context.Context, string, *lvm.FDCache, string, *zap.Log
 func (d *LVMDevice) Path() string      { return "" }
 func (d *LVMDevice) SizeBytes() uint64 { return 0 }
 func (d *LVMDevice) BlockSize() uint64 { return 0 }
-func (d *LVMDevice) Close() error      { return nil }
+func (d *LVMDevice) Identity() (DeviceIdentity, error) {
+	return DeviceIdentity{}, fmt.Errorf("unsupported")
+}
+func (d *LVMDevice) AppendWAL(r Range) error               { return nil }
+func (d *LVMDevice) RecoverWAL(fn func(Range) error) error { return nil }
+func (d *LVMDevice) Close() error                          { return nil }
 func (d *LVMDevice) Snapshot(context.Context, string) (Device, error) {
 	return nil, fmt.Errorf("LVM snapshots are only supported on Linux")
 }

--- a/device/raw.go
+++ b/device/raw.go
@@ -33,6 +33,7 @@ type RawDevice struct {
 	thawCmdPath   string
 	thawCmdArgs   []string
 	runner        *Runner
+	wal           *WAL
 }
 
 // prepareFreeze validates and runs the filesystem freeze command when offline is false.
@@ -180,6 +181,44 @@ func (d *RawDevice) SizeBytes() uint64 { return d.size }
 
 // BlockSize returns the logical block size of the device in bytes.
 func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
+
+// Identity gathers size, kernel uuid and GPT information for the device.
+func (d *RawDevice) Identity() (DeviceIdentity, error) {
+	id := DeviceIdentity{SizeBytes: d.SizeBytes()}
+	out, err := exec.Command("blkid", "-o", "value", "-s", "UUID", d.Path()).Output()
+	if err != nil {
+		return DeviceIdentity{}, err
+	}
+	id.KernelUUID = strings.TrimSpace(string(out))
+	if out, err = exec.Command("blkid", "-o", "value", "-s", "PTUUID", d.Path()).Output(); err == nil {
+		id.GPTUUID = strings.TrimSpace(string(out))
+	}
+	return id, nil
+}
+
+// SetWAL attaches a WAL to the device.
+func (d *RawDevice) SetWAL(w *WAL) { d.wal = w }
+
+// AppendWAL records the applied range in the attached WAL.
+func (d *RawDevice) AppendWAL(r Range) error {
+	if d.wal == nil {
+		return nil
+	}
+	return d.wal.Append(r)
+}
+
+// RecoverWAL replays recorded ranges using fn.
+func (d *RawDevice) RecoverWAL(fn func(Range) error) error {
+	if d.wal == nil {
+		return nil
+	}
+	for _, r := range d.wal.Ranges() {
+		if err := fn(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // Close closes the underlying file descriptor.
 func (d *RawDevice) Close() error {

--- a/device/raw_nonlinux.go
+++ b/device/raw_nonlinux.go
@@ -23,6 +23,11 @@ func OpenRaw(context.Context, string, bool, string, []string, string, []string, 
 func (d *RawDevice) Path() string      { return "" }
 func (d *RawDevice) SizeBytes() uint64 { return 0 }
 func (d *RawDevice) BlockSize() uint64 { return 0 }
+func (d *RawDevice) Identity() (DeviceIdentity, error) {
+	return DeviceIdentity{}, fmt.Errorf("unsupported")
+}
+func (d *RawDevice) AppendWAL(r Range) error               { return nil }
+func (d *RawDevice) RecoverWAL(fn func(Range) error) error { return nil }
 func (d *RawDevice) Snapshot(context.Context, string) (Device, error) {
 	return nil, fmt.Errorf("raw device snapshots are only supported on Linux")
 }

--- a/device/wal.go
+++ b/device/wal.go
@@ -1,0 +1,121 @@
+package device
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/zeebo/blake3"
+)
+
+type walHeader struct {
+	Size   uint64
+	Kernel [64]byte
+	GPT    [64]byte
+	MAC    [32]byte
+}
+
+type WAL struct {
+	f      *os.File
+	header walHeader
+	ranges []Range
+}
+
+func walHeaderMAC(h *walHeader) [32]byte {
+	var buf [8 + 64 + 64]byte
+	binary.LittleEndian.PutUint64(buf[0:8], h.Size)
+	copy(buf[8:72], h.Kernel[:])
+	copy(buf[72:], h.GPT[:])
+	return blake3.Sum256(buf[:])
+}
+
+// OpenWAL opens or creates a WAL at path for the given device identity.
+// It verifies metadata on existing WALs and loads recorded ranges.
+func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	st, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	w := &WAL{f: f}
+	if st.Size() == 0 {
+		var hdr walHeader
+		hdr.Size = id.SizeBytes
+		copy(hdr.Kernel[:], []byte(id.KernelUUID))
+		copy(hdr.GPT[:], []byte(id.GPTUUID))
+		hdr.MAC = walHeaderMAC(&hdr)
+		var buf [8 + 64 + 64 + 32]byte
+		binary.LittleEndian.PutUint64(buf[0:8], hdr.Size)
+		copy(buf[8:72], hdr.Kernel[:])
+		copy(buf[72:136], hdr.GPT[:])
+		copy(buf[136:], hdr.MAC[:])
+		if _, err := f.Write(buf[:]); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, err
+		}
+		w.header = hdr
+		return w, nil
+	}
+	var buf [8 + 64 + 64 + 32]byte
+	if _, err := f.ReadAt(buf[:], 0); err != nil {
+		f.Close()
+		return nil, err
+	}
+	var hdr walHeader
+	hdr.Size = binary.LittleEndian.Uint64(buf[0:8])
+	copy(hdr.Kernel[:], buf[8:72])
+	copy(hdr.GPT[:], buf[72:136])
+	copy(hdr.MAC[:], buf[136:])
+	if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
+		f.Close()
+		return nil, fmt.Errorf("wal: header mac mismatch")
+	}
+	if hdr.Size != id.SizeBytes ||
+		string(hdr.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
+		string(hdr.GPT[:len(id.GPTUUID)]) != id.GPTUUID {
+		f.Close()
+		return nil, fmt.Errorf("wal: metadata mismatch")
+	}
+	w.header = hdr
+	off := int64(len(buf))
+	entry := make([]byte, 16)
+	for {
+		n, err := f.ReadAt(entry, off)
+		if err != nil || n != 16 {
+			break
+		}
+		start := binary.LittleEndian.Uint64(entry[0:8])
+		end := binary.LittleEndian.Uint64(entry[8:16])
+		w.ranges = append(w.ranges, Range{Start: start, End: end})
+		off += 16
+	}
+	return w, nil
+}
+
+func (w *WAL) Append(r Range) error {
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[0:8], r.Start)
+	binary.LittleEndian.PutUint64(buf[8:16], r.End)
+	if _, err := w.f.Write(buf[:]); err != nil {
+		return err
+	}
+	return w.f.Sync()
+}
+
+// Ranges returns the ranges recorded in the WAL.
+func (w *WAL) Ranges() []Range { return append([]Range(nil), w.ranges...) }
+
+func (w *WAL) Close() error {
+	if w.f != nil {
+		return w.f.Close()
+	}
+	return nil
+}

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -1,0 +1,50 @@
+package device
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWALIdentityMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt"}
+	w, err := OpenWAL(path, id)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	badID := DeviceIdentity{SizeBytes: 101, KernelUUID: "dev", GPTUUID: "gpt"}
+	if _, err := OpenWAL(path, badID); err == nil {
+		t.Fatalf("expected size mismatch error")
+	}
+	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev2", GPTUUID: "gpt"}
+	if _, err := OpenWAL(path, badID); err == nil {
+		t.Fatalf("expected uuid mismatch error")
+	}
+}
+
+func TestWALRecovery(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt"}
+	w, err := OpenWAL(path, id)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Append(Range{Start: 0, End: 10}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	w.Close()
+	w, err = OpenWAL(path, id)
+	if err != nil {
+		t.Fatalf("reopen wal: %v", err)
+	}
+	rs := w.Ranges()
+	if len(rs) != 1 || rs[0].Start != 0 || rs[0].End != 10 {
+		t.Fatalf("unexpected ranges %#v", rs)
+	}
+	w.Close()
+}

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -31,13 +31,6 @@ func (b *builder) Build() (*Config, error) {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
 	}
 
-	if b.resumeVerify {
-		conf.ResumeVerify = true
-		if conf.ResumeState == "" {
-			conf.ResumeState = defaultResumeState
-		}
-	}
-
 	if err := b.applyDefaults(&conf); err != nil {
 		return nil, err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -32,6 +32,11 @@ func (m *mockDevice) BlockSize() uint64                                       { 
 func (m *mockDevice) Close() error                                            { return nil }
 func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
 func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
+func (m *mockDevice) Identity() (device.DeviceIdentity, error) {
+	return device.DeviceIdentity{SizeBytes: m.size}, nil
+}
+func (m *mockDevice) AppendWAL(r device.Range) error               { return nil }
+func (m *mockDevice) RecoverWAL(fn func(device.Range) error) error { return nil }
 
 func TestIndexCRUD(t *testing.T) {
 	dir := t.TempDir()

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
-	"strings"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -154,10 +154,6 @@ func readResumeState(cfg *config.Config, logger *zap.Logger, size uint64, device
 	if strings.ToLower(cfg.VerifyLevel) != "none" {
 		cfg.ResumeVerify = true
 	}
-	if strings.ToLower(cfg.VerifyLevel) != "none" {
-		cfg.ResumeVerify = true
-	}
-	data, err := os.ReadFile(cfg.ResumeState)
 	return resumeCheckpoint{}
 }
 

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -25,6 +25,11 @@ func (m *mockDevice) BlockSize() uint64                                       { 
 func (m *mockDevice) Close() error                                            { return nil }
 func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
 func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
+func (m *mockDevice) Identity() (device.DeviceIdentity, error) {
+	return device.DeviceIdentity{SizeBytes: m.size}, nil
+}
+func (m *mockDevice) AppendWAL(r device.Range) error               { return nil }
+func (m *mockDevice) RecoverWAL(fn func(device.Range) error) error { return nil }
 
 func buildManifest(t *testing.T, devPath, manPath, uuid string, size uint64) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- extend device interface with identity and WAL hooks
- implement WAL with integrity checks and range replay
- gather device identity in raw and LVM devices and add tests for mismatch and recovery

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3af3cc01883238cb39ed6345e5191