### PR TITLE
docs: document exit codes

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -56,18 +56,34 @@ Exit code `60` indicates a verification mismatch and leaves the destination unto
 
 ## Exit Codes and Recovery
 
-| Code | Meaning | Recovery Step |
-|------|---------|---------------|
-| `0`  | Success | None |
-| `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
-| `20` | Device error | Verify device paths and snapshot health. |
-| `30` | Unsupported platform | Run on a supported Linux platform. |
-| `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
-| `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
-| `60` | Verification mismatch | Investigate mismatched data before retrying. |
-| `70` | Partial transfer | Address the error and resume with `--resume`. |
-| `80` | Precondition failed | Fix prerequisites and retry. |
-| `90` | Resumable exit | Resume with `--resume` after resolving the issue. |
+| Constant | Code | Meaning | Recovery Step |
+|----------|------|---------|---------------|
+| [`exitcode.OK`](internal/exitcode/exitcode.go) | `0`  | Success | None |
+| [`exitcode.ErrCapability`](internal/exitcode/exitcode.go) | `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
+| [`exitcode.ErrDevice`](internal/exitcode/exitcode.go) | `20` | Device error | Verify device paths and snapshot health. |
+| [`exitcode.ErrPlatform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform | Run on a supported Linux platform. |
+| [`exitcode.ErrConfig`](internal/exitcode/exitcode.go) | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
+| [`exitcode.ErrRuntime`](internal/exitcode/exitcode.go) | `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
+| [`exitcode.ErrVerify`](internal/exitcode/exitcode.go) | `60` | Verification mismatch | Investigate mismatched data before retrying. |
+| [`exitcode.ErrPartial`](internal/exitcode/exitcode.go) | `70` | Partial transfer | Address the error and resume with `--resume`. |
+| [`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) | `80` | Precondition failed | Fix prerequisites and retry. |
+| [`exitcode.ErrResumable`](internal/exitcode/exitcode.go) | `90` | Resumable exit | Resume with `--resume` after resolving the issue. |
+
+Definitions live in [internal/exitcode](internal/exitcode/exitcode.go).
+
+Verification mismatches exit with [`exitcode.ErrVerify`](internal/exitcode/exitcode.go):
+
+```sh
+lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/bad_target || echo "verify failed with exit $?"
+# verify failed with exit 60
+```
+
+Precondition failures exit with [`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go):
+
+```sh
+lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with exit $?"
+# precondition failed with exit 80
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,20 @@ Invalid configurations will cause the tool to abort with a clear error message.
 
 Exit code definitions live in [internal/exitcode](internal/exitcode/exitcode.go), and handling resides in [cmd/root/root.go](cmd/root/root.go).
 
+Verification mismatches exit with [`exitcode.ErrVerify`](internal/exitcode/exitcode.go):
+
+```sh
+lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/bad_target || echo "verify failed with exit $?"
+# verify failed with exit 60
+```
+
+Precondition failures exit with [`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go):
+
+```sh
+lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with exit $?"
+# precondition failed with exit 80
+```
+
 Shell scripts can rely on `set -e` to abort on non-zero exit codes:
 
 ```sh


### PR DESCRIPTION
## Summary
- link exit code documentation to internal constants
- add examples for verification failures and precondition errors

## Testing
- `go build ./...` *(fails: b.resumeVerify undefined)*
- `go test -coverprofile=coverage.out ./...` *(fails: b.resumeVerify undefined)*
- `golangci-lint run`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_68a3af4075288323a22d21aee7a37a60