### PR TITLE
transport: add TLS/SSH security tests

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -100,15 +100,16 @@ func NewLogger(cfg *config.Config, component string, opts ...Option) (*zap.Logge
 	if o.samplingFirst == 0 || o.samplingThereafter == 0 {
 		c.Sampling = nil
 	} else {
-		c.Sampling = &zap.SamplingConfig{Initial: o.samplingFirst, Thereafter: o.samplingThereafter}
+		c.Sampling = &zap.SamplingConfig{Initial: int(o.samplingFirst), Thereafter: int(o.samplingThereafter)}
 	}
-	zapOpts := []zap.Option{zap.AddCaller(), zap.Fields(zap.String("component", component))}
+	zapOpts := []zap.Option{zap.AddCaller()}
 	if o.redactor != nil {
 		zapOpts = append(zapOpts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 			return redactingCore{Core: core, redactor: o.redactor}
 		}))
 	}
 	zapOpts = append(zapOpts, o.zapOpts...)
+	zapOpts = append(zapOpts, zap.Fields(zap.String("component", component)))
 	return c.Build(zapOpts...)
 }
 

--- a/transport/ssh/hostkey_pin_test.go
+++ b/transport/ssh/hostkey_pin_test.go
@@ -1,0 +1,107 @@
+package ssh
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/crypto/ssh"
+
+	"lvmsync_go/transport"
+)
+
+func checkLog(t *testing.T, logs *observer.ObservedLogs, msg string, wantErr bool, level zapcore.Level) {
+	entries := logs.FilterMessage(msg).All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 %s log, got %d", msg, len(entries))
+	}
+	e := entries[0]
+	if e.Level != level {
+		t.Fatalf("expected level %v for %s log, got %v", level, msg, e.Level)
+	}
+	ctx := e.ContextMap()
+	for _, k := range []string{"address", "role", "duration_ms"} {
+		if _, ok := ctx[k]; !ok {
+			t.Fatalf("expected field %q in %s log", k, msg)
+		}
+	}
+	if _, ok := ctx["error"]; wantErr && !ok {
+		t.Fatalf("expected error field in %s log", msg)
+	} else if !wantErr && ok {
+		t.Fatalf("unexpected error field in %s log", msg)
+	}
+}
+
+func TestSSHHostKeyPinMismatch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+	hostBytes := x509.MarshalPKCS1PrivateKey(hostKey)
+	hostPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: hostBytes})
+	hostPath := filepath.Join(dir, "host_key")
+	if err := os.WriteFile(hostPath, hostPEM, 0600); err != nil {
+		t.Fatalf("write host key: %v", err)
+	}
+	srvIface, err := New(ctx, transport.Config{Logger: zap.NewNop(), SSHUser: "u", SSHPassword: "p", HostKeyPath: hostPath, AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new server transport: %v", err)
+	}
+	srv := srvIface.(*Transport)
+	ln, err := srv.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		_, err := ln.Accept()
+		acceptErr <- err
+	}()
+
+	wrongKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate wrong key: %v", err)
+	}
+	wrongSigner, err := ssh.NewSignerFromKey(wrongKey)
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	wrongHostKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(wrongSigner.PublicKey())))
+
+	core, logs := observer.New(zap.InfoLevel)
+	cliIface, err := New(ctx, transport.Config{Logger: zap.New(core), SSHUser: "u", SSHPassword: "p", SSHHostKey: wrongHostKey, HostKeyPath: hostPath})
+	if err != nil {
+		t.Fatalf("new client transport: %v", err)
+	}
+	cli := cliIface.(*Transport)
+	dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+	_, err = cli.Dial(dialCtx, ln.Addr().String())
+	cancel()
+	if err == nil {
+		t.Fatalf("expected dial error")
+	}
+	if !strings.Contains(err.Error(), "host key") {
+		t.Fatalf("expected host key error, got %v", err)
+	}
+	if err := <-acceptErr; err == nil {
+		t.Fatalf("expected server accept error")
+	}
+
+	checkLog(t, logs, "dial_start", false, zapcore.InfoLevel)
+	checkLog(t, logs, "dial_end", true, zapcore.ErrorLevel)
+}

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -680,6 +680,84 @@ func TestTCPTLSTransportRequiresServerCert(t *testing.T) {
 	}
 }
 
+func TestTCPTLSHandshakeCAValidation(t *testing.T) {
+	cert, root := generateSelfSignedCert(t)
+	srvIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert, ServerCert: cert})
+	if err != nil {
+		t.Fatalf("new server transport: %v", err)
+	}
+	srv := srvIface.(*Transport)
+	baseCtx := context.Background()
+	listenCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+	ln, err := srv.Listen(listenCtx, "127.0.0.1:0")
+	if err != nil {
+		cancel()
+		t.Fatalf("listen: %v", err)
+	}
+	defer cancel()
+	defer ln.Close()
+
+	t.Run("trusted_ca", func(t *testing.T) {
+		done := make(chan error, 1)
+		go func() {
+			conn, err := ln.Accept()
+			if err != nil {
+				done <- err
+				return
+			}
+			defer conn.Close()
+			srvCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+			_, err = srv.Negotiate(srvCtx, conn, transport.Server, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true})
+			cancel()
+			done <- err
+		}()
+		cliIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert, ServerCert: cert})
+		if err != nil {
+			t.Fatalf("new client transport: %v", err)
+		}
+		cli := cliIface.(*Transport)
+		dialCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+		conn, err := cli.Dial(dialCtx, ln.Addr().String())
+		cancel()
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		defer conn.Close()
+		negCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+		if _, err := cli.Negotiate(negCtx, conn, transport.Client, common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}); err != nil {
+			cancel()
+			t.Fatalf("client negotiate: %v", err)
+		}
+		cancel()
+		if err := <-done; err != nil {
+			t.Fatalf("server negotiate: %v", err)
+		}
+	})
+
+	t.Run("wrong_ca", func(t *testing.T) {
+		done := make(chan struct{})
+		go func() {
+			if conn, err := ln.Accept(); err == nil {
+				conn.Close()
+			}
+			close(done)
+		}()
+		_, wrongRoot := generateSelfSignedCert(t)
+		cliIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: wrongRoot, ClientCert: cert, ServerCert: cert})
+		if err != nil {
+			t.Fatalf("new client transport: %v", err)
+		}
+		cli := cliIface.(*Transport)
+		dialCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+		_, err = cli.Dial(dialCtx, ln.Addr().String())
+		cancel()
+		if err == nil {
+			t.Fatalf("expected dial failure with wrong CA")
+		}
+		<-done
+	})
+}
+
 func TestTCPTLSClientAuthDefaults(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
 	trIface, err := New(transport.Config{Logger: zap.NewNop(), Roots: root, ClientCert: cert, ServerCert: cert})


### PR DESCRIPTION
## Summary
- add TLS CA validation test verifying handshake success and failure when mismatched
- add SSH host-key pin mismatch test with error logging
- fix logger sampling config and component propagation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68a3b7bb5bb08323b1fc3d2fecbfe1f5