### PR TITLE
test: ensure raw device requires offline

### DIFF
--- a/cmd/dump/raw_device_offline_test.go
+++ b/cmd/dump/raw_device_offline_test.go
@@ -1,0 +1,54 @@
+package dump
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/config"
+)
+
+func setupLoop(t *testing.T, size int64) (string, func()) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "loopback")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if err := f.Truncate(size); err != nil {
+		f.Close()
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+	out, err := exec.Command("losetup", "--show", "-f", f.Name()).Output()
+	if err != nil {
+		t.Skipf("losetup: %v", err)
+	}
+	loop := strings.TrimSpace(string(out))
+	loop = filepath.Clean(loop)
+	cleanup := func() { exec.Command("losetup", "-d", loop).Run() }
+	return loop, cleanup
+}
+
+func TestRunRawDeviceWithoutOfflineErrors(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	_, err = Run(context.Background(), cfg, loop, filepath.Join(t.TempDir(), "dest"), zap.NewNop())
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "--offline") && !strings.Contains(err.Error(), "--fs-freeze-command") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add test to ensure `lvmsync run` rejects writable raw devices without `--offline` or freeze hooks

## Testing
- `go build ./...` *(fails: cannot use o.samplingFirst as int value)*
- `go test -coverprofile=coverage.out ./...` *(fails: cannot use o.samplingFirst as int value)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3b7adea608323a38d4ca787b1e05e