### PR TITLE
Add sparse flag to disable hole punching

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For snapshot cleanup, resuming transfers, and verify-only rollback procedures, s
 - **Planning**: `--plan` prints resolved configuration, transport order, estimated bytes, and compression decisions as JSON without transferring data.
 - **Device Identity Tuple**: Each run records `(device_id, fs_uuid, size_bytes, major:minor)` to prevent writing to the wrong destination.
 - **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
-- **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it, logging a warning once and disabling hole punching when unsupported.
+- **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it. Use `--sparse=never` to always write zeros instead.
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to a device's NUMA node (`--numa-pin`) or an explicit node (`--numa-node`).
 - **LVM Snapshot Management**:
   - Automatic snapshot creation and removal.
@@ -689,6 +689,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--plan` | `LVMSYNC_PLAN` | `plan` | Print configuration plan as JSON and exit |
 | `--verify-only` | `LVMSYNC_VERIFY_ONLY` | `verify_only` | Read source and destination and report mismatches without writing data |
 | `--probe-only` | `LVMSYNC_PROBE_ONLY` | `probe_only` | Validate devices and privileges and log estimates without transferring data |
+| `--sparse` | `LVMSYNC_SPARSE` | `sparse` | Sparse file handling: `auto` punches holes, `never` writes zero blocks |
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | `transport` | Ordered transports to try (e.g., `ssh,tcp+tls,h2,quic`) |
 | `--tcp-port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |
 | `--tcp-parallel` | `LVMSYNC_TRANSPORT_TCP_PARALLEL` | `tcp_parallel` | Number of parallel TCP connections |
@@ -1103,6 +1104,7 @@ Flags are parsed via Viper, so the same settings can be provided through
 | `--dry-run`         | Print actions without executing | `false`   |
 | `--plan`            | Print configuration plan as JSON and exit | `false`   |
 | `--discard`         | Issue BLKDISCARD before writing blocks | `false`   |
+| `--sparse`          | Sparse file handling: `auto` punches holes, `never` writes zero blocks | `"auto"`   |
 | `--offline`         | Assume source raw device is offline | `false`   |
 | `--fs-freeze-command` | Command to freeze filesystem before reading raw source; path must be absolute and arguments use shell-style quoting | `""` |
 | `--fs-thaw-command`  | Command to thaw filesystem after reading raw source; path must be absolute and arguments use shell-style quoting | `""` |

--- a/docs/env.md
+++ b/docs/env.md
@@ -60,6 +60,7 @@
 | LVMSYNC_SKIP_SNAPSHOT_CREATION | `--skip-snapshot-creation` | `skip-snapshot-creation` | Skip snapshot creation |
 | LVMSYNC_SNAPSHOT_SIZE | `--snapshot-size` | `snapshot-size` | Snapshot size (bytes or percentage) |
 | LVMSYNC_SOURCE_TYPE | `--source-type` | `source-type` | Source device type (auto,file,raw,lvm) |
