### PR TITLE
manifest: detect corruption and add fuzzing

### DIFF
--- a/manifest/corruption_test.go
+++ b/manifest/corruption_test.go
@@ -1,0 +1,30 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenSizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.man")
+	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := os.Truncate(path, info.Size()-1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if _, err := Open(path); err == nil || !strings.Contains(err.Error(), "unexpected file size") {
+		t.Fatalf("expected size error, got %v", err)
+	}
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -186,6 +186,14 @@ func (i *Index) readHeader() error {
 	return nil
 }
 
+func (i *Index) validateSize() error {
+	expected := uint64(HeaderSize) + i.hdr.ChunkCount*uint64(entrySize)
+	if uint64(len(i.data)) != expected {
+		return fmt.Errorf("manifest: unexpected file size: got %d, want %d", len(i.data), expected)
+	}
+	return nil
+}
+
 // Close flushes the mmap and closes the underlying file.
 func (i *Index) Close() error {
 	var err error
@@ -283,6 +291,10 @@ func Open(path string, opts ...IndexOption) (*Index, error) {
 		idx.Close()
 		return nil, err
 	}
+	if err := idx.validateSize(); err != nil {
+		idx.Close()
+		return nil, err
+	}
 	idx.buildTables()
 	return idx, nil
 }
@@ -321,6 +333,10 @@ func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 			idx.Close()
 			return nil, fmt.Errorf("manifest: unsupported version %d", idx.hdr.Version)
 		}
+	}
+	if err := idx.validateSize(); err != nil {
+		idx.Close()
+		return nil, err
 	}
 	idx.buildTables()
 	return idx, nil

--- a/manifest/manifest_fuzz_test.go
+++ b/manifest/manifest_fuzz_test.go
@@ -1,0 +1,32 @@
+package manifest
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func FuzzOpenCorrupt(f *testing.F) {
+	f.Add([]byte{})
+	f.Add(make([]byte, HeaderSize-1))
+	garbled := make([]byte, HeaderSize)
+	binary.LittleEndian.PutUint32(garbled[0:4], Version)
+	// leave rest zero, so MAC mismatches
+	f.Add(garbled)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "fuzz.man")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_, err := Open(path)
+		if err == nil {
+			t.Fatalf("Open succeeded on corrupt input of length %d", len(data))
+		}
+		_, err2 := Open(path)
+		if err2 == nil || err2.Error() != err.Error() {
+			t.Fatalf("error not deterministic: %v vs %v", err, err2)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- validate manifest file size and version when opening to catch corruption
- detect truncated manifests with explicit error messages
- fuzz manifest opening to ensure deterministic failure on garbled input

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: found 1 unresolved gap(s); update reports/gaps.* after fixing)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4169ea3448323ab9d3e70dac27fdf