### PR TITLE
docs: document manifest GC and version upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Transfers rely on a manifest that tracks chunk offsets and digests:
 2. `lvmsync run <source> <destination>` streams blocks, skipping chunks already recorded in the manifest.
 3. `lvmsync verify <source> <destination>` compares the destination with the manifest and logs any mismatches.
 
+[Garbage Collection & Atomic Commit](docs/manifest.md#garbage-collection--atomic-commit)
+describes how obsolete entries are pruned and rewritten safely.
 
 authentication. Provide certificate files with `--server-cert`, `--server-key`,
 `--client-cert`, `--client-key`, and `--ca-cert`. Insecure mode disables

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -95,8 +95,10 @@ Each subsequent entry describes one chunk and also uses little‑endian encoding
 | `xxh3`    | 8    | Fast non‑cryptographic hash |
 | `blake3`  | 32   | BLAKE3 digest of the chunk |
 
-The header `version` field allows future format changes without breaking
-backwards compatibility.
+The `version` field records the manifest format revision. LVMSync upgrades
+older headers in place when possible and recalculates the header MAC.
+Manifests written with unknown versions should be regenerated with
+`lvmsync manifest rebuild` to migrate to the current layout.
 
 ## Two-Level Index
 
@@ -111,6 +113,14 @@ populates both the hash table and Bloom filters on the fly.
 
 Device identifiers are stored in a fixed 64-byte field; creation fails if the
 ID exceeds this limit.
+
+## Garbage Collection & Atomic Commit
+
+The `manifest` package exposes a [`GC`](../manifest/index.go) helper that
+rewrites the manifest, dropping orphaned or duplicate entries before updating
+the header MAC. Once written to a temporary file, [`fsyncRename`](../manifest/index.go)
+flushes the directory and atomically swaps the new file into place so crashes
+never leave a partial manifest behind.
 
 ## Resume Tokens
 


### PR DESCRIPTION
## Summary
- document manifest header version and upgrade path
- describe GC compaction and atomic commit helpers
- link GC section from README manifest overview

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 907 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bce6a93c8323bb83736358f0463b