### PR TITLE
Fix config precedence tests for parallel and compression threshold

### DIFF
--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -169,7 +169,15 @@ func TestParallelFlagOverridesEnvAndYAML(t *testing.T) {
 	}
 }
 
-func TestParallelEnvOverridesYAML(t *testing.T) {
+func TestCompressThresholdFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
 	if err := os.WriteFile(cfgFile, []byte("compress_threshold: 0.5\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -193,13 +201,10 @@ func TestCompressThresholdEnvOverridesYAML(t *testing.T) {
 	b := NewBuilder(defaults)
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "cfg.yaml")
-	if err := os.WriteFile(cfgFile, []byte("parallel: 4\n"), 0o644); err != nil {
+	if err := os.WriteFile(cfgFile, []byte("parallel: 4\ncompress_threshold: 0.5\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Setenv("LVMSYNC_PARALLEL", "8")
-	if err := os.WriteFile(cfgFile, []byte("compress_threshold: 0.5\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
 	t.Setenv("LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD", "0.6")
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
@@ -208,6 +213,7 @@ func TestCompressThresholdEnvOverridesYAML(t *testing.T) {
 	}
 	if cfg.Parallel != 8 {
 		t.Fatalf("Parallel=%d want %d", cfg.Parallel, 8)
+	}
 	if cfg.CompressThreshold != 0.6 {
 		t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.6)
 	}


### PR DESCRIPTION
## Summary
- ensure compression threshold flag precedence test initializes config and env correctly
- write both `parallel` and `compress_threshold` in config to verify env overrides and fix missing brace

## Testing
- `go test ./internal/config`


------
https://chatgpt.com/codex/tasks/task_e_68a420706268832395efd7c2b2de3798