### PR TITLE
refactor: require explicit loggers

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -227,9 +227,6 @@ func Execute(args []string, logger *zap.Logger) error {
 // ExecuteWithRunner runs the command tree using the provided Runner.
 // If args is nil, the global os.Args are used by cobra.
 func ExecuteWithRunner(args []string, logger *zap.Logger, r *Runner) error {
-	if logger == nil {
-		return fmt.Errorf("nil logger")
-	}
 	defer rootcmd.SyncLogger(logger)
 	cmd := NewRootCmd(logger, r)
 	if args != nil {
@@ -239,9 +236,6 @@ func ExecuteWithRunner(args []string, logger *zap.Logger, r *Runner) error {
 }
 
 func estimateTransfer(src string, cfg *config.Config, logger *zap.Logger) error {
-	if logger == nil {
-		return fmt.Errorf("nil logger")
-	}
 	info, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("stat source: %w", err)

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -289,14 +289,25 @@ func TestEstimateTransferMissingManifest(t *testing.T) {
 	}
 }
 
-func TestExecuteWithRunnerNilLoggerError(t *testing.T) {
-	if err := ExecuteWithRunner([]string{"run", "src", "dst"}, nil, nil); err == nil {
-		t.Fatalf("expected error")
-	}
+func TestExecuteWithRunnerNilLoggerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	_ = ExecuteWithRunner([]string{"run", "src", "dst"}, nil, nil)
 }
 
-func TestEstimateTransferNilLoggerError(t *testing.T) {
-	if err := estimateTransfer("", &config.Config{}, nil); err == nil {
-		t.Fatalf("expected error")
+func TestEstimateTransferNilLoggerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	f, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
 	}
+	f.Close()
+	_ = estimateTransfer(f.Name(), &config.Config{}, nil)
 }

--- a/cmd/lvmsyncd/lvmsyncd.go
+++ b/cmd/lvmsyncd/lvmsyncd.go
@@ -90,9 +90,6 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 }
 
 func run(args []string, logger *zap.Logger) error {
-	if logger == nil {
-		return fmt.Errorf("nil logger")
-	}
 	defer rootcmd.SyncLogger(logger)
 
 	v := viper.New()

--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -151,8 +151,11 @@ func TestExitCodeMapping(t *testing.T) {
 	}
 }
 
-func TestRunNilLoggerError(t *testing.T) {
-	if err := run([]string{}, nil); err == nil {
-		t.Fatalf("expected error")
-	}
+func TestRunNilLoggerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	_ = run([]string{}, nil)
 }

--- a/cmd/manifest/rebuild.go
+++ b/cmd/manifest/rebuild.go
@@ -41,9 +41,6 @@ func init() {
 
 // Run executes manifest subcommands.
 func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) error {
-	if logger == nil {
-		return fmt.Errorf("nil logger")
-	}
 	defer rootcmd.SyncLogger(logger)
 	if len(args) == 0 {
 		fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -176,15 +176,18 @@ func TestRunMissingArgs(t *testing.T) {
 	}
 }
 
-func TestRunNilLoggerError(t *testing.T) {
+func TestRunNilLoggerPanics(t *testing.T) {
 	cfg, err := config.DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 	r := NewRunner()
-	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, nil); err == nil {
-		t.Fatalf("expected error")
-	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	_ = r.Run(cfg, []string{"rebuild", "/dev/test"}, nil)
 }
 
 func TestRunAppliesManifestTimeout(t *testing.T) {

--- a/cmd/root/plan.go
+++ b/cmd/root/plan.go
@@ -38,9 +38,6 @@ const (
 )
 
 func emitPlan(cfg *config.Config, args []string, logger *zap.Logger) error {
-	if logger == nil {
-		return fmt.Errorf("nil logger")
-	}
 	if len(args) < 1 {
 		return fmt.Errorf("missing source argument")
 	}

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -45,9 +45,6 @@ func init() {
 // Run executes the verify command with the provided arguments and logger.
 // Args should exclude the "verify" subcommand itself.
 func (r *Runner) Run(args []string, logger *zap.Logger) error {
-	if logger == nil {
-		return fmt.Errorf("nil logger")
-	}
 	defer rootcmd.SyncLogger(logger)
 	cmd := &cobra.Command{
 		Use:                "verify [flags] <source> <dest>",

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -162,10 +162,13 @@ func TestVerifyWithManifestAllocations(t *testing.T) {
 	}
 }
 
-func TestRunNilLoggerError(t *testing.T) {
-	if err := Run([]string{"--dry-run", "src", "dst"}, nil); err == nil {
-		t.Fatalf("expected error")
-	}
+func TestRunNilLoggerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	_ = Run([]string{"--dry-run", "src", "dst"}, nil)
 }
 
 func TestVerifyDevicesRebuildsManifest(t *testing.T) {

--- a/device/discard_linux.go
+++ b/device/discard_linux.go
@@ -14,9 +14,6 @@ import (
 )
 
 func blkdiscard(f *os.File, offset, length uint64, logger *zap.Logger) error {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	if reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{}, logger); err != nil {
 		return err
 	} else if reexeced {

--- a/device/discard_linux_test.go
+++ b/device/discard_linux_test.go
@@ -45,3 +45,17 @@ func TestDiscardRangeStubAndRestore(t *testing.T) {
 		t.Fatalf("stub called after restore: %d", calls)
 	}
 }
+
+func TestDiscardRangeNilLoggerPanics(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "discard")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer f.Close()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	_ = DiscardRange(f, 0, 0, nil)
+}

--- a/device/raw.go
+++ b/device/raw.go
@@ -84,9 +84,6 @@ func prepareFreeze(
 
 // openDevice ensures the path is a block device and opens it for reading and writing.
 func openDevice(path string, logger *zap.Logger) (*os.File, error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	if reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{}, logger); err != nil {
 		return nil, err
 	} else if reexeced {

--- a/device/raw_helpers_test.go
+++ b/device/raw_helpers_test.go
@@ -66,6 +66,15 @@ func TestOpenDeviceFailure(t *testing.T) {
 	}
 }
 
+func TestOpenDeviceNilLoggerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	openDevice("", nil)
+}
+
 func TestQueryDeviceInfoSuccess(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root")

--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -77,9 +77,6 @@ func IsRoot(opts Options) bool {
 // If not root, re-execs the current binary through `sudo -n` and returns (true, err).
 // When (true, nil) is returned, the caller should exit immediately.
 func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	argv := opts.Args
 	if argv == nil {
 		argv = os.Args
@@ -152,9 +149,6 @@ func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
 // via sudo (SUDO_UID/SUDO_GID). No-op if those env vars are absent.
 // Dependency seams are provided via opts.
 func DropToInvokerIfSudo(opts Options, logger *zap.Logger) error {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	argv := opts.Args
 	if argv == nil {
 		argv = os.Args

--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -47,13 +47,9 @@ type Server struct {
 	lv      string
 }
 
-// New constructs a Server using the provided Device and logger. The digest
-// algorithm and expected sum are supplied via a later digest frame. A nil
-// logger is replaced with zap.NewNop().
+// New constructs a Server using the provided Device and logger.
+// The digest algorithm and expected sum are supplied via a later digest frame.
 func New(dev Device, logger *zap.Logger, cache *signaturecache.Cache, vg, lv string) *Server {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	return &Server{dev: dev, logger: logger, cache: cache, vg: vg, lv: lv}
 }
 

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -100,14 +100,6 @@ func TestHandleApplyDelta(t *testing.T) {
 	}
 }
 
-func TestNewNilLoggerDefaults(t *testing.T) {
-	dev := &memDevice{}
-	srv := New(dev, nil, nil, "", "")
-	if srv.logger == nil {
-		t.Fatalf("expected non-nil logger")
-	}
-}
-
 func TestHandleShortWrite(t *testing.T) {
 	c1, c2 := net.Pipe()
 	defer c1.Close()

--- a/lvm/fd_cache.go
+++ b/lvm/fd_cache.go
@@ -31,9 +31,6 @@ func NewFDCache(size int, logger *zap.Logger) (*FDCache, error) {
 	if size <= 0 {
 		size = fdCacheSize
 	}
-	if logger == nil {
-		return nil, fmt.Errorf("nil logger")
-	}
 	return &FDCache{
 		fds:    make(map[string]*list.Element, size),
 		order:  list.New(),
@@ -49,9 +46,6 @@ func NewDeviceFDCache(logger *zap.Logger) (*FDCache, error) {
 
 // SetLogger updates the logger used by the cache.
 func (c *FDCache) SetLogger(logger *zap.Logger) error {
-	if logger == nil {
-		return fmt.Errorf("nil logger")
-	}
 	c.logger = logger
 	return nil
 }

--- a/lvm/fdcache_test.go
+++ b/lvm/fdcache_test.go
@@ -10,20 +10,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestNewFDCacheNilLoggerError(t *testing.T) {
-	if _, err := NewFDCache(fdCacheSize, nil); err == nil {
-		t.Fatalf("expected error")
-	}
-}
-
-func TestSetLoggerNilError(t *testing.T) {
-	cache, err := NewFDCache(fdCacheSize, zap.NewNop())
+func TestFDCacheNilLoggerPanics(t *testing.T) {
+	cache, err := NewFDCache(fdCacheSize, nil)
 	if err != nil {
 		t.Fatalf("NewFDCache: %v", err)
 	}
-	if err := cache.SetLogger(nil); err == nil {
-		t.Fatalf("expected error")
-	}
+	cache.fds["bad"] = cache.order.PushBack(&fdCacheEntry{path: "bad", fd: -1})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	cache.Close()
 }
 
 func TestFDCacheEvictionOrder(t *testing.T) {

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -72,9 +72,6 @@ func GetOrdered(names []string, cfg Config) ([]Interface, error) {
 // message. If all transports fail to dial, an error is returned.
 func DialWithFallback(ctx context.Context, address string, names []string, cfg Config) (Interface, net.Conn, error) {
 	logger := cfg.Logger
-	if logger == nil {
-		return nil, nil, fmt.Errorf("logger is nil")
-	}
 	for _, name := range names {
 		logger.Info("dial_attempt", zap.String("transport", name))
 		tr, err := Get(name, cfg)

--- a/transport/registry_fallback_test.go
+++ b/transport/registry_fallback_test.go
@@ -86,9 +86,12 @@ func TestRegistryDialFallbackSequence(t *testing.T) {
 	}
 }
 
-func TestDialWithFallbackNilLogger(t *testing.T) {
+func TestDialWithFallbackNilLoggerPanics(t *testing.T) {
 	ctx := context.Background()
-	if _, _, err := DialWithFallback(ctx, "addr", []string{}, Config{}); err == nil {
-		t.Fatalf("expected error")
-	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	_, _, _ = DialWithFallback(ctx, "addr", []string{"tcp"}, Config{})
 }


### PR DESCRIPTION
## Summary
- drop nil logger fallbacks across helpers and commands
- add regression tests asserting nil loggers panic

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: many revive/staticcheck issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a474201d7c83238736bc2d9238cf34