### PR TITLE
Add WAL versioning with upgrade support

### DIFF
--- a/device/wal.go
+++ b/device/wal.go
@@ -3,12 +3,28 @@ package device
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/zeebo/blake3"
 )
 
+const (
+	walVersion      = 1
+	walHeaderV0Size = 8 + 64 + 64 + 64 + 32
+	walHeaderSize   = 8 + walHeaderV0Size
+)
+
 type walHeader struct {
+	Version uint64
+	Size    uint64
+	Kernel  [64]byte
+	GPT     [64]byte
+	FS      [64]byte
+	MAC     [32]byte
+}
+
+type walHeaderV0 struct {
 	Size   uint64
 	Kernel [64]byte
 	GPT    [64]byte
@@ -23,6 +39,16 @@ type WAL struct {
 }
 
 func walHeaderMAC(h *walHeader) [32]byte {
+	var buf [8 + 8 + 64 + 64 + 64]byte
+	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
+	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
+	copy(buf[16:80], h.Kernel[:])
+	copy(buf[80:144], h.GPT[:])
+	copy(buf[144:], h.FS[:])
+	return blake3.Sum256(buf[:])
+}
+
+func walHeaderMACV0(h *walHeaderV0) [32]byte {
 	var buf [8 + 64 + 64 + 64]byte
 	binary.LittleEndian.PutUint64(buf[0:8], h.Size)
 	copy(buf[8:72], h.Kernel[:])
@@ -46,17 +72,19 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 	w := &WAL{f: f}
 	if st.Size() == 0 {
 		var hdr walHeader
+		hdr.Version = walVersion
 		hdr.Size = id.SizeBytes
 		copy(hdr.Kernel[:], []byte(id.KernelUUID))
 		copy(hdr.GPT[:], []byte(id.GPTUUID))
 		copy(hdr.FS[:], []byte(id.FSUUID))
 		hdr.MAC = walHeaderMAC(&hdr)
-		var buf [8 + 64 + 64 + 64 + 32]byte
-		binary.LittleEndian.PutUint64(buf[0:8], hdr.Size)
-		copy(buf[8:72], hdr.Kernel[:])
-		copy(buf[72:136], hdr.GPT[:])
-		copy(buf[136:200], hdr.FS[:])
-		copy(buf[200:], hdr.MAC[:])
+		var buf [walHeaderSize]byte
+		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
+		copy(buf[16:80], hdr.Kernel[:])
+		copy(buf[80:144], hdr.GPT[:])
+		copy(buf[144:208], hdr.FS[:])
+		copy(buf[208:240], hdr.MAC[:])
 		if _, err := f.Write(buf[:]); err != nil {
 			f.Close()
 			return nil, err
@@ -68,42 +96,134 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 		w.header = hdr
 		return w, nil
 	}
-	var buf [8 + 64 + 64 + 64 + 32]byte
-	if _, err := f.ReadAt(buf[:], 0); err != nil {
+
+	var vbuf [8]byte
+	if _, err := f.ReadAt(vbuf[:], 0); err != nil {
 		f.Close()
 		return nil, err
 	}
-	var hdr walHeader
-	hdr.Size = binary.LittleEndian.Uint64(buf[0:8])
-	copy(hdr.Kernel[:], buf[8:72])
-	copy(hdr.GPT[:], buf[72:136])
-	copy(hdr.FS[:], buf[136:200])
-	copy(hdr.MAC[:], buf[200:])
-	if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
-		f.Close()
-		return nil, fmt.Errorf("wal: header mac mismatch")
-	}
-	if hdr.Size != id.SizeBytes ||
-		string(hdr.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
-		string(hdr.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
-		string(hdr.FS[:len(id.FSUUID)]) != id.FSUUID {
-		f.Close()
-		return nil, fmt.Errorf("wal: metadata mismatch")
-	}
-	w.header = hdr
-	off := int64(len(buf))
-	entry := make([]byte, 16)
-	for {
-		n, err := f.ReadAt(entry, off)
-		if err != nil || n != 16 {
-			break
+	ver := binary.LittleEndian.Uint64(vbuf[:])
+	if ver == walVersion && st.Size() >= walHeaderSize {
+		var buf [walHeaderSize]byte
+		if _, err := f.ReadAt(buf[:], 0); err != nil {
+			f.Close()
+			return nil, err
 		}
-		start := binary.LittleEndian.Uint64(entry[0:8])
-		end := binary.LittleEndian.Uint64(entry[8:16])
-		w.ranges = append(w.ranges, Range{Start: start, End: end})
-		off += 16
+		var hdr walHeader
+		hdr.Version = binary.LittleEndian.Uint64(buf[0:8])
+		hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
+		copy(hdr.Kernel[:], buf[16:80])
+		copy(hdr.GPT[:], buf[80:144])
+		copy(hdr.FS[:], buf[144:208])
+		copy(hdr.MAC[:], buf[208:240])
+		if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
+			f.Close()
+			return nil, fmt.Errorf("wal: header mac mismatch")
+		}
+		if hdr.Size != id.SizeBytes ||
+			string(hdr.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
+			string(hdr.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
+			string(hdr.FS[:len(id.FSUUID)]) != id.FSUUID {
+			f.Close()
+			return nil, fmt.Errorf("wal: metadata mismatch")
+		}
+		w.header = hdr
+		off := int64(walHeaderSize)
+		entry := make([]byte, 16)
+		for {
+			n, err := f.ReadAt(entry, off)
+			if err != nil || n != 16 {
+				break
+			}
+			start := binary.LittleEndian.Uint64(entry[0:8])
+			end := binary.LittleEndian.Uint64(entry[8:16])
+			w.ranges = append(w.ranges, Range{Start: start, End: end})
+			off += 16
+		}
+		if _, err := f.Seek(off, 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		return w, nil
 	}
-	return w, nil
+
+	if st.Size() >= walHeaderV0Size {
+		var buf0 [walHeaderV0Size]byte
+		if _, err := f.ReadAt(buf0[:], 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		var hdr0 walHeaderV0
+		hdr0.Size = binary.LittleEndian.Uint64(buf0[0:8])
+		copy(hdr0.Kernel[:], buf0[8:72])
+		copy(hdr0.GPT[:], buf0[72:136])
+		copy(hdr0.FS[:], buf0[136:200])
+		copy(hdr0.MAC[:], buf0[200:])
+		if mac := walHeaderMACV0(&hdr0); mac != hdr0.MAC {
+			f.Close()
+			return nil, fmt.Errorf("wal: header mac mismatch")
+		}
+		if hdr0.Size != id.SizeBytes ||
+			string(hdr0.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
+			string(hdr0.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
+			string(hdr0.FS[:len(id.FSUUID)]) != id.FSUUID {
+			f.Close()
+			return nil, fmt.Errorf("wal: metadata mismatch")
+		}
+		data := make([]byte, st.Size()-walHeaderV0Size)
+		if _, err := f.ReadAt(data, walHeaderV0Size); err != nil && err != io.EOF {
+			f.Close()
+			return nil, err
+		}
+		ranges := []Range{}
+		for off := 0; off+16 <= len(data); off += 16 {
+			start := binary.LittleEndian.Uint64(data[off : off+8])
+			end := binary.LittleEndian.Uint64(data[off+8 : off+16])
+			ranges = append(ranges, Range{Start: start, End: end})
+		}
+		var hdr walHeader
+		hdr.Version = walVersion
+		hdr.Size = hdr0.Size
+		hdr.Kernel = hdr0.Kernel
+		hdr.GPT = hdr0.GPT
+		hdr.FS = hdr0.FS
+		hdr.MAC = walHeaderMAC(&hdr)
+		var buf [walHeaderSize]byte
+		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
+		copy(buf[16:80], hdr.Kernel[:])
+		copy(buf[80:144], hdr.GPT[:])
+		copy(buf[144:208], hdr.FS[:])
+		copy(buf[208:240], hdr.MAC[:])
+		if _, err := f.WriteAt(buf[:], 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if len(data) > 0 {
+			if _, err := f.WriteAt(data, walHeaderSize); err != nil {
+				f.Close()
+				return nil, err
+			}
+		}
+		if err := f.Truncate(int64(walHeaderSize + len(data))); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, err
+		}
+		w.header = hdr
+		w.ranges = ranges
+		if _, err := f.Seek(int64(walHeaderSize+len(data)), 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		return w, nil
+	}
+
+	f.Close()
+	return nil, fmt.Errorf("wal: file too small")
 }
 
 func (w *WAL) Append(r Range) error {

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -1,6 +1,8 @@
 package device
 
 import (
+	"encoding/binary"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -51,4 +53,92 @@ func TestWALRecovery(t *testing.T) {
 		t.Fatalf("unexpected ranges %#v", rs)
 	}
 	w.Close()
+}
+
+func TestWALVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs"}
+	w, err := OpenWAL(path, id)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	var buf [walHeaderSize]byte
+	if _, err := f.ReadAt(buf[:], 0); err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	var hdr walHeader
+	hdr.Version = walVersion + 1
+	hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
+	copy(hdr.Kernel[:], buf[16:80])
+	copy(hdr.GPT[:], buf[80:144])
+	copy(hdr.FS[:], buf[144:208])
+	hdr.MAC = walHeaderMAC(&hdr)
+	binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+	copy(buf[208:240], hdr.MAC[:])
+	if _, err := f.WriteAt(buf[:], 0); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	f.Close()
+	if _, err := OpenWAL(path, id); err == nil {
+		t.Fatalf("expected version mismatch error")
+	}
+}
+
+func TestWALUpgrade(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	var hdr0 walHeaderV0
+	hdr0.Size = 100
+	copy(hdr0.Kernel[:], []byte("dev"))
+	copy(hdr0.GPT[:], []byte("gpt"))
+	copy(hdr0.FS[:], []byte("fs"))
+	hdr0.MAC = walHeaderMACV0(&hdr0)
+	var hbuf [walHeaderV0Size]byte
+	binary.LittleEndian.PutUint64(hbuf[0:8], hdr0.Size)
+	copy(hbuf[8:72], hdr0.Kernel[:])
+	copy(hbuf[72:136], hdr0.GPT[:])
+	copy(hbuf[136:200], hdr0.FS[:])
+	copy(hbuf[200:232], hdr0.MAC[:])
+	if _, err := f.Write(hbuf[:]); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	var entry [16]byte
+	binary.LittleEndian.PutUint64(entry[0:8], 0)
+	binary.LittleEndian.PutUint64(entry[8:16], 10)
+	if _, err := f.Write(entry[:]); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	f.Close()
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs"}
+	w, err := OpenWAL(path, id)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if w.header.Version != walVersion {
+		t.Fatalf("expected version %d got %d", walVersion, w.header.Version)
+	}
+	rs := w.Ranges()
+	if len(rs) != 1 || rs[0].Start != 0 || rs[0].End != 10 {
+		t.Fatalf("unexpected ranges %#v", rs)
+	}
+	w.Close()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if want := int64(walHeaderSize + 16); info.Size() != want {
+		t.Fatalf("expected size %d got %d", want, info.Size())
+	}
 }

--- a/docs/wal.md
+++ b/docs/wal.md
@@ -4,16 +4,23 @@ LVMSync uses a write-ahead log (WAL) to record applied block ranges so interrupt
 
 ## Header Layout
 
-The first 112 bytes contain fixed metadata:
+The first 120 bytes contain fixed metadata:
 
-| Offset | Length | Field      | Description                 |
-|--------|--------|------------|-----------------------------|
-| 0      | 8      | size       | Total device size in bytes  |
-| 8      | 8      | epoch      | Transfer epoch              |
-| 16     | 64     | device_id  | UTF-8 identifier, zero padded |
-| 80     | 32     | mac        | BLAKE3-256 of previous fields |
+| Offset | Length | Field      | Description                          |
+|--------|--------|------------|--------------------------------------|
+| 0      | 8      | version    | WAL format version (currently `1`)   |
+| 8      | 8      | size       | Total device size in bytes           |
+| 16     | 8      | epoch      | Transfer epoch                       |
+| 24     | 64     | device_id  | UTF-8 identifier, zero padded        |
+| 88     | 32     | mac        | BLAKE3-256 of the previous fields    |
 
 Each subsequent entry is 16 bytes and encodes a completed range as little-endian `start` and `end` offsets.
+
+## Version Semantics
+
+New WALs default to version `1`. `OpenWAL` rejects headers with any other version.
+WALs written by earlier releases are automatically upgraded to version `1` on
+open, rewriting the header and preserving existing entries.
 
 ## Fsync Requirements
 

--- a/transfer/wal.go
+++ b/transfer/wal.go
@@ -3,13 +3,28 @@ package transfer
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/zeebo/blake3"
 )
 
+const (
+	walVersion      = 1
+	walHeaderV0Size = 8 + 8 + 64 + 32
+	walHeaderSize   = 8 + walHeaderV0Size
+)
+
 type walHeader struct {
+	Version  uint64
+	Size     uint64
+	Epoch    uint64
+	DeviceID [64]byte
+	MAC      [32]byte
+}
+
+type walHeaderV0 struct {
 	Size     uint64
 	Epoch    uint64
 	DeviceID [64]byte
@@ -31,6 +46,15 @@ type WAL struct {
 }
 
 func walHeaderMAC(h *walHeader) [32]byte {
+	var buf [8 + 8 + 8 + 64]byte
+	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
+	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
+	binary.LittleEndian.PutUint64(buf[16:24], h.Epoch)
+	copy(buf[24:], h.DeviceID[:])
+	return blake3.Sum256(buf[:])
+}
+
+func walHeaderMACV0(h *walHeaderV0) [32]byte {
 	var buf [8 + 8 + 64]byte
 	binary.LittleEndian.PutUint64(buf[0:8], h.Size)
 	binary.LittleEndian.PutUint64(buf[8:16], h.Epoch)
@@ -54,20 +78,22 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []R
 	}
 	w := &WAL{f: f}
 	if st.Size() == 0 {
-		copy(w.header.DeviceID[:], []byte(deviceID))
+		w.header.Version = walVersion
 		w.header.Size = size
 		w.header.Epoch = epoch
+		copy(w.header.DeviceID[:], []byte(deviceID))
 		w.header.MAC = walHeaderMAC(&w.header)
-		var buf [8 + 8 + 64 + 32]byte
-		binary.LittleEndian.PutUint64(buf[0:8], w.header.Size)
-		binary.LittleEndian.PutUint64(buf[8:16], w.header.Epoch)
-		copy(buf[16:80], w.header.DeviceID[:])
-		copy(buf[80:], w.header.MAC[:])
+		var buf [walHeaderSize]byte
+		binary.LittleEndian.PutUint64(buf[0:8], w.header.Version)
+		binary.LittleEndian.PutUint64(buf[8:16], w.header.Size)
+		binary.LittleEndian.PutUint64(buf[16:24], w.header.Epoch)
+		copy(buf[24:88], w.header.DeviceID[:])
+		copy(buf[88:120], w.header.MAC[:])
 		if _, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, nil, err
 		}
-		if _, err := f.Seek(int64(len(buf)), 0); err != nil {
+		if _, err := f.Seek(int64(walHeaderSize), 0); err != nil {
 			f.Close()
 			return nil, nil, err
 		}
@@ -75,55 +101,134 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []R
 			f.Close()
 			return nil, nil, err
 		}
-		// Ensure the new WAL is durably linked from the parent directory.
 		if err := syncDir(filepath.Dir(path)); err != nil {
 			f.Close()
 			return nil, nil, err
 		}
 		return w, nil, nil
 	}
-	var hdr walHeader
-	var buf [8 + 8 + 64 + 32]byte
-	if _, err := f.ReadAt(buf[:], 0); err != nil {
+
+	var vbuf [8]byte
+	if _, err := f.ReadAt(vbuf[:], 0); err != nil {
 		f.Close()
 		return nil, nil, err
 	}
-	hdr.Size = binary.LittleEndian.Uint64(buf[0:8])
-	hdr.Epoch = binary.LittleEndian.Uint64(buf[8:16])
-	copy(hdr.DeviceID[:], buf[16:80])
-	copy(hdr.MAC[:], buf[80:])
-	if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
-		f.Close()
-		return nil, nil, fmt.Errorf("wal: header mac mismatch")
-	}
-	if hdr.Size != size || hdr.Epoch != epoch || string(hdr.DeviceID[:len(deviceID)]) != deviceID {
-		f.Close()
-		return nil, nil, fmt.Errorf("wal: metadata mismatch")
-	}
-	w.header = hdr
-	ranges := []Range{}
-	off := int64(len(buf))
-	entry := make([]byte, 16)
-	for {
-		n, err := f.ReadAt(entry, off)
-		if err != nil || n != 16 {
-			break
+	ver := binary.LittleEndian.Uint64(vbuf[:])
+	if ver == walVersion && st.Size() >= walHeaderSize {
+		var buf [walHeaderSize]byte
+		if _, err := f.ReadAt(buf[:], 0); err != nil {
+			f.Close()
+			return nil, nil, err
 		}
-		start := binary.LittleEndian.Uint64(entry[0:8])
-		end := binary.LittleEndian.Uint64(entry[8:16])
-		ranges = append(ranges, Range{Start: start, End: end})
-		off += 16
+		var hdr walHeader
+		hdr.Version = binary.LittleEndian.Uint64(buf[0:8])
+		hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
+		hdr.Epoch = binary.LittleEndian.Uint64(buf[16:24])
+		copy(hdr.DeviceID[:], buf[24:88])
+		copy(hdr.MAC[:], buf[88:120])
+		if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
+			f.Close()
+			return nil, nil, fmt.Errorf("wal: header mac mismatch")
+		}
+		if hdr.Size != size || hdr.Epoch != epoch || string(hdr.DeviceID[:len(deviceID)]) != deviceID {
+			f.Close()
+			return nil, nil, fmt.Errorf("wal: metadata mismatch")
+		}
+		w.header = hdr
+		ranges := []Range{}
+		off := int64(walHeaderSize)
+		entry := make([]byte, 16)
+		for {
+			n, err := f.ReadAt(entry, off)
+			if err != nil || n != 16 {
+				break
+			}
+			start := binary.LittleEndian.Uint64(entry[0:8])
+			end := binary.LittleEndian.Uint64(entry[8:16])
+			ranges = append(ranges, Range{Start: start, End: end})
+			off += 16
+		}
+		if err := f.Truncate(off); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		if _, err := f.Seek(off, 0); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		return w, ranges, nil
 	}
-	// Truncate any partially written tail and seek to the end for future appends.
-	if err := f.Truncate(off); err != nil {
-		f.Close()
-		return nil, nil, err
+
+	if st.Size() >= walHeaderV0Size {
+		var buf0 [walHeaderV0Size]byte
+		if _, err := f.ReadAt(buf0[:], 0); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		var hdr0 walHeaderV0
+		hdr0.Size = binary.LittleEndian.Uint64(buf0[0:8])
+		hdr0.Epoch = binary.LittleEndian.Uint64(buf0[8:16])
+		copy(hdr0.DeviceID[:], buf0[16:80])
+		copy(hdr0.MAC[:], buf0[80:112])
+		if mac := walHeaderMACV0(&hdr0); mac != hdr0.MAC {
+			f.Close()
+			return nil, nil, fmt.Errorf("wal: header mac mismatch")
+		}
+		if hdr0.Size != size || hdr0.Epoch != epoch || string(hdr0.DeviceID[:len(deviceID)]) != deviceID {
+			f.Close()
+			return nil, nil, fmt.Errorf("wal: metadata mismatch")
+		}
+		data := make([]byte, st.Size()-walHeaderV0Size)
+		if _, err := f.ReadAt(data, walHeaderV0Size); err != nil && err != io.EOF {
+			f.Close()
+			return nil, nil, err
+		}
+		ranges := []Range{}
+		for off := 0; off+16 <= len(data); off += 16 {
+			start := binary.LittleEndian.Uint64(data[off : off+8])
+			end := binary.LittleEndian.Uint64(data[off+8 : off+16])
+			ranges = append(ranges, Range{Start: start, End: end})
+		}
+		var hdr walHeader
+		hdr.Version = walVersion
+		hdr.Size = hdr0.Size
+		hdr.Epoch = hdr0.Epoch
+		hdr.DeviceID = hdr0.DeviceID
+		hdr.MAC = walHeaderMAC(&hdr)
+		var buf [walHeaderSize]byte
+		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
+		binary.LittleEndian.PutUint64(buf[16:24], hdr.Epoch)
+		copy(buf[24:88], hdr.DeviceID[:])
+		copy(buf[88:120], hdr.MAC[:])
+		if _, err := f.WriteAt(buf[:], 0); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		if len(data) > 0 {
+			if _, err := f.WriteAt(data, walHeaderSize); err != nil {
+				f.Close()
+				return nil, nil, err
+			}
+		}
+		if err := f.Truncate(int64(walHeaderSize + len(data))); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		w.header = hdr
+		if _, err := f.Seek(int64(walHeaderSize+len(data)), 0); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		return w, ranges, nil
 	}
-	if _, err := f.Seek(off, 0); err != nil {
-		f.Close()
-		return nil, nil, err
-	}
-	return w, ranges, nil
+
+	f.Close()
+	return nil, nil, fmt.Errorf("wal: file too small")
 }
 
 // Append records the range and fsyncs the WAL before returning.

--- a/transfer/wal_crash_test.go
+++ b/transfer/wal_crash_test.go
@@ -23,7 +23,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("open file: %v", err)
 		}
-		if _, err := f.Seek(8+8+64+32, 0); err != nil {
+		if _, err := f.Seek(walHeaderSize, 0); err != nil {
 			t.Fatalf("seek: %v", err)
 		}
 		var buf [8]byte
@@ -63,7 +63,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := w.f.Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
-		if err := os.Truncate(path, 8+8+64+32+16); err != nil {
+		if err := os.Truncate(path, walHeaderSize+16); err != nil {
 			t.Fatalf("truncate: %v", err)
 		}
 		w2, ranges, err := OpenWAL(path, 128, "dev", 1)

--- a/transfer/wal_test.go
+++ b/transfer/wal_test.go
@@ -83,7 +83,7 @@ func TestWALPartialWrite(t *testing.T) {
 		t.Fatalf("open file: %v", err)
 	}
 	// Append half of an entry to simulate a crash during write.
-	if _, err := f.Seek(8+8+64+32, 0); err != nil {
+	if _, err := f.Seek(walHeaderSize, 0); err != nil {
 		t.Fatalf("seek: %v", err)
 	}
 	var buf [8]byte
@@ -107,7 +107,7 @@ func TestWALPartialWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if want := int64(8 + 8 + 64 + 32); st.Size() != want {
+	if want := int64(walHeaderSize); st.Size() != want {
 		t.Fatalf("expected size %d, got %d", want, st.Size())
 	}
 }

--- a/transfer/wal_version_test.go
+++ b/transfer/wal_version_test.go
@@ -1,0 +1,90 @@
+package transfer
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWALVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	w, _, err := OpenWAL(path, 100, "dev", 1)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	var buf [walHeaderSize]byte
+	if _, err := f.ReadAt(buf[:], 0); err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	var hdr walHeader
+	hdr.Version = walVersion + 1
+	hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
+	hdr.Epoch = binary.LittleEndian.Uint64(buf[16:24])
+	copy(hdr.DeviceID[:], buf[24:88])
+	hdr.MAC = walHeaderMAC(&hdr)
+	binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+	copy(buf[88:120], hdr.MAC[:])
+	if _, err := f.WriteAt(buf[:], 0); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	f.Close()
+	if _, _, err := OpenWAL(path, 100, "dev", 1); err == nil {
+		t.Fatalf("expected version mismatch error")
+	}
+}
+
+func TestWALUpgrade(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	var hdr0 walHeaderV0
+	hdr0.Size = 100
+	hdr0.Epoch = 1
+	copy(hdr0.DeviceID[:], []byte("dev"))
+	hdr0.MAC = walHeaderMACV0(&hdr0)
+	var buf0 [walHeaderV0Size]byte
+	binary.LittleEndian.PutUint64(buf0[0:8], hdr0.Size)
+	binary.LittleEndian.PutUint64(buf0[8:16], hdr0.Epoch)
+	copy(buf0[16:80], hdr0.DeviceID[:])
+	copy(buf0[80:112], hdr0.MAC[:])
+	if _, err := f.Write(buf0[:]); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	var entry [16]byte
+	binary.LittleEndian.PutUint64(entry[0:8], 0)
+	binary.LittleEndian.PutUint64(entry[8:16], 10)
+	if _, err := f.Write(entry[:]); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	f.Close()
+	w, ranges, err := OpenWAL(path, 100, "dev", 1)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if w.header.Version != walVersion {
+		t.Fatalf("expected version %d got %d", walVersion, w.header.Version)
+	}
+	if len(ranges) != 1 || ranges[0].Start != 0 || ranges[0].End != 10 {
+		t.Fatalf("unexpected ranges %#v", ranges)
+	}
+	w.Close()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if want := int64(walHeaderSize + 16); info.Size() != want {
+		t.Fatalf("expected size %d got %d", want, info.Size())
+	}
+}


### PR DESCRIPTION
## Summary
- track WAL format with a version field and include it in the header MAC
- reject mismatched versions and upgrade legacy WAL headers to v1
- document WAL header layout and version semantics

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: many existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a463cada548323a69243192f0f8f14