### PR TITLE
docs: document FlagSets and add binding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,8 @@ Logger.Warn("Zero-copy transfer failed",
 ## Configuration
 
 LVMSync uses [`pflag`](https://github.com/spf13/pflag) and [`viper`](https://github.com/spf13/viper) to accept options from
-flags, environment variables, and a YAML file. The CLI exposes subcommands using `cobra`, with `run` handling transfers,
+flags, environment variables, and a YAML file. Flag groups are organized into dedicated
+[FlagSets](docs/flagsets.md) that are registered with the root command and bound to Viper. The CLI exposes subcommands using `cobra`, with `run` handling transfers,
 `manifest rebuild` regenerating manifests, and `verify` checking source and destination data. Source and destination paths
 for `run` and `verify` are provided as positional arguments after any flags:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [Operations](OPERATIONS.md) – snapshot flow, resume and verify sequences, and exit codes.
 - [Privilege Escalation](privilege_escalation.md) – configuring LVM privilege escalation.
 - [Daemon](daemon.md) – module configuration, ACLs, and listener options.
+- [FlagSets](flagsets.md) – registering and binding grouped CLI flags.
 - Configuration precedence – flags override environment variables, which in
   turn override `config.yaml`. Unknown YAML keys emit warnings and invalid
   overrides are rejected.

--- a/docs/flagsets.md
+++ b/docs/flagsets.md
@@ -1,0 +1,27 @@
+# FlagSets
+
+LVMSync groups related command-line options into `pflag.FlagSet`s. Each group is
+registered with the root command and bound to Viper so configuration can be read
+from flags, environment variables, or a YAML file.
+
+## Registration and binding
+
+```go
+defaults, _ := config.DefaultConfig()
+flagSets := config.NewFlagSets(defaults)
+
+root := pflag.NewFlagSet("lvmsync", pflag.ExitOnError)
+for _, fs := range flagSets.All() {
+        root.AddFlagSet(fs)
+}
+
+v := viper.New()
+v.SetEnvPrefix("LVMSYNC")
+v.AutomaticEnv()
+for _, fs := range flagSets.All() {
+        v.BindPFlags(fs)
+}
+```
+
+`FlagSets.All()` returns the groups in a stable order, making it easy to iterate
+and apply additional bindings.

--- a/internal/config/flagsets_bindings_test.go
+++ b/internal/config/flagsets_bindings_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestFlagSetEnvBindings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+	flagSets := NewFlagSets(defaults)
+	cases := map[string]struct {
+		flag string
+		env  string
+		val  string
+	}{
+		"General Options":       {flag: "source-type", env: "LVMSYNC_SOURCE_TYPE", val: "raw"},
+		"SSH Options":           {flag: "ssh-host", env: "LVMSYNC_SSH_HOST", val: "ssh.example"},
+		"Remote Options":        {flag: "lvmsync-path", env: "LVMSYNC_LVMSYNC_PATH", val: "/bin/lvmsync"},
+		"Deduplication Options": {flag: "dedup-strategy", env: "LVMSYNC_DEDUP_STRATEGY", val: "bloom"},
+		"Compression Options":   {flag: "compress", env: "LVMSYNC_COMPRESSION_COMPRESS", val: "zstd"},
+		"LVM Options":           {flag: "lvm-escalation", env: "LVMSYNC_LVM_ESCALATION", val: "su"},
+		"Transport Options":     {flag: "transport", env: "LVMSYNC_TRANSPORT_TRANSPORT", val: "ssh"},
+		"Manifest Options":      {flag: "manifest-path", env: "LVMSYNC_MANIFEST_PATH", val: "/tmp/manifest"},
+	}
+	for _, fs := range flagSets.All() {
+		tc, ok := cases[fs.Name()]
+		if !ok {
+			t.Fatalf("missing case for %q", fs.Name())
+		}
+		t.Setenv(tc.env, tc.val)
+	}
+	v, _, _, err := buildViper(flagSets)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	for _, fs := range flagSets.All() {
+		tc := cases[fs.Name()]
+		if got := v.GetString(tc.flag); got != tc.val {
+			t.Errorf("%s %s=%q want %q", fs.Name(), tc.flag, got, tc.val)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- document how grouped FlagSets are registered and bound to viper
- add unit test ensuring each FlagSet's representative flag binds to viper via environment variables
- link new guide from README and docs index

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameters, missing comments, and other lint errors)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a436987d4883239c8cafcfbb654a20