### PR TITLE
ci: add loopback integration workflow

### DIFF
--- a/.github/workflows/loopback-integration.yml
+++ b/.github/workflows/loopback-integration.yml
@@ -1,0 +1,36 @@
+---
+# .github/workflows/loopback-integration.yml
+
+name: Loopback integration
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  loopback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24' }}"
+          cache: true
+
+      - name: Install LVM tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lvm2
+
+      - name: Run loopback integration test
+        run: sudo --preserve-env=PATH bash integration/loopback.sh


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to exercise loopback LVM integration script

## Testing
- `go build ./...` *(fails: cannot use o.samplingFirst as int)*
- `go test -coverprofile=coverage.out ./...` *(fails: cannot use o.samplingFirst as int)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3b7b6d91c8323b0ddb5da0a0c9f96