### PR TITLE
test: verify compress-threshold flag override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,10 +1213,29 @@ lvmsync run /dev/vg0/snap0 user@remote:/dev/vg0/data
 
 #### Using Compression
 
-Estimate a sample of each chunk and compress only when it's worthwhile:
+Estimate a sample of each chunk and compress only when it's worthwhile.
+
+CLI:
 
 ```sh
 lvmsync run --compress auto --zstd-level 2 --compress-threshold 0.85 /dev/vg0/snap0 /dev/vg0/data
+```
+
+Environment:
+
+```sh
+LVMSYNC_COMPRESSION_COMPRESS=auto \
+LVMSYNC_COMPRESSION_ZSTD_LEVEL=2 \
+LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD=0.85 \
+lvmsync run /dev/vg0/snap0 /dev/vg0/data
+```
+
+YAML:
+
+```yaml
+compress: auto
+zstd_level: 2
+compress_threshold: 0.85
 ```
 
 #### Rate Limiting

--- a/internal/compressiondetect/compress_threshold_flag_test.go
+++ b/internal/compressiondetect/compress_threshold_flag_test.go
@@ -1,0 +1,36 @@
+package compressiondetect_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"lvmsync_go/internal/config"
+)
+
+func TestCompressThresholdFlagOverridesDefault(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := config.NewBuilder(defaults)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{})
+	if err != nil {
+		t.Fatalf("build default: %v", err)
+	}
+	if cfg.CompressThreshold != defaults.CompressThreshold {
+		t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, defaults.CompressThreshold)
+	}
+
+	b = config.NewBuilder(defaults)
+	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err = b.Build(fs, []string{"--compress-threshold", "0.85"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.CompressThreshold != 0.85 {
+		t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.85)
+	}
+}


### PR DESCRIPTION
## Summary
- test `--compress-threshold` flag overrides default configuration
- document compression threshold flag with CLI, environment, and YAML examples

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: found 1 unresolved gap(s))*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 932 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a416bb3b8c8323bf8765fe46d1efce