### PR TITLE
test: verify config precedence for parallel and compression threshold

### DIFF
--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -170,45 +170,74 @@ func TestParallelFlagOverridesEnvAndYAML(t *testing.T) {
 }
 
 func TestParallelEnvOverridesYAML(t *testing.T) {
-	if err := os.WriteFile(cfgFile, []byte("compress_threshold: 0.5\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	t.Setenv("LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD", "0.6")
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--compress-threshold", "0.7"})
-	if err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	if cfg.CompressThreshold != 0.7 {
-		t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.7)
-	}
+       t.Setenv("HOME", t.TempDir())
+       defaults, err := DefaultConfig()
+       if err != nil {
+               t.Fatalf("default: %v", err)
+       }
+       b := NewBuilder(defaults)
+       dir := t.TempDir()
+       cfgFile := filepath.Join(dir, "cfg.yaml")
+       if err := os.WriteFile(cfgFile, []byte("parallel: 4\n"), 0o644); err != nil {
+               t.Fatalf("write config: %v", err)
+       }
+       t.Setenv("LVMSYNC_PARALLEL", "8")
+       fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+       cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+       if err != nil {
+               t.Fatalf("build: %v", err)
+       }
+       if cfg.Parallel != 8 {
+               t.Fatalf("Parallel=%d want %d", cfg.Parallel, 8)
+       }
+}
+
+func TestCompressThresholdFlagOverridesEnvAndYAML(t *testing.T) {
+       t.Setenv("HOME", t.TempDir())
+       defaults, err := DefaultConfig()
+       if err != nil {
+               t.Fatalf("default: %v", err)
+       }
+       b := NewBuilder(defaults)
+       dir := t.TempDir()
+       cfgFile := filepath.Join(dir, "cfg.yaml")
+       if err := os.WriteFile(cfgFile, []byte("compress_threshold: 0.5\n"), 0o644); err != nil {
+               t.Fatalf("write config: %v", err)
+       }
+       t.Setenv("LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD", "0.6")
+       fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+       cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--compress-threshold", "0.7"})
+       if err != nil {
+               t.Fatalf("build: %v", err)
+       }
+       if cfg.CompressThreshold != 0.7 {
+               t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.7)
+       }
 }
 
 func TestCompressThresholdEnvOverridesYAML(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	defaults, err := DefaultConfig()
-	if err != nil {
-		t.Fatalf("default: %v", err)
-	}
-	b := NewBuilder(defaults)
-	dir := t.TempDir()
-	cfgFile := filepath.Join(dir, "cfg.yaml")
-	if err := os.WriteFile(cfgFile, []byte("parallel: 4\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	t.Setenv("LVMSYNC_PARALLEL", "8")
-	if err := os.WriteFile(cfgFile, []byte("compress_threshold: 0.5\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	t.Setenv("LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD", "0.6")
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
-	if err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	if cfg.Parallel != 8 {
-		t.Fatalf("Parallel=%d want %d", cfg.Parallel, 8)
-	if cfg.CompressThreshold != 0.6 {
-		t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.6)
-	}
+       t.Setenv("HOME", t.TempDir())
+       defaults, err := DefaultConfig()
+       if err != nil {
+               t.Fatalf("default: %v", err)
+       }
+       b := NewBuilder(defaults)
+       dir := t.TempDir()
+       cfgFile := filepath.Join(dir, "cfg.yaml")
+       if err := os.WriteFile(cfgFile, []byte("parallel: 4\ncompress_threshold: 0.5\n"), 0o644); err != nil {
+               t.Fatalf("write config: %v", err)
+       }
+       t.Setenv("LVMSYNC_PARALLEL", "8")
+       t.Setenv("LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD", "0.6")
+       fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+       cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+       if err != nil {
+               t.Fatalf("build: %v", err)
+       }
+       if cfg.Parallel != 8 {
+               t.Fatalf("Parallel=%d want %d", cfg.Parallel, 8)
+       }
+       if cfg.CompressThreshold != 0.6 {
+               t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.6)
+       }
 }


### PR DESCRIPTION
## Summary
- ensure `TestCompressThresholdEnvOverridesYAML` writes both `parallel` and `compress_threshold` options to the same YAML file
- add missing tests for parallel and compression threshold precedence

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: unused parameters, missing package comments, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4207513a88323a57c1ea9aaf3564d