### PR TITLE
Disable hole punching after ENOTSUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For details on running with minimal privileges and sudoers examples, see [SECURI
 - **Dry-run Estimates**: `--dry-run` samples the manifest to project bytes and ETA without transferring data.
 - **Device Identity Tuple**: Each run records `(device_id, size_bytes, major:minor)` to prevent writing to the wrong destination.
 - **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
-- **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it.
+- **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it, logging a warning once and disabling hole punching when unsupported.
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to a device's NUMA node (`--numa-pin`) or an explicit node (`--numa-node`).
 - **LVM Snapshot Management**:
   - Automatic snapshot creation and removal.

--- a/transfer/chunk_reader_test.go
+++ b/transfer/chunk_reader_test.go
@@ -5,6 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sys/unix"
+
+	"lvmsync_go/internal/config"
 )
 
 func TestChunkReaderSkipsConfirmed(t *testing.T) {
@@ -72,5 +78,45 @@ func TestPunchHoleError(t *testing.T) {
 	defer f.Close()
 	if err := punchHole(f, 0, 4096); err == nil {
 		t.Fatalf("expected error punching hole on read-only file")
+	}
+}
+
+func TestPunchHoleENOTSUPDisables(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "file")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	orig := punchHoleFunc
+	var calls int
+	punchHoleFunc = func(_ *os.File, _ uint64, _ int) error {
+		calls++
+		return unix.ENOTSUP
+	}
+	punchHoleDisabled.Store(false)
+	defer func() {
+		punchHoleFunc = orig
+		punchHoleDisabled.Store(false)
+	}()
+
+	cfg := &config.Config{BlockSize: 4096}
+	core, obs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	if err := writeZeroBlock(cfg, f, 0, logger); err != nil {
+		t.Fatalf("writeZeroBlock: %v", err)
+	}
+	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), logger); err != nil {
+		t.Fatalf("writeZeroBlock: %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected punchHoleFunc called once, got %d", calls)
+	}
+	if obs.Len() != 1 {
+		t.Fatalf("expected one warning, got %d", obs.Len())
 	}
 }

--- a/transfer/zero.go
+++ b/transfer/zero.go
@@ -2,11 +2,14 @@ package transfer
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"lvmsync_go/internal/config"
 )
@@ -17,6 +20,12 @@ var zeroBufCache sync.Map // map[int][]byte
 
 // zeroHashCache stores BLAKE3 hashes of zero-filled buffers keyed by size.
 var zeroHashCache sync.Map // map[int][32]byte
+
+// punchHoleFunc allows tests to stub punchHole behavior.
+var punchHoleFunc = punchHole
+
+// punchHoleDisabled marks whether punchHole should be skipped after ENOTSUP.
+var punchHoleDisabled atomic.Bool
 
 func zeroBuf(size int) []byte {
 	if v, ok := zeroBufCache.Load(size); ok {
@@ -47,8 +56,14 @@ func isAllZero(b []byte) bool {
 // filled buffer. The buffer respects the O_DIRECT setting by using aligned
 // allocations when necessary.
 func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *zap.Logger) error {
-	if err := punchHole(dest, offset, cfg.BlockSize); err == nil {
-		return nil
+	if !punchHoleDisabled.Load() {
+		if err := punchHoleFunc(dest, offset, cfg.BlockSize); err == nil {
+			return nil
+		} else if errors.Is(err, unix.ENOTSUP) {
+			if punchHoleDisabled.CompareAndSwap(false, true) {
+				logger.Warn("hole punching unsupported; disabling", zap.Error(err))
+			}
+		}
 	}
 	var zero []byte
 	if cfg.ODirect {


### PR DESCRIPTION
## Summary
- disable hole punching after an ENOTSUP error and log a one-time warning
- test disabling punchHole with a mock ENOTSUP
- document that hole punching disables itself after ENOTSUP

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details. --- FAIL: TestRejects0RTT (0.46s) quic_unit_test.go:257: write: 0-RTT rejected)*
- `golangci-lint run` *(fails: 964 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a43af6f6388323b8606bbacef42273