### PR TITLE
Add transport deadline and fallback integration tests

### DIFF
--- a/transport/deadline_integration_test.go
+++ b/transport/deadline_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package transport_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+	"lvmsync_go/transport/testutil"
+
+	_ "lvmsync_go/transport/h2"
+	_ "lvmsync_go/transport/quic"
+	_ "lvmsync_go/transport/ssh"
+	_ "lvmsync_go/transport/tcp_tls"
+)
+
+func TestHandshakeDeadline(t *testing.T) {
+	names := []string{"quic", "h2", "tcp+tls", "ssh"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			tr := testutil.NewTransport(t, name)
+			hs := common.Handshake{ALPN: "lvmsync", TLSVersion: "1.3", BlockSize: 4096}
+			if name == "h2" {
+				hs.ALPN = "h2"
+			}
+			timeout := 100 * time.Millisecond
+			delay := 200 * time.Millisecond
+			_, cliRes := testutil.RunNegotiationWithDelay(t, tr, hs, hs, delay, timeout)
+			if cliRes.Err == nil || (!errors.Is(cliRes.Err, context.DeadlineExceeded) &&
+				!strings.Contains(cliRes.Err.Error(), "deadline") &&
+				!strings.Contains(cliRes.Err.Error(), "timeout")) {
+				t.Fatalf("client error = %v, want deadline exceeded", cliRes.Err)
+			}
+		})
+	}
+}
+
+func TestDialWithFallbackOrder(t *testing.T) {
+	cert, pool := testutil.GenerateSelfSignedCert(t)
+	core, obs := observer.New(zap.InfoLevel)
+	cfg := transport.Config{
+		Logger:        zap.New(core),
+		ClientCert:    cert,
+		ServerCert:    cert,
+		Roots:         pool,
+		SSHUser:       "user",
+		SSHPassword:   "pass",
+		AllowInsecure: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	names := []string{"quic", "h2", "tcp+tls", "ssh"}
+	if _, _, err := transport.DialWithFallback(ctx, "127.0.0.1:9", names, cfg); err == nil {
+		t.Fatalf("expected error")
+	}
+	var seq []string
+	for _, entry := range obs.All() {
+		if entry.Message == "dial_attempt" {
+			if n, ok := entry.ContextMap()["transport"].(string); ok {
+				seq = append(seq, n)
+			}
+		}
+	}
+	if !reflect.DeepEqual(seq, names) {
+		t.Fatalf("attempt sequence %v, want %v", seq, names)
+	}
+}

--- a/transport/testutil/testutil.go
+++ b/transport/testutil/testutil.go
@@ -110,3 +110,36 @@ func RunNegotiation(t *testing.T, tr transport.Interface, serverHS, clientHS com
 	srvRes := <-srvCh
 	return srvRes, Result{Peer: peer, Err: err}
 }
+
+func RunNegotiationWithDelay(t *testing.T, tr transport.Interface, serverHS, clientHS common.Handshake, delay, timeout time.Duration) (Result, Result) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ln, err := tr.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	addr := ln.Addr().String()
+	srvCh := make(chan Result)
+	go func() {
+		time.Sleep(delay)
+		conn, err := ln.Accept()
+		if err != nil {
+			srvCh <- Result{Err: err}
+			return
+		}
+		peer, err := tr.Negotiate(ctx, conn, transport.Server, serverHS)
+		conn.Close()
+		srvCh <- Result{Peer: peer, Err: err}
+	}()
+	conn, err := tr.Dial(ctx, addr)
+	if err != nil {
+		srvRes := <-srvCh
+		return srvRes, Result{Err: err}
+	}
+	peer, err := tr.Negotiate(ctx, conn, transport.Client, clientHS)
+	conn.Close()
+	srvRes := <-srvCh
+	return srvRes, Result{Peer: peer, Err: err}
+}


### PR DESCRIPTION
## Summary
- add test helper to simulate delayed transport handshakes
- cover handshake deadline aborts across all transports
- verify dialing fallback order matches README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: internal/config/precedence_test.go:244:8: expected '('...)*
- `go test -tags=integration ./transport/...`
- `golangci-lint run` *(fails: internal/config/precedence_test.go:244:8: expected '('...)*

------
https://chatgpt.com/codex/tasks/task_e_68a4292103bc8323ad6af36a71d69203