### PR TITLE
Ensure destination mismatches trigger precondition errors

### DIFF
--- a/transfer/destination_precondition_test.go
+++ b/transfer/destination_precondition_test.go
@@ -1,0 +1,101 @@
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/device"
+	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/exitcode"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	manifestpkg "lvmsync_go/manifest"
+)
+
+func TestProcessDumpDataDeviceIDMismatchPrecondition(t *testing.T) {
+	stream := minimalStream(t)
+	for _, force := range []bool{false, true} {
+		t.Run("force_"+strconv.FormatBool(force), func(t *testing.T) {
+			info := device.NewInfoWithDeps(
+				func(context.Context, string) (string, error) { return "actual", nil },
+				func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+				func(context.Context, string) (bool, error) { return false, nil },
+				nil,
+				nil,
+			)
+			core, logs := observer.New(zap.ErrorLevel)
+			tr := NewTransfer(zap.New(core), &sync.WaitGroup{}, info)
+			cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DeviceUUID: "expected", DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256"}
+			if force {
+				cfg.Force = true
+			}
+			dest := filepath.Join(t.TempDir(), "dest")
+			if err := os.WriteFile(dest, make([]byte, 1024), 0o600); err != nil {
+				t.Fatalf("write dest: %v", err)
+			}
+			err := tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(stream), dest)
+			if err == nil {
+				t.Fatalf("expected error for device mismatch")
+			}
+			if rootcmd.ExitCode(err) != exitcode.ErrPrecondition {
+				t.Fatalf("expected precondition exit code, got %d: %v", rootcmd.ExitCode(err), err)
+			}
+			if logs.FilterMessage("device_id_mismatch").Len() == 0 {
+				t.Fatalf("expected device_id_mismatch log")
+			}
+		})
+	}
+}
+
+func TestProcessDumpDataSizeMismatchPrecondition(t *testing.T) {
+	stream := minimalStream(t)
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, make([]byte, 1024), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	man := filepath.Join(t.TempDir(), "man")
+	var hdr manifestpkg.Header
+	hdr.Version = manifestpkg.Version
+	hdr.BlockSize = 512
+	hdr.SizeBytes = 2048
+	hdr.ChunkCount = 2
+	copy(hdr.DeviceID[:], []byte("id"))
+	hdr.MAC = manifestHeaderMAC(&hdr)
+	f, err := os.Create(man)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	f.Close()
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "id", nil },
+		func(context.Context, string) (string, error) { return "", errors.New("no lvm") },
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+		nil,
+	)
+	core, logs := observer.New(zap.ErrorLevel)
+	tr := NewTransfer(zap.New(core), &sync.WaitGroup{}, info)
+	cfg := &config.Config{BlockSize: 1024, Compress: "none", MaxRetries: 1, DedupStrategy: "none", VerifyChecksum: true, ChecksumAlgorithm: "sha256", ManifestPath: man}
+	err = tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(stream), dest)
+	if err == nil {
+		t.Fatalf("expected size mismatch error")
+	}
+	if rootcmd.ExitCode(err) != exitcode.ErrPrecondition {
+		t.Fatalf("expected precondition exit code, got %d: %v", rootcmd.ExitCode(err), err)
+	}
+	if logs.FilterMessage("device_size_mismatch").Len() == 0 {
+		t.Fatalf("expected device_size_mismatch log")
+	}
+}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -282,7 +282,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		manID := strings.TrimRight(string(hdr.DeviceID[:]), "\x00")
 		if id != manID {
 			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", manID), zap.String("resource_id", id))
-			return 0, "", 0, fmt.Errorf("destination device id %s does not match manifest %s", id, manID)
+			return 0, "", 0, fmt.Errorf("precondition: destination device id %s does not match manifest %s", id, manID)
 		}
 		size, err = t.Info.SizeBytes(ctx, destPath)
 		if err != nil {
@@ -290,7 +290,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		if size != hdr.SizeBytes {
 			t.Logger.Error("device_size_mismatch", zap.Uint64("expected_size_bytes", hdr.SizeBytes), zap.Uint64("size_bytes", size))
-			return 0, "", 0, fmt.Errorf("destination device size %d does not match manifest %d", size, hdr.SizeBytes)
+			return 0, "", 0, fmt.Errorf("precondition: destination device size %d does not match manifest %d", size, hdr.SizeBytes)
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 		if err != nil {
@@ -308,7 +308,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 			if _, err := os.Stat(cfg.ResumeState); err == nil {
 				chk := readResumeState(cfg, t.Logger, hdr.SizeBytes, manID, hdr.Epoch, hdr.FirstBlockDigest)
 				if chk == (resumeCheckpoint{}) {
-					return 0, "", 0, fmt.Errorf("resume state does not match destination metadata")
+					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata")
 				}
 			}
 		}
@@ -328,12 +328,12 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 				}
 				chk := readResumeState(cfg, t.Logger, size, id, 0, [32]byte{})
 				if chk == (resumeCheckpoint{}) {
-					return 0, "", 0, fmt.Errorf("resume state does not match destination metadata")
+					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata")
 				}
 			}
 			if cfg.DeviceUUID != "" && id != cfg.DeviceUUID {
 				t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", cfg.DeviceUUID), zap.String("resource_id", id))
-				return 0, "", 0, fmt.Errorf("destination device uuid %s does not match expected %s", id, cfg.DeviceUUID)
+				return 0, "", 0, fmt.Errorf("precondition: destination device uuid %s does not match expected %s", id, cfg.DeviceUUID)
 			}
 			t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
 		}


### PR DESCRIPTION
## Summary
- Prefix destination device ID and size mismatches with `precondition:` and surface resume state mismatches similarly
- Add tests ensuring destination mismatches return `ErrPrecondition` and log `device_id_mismatch`, including `--force` coverage

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestNoUnresolvedGaps)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: revive, staticcheck, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4168f3ba083239725d7e6caa48466