### PR TITLE
chore: verify sudoers documentation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -154,6 +154,9 @@ jobs:
       - name: Docs check
         run: make docs-check
 
+      - name: Verify sudoers commands
+        run: scripts/verify_sudoers.sh
+
       - name: Show coverage
         run: go tool cover -func=coverage.out | tail -n 1
 

--- a/scripts/verify_sudoers.sh
+++ b/scripts/verify_sudoers.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+missing=()
+
+# collect lvm commands from Go source excluding tests
+auth_commands=$(rg --type go -g '!*_test.go' -o 'lvcreate|lvremove' | sed 's/.*://' | sort -u)
+for cmd in $auth_commands; do
+  if ! rg -q "$cmd" docs/sudoers.md; then
+    missing+=("$cmd")
+  fi
+done
+
+# collect lvmsync-helper subcommands from Go source
+helper_subs=$(rg --type go -g '!*_test.go' -o 'lvmsync-helper\s+[a-z]+' | sed -E 's/.*lvmsync-helper\s+//' | sort -u)
+for sub in $helper_subs; do
+  if ! rg -q "lvmsync-helper\s+$sub" docs/sudoers.md; then
+    missing+=("lvmsync-helper $sub")
+  fi
+done
+
+if [ ${#missing[@]} -ne 0 ]; then
+  echo "Missing sudoers entries for:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add script to compare sudoers commands with source
- run sudoers verification in CI

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run --config=.golangci.yml` *(fails: 977 issues)*
- `go tool cover -func=coverage.out | tail -n 1`
- `scripts/verify_sudoers.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a463cbed088323893ecf5a3dce7304