### PR TITLE
Add major/minor numbers to device identity and manifest checks

### DIFF
--- a/cmd/dump/probe.go
+++ b/cmd/dump/probe.go
@@ -100,7 +100,9 @@ func manifestHeaderMAC(h *manifestpkg.Header) [32]byte {
 	binary.LittleEndian.PutUint32(buf[32:36], h.MaxChunkSize)
 	binary.LittleEndian.PutUint32(buf[36:40], h.HybridFixedSize)
 	binary.LittleEndian.PutUint64(buf[40:48], h.Epoch)
-	copy(buf[48:112], h.DeviceID[:])
-	copy(buf[112:144], h.FirstBlockDigest[:])
+	binary.LittleEndian.PutUint32(buf[48:52], h.Major)
+	binary.LittleEndian.PutUint32(buf[52:56], h.Minor)
+	copy(buf[56:120], h.DeviceID[:])
+	copy(buf[120:152], h.FirstBlockDigest[:])
 	return blake3.Sum256(buf[:])
 }

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -245,7 +245,7 @@ func TestEstimateTransferWithManifest(t *testing.T) {
 		t.Fatalf("write src: %v", err)
 	}
 	manifestPath := dir + "/manifest"
-	idx, err := manifest.Create(manifestPath, "id", 8, 0, 4, 0, 0, 0, 0)
+	idx, err := manifest.Create(manifestPath, "id", 8, 0, 0, 0, 4, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("create manifest: %v", err)
 	}