+| LVMSYNC_SPARSE | `--sparse` | `sparse` | Sparse file handling: auto or never |
 | LVMSYNC_SPEED | `--speed` | `speed` | Transfer speed limit |
 | LVMSYNC_SSH_HOST | `--ssh-host` | `ssh-host` | SSH host |
 | LVMSYNC_SSH_HOST_KEY | `--ssh-host-key` | `ssh-host-key` | Expected SSH host public key |

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -38,6 +38,7 @@ type Config struct {
 	AllowOverwrite           bool          `mapstructure:"allow_overwrite"`
 	Discard                  bool          `mapstructure:"discard"`
 	Offline                  bool          `mapstructure:"offline"`
+	Sparse                   string        `mapstructure:"sparse"`
 	FSFreezeCommand          string        `mapstructure:"fs-freeze-command"`
 	FSThawCommand            string        `mapstructure:"fs-thaw-command"`
 	FreezeTimeout            time.Duration `mapstructure:"freeze-timeout"`
@@ -180,6 +181,7 @@ func DefaultConfig() (*Config, error) {
 		Force:                    false,
 		AllowOverwrite:           false,
 		Offline:                  false,
+		Sparse:                   Auto,
 		FSFreezeCommand:          "",
 		FSThawCommand:            "",
 		FreezeTimeout:            10 * time.Second,

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -62,6 +62,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("allow-overwrite", cfg.AllowOverwrite, "Skip interactive confirmation when using --force")
 	fs.Bool("discard", cfg.Discard, "Issue BLKDISCARD before writing blocks")
 	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")
+	fs.String("sparse", cfg.Sparse, "Sparse file handling: auto or never")
 	fs.String("fs-freeze-command", cfg.FSFreezeCommand, "Command to freeze filesystem before reading raw source")
 	fs.String("fs-thaw-command", cfg.FSThawCommand, "Command to thaw filesystem after reading raw source")
 	fs.Duration("freeze-timeout", cfg.FreezeTimeout, "Timeout for filesystem freeze command")

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -192,6 +192,52 @@ func TestPlanEnvOverridesYAML(t *testing.T) {
 		t.Fatalf("Plan=%v want true", cfg.Plan)
 	}
 }
+
+func TestSparseFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("sparse: never\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_SPARSE", "never")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--sparse", "auto"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.Sparse != "auto" {
+		t.Fatalf("Sparse=%q want %q", cfg.Sparse, "auto")
+	}
+}
+
+func TestSparseEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("sparse: auto\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_SPARSE", "never")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.Sparse != "never" {
+		t.Fatalf("Sparse=%q want %q", cfg.Sparse, "never")
+	}
+}
 func TestParallelFlagOverridesEnvAndYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -244,6 +244,13 @@
       ],
       "type": "string"
     },
+    "sparse": {
+      "enum": [
+        "auto",
+        "never"
+      ],
+      "type": "string"
+    },
     "speed": {
       "type": "string"
     },

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -33,6 +33,9 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.Output != "" && c.Output != "text" && c.Output != "json" {
 		return fmt.Errorf("invalid output %q: must be \"text\" or \"json\"", c.Output)
 	}
