### PR TITLE
docs: add CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LVMSync
-[![Build Status](https://github.com/oferchen/lvmsync_go/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/oferchen/lvmsync_go/actions/workflows/go.yml)
-[![Build Status](https://github.com/oferchen/lvmsync_go/actions/workflows/super-linter.yml/badge.svg?branch=main)](https://github.com/oferchen/lvmsync_go/actions/workflows/super-linter.yml)
+[![Go](https://github.com/oferchen/lvmsync_go/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/oferchen/lvmsync_go/actions/workflows/go.yml)
+[![Super Linter](https://github.com/oferchen/lvmsync_go/actions/workflows/super-linter.yml/badge.svg?branch=main)](https://github.com/oferchen/lvmsync_go/actions/workflows/super-linter.yml)
+[![Loopback Integration](https://github.com/oferchen/lvmsync_go/actions/workflows/loopback-integration.yml/badge.svg?branch=main)](https://github.com/oferchen/lvmsync_go/actions/workflows/loopback-integration.yml)
+[![Coverage](https://img.shields.io/badge/coverage-71.6%25-brightgreen)](https://github.com/oferchen/lvmsync_go/actions/workflows/go.yml)
 
 LVMSync is a high-performance incremental data replication tool for LVM snapshots. It efficiently transfers only changed blocks using metadata from snapshot COW (Copy-On-Write) devices and communicates with LVM through native Go bindings rather than shell commands.
 


### PR DESCRIPTION
## Summary
- add workflow status badges for Go, Super Linter, loopback integration, and coverage

## Testing
- `go vet ./...`
- `staticcheck ./...` (fails: error strings should not end with punctuation)
- `golangci-lint run` (fails with revive, staticcheck warnings)
- `go test -race ./...` (fails: data race and device tests)
- `go test -tags=integration ./...` (fails: build errors and missing loop device)
- `sudo --preserve-env=PATH bash integration/loopback.sh` (fails: losetup cannot find loop device)
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a3bce0260c8323a6ebe5ec85954cc9