### PR TITLE
Use binary units in size parser

### DIFF
--- a/internal/sizeparse/sizeparse.go
+++ b/internal/sizeparse/sizeparse.go
@@ -40,18 +40,18 @@ func Parse(input string) (float64, bool, error) {
 	switch unit {
 	case "", "B":
 		return f, false, nil
-	case "K", "KB":
-		return f * 1e3, false, nil
-	case "M", "MB":
-		return f * 1e6, false, nil
-	case "G", "GB":
-		return f * 1e9, false, nil
-	case "T", "TB":
-		return f * 1e12, false, nil
-	case "P", "PB":
-		return f * 1e15, false, nil
-	case "E", "EB":
-		return f * 1e18, false, nil
+	case "K", "KB", "KIB":
+		return f * (1 << 10), false, nil
+	case "M", "MB", "MIB":
+		return f * (1 << 20), false, nil
+	case "G", "GB", "GIB":
+		return f * (1 << 30), false, nil
+	case "T", "TB", "TIB":
+		return f * (1 << 40), false, nil
+	case "P", "PB", "PIB":
+		return f * (1 << 50), false, nil
+	case "E", "EB", "EIB":
+		return f * (1 << 60), false, nil
 	default:
 		return 0, false, fmt.Errorf("unknown size suffix %q", unit)
 	}

--- a/internal/sizeparse/sizeparse_test.go
+++ b/internal/sizeparse/sizeparse_test.go
@@ -9,9 +9,11 @@ func TestParse(t *testing.T) {
 		percent bool
 		wantErr bool
 	}{
-		{"1KB", 1000, false, false},
-		{"1MB", 1e6, false, false},
-		{"1.5GB", 1.5e9, false, false},
+		{"1KB", float64(1 << 10), false, false},
+		{"1MB", float64(1 << 20), false, false},
+		{"1.5GB", 1.5 * float64(1<<30), false, false},
+		{"1KiB", float64(1 << 10), false, false},
+		{"1MiB", float64(1 << 20), false, false},
 		{"50%", 50, true, false},
 		{"bad", 0, false, true},
 		{"10XB", 0, false, true},

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -46,7 +46,7 @@ func TestParseSnapshotSize(t *testing.T) {
 		wantErr bool
 	}{
 		{"percent", "50%", 512 * 1024, false},
-		{"absolute", "1M", 1000000, false},
+		{"absolute", "1M", 1 << 20, false},
 		{"invalidPercent", "150%", 0, true},
 		{"invalidValue", "abc", 0, true},
 		{"negative", "-1", 0, true},


### PR DESCRIPTION
## Summary
- parse K/M/G/T/P/E as powers of 1024
- accept KiB/MiB-style suffixes
- adjust tests for binary scaling

## Testing
- `go test ./internal/sizeparse ./lvm`


------
https://chatgpt.com/codex/tasks/task_e_68a47f2b27908323ad2f8321005e8e7c