### PR TITLE
replace logger panics with errors

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -228,7 +228,7 @@ func Execute(args []string, logger *zap.Logger) error {
 // If args is nil, the global os.Args are used by cobra.
 func ExecuteWithRunner(args []string, logger *zap.Logger, r *Runner) error {
 	if logger == nil {
-		panic("nil logger")
+		return fmt.Errorf("nil logger")
 	}
 	defer rootcmd.SyncLogger(logger)
 	cmd := NewRootCmd(logger, r)
@@ -240,7 +240,7 @@ func ExecuteWithRunner(args []string, logger *zap.Logger, r *Runner) error {
 
 func estimateTransfer(src string, cfg *config.Config, logger *zap.Logger) error {
 	if logger == nil {
-		panic("nil logger")
+		return fmt.Errorf("nil logger")
 	}
 	info, err := os.Stat(src)
 	if err != nil {

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -289,20 +289,14 @@ func TestEstimateTransferMissingManifest(t *testing.T) {
 	}
 }
 
-func TestExecuteWithRunnerNilLoggerPanics(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	ExecuteWithRunner([]string{"run", "src", "dst"}, nil, nil)
+func TestExecuteWithRunnerNilLoggerError(t *testing.T) {
+	if err := ExecuteWithRunner([]string{"run", "src", "dst"}, nil, nil); err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
-func TestEstimateTransferNilLoggerPanics(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	estimateTransfer("", &config.Config{}, nil)
+func TestEstimateTransferNilLoggerError(t *testing.T) {
+	if err := estimateTransfer("", &config.Config{}, nil); err == nil {
+		t.Fatalf("expected error")
+	}
 }

--- a/cmd/lvmsyncd/lvmsyncd.go
+++ b/cmd/lvmsyncd/lvmsyncd.go
@@ -91,7 +91,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 
 func run(args []string, logger *zap.Logger) error {
 	if logger == nil {
-		panic("nil logger")
+		return fmt.Errorf("nil logger")
 	}
 	defer rootcmd.SyncLogger(logger)
 

--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -151,11 +151,8 @@ func TestExitCodeMapping(t *testing.T) {
 	}
 }
 
-func TestRunNilLoggerPanics(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	run([]string{}, nil)
+func TestRunNilLoggerError(t *testing.T) {
+	if err := run([]string{}, nil); err == nil {
+		t.Fatalf("expected error")
+	}
 }

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -42,7 +42,7 @@ func init() {
 // Run executes manifest subcommands.
 func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if logger == nil {
-		panic("nil logger")
+		return fmt.Errorf("nil logger")
 	}
 	defer rootcmd.SyncLogger(logger)
 	if len(args) == 0 {

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -188,18 +188,15 @@ func TestRunMissingArgs(t *testing.T) {
 	}
 }
 
-func TestRunNilLoggerPanics(t *testing.T) {
+func TestRunNilLoggerError(t *testing.T) {
 	cfg, err := config.DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	r := NewRunner()
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	r.Run(cfg, []string{"rebuild", "/dev/test"}, nil)
+	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, nil); err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
 func TestRunAppliesManifestTimeout(t *testing.T) {

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -46,7 +46,7 @@ func init() {
 // Args should exclude the "verify" subcommand itself.
 func (r *Runner) Run(args []string, logger *zap.Logger) error {
 	if logger == nil {
-		panic("nil logger")
+		return fmt.Errorf("nil logger")
 	}
 	defer rootcmd.SyncLogger(logger)
 	cmd := &cobra.Command{

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -162,13 +162,10 @@ func TestVerifyWithManifestAllocations(t *testing.T) {
 	}
 }
 
-func TestRunNilLoggerPanics(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	Run([]string{"--dry-run", "src", "dst"}, nil)
+func TestRunNilLoggerError(t *testing.T) {
+	if err := Run([]string{"--dry-run", "src", "dst"}, nil); err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
 func TestVerifyDevicesRebuildsManifest(t *testing.T) {

--- a/device/detect.go
+++ b/device/detect.go
@@ -35,7 +35,10 @@ func detectLVMDevice(ctx context.Context, path, lvmEscalation string, runner *Ru
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
 	}
-	cache := lvm.NewDeviceFDCache(logger)
+	cache, err := lvm.NewDeviceFDCache(logger)
+	if err != nil {
+		return nil, err
+	}
 	defer cache.Close()
 	dev, err := runner.OpenLVM(ctx, path, cache, lvmEscalation, logger)
 	if err != nil {

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -211,7 +211,11 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 		_ = d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err
 	}
-	cache := lvm.NewDeviceFDCache(d.logger)
+	cache, err := lvm.NewDeviceFDCache(d.logger)
+	if err != nil {
+		_ = d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
+		return nil, err
+	}
 	defer cache.Close()
 	snapDev, err := d.runner.OpenLVM(ctx, snapPath, cache, d.escalation, d.logger)
 	if err != nil {

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -30,7 +30,10 @@ func TestOpenLVM(t *testing.T) {
 	t.Cleanup(restoreDir)
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	cache := lvm.NewDeviceFDCache(zap.NewNop())
+	cache, err := lvm.NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 	runner := NewRunner()
 	dev, err := runner.OpenLVM(context.Background(), loop, cache, "", zap.NewNop())
@@ -52,7 +55,10 @@ func TestOpenLVMNonBlockDevice(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	cache := lvm.NewDeviceFDCache(zap.NewNop())
+	cache, err := lvm.NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 	runner := NewRunner()
 	if _, err := runner.OpenLVM(context.Background(), f.Name(), cache, "", zap.NewNop()); err == nil {
@@ -61,7 +67,10 @@ func TestOpenLVMNonBlockDevice(t *testing.T) {
 }
 
 func TestOpenLVMChecks(t *testing.T) {
-	cache := lvm.NewDeviceFDCache(zap.NewNop())
+	cache, err := lvm.NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, defaultIsMountedRW, lock.Acquire, nil)
 	if _, err := runner.OpenLVM(context.Background(), "/dev/missing", cache, "", zap.NewNop()); err == nil {

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -185,7 +185,10 @@ func (r *Runner) createSnapshotIfNeeded(ctx context.Context, cfg *config.Config,
 // It returns the snapshot path, an optional monitor error channel,
 // a cleanup function, and any error encountered.
 func (r *Runner) PrepareSnapshot(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
-	cache := lvm.NewDeviceFDCache(logger)
+	cache, err := lvm.NewDeviceFDCache(logger)
+	if err != nil {
+		return "", nil, nil, err
+	}
 	defer cache.Close()
 
 	snapshotBytes, err := r.calculateSnapshotSize(cfg, originalVolume, cache, logger)

--- a/internal/client/snapshot_helpers_test.go
+++ b/internal/client/snapshot_helpers_test.go
@@ -17,7 +17,10 @@ func TestCalculateSnapshotSize(t *testing.T) {
 		cfg := &config.Config{SnapshotSize: "1024"}
 		r := NewRunnerWithDeps(func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 1024, nil }, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
-		cache := lvm.NewDeviceFDCache(zap.NewNop())
+		cache, err := lvm.NewDeviceFDCache(zap.NewNop())
+		if err != nil {
+			t.Fatalf("NewDeviceFDCache: %v", err)
+		}
 		defer cache.Close()
 		size, err := r.calculateSnapshotSize(cfg, "/dev/vg/lv", cache, zap.NewNop())
 		if err != nil {
@@ -32,7 +35,10 @@ func TestCalculateSnapshotSize(t *testing.T) {
 		cfg := &config.Config{SnapshotSize: "bad"}
 		r := NewRunnerWithDeps(func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 0, errors.New("bad") }, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
-		cache := lvm.NewDeviceFDCache(zap.NewNop())
+		cache, err := lvm.NewDeviceFDCache(zap.NewNop())
+		if err != nil {
+			t.Fatalf("NewDeviceFDCache: %v", err)
+		}
 		defer cache.Close()
 		if _, err := r.calculateSnapshotSize(cfg, "/dev/vg/lv", cache, zap.NewNop()); err == nil {
 			t.Fatalf("expected error for invalid size")
@@ -42,7 +48,10 @@ func TestCalculateSnapshotSize(t *testing.T) {
 
 func TestEnsureVolumeGroups(t *testing.T) {
 	logger := zap.NewNop()
-	cache := lvm.NewDeviceFDCache(logger)
+	cache, err := lvm.NewDeviceFDCache(logger)
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 
 	t.Run("sets missing volume group", func(t *testing.T) {

--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -52,7 +52,7 @@ type Server struct {
 // logger is replaced with zap.NewNop().
 func New(dev Device, logger *zap.Logger, cache *signaturecache.Cache, vg, lv string) *Server {
 	if logger == nil {
-		panic("nil logger")
+		logger = zap.NewNop()
 	}
 	return &Server{dev: dev, logger: logger, cache: cache, vg: vg, lv: lv}
 }

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -100,14 +100,12 @@ func TestHandleApplyDelta(t *testing.T) {
 	}
 }
 
-func TestNewNilLoggerPanics(t *testing.T) {
+func TestNewNilLoggerDefaults(t *testing.T) {
 	dev := &memDevice{}
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	New(dev, nil, nil, "", "")
+	srv := New(dev, nil, nil, "", "")
+	if srv.logger == nil {
+		t.Fatalf("expected non-nil logger")
+	}
 }
 
 func TestHandleShortWrite(t *testing.T) {

--- a/lvm/fd_cache.go
+++ b/lvm/fd_cache.go
@@ -27,32 +27,33 @@ type FDCache struct {
 }
 
 // NewFDCache returns an initialized file descriptor cache with the given capacity.
-func NewFDCache(size int, logger *zap.Logger) *FDCache {
+func NewFDCache(size int, logger *zap.Logger) (*FDCache, error) {
 	if size <= 0 {
 		size = fdCacheSize
 	}
 	if logger == nil {
-		panic("nil logger")
+		return nil, fmt.Errorf("nil logger")
 	}
 	return &FDCache{
 		fds:    make(map[string]*list.Element, size),
 		order:  list.New(),
 		size:   size,
 		logger: logger,
-	}
+	}, nil
 }
 
 // NewDeviceFDCache returns an FDCache preconfigured for device descriptor caching.
-func NewDeviceFDCache(logger *zap.Logger) *FDCache {
+func NewDeviceFDCache(logger *zap.Logger) (*FDCache, error) {
 	return NewFDCache(fdCacheSize, logger)
 }
 
 // SetLogger updates the logger used by the cache.
-func (c *FDCache) SetLogger(logger *zap.Logger) {
+func (c *FDCache) SetLogger(logger *zap.Logger) error {
 	if logger == nil {
-		panic("nil logger")
+		return fmt.Errorf("nil logger")
 	}
 	c.logger = logger
+	return nil
 }
 
 // getFD retrieves an open file descriptor for the specified device path.

--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -10,27 +10,27 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestNewFDCacheNilLoggerPanics(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	NewFDCache(fdCacheSize, nil)
+func TestNewFDCacheNilLoggerError(t *testing.T) {
+	if _, err := NewFDCache(fdCacheSize, nil); err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
-func TestSetLoggerNilPanics(t *testing.T) {
-	cache := NewFDCache(fdCacheSize, zap.NewNop())
-	defer func() {
-		if recover() == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	cache.SetLogger(nil)
+func TestSetLoggerNilError(t *testing.T) {
+	cache, err := NewFDCache(fdCacheSize, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewFDCache: %v", err)
+	}
+	if err := cache.SetLogger(nil); err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
 func TestFDCacheEvictionOrder(t *testing.T) {
-	cache := NewFDCache(fdCacheSize, zap.NewNop())
+	cache, err := NewFDCache(fdCacheSize, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewFDCache: %v", err)
+	}
 
 	tmpDir := t.TempDir()
 	var fd0, fd1 int
@@ -74,7 +74,10 @@ func TestFDCacheEvictionOrder(t *testing.T) {
 }
 
 func TestFDCacheCloseClosesAll(t *testing.T) {
-	cache := NewFDCache(fdCacheSize, zap.NewNop())
+	cache, err := NewFDCache(fdCacheSize, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewFDCache: %v", err)
+	}
 	tmpDir := t.TempDir()
 	var fds []int
 	for i := 0; i < 3; i++ {
@@ -99,7 +102,10 @@ func TestFDCacheCloseClosesAll(t *testing.T) {
 }
 
 func TestGetVolumeSizeCachesFD(t *testing.T) {
-	cache := NewDeviceFDCache(zap.NewNop())
+	cache, err := NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 
 	tmpFile := filepath.Join(t.TempDir(), "vol")
@@ -144,7 +150,10 @@ func TestGetVolumeSizeCachesFD(t *testing.T) {
 }
 
 func TestFDCLOEXEC(t *testing.T) {
-	cache := NewDeviceFDCache(zap.NewNop())
+	cache, err := NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 
 	tmpFile := filepath.Join(t.TempDir(), "file")

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -183,7 +183,9 @@ func GetVolumeSize(volumePath string, cache *FDCache, logger *zap.Logger) (uint6
 	if cache == nil {
 		return 0, fmt.Errorf("fd cache is nil")
 	}
-	cache.SetLogger(logger)
+	if err := cache.SetLogger(logger); err != nil {
+		return 0, err
+	}
 	fd, err := cache.getFD(volumePath)
 	if err != nil {
 		return 0, err

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -33,7 +33,10 @@ func TestParseSnapshotSize(t *testing.T) {
 	if err := os.WriteFile(tmpFile, make([]byte, 1024*1024), 0644); err != nil {
 		t.Fatalf("failed to create temp volume: %v", err)
 	}
-	cache := NewDeviceFDCache(zap.NewNop())
+	cache, err := NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 
 	tests := []struct {
@@ -69,7 +72,10 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("failed to create temp volume: %v", err)
 		}
 
-		cache := NewDeviceFDCache(zap.NewNop())
+		cache, err := NewDeviceFDCache(zap.NewNop())
+		if err != nil {
+			t.Fatalf("NewDeviceFDCache: %v", err)
+		}
 		defer cache.Close()
 		size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
 		if err != nil {
@@ -91,7 +97,10 @@ func TestGetVolumeSize(t *testing.T) {
 			t.Fatalf("truncate failed: %v", err)
 		}
 
-		cache := NewDeviceFDCache(zap.NewNop())
+		cache, err := NewDeviceFDCache(zap.NewNop())
+		if err != nil {
+			t.Fatalf("NewDeviceFDCache: %v", err)
+		}
 		defer cache.Close()
 		size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
 		if err != nil {
@@ -117,7 +126,10 @@ func TestGetVolumeSizeIoctlLarge(t *testing.T) {
 	}
 	defer func() { ioctlGetUint64Func = orig }()
 
-	cache := NewDeviceFDCache(zap.NewNop())
+	cache, err := NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
 	defer cache.Close()
 	size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
 	if err != nil {


### PR DESCRIPTION
## Summary
- return errors instead of panicking when loggers are nil
- allow rsync server to default to zap.NewNop logger
- update fd cache to validate loggers and return errors

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: internal/config/precedence_test.go:214:3: expected '}', found 'EOF')*
- `golangci-lint run` *(fails: internal/config/precedence_test.go:215:1: syntax error: unexpected EOF)*

------
https://chatgpt.com/codex/tasks/task_e_68a42071bb388323a2ceb5ca8242e0d9