### PR TITLE
docs: add rsync delta example and README tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--cdc-min` | `LVMSYNC_DEDUP_CDC_MIN` | `cdc_min` | Minimum chunk size for CDC (must be at least 64 bytes) |
 | `--cdc-avg` | `LVMSYNC_DEDUP_CDC_AVG` | `cdc_avg` | Target average chunk size for CDC |
 | `--cdc-max` | `LVMSYNC_DEDUP_CDC_MAX` | `cdc_max` | Maximum chunk size for CDC |
+| `--chunk-seed` | `LVMSYNC_DEDUP_CHUNK_SEED` | `chunk_seed` | Seed for chunking |
 | `--bloom-entries` | `LVMSYNC_DEDUP_BLOOM_ENTRIES` | `bloom_entries` | Estimated number of entries for bloom filter |
 | `--bloom-fp-rate` | `LVMSYNC_DEDUP_BLOOM_FP_RATE` | `bloom_fp_rate` | False positive rate for bloom filter |
 | `--bloom-mbits` | `LVMSYNC_DEDUP_BLOOM_MBITS` | `bloom_mbits` | Bloom filter m bits power |
@@ -682,6 +683,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--target-volume-group` | `LVMSYNC_TARGET_VOLUME_GROUP` | `target_volume_group` | Volume group name of the target LVM volume |
 | `--target-vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
 | `--force` | `LVMSYNC_FORCE` | `force` | Override safety checks and proceed on mounted destination |
+| `--allow-overwrite` | `LVMSYNC_ALLOW_OVERWRITE` | `allow_overwrite` | Skip interactive confirmation when using `--force` |
 | `--discard` | `LVMSYNC_DISCARD` | `discard` | Issue BLKDISCARD before writing blocks |
 | `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Log estimated transfer bytes without sending data; uses manifest sampling when available |
 | `--plan` | `LVMSYNC_PLAN` | `plan` | Print configuration plan as JSON and exit |
@@ -714,7 +716,10 @@ SSH transport negotiation also derives read and write deadlines from the caller'
   ```
 
 
+- **Rsync delta with dedup and compression**:
+
   ```sh
+  lvmsync run --delta=rsync --dedup-strategy bloom --compress lz4 --transport rsync --dry-run /tmp/src /tmp/dst
   ```
 
 - **Throughput-optimized transfer**:

--- a/readme_examples_test.go
+++ b/readme_examples_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -8,7 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
 	"golang.org/x/tools/imports"
+	lvmsynccmd "lvmsync_go/cmd/lvmsync"
+	"lvmsync_go/internal/config"
 )
 
 // TestReadmeExamplesCompile ensures that Go code blocks in README.md compile.
@@ -48,5 +53,65 @@ func TestReadmeExamplesCompile(t *testing.T) {
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("example %d: %v\n%s", i+1, err, out)
 		}
+	}
+}
+
+// TestReadmeShellExamples runs runnable shell blocks from README.md.
+func TestReadmeShellExamples(t *testing.T) {
+	data, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	re := regexp.MustCompile("(?s)```sh\n(.*?)\n```")
+	matches := re.FindAllSubmatch(data, -1)
+	for i, m := range matches {
+		block := strings.TrimSpace(string(m[1]))
+		lines := strings.Split(block, "\n")
+		for j, line := range lines {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "lvmsync") || !strings.Contains(line, "/tmp/src") || !strings.Contains(line, "/tmp/dst") {
+				continue
+			}
+			t.Run(fmt.Sprintf("sh_%d_%d", i, j), func(t *testing.T) {
+				if strings.Contains(line, "/tmp/src") {
+					if err := os.WriteFile("/tmp/src", nil, 0o644); err != nil {
+						t.Fatalf("prep src: %v", err)
+					}
+				}
+				if strings.Contains(line, "/tmp/dst") {
+					if err := os.WriteFile("/tmp/dst", nil, 0o644); err != nil {
+						t.Fatalf("prep dst: %v", err)
+					}
+				}
+				args := strings.Fields(line)[1:]
+				if err := lvmsynccmd.ExecuteWithRunner(args, zap.NewNop(), nil); err != nil {
+					t.Fatalf("%s: %v", line, err)
+				}
+			})
+		}
+	}
+}
+
+// TestFlagDocumentation ensures every flag has a README example.
+func TestFlagDocumentation(t *testing.T) {
+	data, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaults, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sets := config.NewFlagSets(defaults)
+	var missing []string
+	for _, fs := range sets.All() {
+		fs.VisitAll(func(f *pflag.Flag) {
+			if !strings.Contains(string(data), "--"+f.Name) {
+				missing = append(missing, "--"+f.Name)
+			}
+		})
+	}
+	if len(missing) > 0 {
+		t.Fatalf("flags missing from README: %v", missing)
 	}
 }


### PR DESCRIPTION
## Summary
- document `--allow-overwrite` and `--chunk-seed`
- add rsync delta CLI example with dedup and compression flags
- test README shell blocks and ensure every CLI flag is documented

## Testing
- `go build ./...`
- `go test ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a45cd6c2148323b0a4efa2a46abd34