### PR TITLE
privilege: test env sanitization toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--skip-disk-check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot-size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
 | `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; parsed with shell-style quoting and validated at startup |
-| `--sanitize-env` | `LVMSYNC_SANITIZE_ENV` | `sanitize_env` | Drop dangerous variables like `LD_PRELOAD` and enforce a safe `PATH` during escalation |
+| `--sanitize-env` | `LVMSYNC_SANITIZE_ENV` | `sanitize_env` | Drop dangerous variables like `LD_PRELOAD` and remove `PATH`/`LANG` during escalation |
 | `--lvm-timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations and privilege checks |
 | `--sig-cache-ttl` | `LVMSYNC_LVM_SIG_CACHE_TTL` | `sig-cache-ttl` | TTL for cached LVM signatures |
 | `--sig-cache-max` | `LVMSYNC_LVM_SIG_CACHE_MAX` | `sig-cache-max` | Maximum cached LVM signatures |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,11 +49,11 @@ complete destruction or disclosure of data across the entire disk.
 ## Environment sanitization
 
 The helper normally inherits the caller's environment, including `PATH` and
-potentially unsafe variables such as `LD_PRELOAD` or `GCONV_PATH`. Pass the
-`--sanitize-env` flag or enable the `SanitizeEnv` option to run the helper with
-a minimal, whitelisted environment that drops those variables and enforces a
-safe `PATH` (`/usr/sbin:/usr/bin:/sbin:/bin`). Sanitization is disabled by
-default to avoid surprising behavior in mixed environments.
+`LANG`, as well as potentially unsafe variables such as `LD_PRELOAD` or
+`GCONV_PATH`. Pass the `--sanitize-env` flag or enable the `SanitizeEnv` option
+to run the helper with a minimal, whitelisted environment that drops those
+variables entirely. Sanitization is disabled by default to avoid surprising
+behavior in mixed environments.
 
 ## Risks of raw-device writes
 

