### PR TITLE
docs: reference exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1503,43 +1503,7 @@ Invalid configurations will cause the tool to abort with a clear error message.
 
 ## Exit Codes
 
-| Constant | Code | Meaning | Recovery Step |
-|----------|------|---------|---------------|
-| [`exitcode.OK`](internal/exitcode/exitcode.go) | `0`  | Success | None |
-| [`exitcode.ErrCapability`](internal/exitcode/exitcode.go) | `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
-| [`exitcode.ErrDevice`](internal/exitcode/exitcode.go) | `20` | Device error | Verify device paths and snapshot health. |
-| [`exitcode.ErrPlatform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform | Run on a supported Linux platform. |
-| [`exitcode.ErrConfig`](internal/exitcode/exitcode.go) | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
-| [`exitcode.ErrRuntime`](internal/exitcode/exitcode.go) | `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
-| [`exitcode.ErrVerify`](internal/exitcode/exitcode.go) | `60` | Verification mismatch | Investigate mismatched data before retrying. |
-| [`exitcode.ErrPartial`](internal/exitcode/exitcode.go) | `70` | Partial transfer | Address the error and resume with `--resume`. |
-| [`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) | `80` | Precondition failed | Fix prerequisites and retry. |
-| [`exitcode.ErrResumable`](internal/exitcode/exitcode.go) | `90` | Resumable exit | Resume with `--resume` after resolving the issue. |
-
-Exit code definitions live in [internal/exitcode](internal/exitcode/exitcode.go), and handling resides in [cmd/root/root.go](cmd/root/root.go).
-
-Verification mismatches exit with [`exitcode.ErrVerify`](internal/exitcode/exitcode.go):
-
-```sh
-lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/bad_target || echo "verify failed with exit $?"
-# verify failed with exit 60
-```
-
-Precondition failures exit with [`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go):
-
-```sh
-lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with exit $?"
-# precondition failed with exit 80
-```
-
-Shell scripts can rely on `set -e` to abort on non-zero exit codes:
-
-```sh
-#!/bin/sh
-set -e
-lvmsync "$@"
-echo "transfer completed successfully"
-```
+LVMSync signals success and failure with structured exit codes. Refer to the [operations guide](docs/OPERATIONS.md#exit-codes) for the complete list and recommended recovery steps.
 
 ## Credits
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -53,7 +53,7 @@ Reads both devices and reports mismatches without writing data.
 
 The write-ahead log records completed block ranges so interrupted transfers can resume safely. Each appended range is fsynced before returning. On restart `OpenWAL` validates a MAC over the header and ensures the size, epoch, and device ID match the current transfer. Corrupted headers or tampered device IDs cause the log to be rejected, and entries written without a matching fsync are ignored after power loss.
 
-## Exit Codes and Recovery
+## Exit Codes
 
 | Code | Meaning | Recovery Step |
 |------|---------|---------------|

--- a/reports/doc-updates.md
+++ b/reports/doc-updates.md
@@ -3,3 +3,4 @@
 - README.md: clarified `--strict-host-key-checking` flag; disabling it now skips SSH host key verification.
 - README.md: documented SSH agent usage when `--ssh-key` is unset and that the connection respects `--ssh-timeout`.
 - README.md: document validation for raw freeze/thaw commands.
+- README.md: condensed exit code section and linked to docs/OPERATIONS.md#exit-codes.


### PR DESCRIPTION
## Summary
- shorten README exit codes section and link to docs/OPERATIONS.md
- align operations guide heading for exit codes
- record doc update to track README/OPERATIONS sync

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 963 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a43afbbcc4832398e98d610e57542c