### PR TITLE
Require --force when skipping snapshots

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -32,6 +32,14 @@ lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
 
 Reads both devices and reports mismatches without writing data.
 
+## Skipping Snapshot Creation
+
+`--skip-snapshot-creation` uses the source volume directly without creating a snapshot. To confirm the operator understands the risk, this flag must be combined with `--force`:
+
+```sh
+lvmsync run --skip-snapshot-creation --force /dev/vg0/src /dev/vg0/target
+```
+
 ## Safe Overwrite Procedure
 
 1. Probe devices and ensure privileges are correct:

--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--lz4-level` | `LVMSYNC_COMPRESSION_LZ4_LEVEL` | `lz4_level` | LZ4 compression level: `fast` or `hc` |
 | `--compress-concurrency` | `LVMSYNC_COMPRESSION_COMPRESS_CONCURRENCY` | `compress_concurrency` | Compression concurrency (0 to use `GOMAXPROCS`) |
 | `--compress-threshold` | `LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD` | `compress_threshold` | Skip compression when estimated ratio exceeds this value |
-| `--skip-snapshot-creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation |
+| `--skip-snapshot-creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation (requires `--force`) |
 | `--skip-disk-check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot-size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
 | `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; parsed with shell-style quoting and validated at startup |

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -143,6 +143,9 @@ func (r *Runner) createSnapshotIfNeeded(ctx context.Context, cfg *config.Config,
 	cleanup := func() {}
 
 	if cfg.SkipSnapshotCreation {
+		if !cfg.Force {
+			return "", nil, nil, fmt.Errorf("skip snapshot creation requires --force")
+		}
 		return snapshotPath, monitorErrCh, cleanup, nil
 	}
 

--- a/internal/client/snapshot_test.go
+++ b/internal/client/snapshot_test.go
@@ -20,6 +20,7 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 		t.Fatalf("DefaultConfig error: %v", err)
 	}
 	cfg.SkipSnapshotCreation = true
+	cfg.Force = true
 	cfg.SkipDiskCheck = true
 	cfg.VolumeGroup = "vg"
 	cfg.TargetVolumeGroup = "vg2"
@@ -38,6 +39,24 @@ func TestPrepareSkipSnapshot(t *testing.T) {
 		t.Fatalf("expected nil monitor channel")
 	}
 	cleanup()
+}
+
+func TestPrepareSkipSnapshotRequiresForce(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.SkipSnapshotCreation = true
+	cfg.SkipDiskCheck = true
+	cfg.VolumeGroup = "vg"
+	cfg.TargetVolumeGroup = "vg2"
+
+	r := client.NewRunnerWithDeps(func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 1, nil }, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	logger := zap.NewNop()
+	if _, _, _, err := r.PrepareSnapshot(context.Background(), cfg, "/dev/vg/orig", logger); err == nil {
+		t.Fatalf("expected error when skipping snapshot without force")
+	}
 }
 
 func TestPrepareSnapshotCreatesSnapshot(t *testing.T) {


### PR DESCRIPTION
## Summary
- error if --skip-snapshot-creation is used without --force
- test skipping snapshots with and without --force
- document that --force is mandatory when bypassing snapshots

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unused parameters, missing comments, many lint findings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4741e07f883239eb39f5ef2bd291d