### PR TITLE
Add compressed resume integration test

### DIFF
--- a/integration/framed_resume.sh
+++ b/integration/framed_resume.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+SRC_LOOP=""
+DST_LOOP=""
+cleanup() {
+  set +e
+  lvremove -f vgsrc/snap vgsrc/origin vgd/dest >/dev/null 2>&1
+  vgremove -f vgsrc vgd >/dev/null 2>&1
+  if [ -n "$SRC_LOOP" ]; then
+    pvremove -ff "$SRC_LOOP" >/dev/null 2>&1
+    losetup -d "$SRC_LOOP" >/dev/null 2>&1
+  fi
+  if [ -n "$DST_LOOP" ]; then
+    pvremove -ff "$DST_LOOP" >/dev/null 2>&1
+    losetup -d "$DST_LOOP" >/dev/null 2>&1
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+BIN="$TMPDIR/lvmsync"
+go build -o "$BIN" .
+
+# Prepare source LV
+SRC_IMG="$TMPDIR/src.img"
+dd if=/dev/urandom of="$SRC_IMG" bs=1M count=64
+SRC_LOOP=$(losetup --find --show "$SRC_IMG")
+pvcreate -ffy "$SRC_LOOP"
+vgcreate vgsrc "$SRC_LOOP"
+lvcreate -n origin -L 32M vgsrc
+dd if=/dev/urandom of=/dev/vgsrc/origin bs=1M count=32
+lvcreate -s -n snap -L 32M vgsrc/origin
+
+# Prepare destination LV
+DST_IMG="$TMPDIR/dst.img"
+dd if=/dev/zero of="$DST_IMG" bs=1M count=64
+DST_LOOP=$(losetup --find --show "$DST_IMG")
+pvcreate -ffy "$DST_LOOP"
+vgcreate vgd "$DST_LOOP"
+lvcreate -n dest -L 32M vgd
+
+STATE="$TMPDIR/state.json"
+# Run with compression and kill mid-frame after at least one frame
+"$BIN" run --speed=2M --block-size=1M --compress auto --output=json --resume="$STATE" /dev/vgsrc/snap /dev/vgd/dest >"$TMPDIR/first.log" 2>&1 &
+PID=$!
+# allow first 1M frame to complete and second to start
+sleep 0.8
+kill -9 $PID || true
+if [ ! -f "$STATE" ]; then
+  echo "resume state missing"
+  exit 1
+fi
+BYTES1=$(grep '"bytes_transferred"' "$TMPDIR/first.log" | tail -1 | sed -E 's/.*"bytes_transferred":([0-9]+).*/\1/')
+BLOCK=$((1024*1024))
+if [ "$BYTES1" -lt "$BLOCK" ] || [ "$BYTES1" -ge $((2*BLOCK)) ]; then
+  echo "mid-frame drop did not occur"
+  exit 1
+fi
+
+"$BIN" run --speed=2M --block-size=1M --compress auto --output=json --resume="$STATE" /dev/vgsrc/snap /dev/vgd/dest >"$TMPDIR/resume.log" 2>&1
+BYTES2=$(grep '"bytes_transferred"' "$TMPDIR/resume.log" | tail -1 | sed -E 's/.*"bytes_transferred":([0-9]+).*/\1/')
+TOTAL=$(grep '"bytes_total"' "$TMPDIR/resume.log" | tail -1 | sed -E 's/.*"bytes_total":([0-9]+).*/\1/')
+if [ $((BYTES1 + BYTES2)) -ne "$TOTAL" ]; then
+  echo "resume transfer mismatch"
+  exit 1
+fi
+if [ "$BYTES2" -ge "$TOTAL" ]; then
+  echo "resume re-sent data"
+  exit 1
+fi
+"$BIN" verify /dev/vgsrc/snap /dev/vgd/dest
+exit 0

--- a/integration/framed_resume_test.go
+++ b/integration/framed_resume_test.go
@@ -1,0 +1,17 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestFramedResumeWithCompression(t *testing.T) {
+	cmd := exec.Command("bash", "./integration/framed_resume.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("framed resume integration failed: %v\n%s", err, out)
+	}
+}


### PR DESCRIPTION
## Summary
- test resuming compressed transfers without resending completed frames

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: many lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b6001b083238310fcba95fac428