### PR TITLE
Add JSON progress output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--verify` | `LVMSYNC_VERIFY` | `verify` | Verification level: `full`, `sampled`, or `none` |
 | `--digest` | `LVMSYNC_DIGEST` | `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
+| `--output` | `LVMSYNC_OUTPUT` | `output` | Output format for progress: `text` or `json` |
 | `--delta` | `LVMSYNC_DELTA` | `delta` | Delta algorithm: `none` or `rsync` |
 | `--manifest-path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
 | `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |
@@ -922,8 +923,16 @@ mode: throughput
 
 ### Logging and progress
 
-Logs are emitted with [zap](https://github.com/uber-go/zap) to stderr. Progress updates are also written to stderr when
-`--progress` is enabled (default). Disable them with `--progress=false`.
+Logs are emitted with [zap](https://github.com/uber-go/zap) to stderr. When `--output=text` (default), progress updates are
+logged to stderr when `--progress` is enabled. Set `--output=json` to emit progress events on stdout as line-delimited JSON
+objects while preserving the regular logs on stderr. Each object follows this schema:
+
+```json
+{"event": "progress", "bytes_transferred": 12345, "bytes_total": 67890, "progress_percent": 18.2}
+```
+
+A final object with `{"event": "complete", "progress_percent": 100}` marks completion. Disable progress entirely with
+`--progress=false`.
 
 ## Installation
 

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -30,6 +30,7 @@ type RunOptions struct {
 	CDCAvg    int
 	CDCMax    int
 	ChunkSeed uint64
+	Output    string
 }
 
 // Runner holds command behaviors to allow dependency injection in tests.
@@ -161,6 +162,7 @@ func NewRootCmd(logger *zap.Logger, r *Runner) *cobra.Command {
 				CDCAvg:    cfg.CDCAvg,
 				CDCMax:    cfg.CDCMax,
 				ChunkSeed: cfg.ChunkSeed,
+				Output:    cfg.Output,
 			}
 			return r.Run(remaining[0], remaining[1], opts, logger)
 		},

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -88,7 +88,7 @@ func TestRunCommandDryRunEnv(t *testing.T) {
 
 func TestRunCommandDeltaFlag(t *testing.T) {
 	var gotOpts RunOptions
-	r := NewRunnerWithDeps(func(src, dst string, opts RunOptions, logger *zap.Logger) error {
+	r := NewRunnerWithDeps(func(_, _ string, opts RunOptions, _ *zap.Logger) error {
 		gotOpts = opts
 		return nil
 	}, nil, nil)
@@ -97,6 +97,34 @@ func TestRunCommandDeltaFlag(t *testing.T) {
 	}
 	if gotOpts.Delta != "rsync" {
 		t.Fatalf("expected delta rsync, got %q", gotOpts.Delta)
+	}
+}
+
+func TestRunCommandOutputFlag(t *testing.T) {
+	var gotOpts RunOptions
+	r := NewRunnerWithDeps(func(_, _ string, opts RunOptions, _ *zap.Logger) error {
+		gotOpts = opts
+		return nil
+	}, nil, nil)
+	if err := ExecuteWithRunner([]string{"run", "--output", "json", "src", "dst"}, zap.NewNop(), r); err != nil {
+		t.Fatalf("execute run: %v", err)
+	}
+	if gotOpts.Output != "json" {
+		t.Fatalf("expected output json, got %q", gotOpts.Output)
+	}
+}
+
+func TestRunCommandInvalidOutput(t *testing.T) {
+	called := false
+	r := NewRunnerWithDeps(func(_, _ string, _ RunOptions, _ *zap.Logger) error {
+		called = true
+		return nil
+	}, nil, nil)
+	if err := ExecuteWithRunner([]string{"run", "--output", "xml", "src", "dst"}, zap.NewNop(), r); err == nil {
+		t.Fatalf("expected error for invalid output")
+	}
+	if called {
+		t.Fatalf("runCommand should not be called on invalid output")
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -91,6 +91,7 @@ type Config struct {
 	SigCacheTTL              time.Duration `mapstructure:"sig_cache_ttl"`
 	SigCacheMax              int           `mapstructure:"sig_cache_max"`
 	Progress                 bool          `mapstructure:"progress"`
+	Output                   string        `mapstructure:"output"`
 	BlockSize                int           `mapstructure:"-"`
 	BlockSizeRaw             string        `mapstructure:"-"`
 	Delta                    string        `mapstructure:"delta"`
@@ -227,6 +228,7 @@ func DefaultConfig() (*Config, error) {
 		SigCacheTTL:              24 * time.Hour,
 		SigCacheMax:              128,
 		Progress:                 true,
+		Output:                   "text",
 		BlockSize:                0,
 		BlockSizeRaw:             Auto,
 		Delta:                    "none",

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -86,6 +86,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("verify", cfg.VerifyLevel, "Verification level: full, sampled, or none")
 	fs.String("digest", cfg.ChecksumAlgorithm, fmt.Sprintf("Digest algorithm: %v", SupportedChecksumAlgorithms))
 	fs.Bool("progress", cfg.Progress, "Show progress during transfer")
+	fs.String("output", cfg.Output, "Output format: text or json")
 	return fs
 }
 

--- a/internal/config/output_test.go
+++ b/internal/config/output_test.go
@@ -1,0 +1,18 @@
+package config
+
+import "testing"
+
+func TestValidateOutput(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+	cfg.Output = "xml"
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected error for invalid output")
+	}
+	cfg.Output = "json"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate json output: %v", err)
+	}
+}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -30,6 +30,9 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.DestType != "" && c.DestType != "auto" && c.DestType != "file" && c.DestType != "raw" && c.DestType != "lvm" {
 		return fmt.Errorf("invalid dest type %q", c.DestType)
 	}
+	if c.Output != "" && c.Output != "text" && c.Output != "json" {
+		return fmt.Errorf("invalid output %q: must be \"text\" or \"json\"", c.Output)
+	}
 	if c.FSFreezeCommand != "" {
 		parts, err := shellquote.Split(c.FSFreezeCommand)
 		if err != nil {

--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -1,6 +1,8 @@
 package transfer
 
 import (
+	"encoding/json"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -8,9 +10,19 @@ import (
 	"lvmsync_go/internal/config"
 )
 
+type progressEvent struct {
+	Event            string  `json:"event"`
+	Progress         float64 `json:"progress_percent"`
+	BytesTransferred int64   `json:"bytes_transferred,omitempty"`
+	BytesTotal       int64   `json:"bytes_total,omitempty"`
+}
+
 func finalizeProgress(cfg *config.Config, logger *zap.Logger) {
 	if cfg.Progress {
 		logger.Info("progress complete")
+		if cfg.Output == "json" {
+			_ = json.NewEncoder(os.Stdout).Encode(progressEvent{Event: "complete", Progress: 100})
+		}
 	}
 }
 
@@ -19,6 +31,14 @@ func reportProgress(cfg *config.Config, transferred, total int64, index int, sta
 		progressPercent := float64(transferred) / float64(total) * 100.0
 
 		logger.Info("transfer progress", zap.Float64("progress_percent", progressPercent))
+		if cfg.Output == "json" {
+			_ = json.NewEncoder(os.Stdout).Encode(progressEvent{
+				Event:            "progress",
+				Progress:         progressPercent,
+				BytesTransferred: transferred,
+				BytesTotal:       total,
+			})
+		}
 	}
 	if cfg.Verbose > 0 && index > 0 && index%100 == 0 {
 		elapsed := time.Since(start).Seconds()

--- a/transfer/progress_test.go
+++ b/transfer/progress_test.go
@@ -1,6 +1,9 @@
 package transfer
 
 import (
+	"encoding/json"
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -41,6 +44,52 @@ func TestReportProgressVerbose(t *testing.T) {
 	}
 	if logs.FilterMessage("parallel dump progress").Len() != 1 {
 		t.Fatalf("expected parallel dump progress log, got %d", logs.FilterMessage("parallel dump progress").Len())
+	}
+}
+
+func TestReportProgressJSON(t *testing.T) {
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	core, _ := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	cfg := &config.Config{Progress: true, Output: "json"}
+	reportProgress(cfg, 50, 100, 1, time.Now(), logger)
+	w.Close()
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var ev progressEvent
+	if err := json.Unmarshal(out, &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Event != "progress" || ev.Progress != 50 {
+		t.Fatalf("unexpected event %+v", ev)
+	}
+}
+
+func TestFinalizeProgressJSON(t *testing.T) {
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	core, _ := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	cfg := &config.Config{Progress: true, Output: "json"}
+	finalizeProgress(cfg, logger)
+	w.Close()
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var ev progressEvent
+	if err := json.Unmarshal(out, &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Event != "complete" || ev.Progress != 100 {
+		t.Fatalf("unexpected event %+v", ev)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `--output` flag to select `text` or `json`
- emit line-delimited JSON progress events
- document output formats and cover flag in tests

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: revive, staticcheck, errcheck)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bcec26288323801a8491418fb564