--- a/cmd/manifest/compact_test.go
+++ b/cmd/manifest/compact_test.go
@@ -19,7 +19,7 @@ const compactEntrySize = 56
 func TestRunCompactReordersEntries(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.man")
-	idx, err := manifestpkg.Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := manifestpkg.Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/cmd/manifest/gc_test.go
+++ b/cmd/manifest/gc_test.go
@@ -19,7 +19,7 @@ const entrySize = 56
 func TestRunGCRemovesDuplicates(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.man")
-	idx, err := manifestpkg.Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := manifestpkg.Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/cmd/verify/resume_verify_integration_test.go
+++ b/cmd/verify/resume_verify_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
+	"golang.org/x/sys/unix"
 	"lvmsync_go/common"
 	"lvmsync_go/device"
 	hashutil "lvmsync_go/hash"
@@ -58,7 +59,11 @@ func TestResumeVerifySuccess(t *testing.T) {
 		t.Fatalf("write dest: %v", err)
 	}
 	man := filepath.Join(dir, "dest.man")
-	idx, err := manifestpkg.Create(man, "uuid", uint64(len(data)), 0, uint32(blockSize), 0, 0, 0, 0)
+	var st unix.Stat_t
+	if err := unix.Stat(dest, &st); err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	idx, err := manifestpkg.Create(man, "uuid", uint64(len(data)), 0, uint32(unix.Major(uint64(st.Rdev))), uint32(unix.Minor(uint64(st.Rdev))), uint32(blockSize), 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("manifest create: %v", err)
 	}
@@ -124,7 +129,11 @@ func TestResumeVerifyMismatch(t *testing.T) {
 		t.Fatalf("write dest: %v", err)
 	}
 	man := filepath.Join(dir, "dest.man")
-	idx, err := manifestpkg.Create(man, "uuid", uint64(len(data)), 0, uint32(blockSize), 0, 0, 0, 0)
+	var st2 unix.Stat_t
+	if err := unix.Stat(dest, &st2); err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	idx, err := manifestpkg.Create(man, "uuid", uint64(len(data)), 0, uint32(unix.Major(uint64(st2.Rdev))), uint32(unix.Minor(uint64(st2.Rdev))), uint32(blockSize), 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("manifest create: %v", err)
 	}

--- a/cmd/verify/verify_mismatch_test.go
+++ b/cmd/verify/verify_mismatch_test.go
@@ -27,7 +27,7 @@ func TestRunLogsMismatchBlock(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
 	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
-		idx, err := manifestpkg.Create(output, "dev", 3, 0, 4096, 0, 0, 0, 0)
+		idx, err := manifestpkg.Create(output, "dev", 3, 0, 0, 0, 4096, 0, 0, 0, 0)
 		if err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func TestRunLogsMismatchBlockSHA256(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
 	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
-		idx, err := manifestpkg.Create(output, "dev", 3, 0, 4096, 0, 0, 0, 0)
+		idx, err := manifestpkg.Create(output, "dev", 3, 0, 0, 0, 4096, 0, 0, 0, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -75,7 +75,7 @@ func TestRunFlagOverridesEnvAndYAML(t *testing.T) {
 		t.Fatalf("write dst: %v", err)
 	}
 	manifestPath := src + ".manifest"
-	idx, err := manifestpkg.Create(manifestPath, "dev", uint64(len("foo")), 0, uint32(len("foo")), 0, 0, 0, 0)
+	idx, err := manifestpkg.Create(manifestPath, "dev", uint64(len("foo")), 0, 0, 0, uint32(len("foo")), 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("manifest create: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestVerifyWithManifestAllocations(t *testing.T) {
 	size := blockSize * 3
 	src := createTestFile(t, size)
 	manifestPath := filepath.Join(t.TempDir(), "manifest")
-	idx, err := manifestpkg.Create(manifestPath, "dev", uint64(size), 0, uint32(blockSize), 0, 0, 0, 0)
+	idx, err := manifestpkg.Create(manifestPath, "dev", uint64(size), 0, 0, 0, uint32(blockSize), 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("manifest create: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestVerifyDevicesRebuildsManifest(t *testing.T) {
 	called := false
 	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		called = true
-		idx, err := manifestpkg.Create(output, "dev", uint64(len("foo")), 0, 4096, 0, 0, 0, 0)
+		idx, err := manifestpkg.Create(output, "dev", uint64(len("foo")), 0, 0, 0, 4096, 0, 0, 0, 0)
 		if err != nil {
 			return err
 		}

--- a/device/identity.go
+++ b/device/identity.go
@@ -1,11 +1,14 @@
 package device
 
 // DeviceIdentity describes metadata uniquely identifying a block device.
+// The identity tuple is (size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor).
 type DeviceIdentity struct {
 	SizeBytes  uint64
 	KernelUUID string
 	GPTUUID    string
 	FSUUID     string
+	Major      uint32
+	Minor      uint32
 }
 
 // Range represents a byte range on a device.

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -104,9 +104,17 @@ func (d *LVMDevice) SizeBytes() uint64 { return d.size }
 // BlockSize returns the logical block size in bytes.
 func (d *LVMDevice) BlockSize() uint64 { return d.blockSize }
 
-// Identity gathers size, kernel uuid and GPT info for the logical volume.
+// Identity gathers size, device numbers and UUID info for the logical volume.
 func (d *LVMDevice) Identity() (DeviceIdentity, error) {
-	id := DeviceIdentity{SizeBytes: d.SizeBytes()}
+	var st unix.Stat_t
+	if err := unix.Stat(d.Path(), &st); err != nil {
+		return DeviceIdentity{}, err
+	}
+	id := DeviceIdentity{
+		SizeBytes: d.SizeBytes(),
+		Major:     uint32(unix.Major(uint64(st.Rdev))),
+		Minor:     uint32(unix.Minor(uint64(st.Rdev))),
+	}
 	out, err := exec.Command("lvs", "--noheadings", "-o", "lv_uuid", d.Path()).Output()
 	if err != nil {
 		return DeviceIdentity{}, err

--- a/device/raw.go
+++ b/device/raw.go
@@ -187,7 +187,15 @@ func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
 
 // Identity gathers size, kernel uuid and GPT information for the device.
 func (d *RawDevice) Identity() (DeviceIdentity, error) {
-	id := DeviceIdentity{SizeBytes: d.SizeBytes()}
+	var st unix.Stat_t
+	if err := unix.Stat(d.Path(), &st); err != nil {
+		return DeviceIdentity{}, err
+	}
+	id := DeviceIdentity{
+		SizeBytes: d.SizeBytes(),
+		Major:     uint32(unix.Major(uint64(st.Rdev))),
+		Minor:     uint32(unix.Minor(uint64(st.Rdev))),
+	}
 	out, err := exec.Command("blkid", "-o", "value", "-s", "UUID", d.Path()).Output()
 	if err != nil {
 		return DeviceIdentity{}, err

--- a/device/wal.go
+++ b/device/wal.go
@@ -10,12 +10,24 @@ import (
 )
 
 const (
-	walVersion      = 1
+	walVersion      = 2
 	walHeaderV0Size = 8 + 64 + 64 + 64 + 32
-	walHeaderSize   = 8 + walHeaderV0Size
+	walHeaderV1Size = 8 + 8 + 64 + 64 + 64 + 32
+	walHeaderSize   = 8 + 8 + 4 + 4 + 64 + 64 + 64 + 32
 )
 
 type walHeader struct {
+	Version uint64
+	Size    uint64
+	Major   uint32
+	Minor   uint32
+	Kernel  [64]byte
+	GPT     [64]byte
+	FS      [64]byte
+	MAC     [32]byte
+}
+
+type walHeaderV1 struct {
 	Version uint64
 	Size    uint64
 	Kernel  [64]byte
@@ -39,6 +51,18 @@ type WAL struct {
 }
 
 func walHeaderMAC(h *walHeader) [32]byte {
+	var buf [8 + 8 + 4 + 4 + 64 + 64 + 64]byte
+	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
+	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
+	binary.LittleEndian.PutUint32(buf[16:20], h.Major)
+	binary.LittleEndian.PutUint32(buf[20:24], h.Minor)
+	copy(buf[24:88], h.Kernel[:])
+	copy(buf[88:152], h.GPT[:])
+	copy(buf[152:], h.FS[:])
+	return blake3.Sum256(buf[:])
+}
+
+func walHeaderMACV1(h *walHeaderV1) [32]byte {
 	var buf [8 + 8 + 64 + 64 + 64]byte
 	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
 	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
@@ -74,6 +98,8 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 		var hdr walHeader
 		hdr.Version = walVersion
 		hdr.Size = id.SizeBytes
+		hdr.Major = id.Major
+		hdr.Minor = id.Minor
 		copy(hdr.Kernel[:], []byte(id.KernelUUID))
 		copy(hdr.GPT[:], []byte(id.GPTUUID))
 		copy(hdr.FS[:], []byte(id.FSUUID))
@@ -81,10 +107,12 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
 		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
-		copy(buf[16:80], hdr.Kernel[:])
-		copy(buf[80:144], hdr.GPT[:])
-		copy(buf[144:208], hdr.FS[:])
-		copy(buf[208:240], hdr.MAC[:])
+		binary.LittleEndian.PutUint32(buf[16:20], hdr.Major)
+		binary.LittleEndian.PutUint32(buf[20:24], hdr.Minor)
+		copy(buf[24:88], hdr.Kernel[:])
+		copy(buf[88:152], hdr.GPT[:])
+		copy(buf[152:216], hdr.FS[:])
+		copy(buf[216:248], hdr.MAC[:])
 		if _, err := f.Write(buf[:]); err != nil {
 			f.Close()
 			return nil, err
@@ -112,15 +140,17 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 		var hdr walHeader
 		hdr.Version = binary.LittleEndian.Uint64(buf[0:8])
 		hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
-		copy(hdr.Kernel[:], buf[16:80])
-		copy(hdr.GPT[:], buf[80:144])
-		copy(hdr.FS[:], buf[144:208])
-		copy(hdr.MAC[:], buf[208:240])
+		hdr.Major = binary.LittleEndian.Uint32(buf[16:20])
+		hdr.Minor = binary.LittleEndian.Uint32(buf[20:24])
+		copy(hdr.Kernel[:], buf[24:88])
+		copy(hdr.GPT[:], buf[88:152])
+		copy(hdr.FS[:], buf[152:216])
+		copy(hdr.MAC[:], buf[216:248])
 		if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
 			f.Close()
 			return nil, fmt.Errorf("wal: header mac mismatch")
 		}
-		if hdr.Size != id.SizeBytes ||
+		if hdr.Size != id.SizeBytes || hdr.Major != id.Major || hdr.Minor != id.Minor ||
 			string(hdr.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
 			string(hdr.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
 			string(hdr.FS[:len(id.FSUUID)]) != id.FSUUID {
@@ -141,6 +171,85 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 			off += 16
 		}
 		if _, err := f.Seek(off, 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		return w, nil
+	}
+
+	if ver == walVersion-1 && st.Size() >= walHeaderV1Size {
+		var buf1 [walHeaderV1Size]byte
+		if _, err := f.ReadAt(buf1[:], 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		var hdr1 walHeaderV1
+		hdr1.Version = binary.LittleEndian.Uint64(buf1[0:8])
+		hdr1.Size = binary.LittleEndian.Uint64(buf1[8:16])
+		copy(hdr1.Kernel[:], buf1[16:80])
+		copy(hdr1.GPT[:], buf1[80:144])
+		copy(hdr1.FS[:], buf1[144:208])
+		copy(hdr1.MAC[:], buf1[208:240])
+		if mac := walHeaderMACV1(&hdr1); mac != hdr1.MAC {
+			f.Close()
+			return nil, fmt.Errorf("wal: header mac mismatch")
+		}
+		if hdr1.Size != id.SizeBytes ||
+			string(hdr1.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
+			string(hdr1.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
+			string(hdr1.FS[:len(id.FSUUID)]) != id.FSUUID {
+			f.Close()
+			return nil, fmt.Errorf("wal: metadata mismatch")
+		}
+		data := make([]byte, st.Size()-walHeaderV1Size)
+		if _, err := f.ReadAt(data, walHeaderV1Size); err != nil && err != io.EOF {
+			f.Close()
+			return nil, err
+		}
+		var hdr walHeader
+		hdr.Version = walVersion
+		hdr.Size = hdr1.Size
+		hdr.Major = id.Major
+		hdr.Minor = id.Minor
+		hdr.Kernel = hdr1.Kernel
+		hdr.GPT = hdr1.GPT
+		hdr.FS = hdr1.FS
+		hdr.MAC = walHeaderMAC(&hdr)
+		var buf [walHeaderSize]byte
+		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
+		binary.LittleEndian.PutUint32(buf[16:20], hdr.Major)
+		binary.LittleEndian.PutUint32(buf[20:24], hdr.Minor)
+		copy(buf[24:88], hdr.Kernel[:])
+		copy(buf[88:152], hdr.GPT[:])
+		copy(buf[152:216], hdr.FS[:])
+		copy(buf[216:248], hdr.MAC[:])
+		if _, err := f.WriteAt(buf[:], 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if len(data) > 0 {
+			if _, err := f.WriteAt(data, walHeaderSize); err != nil {
+				f.Close()
+				return nil, err
+			}
+		}
+		if err := f.Truncate(int64(walHeaderSize + len(data))); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, err
+		}
+		w.header = hdr
+		w.ranges = []Range{}
+		for off := 0; off+16 <= len(data); off += 16 {
+			start := binary.LittleEndian.Uint64(data[off : off+8])
+			end := binary.LittleEndian.Uint64(data[off+8 : off+16])
+			w.ranges = append(w.ranges, Range{Start: start, End: end})
+		}
+		if _, err := f.Seek(int64(walHeaderSize+len(data)), 0); err != nil {
 			f.Close()
 			return nil, err
 		}
@@ -184,6 +293,8 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 		var hdr walHeader
 		hdr.Version = walVersion
 		hdr.Size = hdr0.Size
+		hdr.Major = id.Major
+		hdr.Minor = id.Minor
 		hdr.Kernel = hdr0.Kernel
 		hdr.GPT = hdr0.GPT
 		hdr.FS = hdr0.FS
@@ -191,10 +302,12 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
 		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
-		copy(buf[16:80], hdr.Kernel[:])
-		copy(buf[80:144], hdr.GPT[:])
-		copy(buf[144:208], hdr.FS[:])
-		copy(buf[208:240], hdr.MAC[:])
+		binary.LittleEndian.PutUint32(buf[16:20], hdr.Major)
+		binary.LittleEndian.PutUint32(buf[20:24], hdr.Minor)
+		copy(buf[24:88], hdr.Kernel[:])
+		copy(buf[88:152], hdr.GPT[:])
+		copy(buf[152:216], hdr.FS[:])
+		copy(buf[216:248], hdr.MAC[:])
 		if _, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, err

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -10,7 +10,7 @@ import (
 func TestWALIdentityMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs"}
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2}
 	w, err := OpenWAL(path, id)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
@@ -18,24 +18,32 @@ func TestWALIdentityMismatch(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	badID := DeviceIdentity{SizeBytes: 101, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs"}
+	badID := DeviceIdentity{SizeBytes: 101, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2}
 	if _, err := OpenWAL(path, badID); err == nil {
 		t.Fatalf("expected size mismatch error")
 	}
-	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev2", GPTUUID: "gpt", FSUUID: "fs"}
+	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev2", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2}
 	if _, err := OpenWAL(path, badID); err == nil {
 		t.Fatalf("expected uuid mismatch error")
 	}
-	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs2"}
+	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs2", Major: 1, Minor: 2}
 	if _, err := OpenWAL(path, badID); err == nil {
 		t.Fatalf("expected fs uuid mismatch error")
+	}
+	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 3, Minor: 2}
+	if _, err := OpenWAL(path, badID); err == nil {
+		t.Fatalf("expected major mismatch error")
+	}
+	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 4}
+	if _, err := OpenWAL(path, badID); err == nil {
+		t.Fatalf("expected minor mismatch error")
 	}
 }
 
 func TestWALRecovery(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs"}
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2}
 	w, err := OpenWAL(path, id)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
@@ -58,7 +66,7 @@ func TestWALRecovery(t *testing.T) {
 func TestWALVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs"}
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2}
 	w, err := OpenWAL(path, id)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
@@ -77,12 +85,14 @@ func TestWALVersionMismatch(t *testing.T) {
 	var hdr walHeader
 	hdr.Version = walVersion + 1
 	hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
-	copy(hdr.Kernel[:], buf[16:80])
-	copy(hdr.GPT[:], buf[80:144])
-	copy(hdr.FS[:], buf[144:208])
+	hdr.Major = binary.LittleEndian.Uint32(buf[16:20])
+	hdr.Minor = binary.LittleEndian.Uint32(buf[20:24])
+	copy(hdr.Kernel[:], buf[24:88])
+	copy(hdr.GPT[:], buf[88:152])
+	copy(hdr.FS[:], buf[152:216])
 	hdr.MAC = walHeaderMAC(&hdr)
 	binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
-	copy(buf[208:240], hdr.MAC[:])
+	copy(buf[216:248], hdr.MAC[:])
 	if _, err := f.WriteAt(buf[:], 0); err != nil {
 		t.Fatalf("write header: %v", err)
 	}
@@ -121,7 +131,7 @@ func TestWALUpgrade(t *testing.T) {
 		t.Fatalf("write entry: %v", err)
 	}
 	f.Close()
-	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs"}
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2}
 	w, err := OpenWAL(path, id)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)

--- a/manifest/cdc_chunks_test.go
+++ b/manifest/cdc_chunks_test.go
@@ -11,7 +11,7 @@ import (
 func TestIndexCDCChunks(t *testing.T) {
 	dir := t.TempDir()
 	manPath := filepath.Join(dir, "man")
-	idx, err := Create(manPath, "dev", 1024, 0, 4, 0, 0, 0, 0)
+	idx, err := Create(manPath, "dev", 1024, 0, 0, 0, 4, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/manifest/commit_crash_test.go
+++ b/manifest/commit_crash_test.go
@@ -15,7 +15,7 @@ import (
 func TestCommitCrashMidway(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "manifest")
-	idx, err := Create(path, "dev", 8192, 1, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 1, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestCommitCrashMidway(t *testing.T) {
 		t.Fatalf("close2: %v", err)
 	}
 	deviceID := string(bytes.TrimRight(hdr.DeviceID[:], "\x00"))
-	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch+1, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize)
+	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch+1, hdr.Major, hdr.Minor, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize)
 	if err != nil {
 		t.Fatalf("Create new: %v", err)
 	}

--- a/manifest/compact_test.go
+++ b/manifest/compact_test.go
@@ -13,7 +13,7 @@ import (
 func TestCompactPreservesCardinalityAndOrder(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "compact.man")
-	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/manifest/compaction_test.go
+++ b/manifest/compaction_test.go
@@ -14,7 +14,7 @@ import (
 func TestCompactionRemovesDeleted(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "compaction.man")
-	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/manifest/corruption_test.go
+++ b/manifest/corruption_test.go
@@ -10,7 +10,7 @@ import (
 func TestOpenSizeMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "corrupt.man")
-	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/manifest/gc_crash_test.go
+++ b/manifest/gc_crash_test.go
@@ -14,7 +14,7 @@ import (
 func TestGCCrashMidway(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "manifest")
-	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestGCCrashMidway(t *testing.T) {
 		t.Fatalf("close2: %v", err)
 	}
 	deviceID := string(bytes.TrimRight(hdr.DeviceID[:], "\x00"))
-	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize)
+	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch, hdr.Major, hdr.Minor, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize)
 	if err != nil {
 		t.Fatalf("Create new: %v", err)
 	}

--- a/manifest/index.go
+++ b/manifest/index.go
@@ -83,7 +83,7 @@ func GC(path string, opts ...IndexOption) error {
 	}
 
 	deviceID := string(bytes.TrimRight(hdr.DeviceID[:], "\x00"))
-	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize, opts...)
+	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch, hdr.Major, hdr.Minor, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize, opts...)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func Compact(path string, opts ...IndexOption) error {
 	}
 
 	deviceID := string(bytes.TrimRight(hdr.DeviceID[:], "\x00"))
-	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize, opts...)
+	newIdx, err := Create(path, deviceID, hdr.SizeBytes, hdr.Epoch, hdr.Major, hdr.Minor, hdr.BlockSize, hdr.MinChunkSize, hdr.AvgChunkSize, hdr.MaxChunkSize, hdr.HybridFixedSize, opts...)
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -26,8 +26,8 @@ const (
 	Version uint32 = 2
 
 	// HeaderSize is the binary size of Header.
-	HeaderSize = 4 + 4 + 8 + 8 + 4 + 4 + 4 + 4 + 8 + 64 + 32 + 32 // 176 bytes
-	entrySize  = 8 + 4 + 4 + 8 + 32                               // 56 bytes
+	HeaderSize = 4 + 4 + 8 + 8 + 4 + 4 + 4 + 4 + 8 + 4 + 4 + 64 + 32 + 32 // 184 bytes
+	entrySize  = 8 + 4 + 4 + 8 + 32                                       // 56 bytes
 
 	// FlagCDC marks chunks produced by content-defined chunking.
 	FlagCDC uint32 = 1 << 0
@@ -52,6 +52,8 @@ type Header struct {
 	MaxChunkSize     uint32
 	HybridFixedSize  uint32
 	Epoch            uint64
+	Major            uint32
+	Minor            uint32
 	DeviceID         [64]byte
 	FirstBlockDigest [32]byte
 	MAC              [32]byte
@@ -137,8 +139,10 @@ func headerMAC(h *Header) [32]byte {
 	binary.LittleEndian.PutUint32(buf[32:36], h.MaxChunkSize)
 	binary.LittleEndian.PutUint32(buf[36:40], h.HybridFixedSize)
 	binary.LittleEndian.PutUint64(buf[40:48], h.Epoch)
-	copy(buf[48:112], h.DeviceID[:])
-	copy(buf[112:144], h.FirstBlockDigest[:])
+	binary.LittleEndian.PutUint32(buf[48:52], h.Major)
+	binary.LittleEndian.PutUint32(buf[52:56], h.Minor)
+	copy(buf[56:120], h.DeviceID[:])
+	copy(buf[120:152], h.FirstBlockDigest[:])
 	sum := blake3.Sum256(buf[:])
 	return sum
 }
@@ -154,9 +158,11 @@ func (i *Index) writeHeader() {
 	binary.LittleEndian.PutUint32(buf[32:36], i.hdr.MaxChunkSize)
 	binary.LittleEndian.PutUint32(buf[36:40], i.hdr.HybridFixedSize)
 	binary.LittleEndian.PutUint64(buf[40:48], i.hdr.Epoch)
-	copy(buf[48:112], i.hdr.DeviceID[:])
-	copy(buf[112:144], i.hdr.FirstBlockDigest[:])
-	copy(buf[144:176], i.hdr.MAC[:])
+	binary.LittleEndian.PutUint32(buf[48:52], i.hdr.Major)
+	binary.LittleEndian.PutUint32(buf[52:56], i.hdr.Minor)
+	copy(buf[56:120], i.hdr.DeviceID[:])
+	copy(buf[120:152], i.hdr.FirstBlockDigest[:])
+	copy(buf[152:184], i.hdr.MAC[:])
 	copy(i.data[:HeaderSize], buf[:])
 }
 
@@ -174,9 +180,11 @@ func (i *Index) readHeader() error {
 	i.hdr.MaxChunkSize = binary.LittleEndian.Uint32(buf[32:36])
 	i.hdr.HybridFixedSize = binary.LittleEndian.Uint32(buf[36:40])
 	i.hdr.Epoch = binary.LittleEndian.Uint64(buf[40:48])
-	copy(i.hdr.DeviceID[:], buf[48:112])
-	copy(i.hdr.FirstBlockDigest[:], buf[112:144])
-	copy(i.hdr.MAC[:], buf[144:176])
+	i.hdr.Major = binary.LittleEndian.Uint32(buf[48:52])
+	i.hdr.Minor = binary.LittleEndian.Uint32(buf[52:56])
+	copy(i.hdr.DeviceID[:], buf[56:120])
+	copy(i.hdr.FirstBlockDigest[:], buf[120:152])
+	copy(i.hdr.MAC[:], buf[152:184])
 	if mac := headerMAC(&i.hdr); !bytes.Equal(mac[:], i.hdr.MAC[:]) {
 		return fmt.Errorf("manifest: header MAC mismatch")
 	}
@@ -227,7 +235,7 @@ func (i *Index) Close() error {
 }
 
 // Create initializes a new manifest index at path for the given device.
-func Create(path, deviceID string, size, epoch uint64, blockSize, cdcMin, cdcAvg, cdcMax, hybridFixed uint32, opts ...IndexOption) (*Index, error) {
+func Create(path, deviceID string, size, epoch uint64, major, minor uint32, blockSize, cdcMin, cdcAvg, cdcMax, hybridFixed uint32, opts ...IndexOption) (*Index, error) {
 	cfg := applyOptions(opts)
 	if len(deviceID) > 64 {
 		return nil, fmt.Errorf("manifest: device ID exceeds 64 bytes")
@@ -252,6 +260,8 @@ func Create(path, deviceID string, size, epoch uint64, blockSize, cdcMin, cdcAvg
 		MaxChunkSize:    cdcMax,
 		HybridFixedSize: hybridFixed,
 		Epoch:           epoch,
+		Major:           major,
+		Minor:           minor,
 	}
 	copy(idx.hdr.DeviceID[:], []byte(deviceID))
 	idx.hdr.MAC = headerMAC(&idx.hdr)
@@ -537,6 +547,10 @@ func Rebuild(
 	if err != nil {
 		return err
 	}
+	identity, err := dev.Identity()
+	if err != nil {
+		return err
+	}
 	if err = ctx.Err(); err != nil {
 		return err
 	}
@@ -548,7 +562,7 @@ func Rebuild(
 	defer f.Close()
 	var idx *Index
 	epoch := uint64(time.Now().UnixNano())
-	idx, err = Create(output, id, size, epoch, blockSize, cdcMin, cdcAvg, cdcMax, hybridFixed, opts...)
+	idx, err = Create(output, id, size, epoch, identity.Major, identity.Minor, blockSize, cdcMin, cdcAvg, cdcMax, hybridFixed, opts...)
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -41,7 +41,7 @@ func (m *mockDevice) RecoverWAL(fn func(device.Range) error) error { return nil 
 func TestIndexCRUD(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.man")
-	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestIndexCRUD(t *testing.T) {
 func TestMatchBloomNegative(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bloom.man")
-	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestMatchBloomNegative(t *testing.T) {
 func TestHashCollision(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "collision.man")
-	idx, err := Create(path, "dev", 8192, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -150,12 +150,12 @@ func TestDeviceIDLength(t *testing.T) {
 	dir := t.TempDir()
 	good := strings.Repeat("a", 64)
 	goodPath := filepath.Join(dir, "good.man")
-	if _, err := Create(goodPath, good, 4096, 0, 4096, 0, 0, 0, 0); err != nil {
+	if _, err := Create(goodPath, good, 4096, 0, 0, 0, 4096, 0, 0, 0, 0); err != nil {
 		t.Fatalf("expected success for 64-byte id: %v", err)
 	}
 	bad := strings.Repeat("b", 65)
 	badPath := filepath.Join(dir, "bad.man")
-	if _, err := Create(badPath, bad, 4096, 0, 4096, 0, 0, 0, 0); err == nil {
+	if _, err := Create(badPath, bad, 4096, 0, 0, 0, 4096, 0, 0, 0, 0); err == nil {
 		t.Fatalf("expected error for id >64 bytes")
 	}
 }
@@ -163,7 +163,7 @@ func TestDeviceIDLength(t *testing.T) {
 func TestCreateZeroBlockSize(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "zero.man")
-	if _, err := Create(path, "dev", 4096, 0, 0, 0, 0, 0, 0); err == nil {
+	if _, err := Create(path, "dev", 4096, 0, 0, 0, 0, 0, 0, 0, 0); err == nil {
 		t.Fatalf("expected error for zero block size")
 	}
 }
@@ -171,7 +171,7 @@ func TestCreateZeroBlockSize(t *testing.T) {
 func TestReadHeaderMACMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mac.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestReadHeaderMACMismatch(t *testing.T) {
 func TestCreateSyncsHeader(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "crash.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestCreateSyncsHeader(t *testing.T) {
 func TestUpgrade(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "old.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestCreateCloseHook(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hook.man")
 	called := 0
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0, WithCloseHook(func() error { called++; return nil }))
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0, WithCloseHook(func() error { called++; return nil }))
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestCreateCloseHook(t *testing.T) {
 func TestOpenCloseHook(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hook.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestOpenCloseHook(t *testing.T) {
 func TestUpgradeCloseHook(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hook.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestUpgradeCloseHook(t *testing.T) {
 func TestIndexCloseAggregatesErrors(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "aggregate.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestIndexCloseAggregatesErrors(t *testing.T) {
 func TestMatchXXHShortcut(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "shortcut.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestMatchXXHShortcut(t *testing.T) {
 func TestMatchFlagsMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "flags.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestIndexLargeOffsets(t *testing.T) {
 	const blockSize = uint32(1 << 31) // 2 GiB
 	const chunks = uint64(3)
 	size := uint64(blockSize) * chunks
-	idx, err := Create(path, "dev", size, 0, blockSize, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", size, 0, 0, 0, blockSize, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestIndexLargeOffsets(t *testing.T) {
 func TestIndexOutOfRange(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "oor.man")
-	idx, err := Create(path, "dev", 4096, 0, 4096, 0, 0, 0, 0)
+	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -18,6 +18,7 @@ import (
 	manifestpkg "lvmsync_go/manifest"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
 func minimalStream(t *testing.T) []byte {
@@ -323,6 +324,12 @@ func TestVerifyDestinationDigestMismatch(t *testing.T) {
 	hdr.BlockSize = 512
 	hdr.SizeBytes = 1024
 	hdr.ChunkCount = 2
+	var st unix.Stat_t
+	if err := unix.Stat(dest, &st); err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	hdr.Major = uint32(unix.Major(uint64(st.Rdev)))
+	hdr.Minor = uint32(unix.Minor(uint64(st.Rdev)))
 	copy(hdr.DeviceID[:], []byte("id"))
 	hdr.FirstBlockDigest[0] = 2
 	hdr.MAC = manifestHeaderMAC(&hdr)

--- a/transfer/destination_precondition_test.go
+++ b/transfer/destination_precondition_test.go
@@ -18,6 +18,7 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sys/unix"
 	manifestpkg "lvmsync_go/manifest"
 )
 
@@ -68,6 +69,12 @@ func TestProcessDumpDataSizeMismatchPrecondition(t *testing.T) {
 	hdr.BlockSize = 512
 	hdr.SizeBytes = 2048
 	hdr.ChunkCount = 2
+	var st unix.Stat_t
+	if err := unix.Stat(dest, &st); err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	hdr.Major = uint32(unix.Major(uint64(st.Rdev)))
+	hdr.Minor = uint32(unix.Minor(uint64(st.Rdev)))
 	copy(hdr.DeviceID[:], []byte("id"))
 	hdr.MAC = manifestHeaderMAC(&hdr)
 	f, err := os.Create(man)

--- a/transfer/manifest_header_mac_test.go
+++ b/transfer/manifest_header_mac_test.go
@@ -21,6 +21,8 @@ func TestManifestHeaderMACSize(t *testing.T) {
 	hdr.MaxChunkSize = 3
 	hdr.HybridFixedSize = 4
 	hdr.Epoch = 1
+	hdr.Major = 1
+	hdr.Minor = 2
 	copy(hdr.DeviceID[:], []byte("dev"))
 	digest := blake3.Sum256([]byte("data"))
 	hdr.FirstBlockDigest = digest

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
@@ -228,8 +229,10 @@ func manifestHeaderMAC(h *manifestpkg.Header) [32]byte {
 	binary.LittleEndian.PutUint32(buf[32:36], h.MaxChunkSize)
 	binary.LittleEndian.PutUint32(buf[36:40], h.HybridFixedSize)
 	binary.LittleEndian.PutUint64(buf[40:48], h.Epoch)
-	copy(buf[48:112], h.DeviceID[:])
-	copy(buf[112:144], h.FirstBlockDigest[:])
+	binary.LittleEndian.PutUint32(buf[48:52], h.Major)
+	binary.LittleEndian.PutUint32(buf[52:56], h.Minor)
+	copy(buf[56:120], h.DeviceID[:])
+	copy(buf[120:152], h.FirstBlockDigest[:])
 	return blake3.Sum256(buf[:])
 }
 
@@ -291,6 +294,16 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		if size != hdr.SizeBytes {
 			t.Logger.Error("device_size_mismatch", zap.Uint64("expected_size_bytes", hdr.SizeBytes), zap.Uint64("size_bytes", size))
 			return 0, "", 0, fmt.Errorf("precondition: destination device size %d does not match manifest %d", size, hdr.SizeBytes)
+		}
+		var st unix.Stat_t
+		if err := unix.Stat(destPath, &st); err != nil {
+			return 0, "", 0, fmt.Errorf("stat destination: %w", err)
+		}
+		major := uint32(unix.Major(uint64(st.Rdev)))
+		minor := uint32(unix.Minor(uint64(st.Rdev)))
+		if major != hdr.Major || minor != hdr.Minor {
+			t.Logger.Error("device_number_mismatch", zap.Uint32("expected_major", hdr.Major), zap.Uint32("expected_minor", hdr.Minor), zap.Uint32("major", major), zap.Uint32("minor", minor))
+			return 0, "", 0, fmt.Errorf("precondition: destination device number mismatch")
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 		if err != nil {

--- a/transfer/verify_destination_validation_test.go
+++ b/transfer/verify_destination_validation_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
@@ -36,6 +37,12 @@ func TestVerifyDestinationManifestDigestError(t *testing.T) {
 	hdr.BlockSize = 512
 	hdr.SizeBytes = 1024
 	hdr.ChunkCount = 2
+	var st unix.Stat_t
+	if err := unix.Stat(dest, &st); err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	hdr.Major = uint32(unix.Major(uint64(st.Rdev)))
+	hdr.Minor = uint32(unix.Minor(uint64(st.Rdev)))
 	copy(hdr.DeviceID[:], []byte("id"))
 	hdr.MAC = manifestHeaderMAC(&hdr)
 	f, err := os.Create(man)
@@ -72,5 +79,42 @@ func TestVerifyDestinationFirstBlockDigestMismatch(t *testing.T) {
 	cfg := &config.Config{FirstBlockDigest: strings.Repeat("00", 32)}
 	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("expected digest mismatch, got %v", err)
+	}
+}
+
+func TestVerifyDestinationDeviceNumberMismatch(t *testing.T) {
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "id", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, make([]byte, 1024), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	man := filepath.Join(t.TempDir(), "man")
+	var hdr manifestpkg.Header
+	hdr.Version = manifestpkg.Version
+	hdr.BlockSize = 512
+	hdr.SizeBytes = 1024
+	hdr.ChunkCount = 2
+	hdr.Major = 1
+	hdr.Minor = 1
+	copy(hdr.DeviceID[:], []byte("id"))
+	hdr.MAC = manifestHeaderMAC(&hdr)
+	f, err := os.Create(man)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	f.Close()
+	cfg := &config.Config{ManifestPath: man}
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "number mismatch") {
+		t.Fatalf("expected device number mismatch, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- track device major/minor numbers in `DeviceIdentity`
- persist and validate new fields in WAL headers and manifest metadata
- abort resume/verify when major/minor numbers mismatch

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused-parameter, package-comments, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4741f16888323922726b8888e1e3f