+	if c.Sparse != "" && c.Sparse != Auto && c.Sparse != "never" {
+		return fmt.Errorf("invalid sparse %q: must be %q or %q", c.Sparse, Auto, "never")
+	}
 	if c.FSFreezeCommand != "" {
 		parts, err := shellquote.Split(c.FSFreezeCommand)
 		if err != nil {

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -72,6 +72,9 @@ func (b *builder) applyDefaults(conf *Config) error {
 	if !isSet(b.v, "manifest-allow-mounted") {
 		conf.ManifestAllowMounted = b.defaults.ManifestAllowMounted
 	}
+	if conf.Sparse == "" {
+		conf.Sparse = b.defaults.Sparse
+	}
 
 	if conf.LVMEscalation == "" {
 		conf.LVMEscalation = b.defaults.LVMEscalation

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -78,7 +78,8 @@ func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup Deduplicati
 }
 
 // write consumes block records from reader and writes them to the destination
-// file. It applies sparse punching for zero ranges, performs optional
+// file. It punches sparse holes for zero ranges when cfg.Sparse != "never",
+// performs optional
 // checksum verification, and issues fdatasync calls after each configured
 // interval. It returns the total number of bytes written.
 func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {

--- a/transfer/sparse_never_linux_test.go
+++ b/transfer/sparse_never_linux_test.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package transfer
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"lvmsync_go/internal/config"
+)
+
+func TestSparseNeverLoopback(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	if _, err := exec.LookPath("losetup"); err != nil {
+		t.Skip("losetup not installed")
+	}
+	fsTypes := []struct {
+		name string
+		mkfs []string
+	}{
+		{"ext4", []string{"mkfs.ext4", "-F", "-q"}},
+		{"xfs", []string{"mkfs.xfs", "-f"}},
+	}
+	for _, fs := range fsTypes {
+		t.Run(fs.name, func(t *testing.T) {
+			if _, err := exec.LookPath(fs.mkfs[0]); err != nil {
+				t.Skipf("%s not installed", fs.mkfs[0])
+			}
+			dir := t.TempDir()
+			img := filepath.Join(dir, "img")
+			f, err := os.Create(img)
+			if err != nil {
+				t.Fatalf("create img: %v", err)
+			}
+			if err := f.Truncate(32 << 20); err != nil {
+				t.Fatalf("truncate: %v", err)
+			}
+			f.Close()
+			out, err := exec.Command("losetup", "--find", "--show", img).CombinedOutput()
+			if err != nil {
+				t.Skipf("losetup failed: %v %s", err, out)
+			}
+			loop := strings.TrimSpace(string(out))
+			t.Cleanup(func() { exec.Command("losetup", "-d", loop).Run() })
+			mkfsCmd := append(fs.mkfs, loop)
+			if out, err := exec.Command(mkfsCmd[0], mkfsCmd[1:]...).CombinedOutput(); err != nil {
+				t.Skipf("mkfs failed: %v %s", err, out)
+			}
+			mnt := filepath.Join(dir, "mnt")
+			if err := os.Mkdir(mnt, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if out, err := exec.Command("mount", loop, mnt).CombinedOutput(); err != nil {
+				t.Skipf("mount failed: %v %s", err, out)
+			}
+			t.Cleanup(func() { exec.Command("umount", mnt).Run() })
+			path := filepath.Join(mnt, "file")
+			dest, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+			if err != nil {
+				t.Fatalf("open dest: %v", err)
+			}
+			defer dest.Close()
+			bs := 4096
+			if _, err := dest.Write(bytes.Repeat([]byte{1}, bs)); err != nil {
+				t.Fatalf("write prefix: %v", err)
+			}
+			cfg := &config.Config{BlockSize: bs, Sparse: "never"}
+			if err := writeZeroBlock(cfg, dest, uint64(bs), zap.NewNop()); err != nil {
+				t.Fatalf("writeZeroBlock: %v", err)
+			}
+			off, err := unix.Seek(int(dest.Fd()), int64(bs), unix.SEEK_DATA)
+			if err != nil {
+				t.Fatalf("seek data: %v", err)
+			}
+			if off != int64(bs) {
+				t.Fatalf("expected data at %d got %d", bs, off)
+			}
+			buf := make([]byte, bs)
+			if _, err := dest.ReadAt(buf, int64(bs)); err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if !bytes.Equal(buf, make([]byte, bs)) {
+				t.Fatalf("expected zero block")
+			}
+		})
+	}
+}

--- a/transfer/zero.go
+++ b/transfer/zero.go
@@ -51,12 +51,12 @@ func isAllZero(b []byte) bool {
 	return bytes.Equal(b, zeroBuf(len(b)))
 }
 
-// writeZeroBlock attempts to punch a sparse hole at the given offset. If the
-// filesystem does not support hole punching it falls back to writing a zero
-// filled buffer. The buffer respects the O_DIRECT setting by using aligned
-// allocations when necessary.
+// writeZeroBlock attempts to punch a sparse hole at the given offset unless
+// cfg.Sparse is "never". If the filesystem does not support hole punching it
+// falls back to writing a zero filled buffer. The buffer respects the O_DIRECT
+// setting by using aligned allocations when necessary.
 func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *zap.Logger) error {
-	if !punchHoleDisabled.Load() {
+	if cfg.Sparse != "never" && !punchHoleDisabled.Load() {
 		if err := punchHoleFunc(dest, offset, cfg.BlockSize); err == nil {
 			return nil
 		} else if errors.Is(err, unix.ENOTSUP) {


### PR DESCRIPTION
## Summary
- add `--sparse` flag and config/env bindings
- document sparse handling and defaults
- add loopback tests ensuring `--sparse=never` writes zero blocks

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameters, package comments, etc.)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a463c98bfc83238262c2980363e8bc