### PR TITLE
docs: document bloom defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,9 @@ The three values must be positive, with `--cdc-min` at least 64 bytes, and satis
 LVMSync aborts when the sizes are non-positive, below the minimum, or unordered.
 
 The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom-entries` and desired false positive rate via `--bloom-fp-rate`. For an mmap-backed index, `--bloom-mbits` controls the bitmap size in megabits.
+The defaults (`--bloom-entries=1000000`, `--bloom-fp-rate=0.01`) consume about
+1.14 MiB and yield ~1% false positives, while `--bloom-mbits=27` allocates
+roughly 16 MiB for ~0.8% false positives.
 
 Compression samples 8 KiB from each chunk and skips when the estimated ratio exceeds `--compress-threshold`. `--compress auto` selects LZ4 for chunks under 256 KiB and Zstd for larger chunks when AVX2 or NEON is available, falling back to LZ4 otherwise.
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -111,7 +111,10 @@ value to its entry index. To avoid unnecessary BLAKE3 computations, every
 that range. During `Match`, the Bloom filter for the chunk's range is checked
 first; only if it may contain the hash does the hash table probe proceed and, if
 needed, the strong digest is computed. `Rebuild` streams the device and
-populates both the hash table and Bloom filters on the fly.
+populates both the hash table and Bloom filters on the fly. The default filter
+settings (`--bloom-entries=1000000`, `--bloom-fp-rate=0.01`) consume about
+1.14 MiB with ~1% false positives, while enabling the optional mmap index with
+`--bloom-mbits=27` allocates roughly 16 MiB for ~0.8% false positives.
 
 Device identifiers are stored in a fixed 64-byte field; creation fails if the
 ID exceeds this limit.

--- a/perf.md
+++ b/perf.md
@@ -248,14 +248,21 @@ Benchmarks were recorded from commit `c3a2374`.
 ### Command
 
 ```sh
-go test -bench BloomLookup -run ^$ /tmp/bloom_lookup_test.go -bloom_entries=N -bloom_fp_rate=R
+go test -bench BloomLookup -run ^$ /tmp/bloom_lookup_test.go -bloom_mbits=MBITS
 ```
 
-### Default Parameters
+### Default Sizing
 
-- `--bloom-entries`: `1000000`
-- `--bloom-fp-rate`: `0.01`
-- Memory footprint: ~1.14 MiB
+With the default filter settings (`--bloom-entries=1000000` and
+`--bloom-fp-rate=0.01`, ~1.14 MiB for ~1% false positives), the optional
+memory-mapped index is sized with `--bloom-mbits`:
+
+| `--bloom-mbits` | Memory (MiB) | Approx FP Rate |
+|----------------:|-------------:|---------------:|
+| 24              | 2            | ~6%            |
+| 26              | 8            | ~1.5%          |
+| 27              | 16           | ~0.8%          |
+| 28              | 32           | ~0.4%          |
 
 ### Results
 


### PR DESCRIPTION
## Summary
- document bloom filter defaults and benchmark command
- describe default bloom memory usage and false-positive rates
- cross-reference bloom filter defaults in manifest docs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: many unchecked errors and lints)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b6550448323b990b9720afdf2bb