### PR TITLE
Add markdown link check and CI step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -122,26 +122,29 @@ jobs:
         if: github.event_name == 'pull_request'
         run: make test-race
 
-      - name: Integration tests
-        if: github.event_name == 'pull_request'
-        run: make integration
-        
-      - name: Build, test, and lint
-        run: make verify
+        - name: Integration tests
+          if: github.event_name == 'pull_request'
+          run: make integration
 
-      - name: Verify prune candidates
-        run: |
-          go run ./cmd/reachmap > .prune_candidates.txt
-          test ! -s .prune_candidates.txt
+        - name: Build, test, and lint
+          run: make verify
 
-      - name: Verify gaps resolved
-        run: |
-          jq -e 'map(select(.type | contains("(resolved)") | not)) | length == 0' reports/machine/gaps.json
+        - name: Verify prune candidates
+          run: |
+            go run ./cmd/reachmap > .prune_candidates.txt
+            test ! -s .prune_candidates.txt
 
-      - name: Show coverage
-        run: go tool cover -func=coverage.out | tail -n 1
+        - name: Verify gaps resolved
+          run: |
+            jq -e 'map(select(.type | contains("(resolved)") | not)) | length == 0' reports/machine/gaps.json
 
-      - name: Enforce coverage threshold
-        run: |
-          pct=$(go tool cover -func=coverage.out | tail -n 1 | awk '{print $3}' | tr -d '%')
-          awk -v p="$pct" 'BEGIN { if (p < 50) { printf("coverage %.2f%% is below 50%%\n", p); exit 1 } }'
+        - name: Docs check
+          run: make docs-check
+
+        - name: Show coverage
+          run: go tool cover -func=coverage.out | tail -n 1
+
+        - name: Enforce coverage threshold
+          run: |
+            pct=$(go tool cover -func=coverage.out | tail -n 1 | awk '{print $3}' | tr -d '%')
+            awk -v p="$pct" 'BEGIN { if (p < 50) { printf("coverage %.2f%% is below 50%%\n", p); exit 1 } }'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX := >
-.PHONY: build test lint verify bench bench-lan bench-wan vet staticcheck test-race integration release
+.PHONY: build test lint verify bench bench-lan bench-wan vet staticcheck test-race integration release docs-check
 
 build:
 > @mkdir -p bin
@@ -22,6 +22,9 @@ verify:
 > go build ./...
 > go test -coverprofile=coverage.out ./...
 > golangci-lint run
+
+docs-check:
+> go test ./docs
 
 test-race:
 > go test -race ./...

--- a/docs/links_test.go
+++ b/docs/links_test.go
@@ -1,0 +1,89 @@
+package docs
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestMarkdownLinks ensures that internal Markdown links resolve.
+func TestMarkdownLinks(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root := filepath.Dir(wd)
+	linkRe := regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".md" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		dir := filepath.Dir(path)
+		for _, m := range linkRe.FindAllSubmatch(data, -1) {
+			link := string(m[1])
+			if i := strings.IndexAny(link, " \t"); i >= 0 {
+				link = link[:i]
+			}
+			if strings.Contains(link, "://") || strings.HasPrefix(link, "mailto:") || strings.HasPrefix(link, "#") {
+				continue
+			}
+			target, frag, _ := strings.Cut(link, "#")
+			targetPath := filepath.Join(dir, target)
+			if _, err := os.Stat(targetPath); err != nil {
+				t.Errorf("%s: broken link %q", path, link)
+				continue
+			}
+			if frag == "" {
+				continue
+			}
+			targetData, err := os.ReadFile(targetPath)
+			if err != nil {
+				t.Errorf("read %s: %v", targetPath, err)
+				continue
+			}
+			if !anchorExists(targetData, frag) {
+				t.Errorf("%s: missing anchor %q in %s", path, frag, targetPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}
+
+func anchorExists(data []byte, frag string) bool {
+	frag = strings.ToLower(frag)
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(line) == 0 || line[0] != '#' {
+			continue
+		}
+		anchor := strings.TrimLeft(string(line), "#")
+		anchor = strings.TrimSpace(anchor)
+		anchor = strings.ToLower(anchor)
+		re := regexp.MustCompile(`[^a-z0-9 -]`)
+		anchor = re.ReplaceAllString(anchor, "")
+		anchor = strings.ReplaceAll(anchor, " ", "-")
+		if anchor == frag {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add a test that walks the repo to verify all internal Markdown links and anchors resolve
- expose `make docs-check` and run it in the Go workflow

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: found 1 unresolved gap(s))*
- `golangci-lint run` *(fails: multiple lint errors)*
- `make docs-check`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a416c97798832381d3e5f5d546d2b0