### PR TITLE
Add NUMA affinity tests

### DIFF
--- a/transfer/numa_integration_test.go
+++ b/transfer/numa_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration && linux
+
+package transfer
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func cpusFromMask(m *unix.CPUSet) []int {
+	var cpus []int
+	for i := 0; i < 64; i++ {
+		if m.IsSet(i) {
+			cpus = append(cpus, i)
+		}
+	}
+	return cpus
+}
+
+func TestPinCurrentThreadToNodeIntegration(t *testing.T) {
+	if _, err := os.Stat("/sys/devices/system/node/node1/cpulist"); err != nil {
+		t.Skip("requires system with multiple NUMA nodes")
+	}
+	var orig unix.CPUSet
+	if err := unix.SchedGetaffinity(0, &orig); err != nil {
+		t.Skipf("get affinity: %v", err)
+	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	defer unix.SchedSetaffinity(0, &orig)
+
+	if err := pinCurrentThreadToNode(1); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	var mask unix.CPUSet
+	if err := unix.SchedGetaffinity(0, &mask); err != nil {
+		t.Fatalf("get affinity: %v", err)
+	}
+	got := cpusFromMask(&mask)
+	b, err := os.ReadFile("/sys/devices/system/node/node1/cpulist")
+	if err != nil {
+		t.Fatalf("read cpulist: %v", err)
+	}
+	want := parseCPUList(strings.TrimSpace(string(b)))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cpuset %v != %v", got, want)
+	}
+}

--- a/transfer/numa_linux.go
+++ b/transfer/numa_linux.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -15,21 +16,37 @@ import (
 	"lvmsync_go/internal/config"
 )
 
