### PR TITLE
logging: add component field and redaction options

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -136,7 +136,7 @@ func ConfigureWithEscalator(esc privilege.Escalator) (*config.Config, []string, 
 	if err = cfg.Validate(); err != nil {
 		return nil, nil, nil, fmt.Errorf("configuration validation error: %w", err)
 	}
-	logger, err := logging.NewLogger(cfg)
+	logger, err := logging.NewLogger(cfg, "root")
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("logger initialization error: %w", err)
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -5,18 +5,111 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	config "lvmsync_go/internal/config"
 )
 
-// NewLogger builds a production logger with sampling enabled and
-// sets debug level when cfg.Verbose > 0.
-func NewLogger(cfg *config.Config, opts ...zap.Option) (*zap.Logger, error) {
+// Option configures NewLogger behavior.
+type Option func(*options)
+
+type options struct {
+	samplingFirst      uint32
+	samplingThereafter uint32
+	redactor           func(zapcore.Field) zapcore.Field
+	zapOpts            []zap.Option
+}
+
+func defaultOptions() options {
+	return options{
+		samplingFirst:      100,
+		samplingThereafter: 100,
+	}
+}
+
+func applyOptions(opts []Option) options {
+	o := defaultOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// WithSampling sets the sampling rates. A zero value disables sampling.
+func WithSampling(first, thereafter uint32) Option {
+	return func(o *options) {
+		o.samplingFirst = first
+		o.samplingThereafter = thereafter
+	}
+}
+
+// WithRedactHook registers a field redaction hook applied to all log fields.
+func WithRedactHook(fn func(zapcore.Field) zapcore.Field) Option {
+	return func(o *options) { o.redactor = fn }
+}
+
+// WithZapOptions appends zap.Options used when building the logger.
+func WithZapOptions(zopts ...zap.Option) Option {
+	return func(o *options) { o.zapOpts = append(o.zapOpts, zopts...) }
+}
+
+type redactingCore struct {
+	zapcore.Core
+	redactor func(zapcore.Field) zapcore.Field
+}
+
+func (c redactingCore) With(fields []zapcore.Field) zapcore.Core {
+	if c.redactor != nil {
+		rf := make([]zapcore.Field, len(fields))
+		for i, f := range fields {
+			rf[i] = c.redactor(f)
+		}
+		return redactingCore{Core: c.Core.With(rf), redactor: c.redactor}
+	}
+	return redactingCore{Core: c.Core.With(fields), redactor: c.redactor}
+}
+
+func (c redactingCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+func (c redactingCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	if c.redactor != nil {
+		rf := make([]zapcore.Field, len(fields))
+		for i, f := range fields {
+			rf[i] = c.redactor(f)
+		}
+		return c.Core.Write(ent, rf)
+	}
+	return c.Core.Write(ent, fields)
+}
+
+// NewLogger builds a production logger with sampling enabled, adds caller
+// information, annotates logs with the provided component name, and
+// applies optional redaction. Debug level is set when cfg.Verbose > 0.
+// Sampling rates and redaction hooks can be customized via opts.
+func NewLogger(cfg *config.Config, component string, opts ...Option) (*zap.Logger, error) {
+	o := applyOptions(opts)
 	c := zap.NewProductionConfig()
 	if cfg != nil && cfg.Verbose > 0 {
 		c.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	}
-	return c.Build(opts...)
+	if o.samplingFirst == 0 || o.samplingThereafter == 0 {
+		c.Sampling = nil
+	} else {
+		c.Sampling = &zap.SamplingConfig{Initial: o.samplingFirst, Thereafter: o.samplingThereafter}
+	}
+	zapOpts := []zap.Option{zap.AddCaller(), zap.Fields(zap.String("component", component))}
+	if o.redactor != nil {
+		zapOpts = append(zapOpts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return redactingCore{Core: core, redactor: o.redactor}
+		}))
+	}
+	zapOpts = append(zapOpts, o.zapOpts...)
+	return c.Build(zapOpts...)
 }
 
 // TLSVersionString returns a string representation of the TLS version number.

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	config "lvmsync_go/internal/config"
 )
 
 func TestNewLoggerSamplingDefaults(t *testing.T) {
-	logger, err := NewLogger(&config.Config{})
+	logger, err := NewLogger(&config.Config{}, "test")
 	if err != nil {
 		t.Fatalf("NewLogger: %v", err)
 	}
@@ -29,11 +31,44 @@ func TestNewLoggerSamplingDefaults(t *testing.T) {
 }
 
 func TestNewLoggerVerboseLevel(t *testing.T) {
-	logger, err := NewLogger(&config.Config{Verbose: 1})
+	logger, err := NewLogger(&config.Config{Verbose: 1}, "test")
 	if err != nil {
 		t.Fatalf("NewLogger: %v", err)
 	}
 	if !logger.Core().Enabled(zap.DebugLevel) {
 		t.Fatalf("logger level %v, want debug", zap.DebugLevel)
+	}
+}
+
+func TestNewLoggerRedactionAndComponent(t *testing.T) {
+	redactor := func(f zapcore.Field) zapcore.Field {
+		if f.Key == "secret" && f.Type == zapcore.StringType {
+			f.String = "[REDACTED]"
+		}
+		return f
+	}
+	core, logs := observer.New(zap.InfoLevel)
+	logger, err := NewLogger(
+		&config.Config{},
+		"comp",
+		WithSampling(0, 0),
+		WithRedactHook(redactor),
+		WithZapOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(c, redactingCore{Core: core, redactor: redactor})
+		})),
+	)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	logger.Info("msg", zap.String("secret", "token"))
+	if logs.Len() != 1 {
+		t.Fatalf("log entries %d, want 1", logs.Len())
+	}
+	fields := logs.All()[0].ContextMap()
+	if v := fields["secret"]; v != "[REDACTED]" {
+		t.Fatalf("secret field %v, want [REDACTED]", v)
+	}
+	if v := fields["component"]; v != "comp" {
+		t.Fatalf("component field %v, want comp", v)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func NewRunner() *Runner {
 		SyncLogger: rootcmd.SyncLogger,
 		Exit:       os.Exit,
 		ExampleLogger: func() *zap.Logger {
-			logger, err := logging.NewLogger(nil)
+			logger, err := logging.NewLogger(nil, "main")
 			if err != nil {
 				return zap.NewNop()
 			}


### PR DESCRIPTION
## Summary
- add sampling and redaction options to logger
- include caller and component fields in NewLogger
- add tests for redaction and component field

## Testing
- `go build ./...` *(fails: internal/config/viper_builder.go:34:7: b.resumeVerify undefined)*
- `go test -coverprofile=coverage.out ./...` *(fails: internal/config/viper_builder.go:34:7: b.resumeVerify undefined)*
- `go tool cover -func=coverage.out | tail -n 5`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3af3f15f48323830ece5103d1d0e8