### PR TITLE
ci: add lint jobs and sbom validation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,88 @@
+---
+# .github/workflows/checks.yml
+
+name: Checks
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24' }}"
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --config=.golangci.yml
+
+  go-vet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24' }}"
+          cache: true
+
+      - name: Go vet
+        run: go vet ./...
+
+  staticcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24' }}"
+          cache: true
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Run staticcheck
+        run: staticcheck ./...
+
+  test-race:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24' }}"
+          cache: true
+
+      - name: Go test with race detector
+        run: go test -race ./...

--- a/.github/workflows/loopback-integration.yml
+++ b/.github/workflows/loopback-integration.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   loopback:
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
+      options: --cap-add SYS_ADMIN
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,8 +32,8 @@ jobs:
 
       - name: Install LVM tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y lvm2
+          apt-get update
+          apt-get install -y lvm2
 
       - name: Run loopback integration test
-        run: sudo --preserve-env=PATH bash integration/loopback.sh
+        run: bash integration/loopback.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
           SKIP_DOCKER_PUSH: ${{ env.SKIP_DOCKER_PUSH }}
 
+      - name: Verify release artifacts
+        run: |
+          ls dist/*checksums.txt
+          ls dist/*.sbom.json
+
       - name: Build distroless image
         run: |
           docker buildx build \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
   - id: *name
     binary: *name
     env: [CGO_ENABLED=1]
-    goos: [linux, darwin]
+    goos: [linux]
     goarch: [amd64, arm64]
 
 archives:
@@ -19,8 +19,6 @@ archives:
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     format_overrides:
       - goos: linux
-        format: tar.gz
-      - goos: darwin
         format: tar.gz
 
 checksum:


### PR DESCRIPTION
## Summary
- add dedicated jobs for linting, vet, staticcheck, and race tests
- run loopback integration tests with SYS_ADMIN capability
- generate linux-only release artifacts with checksums and SBOM and verify SBOMs in CI

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: gaps_test.go:19: found 1 unresolved gap(s))*
- `golangci-lint run --config=.golangci.yml` *(timeout: module downloads did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a416b15d148323a7d5e1ea895a5219