+type numaOps interface {
+	ReadFile(string) ([]byte, error)
+	SchedSetaffinity(int, *unix.CPUSet) error
+}
+
+type osNumaOps struct{}
+
+func (osNumaOps) ReadFile(p string) ([]byte, error) { return os.ReadFile(p) }
+func (osNumaOps) SchedSetaffinity(pid int, mask *unix.CPUSet) error {
+	return unix.SchedSetaffinity(pid, mask)
+}
+
 // pinCurrentThreadToDevice pins the current OS thread to CPUs local to the
 // NUMA node of the provided device file.
 func pinCurrentThreadToDevice(f *os.File) error {
+	return pinCurrentThreadToDeviceWithOps(f, osNumaOps{})
+}
+
+func pinCurrentThreadToDeviceWithOps(f *os.File, ops numaOps) error {
 	st, err := f.Stat()
 	if err != nil {
 		return fmt.Errorf("stat device: %w", err)
 	}
-	sys, ok := st.Sys().(*unix.Stat_t)
+	sys, ok := st.Sys().(*syscall.Stat_t)
 	if !ok {
 		return fmt.Errorf("unexpected stat type")
 	}
 	major := unix.Major(uint64(sys.Rdev))
 	minor := unix.Minor(uint64(sys.Rdev))
 	nodePath := fmt.Sprintf("/sys/dev/block/%d:%d/numa_node", major, minor)
-	b, err := os.ReadFile(nodePath)
+	b, err := ops.ReadFile(nodePath)
 	if err != nil {
 		return err
 	}
@@ -38,7 +55,7 @@ func pinCurrentThreadToDevice(f *os.File) error {
 		return fmt.Errorf("invalid numa node")
 	}
 	cpuListPath := fmt.Sprintf("/sys/devices/system/node/node%d/cpulist", node)
-	cpulist, err := os.ReadFile(cpuListPath)
+	cpulist, err := ops.ReadFile(cpuListPath)
 	if err != nil {
 		return err
 	}
@@ -50,15 +67,19 @@ func pinCurrentThreadToDevice(f *os.File) error {
 	for _, cpu := range cpus {
 		mask.Set(cpu)
 	}
-	if err := unix.SchedSetaffinity(0, &mask); err != nil {
+	if err := ops.SchedSetaffinity(0, &mask); err != nil {
 		return fmt.Errorf("set affinity: %w", err)
 	}
 	return nil
 }
 
 func pinCurrentThreadToNode(node int) error {
+	return pinCurrentThreadToNodeWithOps(node, osNumaOps{})
+}
+
+func pinCurrentThreadToNodeWithOps(node int, ops numaOps) error {
 	cpuListPath := fmt.Sprintf("/sys/devices/system/node/node%d/cpulist", node)
-	cpulist, err := os.ReadFile(cpuListPath)
+	cpulist, err := ops.ReadFile(cpuListPath)
 	if err != nil {
 		return err
 	}
@@ -70,7 +91,7 @@ func pinCurrentThreadToNode(node int) error {
 	for _, cpu := range cpus {
 		mask.Set(cpu)
 	}
-	if err := unix.SchedSetaffinity(0, &mask); err != nil {
+	if err := ops.SchedSetaffinity(0, &mask); err != nil {
 		return fmt.Errorf("set affinity: %w", err)
 	}
 	return nil

--- a/transfer/numa_linux_test.go
+++ b/transfer/numa_linux_test.go
@@ -2,7 +2,13 @@
 
 package transfer
 
-import "testing"
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
 
 func TestParseCPUList(t *testing.T) {
 	cases := []struct {
@@ -26,13 +32,82 @@ func TestParseCPUList(t *testing.T) {
 	}
 }
 
-func TestPinCurrentThreadToNode(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("panic: %v", r)
+type fakeNumaOps struct {
+	files map[string][]byte
+	mask  unix.CPUSet
+}
+
+func (f *fakeNumaOps) ReadFile(p string) ([]byte, error) {
+	if f.files == nil {
+		return nil, os.ErrNotExist
+	}
+	b, ok := f.files[p]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return b, nil
+}
+
+func (f *fakeNumaOps) SchedSetaffinity(_ int, m *unix.CPUSet) error {
+	f.mask = *m
+	return nil
+}
+
+func cpusFromMask(m *unix.CPUSet) []int {
+	var cpus []int
+	for i := 0; i < 64; i++ {
+		if m.IsSet(i) {
+			cpus = append(cpus, i)
 		}
-	}()
+	}
+	return cpus
+}
+
+func TestPinCurrentThreadToNodeMock(t *testing.T) {
+	ops := &fakeNumaOps{files: map[string][]byte{
+		"/sys/devices/system/node/node2/cpulist": []byte("4-5"),
+	}}
+	if err := pinCurrentThreadToNodeWithOps(2, ops); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	got := cpusFromMask(&ops.mask)
+	want := []int{4, 5}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cpuset %v != %v", got, want)
+	}
+}
+
+func TestPinCurrentThreadToDeviceMock(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	ops := &fakeNumaOps{files: map[string][]byte{
+		"/sys/dev/block/0:0/numa_node":           []byte("1"),
+		"/sys/devices/system/node/node1/cpulist": []byte("0-1"),
+	}}
+	if err := pinCurrentThreadToDeviceWithOps(tmp, ops); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	got := cpusFromMask(&ops.mask)
+	want := []int{0, 1}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cpuset %v != %v", got, want)
+	}
+}
+
+func TestPinCurrentThreadToNodeMissing(t *testing.T) {
+	ops := &fakeNumaOps{}
+	if err := pinCurrentThreadToNodeWithOps(3, ops); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestPinCurrentThreadToNodeReal(t *testing.T) {
 	if err := pinCurrentThreadToNode(0); err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("numa unsupported: %v", err)
+		}
 		t.Logf("pin failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- allow NUMA pinning helpers to use mockable ops for testing
- add unit tests for device and node NUMA affinity
- add skipped integration test for systems with multiple NUMA nodes

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: existing linter issues)*


------
https://chatgpt.com/codex/tasks/task_e_68a43699a7088323be5e1a7481daa422