### PR TITLE
chore: configure goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
             | tar -xz -C /usr/local/bin goreleaser
 
       - name: Run GoReleaser
-        run: make release
+        run: goreleaser release --clean --timeout=90m
         env:
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
           SKIP_DOCKER_PUSH: ${{ env.SKIP_DOCKER_PUSH }}
@@ -101,16 +101,6 @@ jobs:
           ls dist/*checksums.txt
           ls dist/*.sbom.json
 
-      - name: Build distroless image
-        run: |
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -f Dockerfile.distroless \
-            --build-arg BIN=bpm \
-            --build-arg BUILD_PATH=. \
-            --tag docker.io/oferchen/bpm:${{ github.ref_name }}-distroless \
-            --tag ghcr.io/oferchen/bpm:${{ github.ref_name }}-distroless \
-            $([ "${{ env.SKIP_DOCKER_PUSH }}" == "true" ] && echo "--load" || echo "--push")
 
       - name: Attach checksums and SBOM to release
         uses: softprops/action-gh-release@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@
 # - Docker pushes remain conditional on SKIP_DOCKER_PUSH.
 # - Multi-arch images + manifests; GoReleaser passes BIN/BUILD_PATH build args.
 
-project_name: &name bpm
+project_name: &name lvmsync
 
 builds:
   - id: *name
@@ -12,6 +12,9 @@ builds:
     env: [CGO_ENABLED=1]
     goos: [linux]
     goarch: [amd64, arm64]
+    flags: ["-trimpath"]
+    ldflags:
+      - "-s -w -X main.version={{.Version}}"
 
 archives:
   - id: default
@@ -31,10 +34,10 @@ sboms:
     artifacts: archive
 
 dockers:
-  # Build per-arch images from Dockerfile (multi-stage Alpine)
-  - id: bpm-amd64
+  # Build per-arch distroless images
+  - id: lvmsync-amd64
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.distroless
     platforms: ["linux/amd64"]
     image_templates:
       - docker.io/oferchen/{{ .ProjectName }}:{{ .Tag }}-amd64
@@ -48,9 +51,9 @@ dockers:
       - "--build-arg=BIN={{ .ProjectName }}"
       - "--build-arg=BUILD_PATH=."
 
-  - id: bpm-arm64
+  - id: lvmsync-arm64
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.distroless
     platforms: ["linux/arm64"]
     image_templates:
       - docker.io/oferchen/{{ .ProjectName }}:{{ .Tag }}-arm64v8

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,0 +1,4 @@
+package config
+
+// BuildVersion is replaced at link time to track build metadata.
+var BuildVersion = "dev"

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package main
+
+// version is populated at build time via -ldflags.
+var version = "dev"


### PR DESCRIPTION
## Summary
- configure GoReleaser for lvmsync binaries and distroless images
- add version variables for linker flags
- streamline release workflow to run GoReleaser directly

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: expected '(' found TestCompressThresholdFlagOverridesEnvAndYAML)*
- `golangci-lint run -v` *(fails: syntax error in internal/config/precedence_test.go)*
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68a4290c54fc832385b60883407bd2fa