--- a/docs/privilege_escalation.md
+++ b/docs/privilege_escalation.md
@@ -26,6 +26,13 @@ Verify escalation availability:
 lvmsync --check-escalation
 ```
 
+## Environment Sanitization
+
+By default LVMSync re-executes itself with the current `PATH` and `LANG`
+values. Enable the `--sanitize-env` flag (or `LVMSYNC_SANITIZE_ENV=1`) to drop
+both variables, providing a minimal environment to the helper process.
+
+
 
 Roles are read from the certificate's `OrganizationalUnit` field and must
 include `replicator` to invoke replication RPCs such as `StartSync`, `Cancel`,

--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -202,15 +202,12 @@ func DropToInvokerIfSudo(opts Options, logger *zap.Logger) error {
 // ---- Internal helpers (kept small, pure, and fully tested) ----
 
 func sanitizedChildEnv(environ []string) []string {
-	const safePath = "PATH=/usr/sbin:/usr/bin:/sbin:/bin"
 	whitelist := map[string]bool{
-		"LANG":     true,
 		"LC_ALL":   true,
 		"LC_CTYPE": true,
 		"TERM":     true,
 	}
-	out := make([]string, 0, 1+len(environ))
-	out = append(out, safePath)
+	out := make([]string, 0, len(environ))
 	for _, kv := range environ {
 		if strings.HasPrefix(kv, "LD_") || strings.HasPrefix(kv, "GCONV_PATH=") {
 			continue

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -38,14 +38,14 @@ func TestSanitizedChildEnv(t *testing.T) {
 	}
 	out := sanitizedChildEnv(in)
 	joined := strings.Join(out, "\n")
-	if strings.Contains(joined, "LD_PRELOAD=") {
-		t.Fatalf("LD_* leaked into env: %v", out)
+	if strings.Contains(joined, "LD_PRELOAD=") || strings.Contains(joined, "GCONV_PATH=") {
+		t.Fatalf("disallowed vars leaked: %v", out)
 	}
-	if !strings.Contains(joined, "LANG=C") || !strings.Contains(joined, "TERM=xterm-256color") {
-		t.Fatalf("whitelisted vars missing: %v", out)
+	if strings.Contains(joined, "PATH=") || strings.Contains(joined, "LANG=") {
+		t.Fatalf("PATH/LANG should be stripped: %v", out)
 	}
-	if !strings.HasPrefix(out[0], "PATH=") {
-		t.Fatalf("first entry must be safe PATH, got %q", out[0])
+	if len(out) != 1 || out[0] != "TERM=xterm-256color" {
+		t.Fatalf("unexpected sanitized env: %v", out)
 	}
 }
 
@@ -214,7 +214,7 @@ func TestEnsureRootOrReexec_ReexecHappyPath(t *testing.T) {
 		ExtraArgs:          []string{"--do-privileged"},
 		SanitizeEnv:        true,
 		Environ: func() []string {
-			return []string{"LD_PRELOAD=/x", "LANG=C", "TERM=dumb", "FOO=BAR"}
+			return []string{"LD_PRELOAD=/x", "PATH=/usr/local/bin", "LANG=C", "TERM=dumb", "FOO=BAR"}
 		},
 		ExecRunner: fakeRunner(&got, nil),
 		Stdout:     io.Discard,
@@ -238,8 +238,11 @@ func TestEnsureRootOrReexec_ReexecHappyPath(t *testing.T) {
 		t.Fatalf("allowed flags not forwarded: %v", got.args)
 	}
 	envJoined := strings.Join(got.env, "\n")
-	if strings.Contains(envJoined, "LD_PRELOAD=") || !strings.Contains(envJoined, "LANG=") {
+	if strings.Contains(envJoined, "LD_PRELOAD=") || strings.Contains(envJoined, "PATH=") || strings.Contains(envJoined, "LANG=") {
 		t.Fatalf("env not sanitized: %v", got.env)
+	}
+	if len(got.env) != 1 || got.env[0] != "TERM=dumb" {
+		t.Fatalf("unexpected env: %v", got.env)
 	}
 }
 
@@ -330,6 +333,7 @@ func TestEnsureRootOrReexec_InvokesSudoWithAllowlistedArgs(t *testing.T) {
 func TestEnsureRootOrReexec_SanitizedEnv(t *testing.T) {
 	var got execCall
 	t.Setenv("LD_PRELOAD", "/tmp/x.so")
+	t.Setenv("PATH", "/usr/local/bin")
 	t.Setenv("LANG", "C")
 	t.Setenv("TERM", "dumb")
 	reexeced, err := EnsureRootOrReexec(Options{
@@ -345,14 +349,11 @@ func TestEnsureRootOrReexec_SanitizedEnv(t *testing.T) {
 		t.Fatal("expected sanitized env")
 	}
 	joined := strings.Join(got.env, "\n")
-	if strings.Contains(joined, "LD_PRELOAD=") {
-		t.Fatalf("LD_PRELOAD leaked: %v", got.env)
+	if strings.Contains(joined, "LD_PRELOAD=") || strings.Contains(joined, "PATH=") || strings.Contains(joined, "LANG=") {
+		t.Fatalf("disallowed vars present: %v", got.env)
 	}
-	if !strings.Contains(joined, "LANG=C") || !strings.Contains(joined, "TERM=dumb") {
-		t.Fatalf("whitelisted vars missing: %v", got.env)
-	}
-	if got.env[0] != "PATH=/usr/sbin:/usr/bin:/sbin:/bin" {
-		t.Fatalf("unexpected PATH: %q", got.env[0])
+	if !strings.Contains(joined, "TERM=dumb") {
+		t.Fatalf("TERM missing: %v", got.env)
 	}
 }
 
@@ -378,21 +379,21 @@ func TestEnsureRootOrReexec_EnvPassthrough(t *testing.T) {
 		Geteuid:  func() int { return 1000 },
 		LookPath: func(string) (string, error) { return "/usr/bin/sudo", nil },
 		Environ: func() []string {
-			return []string{"LD_PRELOAD=/x", "LANG=C"}
+			return []string{"PATH=/usr/local/bin", "LANG=C"}
 		},
 		ExecRunner: fakeRunner(&got, nil),
 	}, zap.NewNop())
 	if err != nil || !reexeced {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)
 	}
-	if len(got.env) != 2 || got.env[0] != "LD_PRELOAD=/x" || got.env[1] != "LANG=C" {
+	if len(got.env) != 2 || got.env[0] != "PATH=/usr/local/bin" || got.env[1] != "LANG=C" {
 		t.Fatalf("env not forwarded: %v", got.env)
 	}
 }
 
 func TestEnsureRootOrReexec_SanitizeEnvTrue(t *testing.T) {
 	var got execCall
-	env := []string{"LD_PRELOAD=/tmp/x.so", "LANG=C", "TERM=dumb"}
+	env := []string{"LD_PRELOAD=/tmp/x.so", "PATH=/usr/local/bin", "LANG=C", "TERM=dumb"}
 	reexeced, err := EnsureRootOrReexec(Options{
 		Geteuid:     func() int { return 1000 },
 		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
@@ -411,7 +412,7 @@ func TestEnsureRootOrReexec_SanitizeEnvTrue(t *testing.T) {
 
 func TestEnsureRootOrReexec_SanitizeEnvFalse(t *testing.T) {
 	var got execCall
-	env := []string{"LD_PRELOAD=/tmp/x.so", "LANG=C"}
+	env := []string{"PATH=/usr/local/bin", "LANG=C"}
 	reexeced, err := EnsureRootOrReexec(Options{
 		Geteuid:     func() int { return 1000 },
 		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
@@ -427,9 +428,27 @@ func TestEnsureRootOrReexec_SanitizeEnvFalse(t *testing.T) {
 	}
 }
 
+func TestEnsureRootOrReexec_SanitizeEnvStripsPathLang(t *testing.T) {
+	var got execCall
+	env := []string{"PATH=/usr/local/bin", "LANG=C"}
+	reexeced, err := EnsureRootOrReexec(Options{
+		Geteuid:     func() int { return 1000 },
+		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
+		SanitizeEnv: true,
+		Environ:     func() []string { return env },
+		ExecRunner:  fakeRunner(&got, nil),
+	}, zap.NewNop())
+	if err != nil || !reexeced {
+		t.Fatalf("unexpected result: %v %v", reexeced, err)
+	}
+	if len(got.env) != 0 {
+		t.Fatalf("expected PATH/LANG stripped, got %v", got.env)
+	}
+}
+
 func TestEnsureRootOrReexec_DefaultPreservesDisallowedEnv(t *testing.T) {
 	var got execCall
-	env := []string{"LD_PRELOAD=/tmp/x.so", "GCONV_PATH=/bad", "LANG=C"}
+	env := []string{"LD_PRELOAD=/tmp/x.so", "GCONV_PATH=/bad", "PATH=/usr/local/bin", "LANG=C"}
 	reexeced, err := EnsureRootOrReexec(Options{
 		Geteuid:    func() int { return 1000 },
 		LookPath:   func(string) (string, error) { return "/usr/bin/sudo", nil },
@@ -446,7 +465,7 @@ func TestEnsureRootOrReexec_DefaultPreservesDisallowedEnv(t *testing.T) {
 
 func TestEnsureRootOrReexec_SanitizeEnvDropsDisallowed(t *testing.T) {
 	var got execCall
-	env := []string{"LD_PRELOAD=/tmp/x.so", "GCONV_PATH=/bad", "LANG=C", "TERM=dumb"}
+	env := []string{"LD_PRELOAD=/tmp/x.so", "GCONV_PATH=/bad", "PATH=/usr/local/bin", "LANG=C", "TERM=dumb"}
 	reexeced, err := EnsureRootOrReexec(Options{
 		Geteuid:     func() int { return 1000 },
 		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
@@ -458,14 +477,11 @@ func TestEnsureRootOrReexec_SanitizeEnvDropsDisallowed(t *testing.T) {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)
 	}
 	joined := strings.Join(got.env, "\n")
-	if strings.Contains(joined, "LD_PRELOAD=") || strings.Contains(joined, "GCONV_PATH=") {
+	if strings.Contains(joined, "LD_PRELOAD=") || strings.Contains(joined, "GCONV_PATH=") || strings.Contains(joined, "PATH=") || strings.Contains(joined, "LANG=") {
 		t.Fatalf("disallowed vars present: %v", got.env)
 	}
-	if !strings.Contains(joined, "LANG=C") || !strings.Contains(joined, "TERM=dumb") {
-		t.Fatalf("whitelisted vars missing: %v", got.env)
-	}
-	if got.env[0] != "PATH=/usr/sbin:/usr/bin:/sbin:/bin" {
-		t.Fatalf("unexpected PATH: %q", got.env[0])
+	if !strings.Contains(joined, "TERM=dumb") {
+		t.Fatalf("TERM missing: %v", got.env)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add env-sanitization tests for PATH/LANG handling
- drop PATH/LANG in sanitized child environment
- document sanitize-env toggle

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: internal/config/precedence_test.go:244:8: expected '(')*
- `golangci-lint run` *(fails: internal/config/precedence_test.go syntax errors)*
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_68a42923e97c8323b1084636a2a10e13