### PR TITLE
test: add verify-only integration test

### DIFF
--- a/integration/verify.sh
+++ b/integration/verify.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+SRC_LOOP=""
+DST_LOOP=""
+cleanup() {
+  set +e
+  lvremove -f vgsrc/snap vgsrc/origin vgd/dest >/dev/null 2>&1
+  vgremove -f vgsrc vgd >/dev/null 2>&1
+  if [ -n "$SRC_LOOP" ]; then
+    pvremove -ff "$SRC_LOOP" >/dev/null 2>&1
+    losetup -d "$SRC_LOOP" >/dev/null 2>&1
+  fi
+  if [ -n "$DST_LOOP" ]; then
+    pvremove -ff "$DST_LOOP" >/dev/null 2>&1
+    losetup -d "$DST_LOOP" >/dev/null 2>&1
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+BIN="$TMPDIR/lvmsync"
+go build -o "$BIN" .
+
+# Prepare source LV
+SRC_IMG="$TMPDIR/src.img"
+dd if=/dev/urandom of="$SRC_IMG" bs=1M count=64
+SRC_LOOP=$(losetup --find --show "$SRC_IMG")
+pvcreate -ffy "$SRC_LOOP"
+vgcreate vgsrc "$SRC_LOOP"
+lvcreate -n origin -L 32M vgsrc
+dd if=/dev/urandom of=/dev/vgsrc/origin bs=1M count=32
+lvcreate -s -n snap -L 32M vgsrc/origin
+
+# Prepare destination LV
+DST_IMG="$TMPDIR/dst.img"
+dd if=/dev/zero of="$DST_IMG" bs=1M count=64
+DST_LOOP=$(losetup --find --show "$DST_IMG")
+pvcreate -ffy "$DST_LOOP"
+vgcreate vgd "$DST_LOOP"
+lvcreate -n dest -L 32M vgd
+
+# Transfer
+"$BIN" run /dev/vgsrc/snap /dev/vgd/dest
+
+# Verify-only success
+if ! "$BIN" run --verify-only /dev/vgsrc/snap /dev/vgd/dest; then
+  echo "verify-only failed unexpectedly"
+  exit 1
+fi
+
+# Corrupt destination
+dd if=/dev/zero of=/dev/vgd/dest bs=1M count=1 conv=notrunc
+
+set +e
+"$BIN" run --verify-only /dev/vgsrc/snap /dev/vgd/dest
+STATUS=$?
+set -e
+if [ "$STATUS" -ne 60 ]; then
+  echo "expected exit code 60, got $STATUS"
+  exit 1
+fi
+
+exit 0

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -1,0 +1,17 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestVerifyOnly(t *testing.T) {
+	cmd := exec.Command("bash", "./integration/verify.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("verify integration failed: %v\n%s", err, out)
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -100,15 +100,16 @@ func NewLogger(cfg *config.Config, component string, opts ...Option) (*zap.Logge
 	if o.samplingFirst == 0 || o.samplingThereafter == 0 {
 		c.Sampling = nil
 	} else {
-		c.Sampling = &zap.SamplingConfig{Initial: o.samplingFirst, Thereafter: o.samplingThereafter}
+		c.Sampling = &zap.SamplingConfig{Initial: int(o.samplingFirst), Thereafter: int(o.samplingThereafter)}
 	}
-	zapOpts := []zap.Option{zap.AddCaller(), zap.Fields(zap.String("component", component))}
+	zapOpts := []zap.Option{zap.AddCaller()}
 	if o.redactor != nil {
 		zapOpts = append(zapOpts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 			return redactingCore{Core: core, redactor: o.redactor}
 		}))
 	}
 	zapOpts = append(zapOpts, o.zapOpts...)
+	zapOpts = append(zapOpts, zap.Fields(zap.String("component", component)))
 	return c.Build(zapOpts...)
 }
 


### PR DESCRIPTION
## Summary
- add loop-backed verify-only integration script to ensure lvmsync exits with ErrVerify on corruption
- fix logger sampling configuration and preserve component field after wrapping

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`
- `go test -tags=integration ./integration` *(fails: losetup: cannot find an unused loop device)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b7b0ca548323a3c22527c0dce802