### PR TITLE
Use CDC chunks for delta pre-pass

### DIFF
--- a/manifest/cdc_chunks_test.go
+++ b/manifest/cdc_chunks_test.go
@@ -1,0 +1,38 @@
+package manifest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
+)
+
+func TestIndexCDCChunks(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "man")
+	idx, err := Create(manPath, "dev", 1024, 0, 4, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	data := []byte("hello world")
+	digest := blake3.Sum256(data)
+	if err := idx.Set(0, uint32(len(data)), FlagCDC, xxh3.Hash(data), digest); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	idx2, err := Open(manPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer idx2.Close()
+	chunks := idx2.CDCChunks()
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Offset != 0 || chunks[0].Length != uint32(len(data)) || chunks[0].Digest != digest {
+		t.Fatalf("chunk mismatch")
+	}
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -453,6 +453,29 @@ func (i *Index) Entry(idx uint64) (offset uint64, length, flags uint32, xxh uint
 // ChunkCount returns the number of chunks tracked by the manifest.
 func (i *Index) ChunkCount() uint64 { return i.hdr.ChunkCount }
 
+// Chunk describes a CDC chunk recorded in the manifest.
+type Chunk struct {
+	Offset uint64
+	Length uint32
+	Digest [32]byte
+}
+
+// CDCChunks returns all CDC chunks stored in the manifest.
+func (i *Index) CDCChunks() []Chunk {
+	out := make([]Chunk, 0, i.hdr.ChunkCount)
+	for idx := uint64(0); idx < i.hdr.ChunkCount; idx++ {
+		offset, length, flags, _, digest, err := i.Entry(idx)
+		if err != nil {
+			continue
+		}
+		if flags&FlagCDC == 0 || length == 0 {
+			continue
+		}
+		out = append(out, Chunk{Offset: offset, Length: length, Digest: digest})
+	}
+	return out
+}
+
 // Rebuild creates a manifest index for device at output path.
 // DeviceID is determined via the configured DeviceInfoProvider. The device is read sequentially using blockSize-sized chunks.
 // Progress is logged at the provided interval; set interval to 0 to log every chunk.

--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -7,10 +7,14 @@ import (
 	"io"
 	"os"
 
+	"github.com/zeebo/blake3"
+
 	"lvmsync_go/common"
+	"lvmsync_go/dedup"
 	"lvmsync_go/internal/config"
 	digestpkg "lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncwire"
+	manifestpkg "lvmsync_go/manifest"
 )
 
 const rsyncMaxFrame = 1 << 20
@@ -44,45 +48,90 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 		return fmt.Errorf("seek origin: %w", err)
 	}
 
-	const chunk = 32 * 1024
-	bufSnap := make([]byte, chunk)
-	bufOrig := make([]byte, chunk)
-	var off int64
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
+	// Load CDC chunk digests from the manifest when available.
+	var digests map[[32]byte]struct{}
+	if cfg.ManifestPath != "" {
+		idx, err := manifestpkg.Open(cfg.ManifestPath)
+		if err != nil {
+			return fmt.Errorf("open manifest: %w", err)
 		}
-		nSnap, errSnap := snap.Read(bufSnap)
-		nOrig, errOrig := orig.Read(bufOrig)
-		n := nSnap
-		if nOrig < n {
-			n = nOrig
+		defer idx.Close()
+		chunks := idx.CDCChunks()
+		digests = make(map[[32]byte]struct{}, len(chunks))
+		for _, ch := range chunks {
+			digests[ch.Digest] = struct{}{}
 		}
-		if n > 0 {
-			i := 0
-			for i < n {
-				if bufSnap[i] != bufOrig[i] {
-					start := i
-					for i < n && bufSnap[i] != bufOrig[i] {
-						i++
-					}
-					if err := cl.SendDelta(off+int64(start), bufSnap[start:i]); err != nil {
-						return fmt.Errorf("send delta: %w", err)
-					}
-				} else {
-					i++
+	}
+
+	if len(digests) > 0 {
+		ch, err := dedup.NewChunker(cfg.CDCMin, cfg.CDCAvg, cfg.CDCMax, cfg.ChunkSeed)
+		if err != nil {
+			return fmt.Errorf("new chunker: %w", err)
+		}
+		var off int64
+		for {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			c, err := ch.NextChunk(snap)
+			if err == io.EOF && c.Length == 0 {
+				break
+			}
+			if err != nil && err != io.EOF {
+				return fmt.Errorf("chunk snapshot: %w", err)
+			}
+			sum := blake3.Sum256(c.Data[:c.Length])
+			if _, ok := digests[sum]; !ok {
+				if err := cl.SendDelta(off, c.Data[:c.Length]); err != nil {
+					return fmt.Errorf("send delta: %w", err)
 				}
 			}
-			off += int64(n)
+			off += int64(c.Length)
+			if err == io.EOF {
+				break
+			}
 		}
-		if errSnap == io.EOF || errOrig == io.EOF {
-			break
-		}
-		if errSnap != nil {
-			return fmt.Errorf("read snapshot: %w", errSnap)
-		}
-		if errOrig != nil {
-			return fmt.Errorf("read origin: %w", errOrig)
+	} else {
+		const chunk = 32 * 1024
+		bufSnap := make([]byte, chunk)
+		bufOrig := make([]byte, chunk)
+		var off int64
+		for {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			nSnap, errSnap := snap.Read(bufSnap)
+			nOrig, errOrig := orig.Read(bufOrig)
+			n := nSnap
+			if nOrig < n {
+				n = nOrig
+			}
+			if n > 0 {
+				i := 0
+				for i < n {
+					if bufSnap[i] != bufOrig[i] {
+						start := i
+						for i < n && bufSnap[i] != bufOrig[i] {
+							i++
+						}
+						if err := cl.SendDelta(off+int64(start), bufSnap[start:i]); err != nil {
+							return fmt.Errorf("send delta: %w", err)
+						}
+					} else {
+						i++
+					}
+				}
+				off += int64(n)
+			}
+			if errSnap == io.EOF || errOrig == io.EOF {
+				break
+			}
+			if errSnap != nil {
+				return fmt.Errorf("read snapshot: %w", errSnap)
+			}
+			if errOrig != nil {
+				return fmt.Errorf("read origin: %w", errOrig)
+			}
 		}
 	}
 

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -11,10 +11,12 @@ import (
 
 	"go.uber.org/zap"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 	digestpkg "lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncserver"
 	"lvmsync_go/internal/rsyncwire"
+	manifestpkg "lvmsync_go/manifest"
 )
 
 type countingConn struct {
@@ -58,6 +60,35 @@ func (m *rsyncserverMemDevice) ReadAt(p []byte, off int64) (int, error) {
 func (m *rsyncserverMemDevice) Size() int64 { return int64(len(m.buf)) }
 
 func (m *rsyncserverMemDevice) Sync() error { return nil }
+
+type rdMockDevice struct {
+	path      string
+	size      uint64
+	blockSize uint64
+}
+
+func (m *rdMockDevice) Path() string      { return m.path }
+func (m *rdMockDevice) SizeBytes() uint64 { return m.size }
+func (m *rdMockDevice) BlockSize() uint64 { return m.blockSize }
+func (m *rdMockDevice) Snapshot(ctx context.Context, snapshotSize string) (device.Device, error) {
+	return m, nil
+}
+func (m *rdMockDevice) Cleanup(ctx context.Context) error         { return nil }
+func (m *rdMockDevice) Close() error                              { return nil }
+func (m *rdMockDevice) Identity() (device.DeviceIdentity, error)  { return device.DeviceIdentity{}, nil }
+func (m *rdMockDevice) AppendWAL(device.Range) error              { return nil }
+func (m *rdMockDevice) RecoverWAL(func(device.Range) error) error { return nil }
+
+func rdBuildManifest(t *testing.T, devPath, manPath string, size uint64, cdcMin, cdcAvg, cdcMax uint32) {
+	t.Helper()
+	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &rdMockDevice{path: devPath, size: size, blockSize: 4}, nil
+	}
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
+	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, cdcMin, cdcAvg, cdcMax, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+}
 
 func TestDumpChangesRsyncDelta(t *testing.T) {
 	cfg, err := config.DefaultConfig()
@@ -105,6 +136,113 @@ func TestDumpChangesRsyncDelta(t *testing.T) {
 	}
 	if cc.n >= int64(len(snapshotData)) {
 		t.Fatalf("delta not efficient: sent %d >= %d", cc.n, len(snapshotData))
+	}
+}
+
+func TestRsyncDeltaCDCShift(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Delta = "rsync"
+	cfg.Compress = "none"
+	cfg.ChecksumAlgorithm = digestpkg.SHA256
+	cfg.CDCMin = 64
+	cfg.CDCAvg = 64
+	cfg.CDCMax = 128
+
+	dir := t.TempDir()
+	origPath := dir + "/orig"
+	snapPath := dir + "/snap"
+	manPath := dir + "/man"
+
+	originData := bytes.Repeat([]byte("a"), 512)
+	snapshotData := append([]byte("abcdefghij"), originData[:len(originData)-10]...)
+	if err := os.WriteFile(origPath, originData, 0o600); err != nil {
+		t.Fatalf("write origin: %v", err)
+	}
+	if err := os.WriteFile(snapPath, snapshotData, 0o600); err != nil {
+		t.Fatalf("write snap: %v", err)
+	}
+	rdBuildManifest(t, origPath, manPath, uint64(len(originData)), 64, 64, 128)
+	cfg.ManifestPath = manPath
+
+	dev := &rsyncserverMemDevice{buf: make([]byte, len(originData))}
+	copy(dev.buf, originData)
+	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+
+	c1, c2 := net.Pipe()
+	cc := &countingConn{Conn: c1}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(context.Background(), rsyncwire.NewStream(c2, rsyncMaxFrame)) }()
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	if err := tr.DumpChangesSequential(context.Background(), cfg, snapPath, origPath, cc); err != nil {
+		t.Fatalf("DumpChangesSequential: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !bytes.Equal(dev.buf, snapshotData) {
+		t.Fatalf("device mismatch")
+	}
+	if cc.n >= int64(len(snapshotData)) {
+		t.Fatalf("delta not efficient: sent %d >= %d", cc.n, len(snapshotData))
+	}
+}
+
+func TestRsyncDeltaCDCMutate(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Delta = "rsync"
+	cfg.Compress = "none"
+	cfg.ChecksumAlgorithm = digestpkg.SHA256
+	cfg.CDCMin = 64
+	cfg.CDCAvg = 64
+	cfg.CDCMax = 128
+
+	dir := t.TempDir()
+	origPath := dir + "/orig"
+	snapPath := dir + "/snap"
+	manPath := dir + "/man"
+
+	originData := bytes.Repeat([]byte("a"), 512)
+	snapshotData := append([]byte(nil), originData...)
+	copy(snapshotData[128:138], []byte("ABCDEFGHIJ"))
+	if err := os.WriteFile(origPath, originData, 0o600); err != nil {
+		t.Fatalf("write origin: %v", err)
+	}
+	if err := os.WriteFile(snapPath, snapshotData, 0o600); err != nil {
+		t.Fatalf("write snap: %v", err)
+	}
+	rdBuildManifest(t, origPath, manPath, uint64(len(originData)), 64, 64, 128)
+	cfg.ManifestPath = manPath
+
+	dev := &rsyncserverMemDevice{buf: make([]byte, len(originData))}
+	copy(dev.buf, originData)
+	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+
+	c1, c2 := net.Pipe()
+	cc := &countingConn{Conn: c1}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(context.Background(), rsyncwire.NewStream(c2, rsyncMaxFrame)) }()
+
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	if err := tr.DumpChangesSequential(context.Background(), cfg, snapPath, origPath, cc); err != nil {
+		t.Fatalf("DumpChangesSequential: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !bytes.Equal(dev.buf, snapshotData) {
+		t.Fatalf("device mismatch")
+	}
+	if cc.n >= int64(len(snapshotData))/2 {
+		t.Fatalf("delta not efficient: sent %d >= %d", cc.n, len(snapshotData)/2)
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose CDC chunk ranges from manifest
- drive rsync delta pre-pass using FastCDC chunks and manifest digests
- add integration tests for shifted and mutated chunks

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many warnings, 914 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bd1542ec83239fb25b8e01b8cc92