### PR TITLE
fsync WAL directory and test crash recovery

### DIFF
--- a/transfer/wal.go
+++ b/transfer/wal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/zeebo/blake3"
 )
@@ -15,6 +16,15 @@ type walHeader struct {
 	MAC      [32]byte
 }
 
+// WAL is a write-ahead log of device ranges. Each 16-byte entry records a
+// committed range and is fsynced before returning from Append. Callers must
+// append entries in monotonically increasing order.
+//
+// On first creation the header is written and both the file and its parent
+// directory are fsynced to ensure durability. When reopened after a crash,
+// OpenWAL scans for the last complete entry and truncates any partially written
+// tail. Close fsyncs the file and its parent directory to guarantee that the
+// final state of the WAL is persistent.
 type WAL struct {
 	f      *os.File
 	header walHeader
@@ -28,6 +38,10 @@ func walHeaderMAC(h *walHeader) [32]byte {
 	return blake3.Sum256(buf[:])
 }
 
+// OpenWAL opens or creates the WAL at path. It validates the metadata and
+// returns any fully committed ranges. If a crash left a partially written
+// entry, the WAL is truncated to the last complete record and positioned for
+// further appends.
 func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []Range, error) {
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
@@ -58,6 +72,11 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []R
 			return nil, nil, err
 		}
 		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		// Ensure the new WAL is durably linked from the parent directory.
+		if err := syncDir(filepath.Dir(path)); err != nil {
 			f.Close()
 			return nil, nil, err
 		}
@@ -95,9 +114,19 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []R
 		ranges = append(ranges, Range{Start: start, End: end})
 		off += 16
 	}
+	// Truncate any partially written tail and seek to the end for future appends.
+	if err := f.Truncate(off); err != nil {
+		f.Close()
+		return nil, nil, err
+	}
+	if _, err := f.Seek(off, 0); err != nil {
+		f.Close()
+		return nil, nil, err
+	}
 	return w, ranges, nil
 }
 
+// Append records the range and fsyncs the WAL before returning.
 func (w *WAL) Append(r Range) error {
 	var buf [16]byte
 	binary.LittleEndian.PutUint64(buf[0:8], r.Start)
@@ -108,6 +137,7 @@ func (w *WAL) Append(r Range) error {
 	return w.f.Sync()
 }
 
+// Sync flushes the WAL to stable storage.
 func (w *WAL) Sync() error {
 	if w.f != nil {
 		return w.f.Sync()
@@ -115,9 +145,29 @@ func (w *WAL) Sync() error {
 	return nil
 }
 
+// Close flushes the WAL and fsyncs its parent directory.
 func (w *WAL) Close() error {
-	if w.f != nil {
-		return w.f.Close()
+	if w.f == nil {
+		return nil
 	}
-	return nil
+	// Flush file contents first.
+	if err := w.f.Sync(); err != nil {
+		w.f.Close()
+		return err
+	}
+	name := w.f.Name()
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	w.f = nil
+	return syncDir(filepath.Dir(name))
+}
+
+func syncDir(path string) error {
+	d, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }

--- a/transfer/wal_test.go
+++ b/transfer/wal_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,5 +47,67 @@ func TestWALRecovery(t *testing.T) {
 	w.Close()
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("stat wal: %v", err)
+	}
+}
+
+func TestWALTruncatedHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	w, _, err := OpenWAL(path, 100, "dev", 1)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := os.Truncate(path, 10); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if _, _, err := OpenWAL(path, 100, "dev", 1); err == nil {
+		t.Fatalf("expected truncated header error")
+	}
+}
+
+func TestWALPartialWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	w, _, err := OpenWAL(path, 100, "dev", 1)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	// Append half of an entry to simulate a crash during write.
+	if _, err := f.Seek(8+8+64+32, 0); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], 5)
+	if _, err := f.Write(buf[:]); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close file: %v", err)
+	}
+	w2, ranges, err := OpenWAL(path, 100, "dev", 1)
+	if err != nil {
+		t.Fatalf("reopen wal: %v", err)
+	}
+	if len(ranges) != 0 {
+		t.Fatalf("expected empty ranges, got %#v", ranges)
+	}
+	w2.Close()
+	// Verify the partial entry was truncated.
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if want := int64(8 + 8 + 64 + 32); st.Size() != want {
+		t.Fatalf("expected size %d, got %d", want, st.Size())
 	}
 }


### PR DESCRIPTION
## Summary
- fsync WAL's parent directory on creation and close for durability
- document WAL ordering and crash recovery semantics
- add tests for truncated and partially written WAL detection

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: many warnings, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bce940e08323ac974f295b8fc244