### PR TITLE
docs: expand operations and benchmarks

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -91,4 +91,44 @@ lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with e
 - Confirm the destination is not mounted read-write. Use `--force` only when intentionally overwriting.
 - Rerun with `--resume` after resolving issues to avoid re-copying completed blocks.
 - Review logs for detailed errors and ensure all configuration values follow the expected flag > environment variable > config file precedence.
+ 
+## Failure Drills
+
+Practice recovery steps regularly so operators are prepared for common failure
+scenarios.
+
+### Snapshot Full
+
+1. Create a small snapshot and start a transfer:
+   ```sh
+   lvcreate -L1G -s -n snap_full /dev/vg0/src
+   lvmsync run /dev/vg0/snap_full /dev/vg0/dst &
+   ```
+2. Write more than 1 GiB to the source to exhaust the snapshot:
+   ```sh
+   dd if=/dev/zero of=/dev/vg0/src bs=1M count=2048
+   ```
+3. LVMSync exits with a device error. Remove the snapshot, create a larger one,
+   and resume with the same command line.
+
+### Identity Mismatch
+
+1. Begin a transfer and capture the resume state file.
+2. Modify the destination (e.g., recreate the LV) and rerun with `--resume`:
+   ```sh
+   lvremove -y /dev/vg0/dst
+   lvcreate -L10G -n dst /dev/vg0
+   lvmsync run --resume state /dev/vg0/snap0 /dev/vg0/dst || echo "mismatch"
+   ```
+3. LVMSync reports a precondition failure due to the changed identity. Fix the
+   destination and restart without `--resume` or regenerate the state.
+
+### TLS Failure
+
+1. Run a remote transfer with an invalid certificate or hostname:
+   ```sh
+   lvmsync run --remote https://badhost /dev/vg0/snap0 user@host:/dev/vg0/dst
+   ```
+2. The TLS handshake fails with `exitcode.ErrRuntime`. Verify certificates and
+   trust stores, then retry the transfer.
 

--- a/docs/sudoers.md
+++ b/docs/sudoers.md
@@ -1,43 +1,28 @@
-# sudoers Entries
+## `sudoers` Entries
 
 LVMSync requires elevated privileges for a small set of operations. The
-following examples show least-privilege `sudoers` rules for each command.
-Adjust paths to match your distribution and test on non-production systems
-before enabling them in production.
-
-## LVM administration
-
-Permit only the LVM utilities needed by LVMSync:
+following rules use `Cmnd_Alias` to keep entries concise while limiting access
+to only the necessary commands. Adjust paths to match your distribution and
+test on non-production systems before enabling them in production.
 
 ```sudoers
-# Allow LVMSync to run LVM commands without a password
-lvmsync ALL=(root) NOPASSWD: \
+Cmnd_Alias LVMSYNC_LVM = \
     /sbin/lvm, \
     /sbin/lvcreate, \
     /sbin/lvremove, \
     /sbin/lvs, \
     /sbin/pvs, \
     /sbin/vgs
-```
 
-## Device helper
-
-The helper performs privileged device operations such as opening block
-devices, writing data and issuing discards:
-
-```sudoers
-lvmsync ALL=(root) NOPASSWD: \
+Cmnd_Alias LVMSYNC_HELPER = \
     /usr/local/bin/lvmsync-helper open, \
     /usr/local/bin/lvmsync-helper write, \
     /usr/local/bin/lvmsync-helper discard
-```
 
-## blkdiscard fallback
+Cmnd_Alias LVMSYNC_BLKDISCARD = /usr/sbin/blkdiscard
 
-Enable direct `blkdiscard` when the helper is unavailable:
-
-```sudoers
-lvmsync ALL=(root) NOPASSWD: /usr/sbin/blkdiscard
+# Allow the "lvmsync" user to run the aliases without a password
+lvmsync ALL=(root) NOPASSWD: LVMSYNC_LVM, LVMSYNC_HELPER, LVMSYNC_BLKDISCARD
 ```
 
 Test each entry carefully to ensure no additional privileges are granted.

--- a/perf.md
+++ b/perf.md
@@ -14,6 +14,14 @@ Benchmarks were recorded from commit `e3591daaed6e9cc31b249961ce8a45d6816f6873`.
 - NVMe SSD storage
 - 10 GbE NICs
 
+Example host details can be captured with:
+
+```sh
+uname -srvmo
+lscpu | head
+lsblk -d -o name,rota,size,model
+```
+
 ## Dataset Generation
 
 The following steps create the reproducible 10 GiB dataset used for all tests:
@@ -164,11 +172,14 @@ $ scripts/bench_wan.sh /dev/vg0/snap0 user@wan:/dev/vg0/vol0
 ## Reproducing
 Benchmark runs are reproducible when the dataset, hardware, and commit hash are recorded.
 
-1. Generate the dataset using the steps above.
-2. Build the binary: `go build ./...`.
-3. Capture the commit: `git rev-parse HEAD`.
-4. Use the helper scripts to iterate through transport and compression combinations:
-   - `scripts/bench_lan.sh`
-   - `scripts/bench_wan.sh`
-5. Each script prints throughput and CPU usage via `/usr/bin/time -f '%e %P'`.
-6. Save the script output together with the commit hash for comparison across runs.
+```sh
+git clone https://github.com/.../lvmsync_go.git
+cd lvmsync_go
+go build ./...
+git rev-parse HEAD
+scripts/bench_lan.sh /dev/vg0/snap0 /mnt/backup/vol0
+scripts/bench_wan.sh /dev/vg0/snap0 user@wan:/dev/vg0/vol0 IFACE=eth0
+```
+
+Each script prints throughput and CPU usage via `/usr/bin/time -f '%e %P'`. Save
+the script output together with the commit hash for comparison across runs.


### PR DESCRIPTION
## Summary
- add Cmnd_Alias sudoers examples
- document recovery drills for snapshot exhaustion, identity mismatches, and TLS errors
- outline hardware details and reproducible benchmark commands

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: reports unresolved gap entries)*
- `golangci-lint run` *(fails: revive/staticcheck warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a416a9385c832387e0056bb7f75f86