### PR TITLE
Enforce insecure flag for rsync transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ no additional coordination.
 LVMSync negotiates transports in the order provided by `--transport` (default
 `ssh,tcp+tls,h2,quic`). All transports require TLS 1.3 with mutual
 authentication or SSH host key verification unless `--allow-insecure` is set.
-See [docs/transports.md](docs/transports.md) for details.
+The `rsync` transport is plaintext and refuses to initialize unless
+`--allow-insecure` acknowledges the lack of encryption. See
+[docs/transports.md](docs/transports.md) for details.
 
 | Transport | Security defaults | Notes |
 |-----------|------------------|-------|
@@ -124,6 +126,7 @@ See [docs/transports.md](docs/transports.md) for details.
 | `h2`      | TLS 1.3                | HTTP/2 streams |
 | `tcp+tls` | TLS 1.3                | Plain TCP wrapped in TLS |
 | `ssh`     | Host key verification  | Uses OpenSSH-style authentication |
+| `rsync`   | Plaintext, requires `--allow-insecure` | rsync wire protocol |
 
 ### Examples
 
@@ -720,7 +723,7 @@ SSH transport negotiation also derives read and write deadlines from the caller'
 - **Rsync delta with dedup and compression**:
 
   ```sh
-  lvmsync run --delta=rsync --dedup-strategy bloom --compress lz4 --transport rsync --dry-run /tmp/src /tmp/dst
+  lvmsync run --delta=rsync --dedup-strategy bloom --compress lz4 --transport rsync --allow-insecure --dry-run /tmp/src /tmp/dst
   ```
 
 - **Throughput-optimized transfer**:

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -124,5 +124,5 @@ lvmsyncd --listen quic://:12000 --server-cert cert.pem --server-key key.pem --cl
 - Plain TCP; no encryption or authentication
 - Interoperates with upstream `rsyncd` implementations (e.g., OpenRSYNC on macOS 15)
 - Known issue: macOS 15 ships OpenRSYNC 0.6 which may abort large transfers; verify with upstream rsync if issues arise
-- Security: traffic is unencrypted and unauthenticated. Run only on trusted networks or within secure tunnels
-- Flags: `--transport rsync` selects this transport
+- Security: traffic is unencrypted and unauthenticated. `--allow-insecure` must be set and connections should only run on trusted networks or within secure tunnels
+- Flags: `--transport rsync` selects this transport and requires `--allow-insecure`

--- a/transport/rsyncwire/rsync_integration_test.go
+++ b/transport/rsyncwire/rsync_integration_test.go
@@ -67,7 +67,7 @@ func TestNegotiateWithRsyncDaemon(t *testing.T) {
 		t.Fatalf("daemon not ready: %v", readyErr)
 	}
 
-	tr, err := New(transport.Config{Logger: zap.NewNop()})
+	tr, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestNegotiateBadGreeting(t *testing.T) {
 		c2.Write([]byte("bad\n"))
 		c2.Close()
 	}()
-	tr, err := New(transport.Config{Logger: zap.NewNop()})
+	tr, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestNegotiateBadGreeting(t *testing.T) {
 
 func TestServerHandshake(t *testing.T) {
 	c1, c2 := net.Pipe()
-	tr, err := New(transport.Config{Logger: zap.NewNop()})
+	tr, err := New(transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
 	if err != nil {
 		t.Fatalf("new transport: %v", err)
 	}

--- a/transport/rsyncwire/rsyncwire.go
+++ b/transport/rsyncwire/rsyncwire.go
@@ -28,6 +28,9 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()
 	}
+	if !cfg.AllowInsecure {
+		return nil, fmt.Errorf("rsync transport requires AllowInsecure")
+	}
 	return &Transport{logger: cfg.Logger}, nil
 }
 

--- a/transport/rsyncwire/rsyncwire_test.go
+++ b/transport/rsyncwire/rsyncwire_test.go
@@ -1,0 +1,15 @@
+package rsyncwire
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/transport"
+)
+
+func TestRequiresAllowInsecure(t *testing.T) {
+	if _, err := New(transport.Config{Logger: zap.NewNop()}); err == nil {
+		t.Fatalf("expected error when AllowInsecure is false")
+	}
+}


### PR DESCRIPTION
## Summary
- prevent rsync transport initialization unless AllowInsecure is set
- document that `--allow-insecure` is mandatory when using `--transport rsync`
- add unit test for missing AllowInsecure

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameter, package-comments, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a46b69613083239527b9560dbedc11