### PR TITLE
manifest: test regenerate size mismatch

### DIFF
--- a/manifest/rebuild_test.go
+++ b/manifest/rebuild_test.go
@@ -112,3 +112,58 @@ func TestRegenerateExisting(t *testing.T) {
 		t.Fatalf("manifest should not change when up to date")
 	}
 }
+
+func TestRegenerateSizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	dev := filepath.Join(dir, "dev")
+	orig := []byte("aaaabbbb")
+	if err := os.WriteFile(dev, orig, 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+	man := filepath.Join(dir, "dev.man")
+	size := uint64(len(orig))
+	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &mockDevice{path: dev, size: size, blockSize: 4}, nil
+	}
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
+	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	before, err := os.Stat(man)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	enlarged := []byte("aaaabbbbcccc")
+	if err := os.WriteFile(dev, enlarged, 0o600); err != nil {
+		t.Fatalf("enlarge device: %v", err)
+	}
+	size = uint64(len(enlarged))
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("regenerate: %v", err)
+	}
+	after, err := os.Stat(man)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("manifest not rebuilt on size mismatch")
+	}
+	idx, err := Open(man)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer idx.Close()
+	if idx.hdr.SizeBytes != uint64(len(enlarged)) || idx.hdr.ChunkCount != uint64(len(enlarged))/4 {
+		t.Fatalf("unexpected header: size %d chunks %d", idx.hdr.SizeBytes, idx.hdr.ChunkCount)
+	}
+	off, length, _, xx, dig, err := idx.Entry(2)
+	if err != nil {
+		t.Fatalf("entry: %v", err)
+	}
+	if off != 8 || length != 4 {
+		t.Fatalf("unexpected entry metadata")
+	}
+	if xx != xxh3.Hash(enlarged[8:12]) || dig != blake3.Sum256(enlarged[8:12]) {
+		t.Fatalf("manifest not rebuilt correctly")
+	}
+}


### PR DESCRIPTION
## Summary
- add TestRegenerateSizeMismatch to ensure Regenerate rebuilds manifest when device grows

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1013 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b5fef9483238e17c4e90a899b2f