### PR TITLE
test: add resume verify success case

### DIFF
--- a/cmd/verify/resume_verify_integration_test.go
+++ b/cmd/verify/resume_verify_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/device"
+	hashutil "lvmsync_go/hash"
 	"lvmsync_go/internal/config"
 	privilege "lvmsync_go/internal/privilege"
 	manifestpkg "lvmsync_go/manifest"
@@ -33,6 +34,9 @@ func (m *mockDevice) BlockSize() uint64                                       { 
 func (m *mockDevice) Close() error                                            { return nil }
 func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
 func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
+func (m *mockDevice) Identity() (device.DeviceIdentity, error)                { return device.DeviceIdentity{}, nil }
+func (m *mockDevice) AppendWAL(device.Range) error                            { return nil }
+func (m *mockDevice) RecoverWAL(func(device.Range) error) error               { return nil }
 
 func minimalStream(t *testing.T) []byte {
 	t.Helper()
@@ -43,14 +47,69 @@ func minimalStream(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
-func buildManifest(t *testing.T, devPath, manPath, uuid string, size uint64) {
-	t.Helper()
-	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
-		return &mockDevice{path: devPath, size: size, blockSize: 4}, nil
+func TestResumeVerifySuccess(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 4096
+	first := bytes.Repeat([]byte{1}, blockSize)
+	second := bytes.Repeat([]byte{2}, blockSize)
+	data := append(first, second...)
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(dest, data, 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
 	}
-	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil, nil)
-	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
-		t.Fatalf("rebuild: %v", err)
+	man := filepath.Join(dir, "dest.man")
+	idx, err := manifestpkg.Create(man, "uuid", uint64(len(data)), 0, uint32(blockSize), 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("manifest create: %v", err)
+	}
+	dig := blake3.Sum256(first)
+	xx := hashutil.SumXXH3(first)
+	if err := idx.Set(0, uint32(blockSize), 0, xx, dig); err != nil {
+		t.Fatalf("manifest set: %v", err)
+	}
+	dig = blake3.Sum256(second)
+	xx = hashutil.SumXXH3(second)
+	if err := idx.Set(uint64(blockSize), uint32(blockSize), 0, xx, dig); err != nil {
+		t.Fatalf("manifest set: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("manifest close: %v", err)
+	}
+	resume := filepath.Join(dir, "resume.state")
+	w, _, err := transfer.OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Append(transfer.Range{Start: 0, End: uint64(blockSize)}); err != nil {
+		t.Fatalf("append wal: %v", err)
+	}
+	if err := w.Append(transfer.Range{Start: uint64(blockSize), End: uint64(len(data))}); err != nil {
+		t.Fatalf("append wal: %v", err)
+	}
+	w.Close()
+	var firstDigest [32]byte
+	detect := func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		return &mockDevice{path: dest, size: uint64(len(data)), blockSize: uint64(blockSize)}, nil
+	}
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "uuid", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(context.Context, string, uint64) ([32]byte, error) { return firstDigest, nil },
+		detect,
+	)
+	tr := transfer.NewTransfer(zap.NewNop(), nil, info)
+	cfg := &config.Config{
+		BlockSize:         blockSize,
+		ManifestPath:      man,
+		ResumeState:       resume,
+		Compress:          "none",
+		ChecksumAlgorithm: "sha256",
+		VerifyLevel:       "full",
+		MaxRetries:        1,
+	}
+	if err := tr.ProcessDumpData(context.Background(), cfg, bytes.NewReader(minimalStream(t)), dest); err != nil {
+		t.Fatalf("verification failed: %v", err)
 	}
 }
 
@@ -65,13 +124,32 @@ func TestResumeVerifyMismatch(t *testing.T) {
 		t.Fatalf("write dest: %v", err)
 	}
 	man := filepath.Join(dir, "dest.man")
-	buildManifest(t, dest, man, "uuid", uint64(len(data)))
+	idx, err := manifestpkg.Create(man, "uuid", uint64(len(data)), 0, uint32(blockSize), 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("manifest create: %v", err)
+	}
+	dig := blake3.Sum256(first)
+	xx := hashutil.SumXXH3(first)
+	if err := idx.Set(0, uint32(blockSize), 0, xx, dig); err != nil {
+		t.Fatalf("manifest set: %v", err)
+	}
+	dig = blake3.Sum256(second)
+	xx = hashutil.SumXXH3(second)
+	if err := idx.Set(uint64(blockSize), uint32(blockSize), 0, xx, dig); err != nil {
+		t.Fatalf("manifest set: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("manifest close: %v", err)
+	}
 	resume := filepath.Join(dir, "resume.state")
 	w, _, err := transfer.OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
-	if err := w.Append(transfer.Range{Start: 0, End: uint64(len(data))}); err != nil {
+	if err := w.Append(transfer.Range{Start: 0, End: uint64(blockSize)}); err != nil {
+		t.Fatalf("append wal: %v", err)
+	}
+	if err := w.Append(transfer.Range{Start: uint64(blockSize), End: uint64(len(data))}); err != nil {
 		t.Fatalf("append wal: %v", err)
 	}
 	w.Close()
@@ -84,7 +162,7 @@ func TestResumeVerifyMismatch(t *testing.T) {
 		t.Fatalf("corrupt dest: %v", err)
 	}
 	f.Close()
-	firstDigest := blake3.Sum256(first)
+	var firstDigest [32]byte
 	detect := func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 		return &mockDevice{path: dest, size: uint64(len(data)), blockSize: uint64(blockSize)}, nil
 	}


### PR DESCRIPTION
## Summary
- ensure resume verification succeeds for matching destinations
- verify WAL mismatch detection on corrupted blocks

## Testing
- `go test ./cmd/verify`
- `go test -tags=integration ./cmd/verify -run ResumeVerify`


------
https://chatgpt.com/codex/tasks/task_e_68a416b547f88323b7e5e55ef30f5e92