### PR TITLE
Add configuration schema validation and env doc generator

### DIFF
--- a/cmd/configdoc/main.go
+++ b/cmd/configdoc/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+
+	cfg "lvmsync_go/internal/config"
+)
+
+func main() {
+	defaults, err := cfg.DefaultConfig()
+	if err != nil {
+		panic(err)
+	}
+	doc := cfg.EnvDoc(cfg.NewFlagSets(defaults))
+	if err := os.WriteFile("docs/env.md", []byte(doc), 0o644); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -139,20 +138,9 @@ func TestRunLogsConfigWarnings(t *testing.T) {
 	}
 
 	args := []string{"rebuild", "--config", cfgPath, devicePath}
-	core, logs := observer.New(zap.InfoLevel)
-	logger := zap.New(core)
-	if err := Run(cfg, args, logger); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	warnLogs := logs.FilterMessage("config_warning").All()
-	if len(warnLogs) != 1 {
-		t.Fatalf("expected 1 config warning, got %d", len(warnLogs))
-	}
-	ctx := warnLogs[0].ContextMap()
-	detail, ok := ctx["detail"].(string)
-	if !ok || !strings.Contains(detail, "bogus") {
-		t.Fatalf("unexpected detail field: %v", ctx["detail"])
+	logger := zap.NewNop()
+	if err := Run(cfg, args, logger); err == nil {
+		t.Fatalf("expected error for unknown key")
 	}
 }
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,89 @@
+| ENV | Flag | YAML | Description |
+| --- | ---- | ---- | ----------- |
+| LVMSYNC_ALLOW_INSECURE | `--allow-insecure` | `allow-insecure` | allow insecure connections (disable TLS and host key verification) |
+| LVMSYNC_ALLOW_OVERWRITE | `--allow-overwrite` | `allow-overwrite` | Skip interactive confirmation when using --force |
+| LVMSYNC_BLOCK_SIZE | `--block-size` | `block-size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
+| LVMSYNC_BLOOM_ENTRIES | `--bloom-entries` | `bloom-entries` | Bloom filter entries |
+| LVMSYNC_BLOOM_FP_RATE | `--bloom-fp-rate` | `bloom-fp-rate` | Bloom filter false positive rate |
+| LVMSYNC_BLOOM_MBITS | `--bloom-mbits` | `bloom-mbits` | Bloom filter M bits per entry |
+| LVMSYNC_CDC_AVG | `--cdc-avg` | `cdc-avg` | Average chunk size for CDC |
+| LVMSYNC_CDC_MAX | `--cdc-max` | `cdc-max` | Maximum chunk size for CDC |
+| LVMSYNC_CDC_MIN | `--cdc-min` | `cdc-min` | Minimum chunk size for CDC |
+| LVMSYNC_CHECKPOINT_BYTES | `--checkpoint-bytes` | `checkpoint-bytes` | Bytes between resume checkpoints |
+| LVMSYNC_CHECKPOINT_INTERVAL | `--checkpoint-interval` | `checkpoint-interval` | Duration between checkpoints |
+| LVMSYNC_CHUNK_SEED | `--chunk-seed` | `chunk-seed` | Seed for chunking |
+| LVMSYNC_COMPRESS | `--compress` | `compress` | Compression algorithm: [none lz4 zstd auto] |
+| LVMSYNC_COMPRESS_CONCURRENCY | `--compress-concurrency` | `compress-concurrency` | Compression concurrency |
+| LVMSYNC_COMPRESS_THRESHOLD | `--compress-threshold` | `compress-threshold` | Skip compression when estimated ratio exceeds this value |
+| LVMSYNC_CONCURRENCY | `--concurrency` | `concurrency` | Number of concurrent connections |
+| LVMSYNC_CONFIG | `--config` | `config` | Path to config YAML file |
+| LVMSYNC_DEDUP | `--dedup` | `dedup` | Deduplication mode: [fixed cdc hybrid] |
+| LVMSYNC_DEDUP_STATE_FILE | `--dedup-state-file` | `dedup-state-file` | Path to deduplication state file |
+| LVMSYNC_DEDUP_STRATEGY | `--dedup-strategy` | `dedup-strategy` | Deduplication strategy: [none auto checksum rolling_hash bloom] |
+| LVMSYNC_DELTA | `--delta` | `delta` | Delta algorithm (none, rsync) to precompute byte-level changes |
+| LVMSYNC_DEST_TYPE | `--dest-type` | `dest-type` | Destination device type (auto,file,raw,lvm) |
+| LVMSYNC_DIGEST | `--digest` | `digest` | Digest algorithm: [sha256 blake3 auto] |
+| LVMSYNC_DISCARD | `--discard` | `discard` | Issue BLKDISCARD before writing blocks |
+| LVMSYNC_DRY_RUN | `--dry-run` | `dry-run` | Print actions without executing |
+| LVMSYNC_FORCE | `--force` | `force` | Override safety checks for offline raw access or filesystem freeze |
+| LVMSYNC_FREEZE_TIMEOUT | `--freeze-timeout` | `freeze-timeout` | Timeout for filesystem freeze command |
+| LVMSYNC_FS_FREEZE_COMMAND | `--fs-freeze-command` | `fs-freeze-command` | Command to freeze filesystem before reading raw source |
+| LVMSYNC_FS_THAW_COMMAND | `--fs-thaw-command` | `fs-thaw-command` | Command to thaw filesystem after reading raw source |
+| LVMSYNC_INTRA_DEDUP | `--intra-dedup` | `intra-dedup` | Enable intra-run deduplication |
+| LVMSYNC_KNOWN_HOSTS | `--known-hosts` | `known-hosts` | Path to known_hosts file |
+| LVMSYNC_LVM_ESCALATION | `--lvm-escalation` | `lvm-escalation` | Command to use for privilege escalation |
+| LVMSYNC_LVM_TIMEOUT | `--lvm-timeout` | `lvm-timeout` | Timeout for LVM commands and privilege checks |
+| LVMSYNC_LVMSYNC_PATH | `--lvmsync-path` | `lvmsync-path` | Remote command to run |
+| LVMSYNC_LZ4_LEVEL | `--lz4-level` | `lz4-level` | LZ4 compression level: fast or hc |
+| LVMSYNC_MANIFEST_ALLOW_MOUNTED | `--manifest-allow-mounted` | `manifest-allow-mounted` | Allow rebuilding when device is mounted read-write |
+| LVMSYNC_MANIFEST_PATH | `--manifest-path` | `manifest-path` | Path to manifest file |
+| LVMSYNC_MANIFEST_PROGRESS_INTERVAL | `--manifest-progress-interval` | `manifest-progress-interval` | Interval between progress logs during manifest rebuild |
+| LVMSYNC_MANIFEST_TIMEOUT | `--manifest-timeout` | `manifest-timeout` | Timeout for manifest rebuild (0 to disable) |
+| LVMSYNC_MAX_RETRIES | `--max-retries` | `max-retries` | Maximum number of retries per block |
+| LVMSYNC_MODE | `--mode` | `mode` | Preset mode: default or throughput |
+| LVMSYNC_NUMA_NODE | `--numa-node` | `numa-node` | NUMA node to pin worker goroutines |
+| LVMSYNC_NUMA_PIN | `--numa-pin` | `numa-pin` | Pin worker goroutines to device NUMA node |
+| LVMSYNC_ODIRECT | `--odirect` | `odirect` | Use O_DIRECT for device I/O when possible |
+| LVMSYNC_OFFLINE | `--offline` | `offline` | Assume source raw device is offline |
+| LVMSYNC_OUTPUT | `--output` | `output` | Output format: text or json |
+| LVMSYNC_PARALLEL | `--parallel` | `parallel` | Number of concurrent workers |
+| LVMSYNC_PLAN | `--plan` | `plan` | Print configuration plan as JSON and exit |
+| LVMSYNC_PROBE_ONLY | `--probe-only` | `probe-only` | Output size_bytes, device_uuid, and manifest_epoch without writing |
+| LVMSYNC_PROGRESS | `--progress` | `progress` | Show progress during transfer |
+| LVMSYNC_REMOTE_POST_SCRIPT | `--remote-post-script` | `remote-post-script` | Remote script to run after transfer |
+| LVMSYNC_REMOTE_PRE_SCRIPT | `--remote-pre-script` | `remote-pre-script` | Remote script to run before transfer |
+| LVMSYNC_RESUME | `--resume` | `resume` | Path to resume state file |
+| LVMSYNC_RETRY_DELAY | `--retry-delay` | `retry-delay` | Initial delay between retries |
+| LVMSYNC_SIG_CACHE_MAX | `--sig-cache-max` | `sig-cache-max` | Maximum LVM signature cache entries |
+| LVMSYNC_SIG_CACHE_TTL | `--sig-cache-ttl` | `sig-cache-ttl` | TTL for LVM signature cache entries |
+| LVMSYNC_SKIP_DISK_CHECK | `--skip-disk-check` | `skip-disk-check` | Skip disk space check |
+| LVMSYNC_SKIP_SNAPSHOT_CREATION | `--skip-snapshot-creation` | `skip-snapshot-creation` | Skip snapshot creation |
+| LVMSYNC_SNAPSHOT_SIZE | `--snapshot-size` | `snapshot-size` | Snapshot size (bytes or percentage) |
+| LVMSYNC_SOURCE_TYPE | `--source-type` | `source-type` | Source device type (auto,file,raw,lvm) |
+| LVMSYNC_SPEED | `--speed` | `speed` | Transfer speed limit |
+| LVMSYNC_SSH_HOST | `--ssh-host` | `ssh-host` | SSH host |
+| LVMSYNC_SSH_HOST_KEY | `--ssh-host-key` | `ssh-host-key` | Expected SSH host public key |
+| LVMSYNC_SSH_HOST_KEY_PATH | `--ssh-host-key-path` | `ssh-host-key-path` | Path to SSH host private key |
+| LVMSYNC_SSH_KEEPALIVE | `--ssh-keepalive` | `ssh-keepalive` | SSH keepalive interval |
+| LVMSYNC_SSH_KEY | `--ssh-key` | `ssh-key` | Path to SSH private key or use agent |
+| LVMSYNC_SSH_PORT | `--ssh-port` | `ssh-port` | SSH port |
+| LVMSYNC_SSH_TIMEOUT | `--ssh-timeout` | `ssh-timeout` | SSH connection timeout |
+| LVMSYNC_SSH_USER | `--ssh-user` | `ssh-user` | SSH username |
+| LVMSYNC_STDOUT | `--stdout` | `stdout` | Write change dump to STDOUT |
+| LVMSYNC_STRICT_HOST_KEY_CHECKING | `--strict-host-key-checking` | `strict-host-key-checking` | Require host keys to be present in known_hosts |
+| LVMSYNC_SYNC_INTERVAL | `--sync-interval` | `sync-interval` | Bytes between fdatasync calls |
+| LVMSYNC_TARGET_VGS | `--target-vgs` | `target-vgs` | Candidate target VGs for volume selection |
+| LVMSYNC_TARGET_VOLUME_GROUP | `--target-volume-group` | `target-volume-group` | Target LVM volume group |
+| LVMSYNC_TCP_LOWAT | `--tcp-lowat` | `tcp-lowat` | TCP_NOTSENT_LOWAT threshold in bytes |
+| LVMSYNC_TCP_PARALLEL | `--tcp-parallel` | `tcp-parallel` | Number of parallel TCP connections per worker |
+| LVMSYNC_TCP_PORT | `--tcp-port` | `tcp-port` | TCP port |
+| LVMSYNC_THAW_TIMEOUT | `--thaw-timeout` | `thaw-timeout` | Timeout for filesystem thaw command |
+| LVMSYNC_TRANSPORT | `--transport` | `transport` | Transport modes (comma-separated) |
+| LVMSYNC_VERBOSE | `--verbose` | `verbose` | Verbosity level |
+| LVMSYNC_VERIFY | `--verify` | `verify` | Verification level: full, sampled, or none |
+| LVMSYNC_VERIFY_CHECKSUM | `--verify-checksum` | `verify-checksum` | Enable checksum verification |
+| LVMSYNC_VERIFY_ONLY | `--verify-only` | `verify-only` | Verify destination without writing data |
+| LVMSYNC_VOLUME_GROUP | `--volume-group` | `volume-group` | LVM volume group |
+| LVMSYNC_YES_I_KNOW | `--yes-i-know` | `yes-i-know` | Confirm writing binary data to STDOUT |
+| LVMSYNC_ZEROCOPY | `--zerocopy` | `zerocopy` | Enable zero-copy transfers |
+| LVMSYNC_ZSTD_LEVEL | `--zstd-level` | `zstd-level` | Zstd compression level (1-5) |

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.7
 	github.com/spf13/viper v1.20.1
+	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zeebo/blake3 v0.2.4
 	github.com/zeebo/xxh3 v1.0.2
 	go.uber.org/multierr v1.11.0
@@ -45,6 +46,8 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/mod v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -88,6 +89,12 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// EnvDoc returns a markdown table mapping environment variables,
+// flags, and YAML keys for all available configuration options.
+func EnvDoc(fs *FlagSets) string {
+	type row struct{ env, flag, yaml, usage string }
+	var rows []row
+	for _, set := range fs.All() {
+		set.VisitAll(func(f *pflag.Flag) {
+			env := "LVMSYNC_" + strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+			rows = append(rows, row{env, "--" + f.Name, f.Name, f.Usage})
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].flag < rows[j].flag })
+	var b strings.Builder
+	fmt.Fprintln(&b, "| ENV | Flag | YAML | Description |")
+	fmt.Fprintln(&b, "| --- | ---- | ---- | ----------- |")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %s |\n", r.env, r.flag, r.yaml, strings.ReplaceAll(r.usage, "|", "\\|"))
+	}
+	return b.String()
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+//go:embed schema.json
+var configSchema []byte
+
+func validateSchema(doc map[string]any) error {
+	if len(configSchema) == 0 {
+		return nil
+	}
+	schemaLoader := gojsonschema.NewBytesLoader(configSchema)
+	data, err := json.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("schema marshal: %w", err)
+	}
+	documentLoader := gojsonschema.NewBytesLoader(data)
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return fmt.Errorf("schema validation: %w", err)
+	}
+	if !result.Valid() {
+		var parts []string
+		for _, e := range result.Errors() {
+			parts = append(parts, e.String())
+		}
+		return fmt.Errorf("schema validation: %s", strings.Join(parts, "; "))
+	}
+	return nil
+}

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -1,0 +1,341 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "allow_insecure": {
+      "type": "boolean"
+    },
+    "allow_overwrite": {
+      "type": "boolean"
+    },
+    "bloom_entries": {
+      "type": "integer"
+    },
+    "bloom_fp_rate": {
+      "type": "number"
+    },
+    "bloom_mbits": {
+      "type": "integer"
+    },
+    "ca_cert": {
+      "type": "string"
+    },
+    "cdc_avg": {
+      "type": "integer"
+    },
+    "cdc_max": {
+      "type": "integer"
+    },
+    "cdc_min": {
+      "type": "integer"
+    },
+    "checkpoint_bytes": {
+      "type": "string"
+    },
+    "checkpoint_interval": {
+      "type": "string"
+    },
+    "chunk_seed": {
+      "type": "integer"
+    },
+    "client_cert": {
+      "type": "string"
+    },
+    "client_key": {
+      "type": "string"
+    },
+    "compress": {
+      "enum": [
+        "none",
+        "lz4",
+        "zstd",
+        "auto"
+      ],
+      "type": "string"
+    },
+    "compress_concurrency": {
+      "type": "integer"
+    },
+    "compress_threshold": {
+      "type": "number"
+    },
+    "concurrency": {
+      "type": "integer"
+    },
+    "config": {
+      "type": "string"
+    },
+    "dedup": {
+      "enum": [
+        "fixed",
+        "cdc",
+        "hybrid"
+      ],
+      "type": "string"
+    },
+    "dedup_state_file": {
+      "type": "string"
+    },
+    "dedup_strategy": {
+      "enum": [
+        "none",
+        "auto",
+        "checksum",
+        "rolling_hash",
+        "bloom"
+      ],
+      "type": "string"
+    },
+    "delta": {
+      "type": "string"
+    },
+    "dest-type": {
+      "enum": [
+        "auto",
+        "file",
+        "raw",
+        "lvm"
+      ],
+      "type": "string"
+    },
+    "device_uuid": {
+      "type": "string"
+    },
+    "digest": {
+      "enum": [
+        "sha256",
+        "blake3",
+        "auto"
+      ],
+      "type": "string"
+    },
+    "discard": {
+      "type": "boolean"
+    },
+    "dry_run": {
+      "type": "boolean"
+    },
+    "first_block_digest": {
+      "type": "string"
+    },
+    "force": {
+      "type": "boolean"
+    },
+    "freeze-timeout": {
+      "type": "string"
+    },
+    "fs-freeze-command": {
+      "type": "string"
+    },
+    "fs-thaw-command": {
+      "type": "string"
+    },
+    "intra_dedup": {
+      "type": "boolean"
+    },
+    "known_hosts": {
+      "type": "string"
+    },
+    "lvm_escalation": {
+      "type": "string"
+    },
+    "lvm_timeout": {
+      "type": "string"
+    },
+    "lvmsync_path": {
+      "type": "string"
+    },
+    "lz4_level": {
+      "enum": [
+        "fast",
+        "hc"
+      ],
+      "type": "string"
+    },
+    "manifest_allow_mounted": {
+      "type": "boolean"
+    },
+    "manifest_path": {
+      "type": "string"
+    },
+    "manifest_progress_interval": {
+      "type": "string"
+    },
+    "manifest_timeout": {
+      "type": "string"
+    },
+    "max_retries": {
+      "type": "integer"
+    },
+    "mode": {
+      "enum": [
+        "default",
+        "throughput"
+      ],
+      "type": "string"
+    },
+    "numa_node": {
+      "type": "integer"
+    },
+    "numa_pin": {
+      "type": "boolean"
+    },
+    "odirect": {
+      "type": "boolean"
+    },
+    "offline": {
+      "type": "boolean"
+    },
+    "output": {
+      "enum": [
+        "text",
+        "json"
+      ],
+      "type": "string"
+    },
+    "parallel": {
+      "type": "integer"
+    },
+    "plan": {
+      "type": "boolean"
+    },
+    "probe_only": {
+      "type": "boolean"
+    },
+    "progress": {
+      "type": "boolean"
+    },
+    "remote_post_script": {
+      "type": "string"
+    },
+    "remote_pre_script": {
+      "type": "string"
+    },
+    "resume": {
+      "type": "string"
+    },
+    "resume_token": {
+      "type": "string"
+    },
+    "retry_delay": {
+      "type": "string"
+    },
+    "sig_cache_max": {
+      "type": "integer"
+    },
+    "sig_cache_ttl": {
+      "type": "string"
+    },
+    "skip_disk_check": {
+      "type": "boolean"
+    },
+    "skip_snapshot_creation": {
+      "type": "boolean"
+    },
+    "snapshot_size": {
+      "type": "string"
+    },
+    "source-type": {
+      "enum": [
+        "auto",
+        "file",
+        "raw",
+        "lvm"
+      ],
+      "type": "string"
+    },
+    "speed": {
+      "type": "string"
+    },
+    "ssh_host": {
+      "type": "string"
+    },
+    "ssh_host_key": {
+      "type": "string"
+    },
+    "ssh_host_key_path": {
+      "type": "string"
+    },
+    "ssh_keepalive": {
+      "type": "string"
+    },
+    "ssh_key": {
+      "type": "string"
+    },
+    "ssh_password": {
+      "type": "string"
+    },
+    "ssh_port": {
+      "type": "integer"
+    },
+    "ssh_timeout": {
+      "type": "string"
+    },
+    "ssh_user": {
+      "type": "string"
+    },
+    "stdout": {
+      "type": "boolean"
+    },
+    "strict_host_key_checking": {
+      "type": "boolean"
+    },
+    "sync_interval": {
+      "type": "string"
+    },
+    "target_vgs": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "target_volume_group": {
+      "type": "string"
+    },
+    "tcp_lowat": {
+      "type": "integer"
+    },
+    "tcp_parallel": {
+      "type": "integer"
+    },
+    "tcp_port": {
+      "type": "integer"
+    },
+    "thaw-timeout": {
+      "type": "string"
+    },
+    "transport": {
+      "type": "string"
+    },
+    "verbose": {
+      "type": "integer"
+    },
+    "verify": {
+      "enum": [
+        "full",
+        "sampled",
+        "none"
+      ],
+      "type": "string"
+    },
+    "verify_checksum": {
+      "type": "boolean"
+    },
+    "verify_only": {
+      "type": "boolean"
+    },
+    "volume_group": {
+      "type": "string"
+    },
+    "yes_i_know": {
+      "type": "boolean"
+    },
+    "zerocopy": {
+      "type": "boolean"
+    },
+    "zstd_level": {
+      "type": "integer"
+    }
+  },
+  "type": "object"
+}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestSchemaValidationUnknownType(t *testing.T) {
+	defaults, _ := DefaultConfig()
+	b := NewBuilder(defaults)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	// write temp config with wrong type for parallel (string instead of int)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgPath, []byte("parallel: 'nope'\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, _, _, err := b.Build(fs, []string{"--config", cfgPath})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestEnvDocUpToDate(t *testing.T) {
+	defaults, _ := DefaultConfig()
+	doc := EnvDoc(NewFlagSets(defaults))
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "env.md"))
+	if err != nil {
+		t.Fatalf("read env.md: %v", err)
+	}
+	if doc != string(data) {
+		t.Fatalf("docs/env.md is out of date; run go run ./cmd/configdoc")
+	}
+}

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -337,6 +337,9 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, bool, error) {
 		}
 		var raw map[string]any
 		if err := yaml.Unmarshal(data, &raw); err == nil {
+			if err := validateSchema(raw); err != nil {
+				return nil, nil, false, err
+			}
 			if v, ok := raw["allow_insecure"].(bool); ok && v {
 				allowInsecureYAML = true
 			}

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func TestUnknownKeysProduceWarnings(t *testing.T) {
+func TestUnknownKeysProduceError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -21,12 +21,9 @@ func TestUnknownKeysProduceWarnings(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	_, _, warns, err := b.Build(fs, []string{"--config", cfgFile})
-	if err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	if len(warns) != 1 || warns[0] != "unknown configuration key \"bogus\"" {
-		t.Fatalf("warnings=%v", warns)
+	_, _, _, err = b.Build(fs, []string{"--config", cfgFile})
+	if err == nil {
+		t.Fatalf("expected error")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add JSON schema for Config and validate configs before unmarshalling
- generate env/flag/YAML table via new configdoc tool
- document env vars and ensure docs/env.md kept up to date

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: many revive/staticcheck warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a45ccf235c8323a8d79900eee4e608