### PR TITLE
feat: add benchmark smoke test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -97,6 +97,12 @@ jobs:
       - name: Go build
         run: go build ./...
 
+      - name: Build lvmsync binary
+        run: go build -o lvmsync ./cmd/lvmsync
+
+      - name: Benchmark smoke test
+        run: scripts/bench_smoke.sh
+
       - name: Go test
         run: go test -coverprofile=coverage.out ./...
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -100,15 +100,16 @@ func NewLogger(cfg *config.Config, component string, opts ...Option) (*zap.Logge
 	if o.samplingFirst == 0 || o.samplingThereafter == 0 {
 		c.Sampling = nil
 	} else {
-		c.Sampling = &zap.SamplingConfig{Initial: o.samplingFirst, Thereafter: o.samplingThereafter}
+		c.Sampling = &zap.SamplingConfig{Initial: int(o.samplingFirst), Thereafter: int(o.samplingThereafter)}
 	}
-	zapOpts := []zap.Option{zap.AddCaller(), zap.Fields(zap.String("component", component))}
+	zapOpts := []zap.Option{zap.AddCaller()}
 	if o.redactor != nil {
 		zapOpts = append(zapOpts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 			return redactingCore{Core: core, redactor: o.redactor}
 		}))
 	}
 	zapOpts = append(zapOpts, o.zapOpts...)
+	zapOpts = append(zapOpts, zap.Fields(zap.String("component", component)))
 	return c.Build(zapOpts...)
 }
 

--- a/reports/bench_smoke.csv
+++ b/reports/bench_smoke.csv
@@ -1,0 +1,3 @@
+commit,compression,throughput_MBps
+6dbe474,none,NA
+6dbe474,zstd,NA

--- a/scripts/bench_smoke.sh
+++ b/scripts/bench_smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# bench_smoke.sh runs a tiny transfer with compression disabled and enabled.
+# It records the throughput of each run along with the current commit hash so
+# results can be compared across revisions.
+
+set -euo pipefail
+
+# Size of the temporary dataset in megabytes.
+SIZE_MB=${SIZE_MB:-8}
+BYTES=$((SIZE_MB * 1024 * 1024))
+# Minimal throughput in MB/s expected for the smoke test to pass.
+MIN_MBPS=${MIN_MBPS:-1}
+
+COMMIT=$(git rev-parse --short HEAD)
+OUT_DIR=$(dirname "$0")/..
+OUT_FILE="$OUT_DIR/reports/bench_smoke.csv"
+mkdir -p "$(dirname "$OUT_FILE")"
+if [ ! -f "$OUT_FILE" ]; then
+    echo "commit,compression,throughput_MBps" >"$OUT_FILE"
+fi
+
+SRC=$(mktemp)
+trap 'rm -f "$SRC" "$DST"' EXIT INT TERM
+dd if=/dev/urandom of="$SRC" bs=1M count="$SIZE_MB" status=none
+
+for COMP in none zstd; do
+    DST=$(mktemp)
+    start=$(date +%s%N)
+    ./lvmsync run --mode throughput --compress "$COMP" "$SRC" "$DST" >/dev/null 2>&1
+    end=$(date +%s%N)
+    rm -f "$DST"
+
+    elapsed_ns=$((end - start))
+    throughput=$(awk -v b="$BYTES" -v ns="$elapsed_ns" 'BEGIN { print (b/1048576)/(ns/1e9) }')
+    printf '%s,%s,%.2f\n' "$COMMIT" "$COMP" "$throughput" >>"$OUT_FILE"
+    awk -v t="$throughput" -v min="$MIN_MBPS" 'BEGIN { if (t < min) exit 1 }'
+done
+
+echo "results appended to $OUT_FILE"


### PR DESCRIPTION
## Summary
- add bench_smoke.sh to measure small transfer with and without compression
- record benchmark results keyed by commit hash
- run benchmark in CI
- fix logger sampling types and option order

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run`
- `scripts/bench_smoke.sh` *(fails: select transport: no supported transports)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b7b89a00832394f389a616b0c5cf