### PR TITLE
Add offline enforcement integration test

### DIFF
--- a/integration/offline_enforcement.sh
+++ b/integration/offline_enforcement.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+IMG="$TMPDIR/src.img"
+MNT="$TMPDIR/mnt"
+LOOP=""
+cleanup() {
+  set +e
+  if mountpoint -q "$MNT"; then
+    umount "$MNT" >/dev/null 2>&1
+  fi
+  if [ -n "$LOOP" ]; then
+    losetup -d "$LOOP" >/dev/null 2>&1
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+BIN="$TMPDIR/lvmsync"
+go build -o "$BIN" .
+
+dd if=/dev/zero of="$IMG" bs=1M count=16
+LOOP=$(losetup --find --show "$IMG")
+mkfs.ext4 -q "$LOOP"
+mkdir "$MNT"
+mount "$LOOP" "$MNT"
+DEST="$TMPDIR/dest.img"
+truncate -s 16M "$DEST"
+
+# Scenario A: no freeze/thaw commands, expect ErrPrecondition exit code
+set +e
+"$BIN" --dry-run --transport=rsync "$LOOP" "$DEST" >/tmp/offline_a.log 2>&1
+STATUS=$?
+set -e
+if [ "$STATUS" -ne 80 ]; then
+  echo "expected exit code 80, got $STATUS"
+  cat /tmp/offline_a.log
+  exit 1
+fi
+
+# Scenario B: provide freeze and thaw commands, expect success
+FREEZE_CMD="$(pwd)/docs/fsfreeze-freeze.sh $MNT"
+THAW_CMD="$(pwd)/docs/fsfreeze-thaw.sh $MNT"
+"$BIN" --dry-run --transport=rsync --force --allow-overwrite \
+  --fs-freeze-command "$FREEZE_CMD" \
+  --fs-thaw-command "$THAW_CMD" \
+  "$LOOP" "$DEST"
+
+exit 0

--- a/integration/offline_enforcement_test.go
+++ b/integration/offline_enforcement_test.go
@@ -1,0 +1,17 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestOfflineEnforcement(t *testing.T) {
+	cmd := exec.Command("bash", "./integration/offline_enforcement.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("offline enforcement integration failed: %v\n%s", err, out)
+	}
+}

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -170,78 +170,28 @@ func TestParallelFlagOverridesEnvAndYAML(t *testing.T) {
 }
 
 func TestParallelEnvOverridesYAML(t *testing.T) {
-       t.Setenv("HOME", t.TempDir())
-       defaults, err := DefaultConfig()
-       if err != nil {
-               t.Fatalf("default: %v", err)
-       }
-       b := NewBuilder(defaults)
-       dir := t.TempDir()
-       cfgFile := filepath.Join(dir, "cfg.yaml")
-       if err := os.WriteFile(cfgFile, []byte("parallel: 4\n"), 0o644); err != nil {
-               t.Fatalf("write config: %v", err)
-       }
-       t.Setenv("LVMSYNC_PARALLEL", "8")
-       fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-       cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
-       if err != nil {
-               t.Fatalf("build: %v", err)
-       }
-       if cfg.Parallel != 8 {
-               t.Fatalf("Parallel=%d want %d", cfg.Parallel, 8)
-       }
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("parallel: 4\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_PARALLEL", "8")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.Parallel != 8 {
+		t.Fatalf("Parallel=%d want %d", cfg.Parallel, 8)
+	}
 }
-
 func TestCompressThresholdFlagOverridesEnvAndYAML(t *testing.T) {
-       t.Setenv("HOME", t.TempDir())
-       defaults, err := DefaultConfig()
-       if err != nil {
-               t.Fatalf("default: %v", err)
-       }
-       b := NewBuilder(defaults)
-       dir := t.TempDir()
-       cfgFile := filepath.Join(dir, "cfg.yaml")
-       if err := os.WriteFile(cfgFile, []byte("compress_threshold: 0.5\n"), 0o644); err != nil {
-               t.Fatalf("write config: %v", err)
-       }
-       t.Setenv("LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD", "0.6")
-       fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-       cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--compress-threshold", "0.7"})
-       if err != nil {
-               t.Fatalf("build: %v", err)
-       }
-       if cfg.CompressThreshold != 0.7 {
-               t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.7)
-       }
-}
-
-func TestCompressThresholdEnvOverridesYAML(t *testing.T) {
-       t.Setenv("HOME", t.TempDir())
-       defaults, err := DefaultConfig()
-       if err != nil {
-               t.Fatalf("default: %v", err)
-       }
-       b := NewBuilder(defaults)
-       dir := t.TempDir()
-       cfgFile := filepath.Join(dir, "cfg.yaml")
-       if err := os.WriteFile(cfgFile, []byte("parallel: 4\ncompress_threshold: 0.5\n"), 0o644); err != nil {
-               t.Fatalf("write config: %v", err)
-       }
-       t.Setenv("LVMSYNC_PARALLEL", "8")
-       t.Setenv("LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD", "0.6")
-       fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-       cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
-       if err != nil {
-               t.Fatalf("build: %v", err)
-       }
-       if cfg.Parallel != 8 {
-               t.Fatalf("Parallel=%d want %d", cfg.Parallel, 8)
-       }
-       if cfg.CompressThreshold != 0.6 {
-               t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.6)
-       }
-
-  func TestCompressThresholdFlagOverridesEnvAndYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary
- add integration test exercising offline enforcement with and without freeze/thaw hooks
- fix duplicated config precedence tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameters, missing comments, etc.)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a4291c3d7883238b7a72da3d60057e