### PR TITLE
transfer: fsync WAL before writing

### DIFF
--- a/transfer/block_sparse_linux_test.go
+++ b/transfer/block_sparse_linux_test.go
@@ -104,7 +104,7 @@ func TestIterateBlocksSkipsSparseRegions(t *testing.T) {
 				t.Fatalf("read block: %v", err)
 			}
 		}
-		if _, err := processBlock(cfg, dest, nil, nil, false, nil, off, crc, nil, block, size, zap.NewNop()); err != nil {
+		if _, err := processBlock(cfg, dest, nil, nil, false, nil, off, crc, nil, block, size, zap.NewNop(), nil); err != nil {
 			t.Fatalf("processBlock: %v", err)
 		}
 	}

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -109,7 +109,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		} else {
 			chunkID = zeroHash(int(chunkSize))
 		}
-		written, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.intra, bw.verify, bw.checksum, offset, crc, transmitted, data, chunkSize, bw.logger)
+		written, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.intra, bw.verify, bw.checksum, offset, crc, transmitted, data, chunkSize, bw.logger, bw.wal)
 		if bw.cfg.ODirect {
 			if data != nil {
 				putAlignedBlockBuffer(data)
@@ -121,11 +121,6 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 			return total, err
 		}
 		saveResumeState(bw.cfg, bw.rt, offset, chunkID, int64(chunkSize), bw.logger)
-		if bw.wal != nil && written {
-			if err := bw.wal.Append(Range{Start: offset, End: offset + uint64(chunkSize)}); err != nil {
-				return total, err
-			}
-		}
 		if written {
 			total += int64(chunkSize)
 			bw.sinceSync += int64(chunkSize)

--- a/transfer/discard_test.go
+++ b/transfer/discard_test.go
@@ -28,7 +28,7 @@ func TestProcessBlockDiscard(t *testing.T) {
 	defer restore()
 	data := []byte("abcd")
 	crc := crc32c(data)
-	if written, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop()); err != nil || !written {
+	if written, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil || !written {
 		t.Fatalf("processBlock: %v written=%v", err, written)
 	}
 	if !called {
@@ -51,7 +51,7 @@ func TestProcessBlockDiscardDisabled(t *testing.T) {
 	defer restore()
 	data := []byte("abcd")
 	crc := crc32c(data)
-	if _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop()); err != nil {
+	if _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil {
 		t.Fatalf("processBlock: %v", err)
 	}
 	if called {

--- a/transfer/intra_dedup_test.go
+++ b/transfer/intra_dedup_test.go
@@ -43,11 +43,11 @@ func TestProcessBlockIntraDedup(t *testing.T) {
 	defer os.Remove(f.Name())
 	data := []byte("data")
 	crc := crc32c(data)
-	written, err := processBlock(cfg, f, nil, cache, false, nil, 0, crc, nil, data, uint32(len(data)), zap.NewNop())
+	written, err := processBlock(cfg, f, nil, cache, false, nil, 0, crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
 	if err != nil || !written {
 		t.Fatalf("first write %v %v", written, err)
 	}
-	written, err = processBlock(cfg, f, nil, cache, false, nil, uint64(len(data)), crc, nil, data, uint32(len(data)), zap.NewNop())
+	written, err = processBlock(cfg, f, nil, cache, false, nil, uint64(len(data)), crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("second write err %v", err)
 	}

--- a/transfer/resume_wal_integration_test.go
+++ b/transfer/resume_wal_integration_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
+
+	"lvmsync_go/device"
+	"lvmsync_go/internal/config"
+	privilege "lvmsync_go/internal/privilege"
+)
+
+// TestApplyHelper is a helper process that runs ProcessDumpData reading from stdin.
+func TestApplyHelper(t *testing.T) {
+	if os.Getenv("APPLY_HELPER") != "1" {
+		return
+	}
+	dest := os.Getenv("DEST")
+	resume := os.Getenv("RESUME")
+	bs, _ := strconv.Atoi(os.Getenv("BLOCKSIZE"))
+
+	detect := func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		return &mockDevice{path: dest, size: uint64(2 * bs), blockSize: uint64(bs)}, nil
+	}
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "uuid", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+		detect,
+	)
+	tr := NewTransfer(zap.NewNop(), nil, info)
+	cfg := &config.Config{BlockSize: bs, Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: resume, MaxRetries: 1}
+	if err := tr.ProcessDumpData(context.Background(), cfg, os.Stdin, dest); err != nil {
+		fmt.Fprintln(os.Stderr, "apply error:", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// TestResumeMidTransfer kills an apply process mid-transfer and verifies resume continues.
+func TestResumeMidTransfer(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 4096
+	snapshot := "vg-lv"
+	_, src := createVolumeFiles(t, snapshot, int64(blockSize), []int{0, 1})
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(dest, make([]byte, blockSize*2), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	resume := filepath.Join(dir, "resume.state")
+
+	// Build dump stream once.
+	detect := func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		return &mockDevice{path: src, size: uint64(2 * blockSize), blockSize: uint64(blockSize)}, nil
+	}
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "uuid", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(context.Context, string, uint64) ([32]byte, error) {
+			first := bytes.Repeat([]byte{1}, blockSize)
+			return blake3.Sum256(first), nil
+		},
+		detect,
+	)
+	tr := NewTransfer(zap.NewNop(), nil, info)
+	var buf bytes.Buffer
+	dumpCfg := &config.Config{BlockSize: blockSize, Compress: "none", ChecksumAlgorithm: "blake3", DedupMode: "fixed", MaxRetries: 1}
+	if err := tr.DumpChangesParallel(context.Background(), dumpCfg, snapshot, src, &buf); err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+
+	// Start apply helper.
+	cmd := exec.Command(os.Args[0], "-test.run=TestApplyHelper", "--")
+	cmd.Env = append(os.Environ(), "APPLY_HELPER=1", fmt.Sprintf("DEST=%s", dest), fmt.Sprintf("RESUME=%s", resume), fmt.Sprintf("BLOCKSIZE=%d", blockSize))
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	go func() {
+		io.Copy(stdin, &buf)
+		stdin.Close()
+	}()
+
+	walPath := resume + ".wal"
+	first := bytes.Repeat([]byte{1}, blockSize)
+	for i := 0; i < 100; i++ {
+		fi, err := os.Stat(walPath)
+		if err == nil && fi.Size() >= 128 {
+			f, _ := os.Open(dest)
+			data := make([]byte, blockSize)
+			f.ReadAt(data, 0)
+			f.Close()
+			if bytes.Equal(data, first) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	cmd.Process.Kill()
+	cmd.Wait()
+
+	// Resume apply.
+	cmd2 := exec.Command(os.Args[0], "-test.run=TestApplyHelper", "--")
+	cmd2.Env = append(os.Environ(), "APPLY_HELPER=1", fmt.Sprintf("DEST=%s", dest), fmt.Sprintf("RESUME=%s", resume), fmt.Sprintf("BLOCKSIZE=%d", blockSize))
+	stdin2, err := cmd2.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin2: %v", err)
+	}
+	if err := cmd2.Start(); err != nil {
+		t.Fatalf("start2: %v", err)
+	}
+	go func() {
+		io.Copy(stdin2, bytes.NewReader(buf.Bytes()))
+		stdin2.Close()
+	}()
+	if err := cmd2.Wait(); err != nil {
+		t.Fatalf("resume apply: %v", err)
+	}
+
+	// Verify destination matches source.
+	srcData, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read src: %v", err)
+	}
+	dstData, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !bytes.Equal(srcData, dstData) {
+		t.Fatalf("destination mismatch after resume")
+	}
+
+	// Ensure WAL contains two sequential entries.
+	w, ranges, err := OpenWAL(walPath, uint64(2*blockSize), "uuid", 0)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	w.Close()
+	if len(ranges) != 2 || ranges[0].Start != 0 || ranges[0].End != uint64(blockSize) || ranges[1].Start != uint64(blockSize) {
+		t.Fatalf("unexpected wal ranges %#v", ranges)
+	}
+}

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -136,6 +136,7 @@ func processBlock(
 	transmitted, data []byte,
 	chunkSize uint32,
 	logger *zap.Logger,
+	wal *WAL,
 ) (bool, error) {
 	if offset > math.MaxInt64 {
 		return false, fmt.Errorf("offset %d overflows int64", offset)
@@ -147,6 +148,11 @@ func processBlock(
 		return false, err
 	}
 	if chunkSize == 0 || isAllZero(data) {
+		if wal != nil {
+			if err := wal.Append(Range{Start: offset, End: offset + uint64(chunkSize)}); err != nil {
+				return false, err
+			}
+		}
 		if err := writeZeroBlock(cfg, destFile, offset, logger); err != nil {
 			return false, err
 		}
@@ -161,6 +167,11 @@ func processBlock(
 	}
 	if intra != nil && intra.Seen(data) {
 		return false, nil
+	}
+	if wal != nil {
+		if err := wal.Append(Range{Start: offset, End: offset + uint64(chunkSize)}); err != nil {
+			return false, err
+		}
 	}
 	if cfg.Discard {
 		if err := device.DiscardRange(destFile, offset, uint64(chunkSize), logger); err != nil {


### PR DESCRIPTION
## Summary
- fsync WAL before writing data blocks
- add integration test verifying resume after crash

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: found 1 unresolved gap(s))*
- `go tool cover -func=coverage.out | tail -n 1`
- `go test -tags=integration ./transfer -run TestResumeMidTransfer -count=1` *(fails: undefined: device.SetUUIDFunc)*
- `golangci-lint run` *(fails: unused-parameter and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a4169b35a883239af9f2b060c649d1