### PR TITLE
test: add network flap simulation in loopback

### DIFF
--- a/.github/workflows/loopback-integration.yml
+++ b/.github/workflows/loopback-integration.yml
@@ -35,5 +35,5 @@ jobs:
           apt-get update
           apt-get install -y lvm2
 
-      - name: Run loopback integration test
-        run: bash integration/loopback.sh
+      - name: Run enhanced loopback integration test
+        run: timeout 5m bash integration/loopback.sh

--- a/integration/loopback.sh
+++ b/integration/loopback.sh
@@ -57,16 +57,21 @@ pvcreate -ffy "$DST_LOOP"
 vgcreate vgd "$DST_LOOP"
 lvcreate -n dest -L 32M vgd
 
-# Mid-transfer crash and resume
+# Mid-transfer interruptions and resume with simulated network flaps
 STATE="$TMPDIR/state.json"
-"$BIN" run --resume="$STATE" /dev/vgsrc/snap /dev/vgd/dest &
-PID=$!
-sleep 1
-kill -9 $PID || true
-if [ ! -f "$STATE" ]; then
-  echo "resume state missing"
-  exit 1
-fi
+for delay in 1 2 3; do
+  "$BIN" run --speed=1M --resume="$STATE" /dev/vgsrc/snap /dev/vgd/dest &
+  PID=$!
+  sleep "$delay"
+  # Simulate an SSH session drop
+  kill -HUP $PID || true
+  sleep 1
+  kill -9 $PID 2>/dev/null || true
+  if [ ! -f "$STATE" ]; then
+    echo "resume state missing"
+    exit 1
+  fi
+done
 "$BIN" run --resume="$STATE" /dev/vgsrc/snap /dev/vgd/dest
 "$BIN" verify /dev/vgsrc/snap /dev/vgd/dest
 


### PR DESCRIPTION
## Summary
- simulate multiple mid-transfer interruptions in `integration/loopback.sh`
- run loopback integration test with timeout in CI

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: many revive/staticcheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a463d030748323a62a48207f8b1503