### PR TITLE
Refactor size parser to use uint64 and update callers

### DIFF
--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -262,11 +262,10 @@ func (b *builder) parseBytesOrFallback(key, fallback string) (int, error) {
 	if err != nil || isPercent {
 		return 0, fmt.Errorf("invalid %s value %q: %w", key, raw, err)
 	}
-	u := uint64(val)
-	if float64(u) != val || u > uint64(math.MaxInt) {
+	if val > uint64(math.MaxInt) {
 		return 0, fmt.Errorf("%s value %q overflows int", key, raw)
 	}
-	return int(u), nil
+	return int(val), nil
 }
 
 func (b *builder) parseBlockSize() (int, string, error) {
@@ -281,11 +280,10 @@ func (b *builder) parseBlockSize() (int, string, error) {
 	if err != nil || isPercent {
 		return 0, "", fmt.Errorf("invalid block-size value %q: %w", raw, err)
 	}
-	u := uint64(val)
-	if float64(u) != val || u > uint64(math.MaxInt) {
+	if val > uint64(math.MaxInt) {
 		return 0, "", fmt.Errorf("block-size value %q overflows int", raw)
 	}
-	return int(u), raw, nil
+	return int(val), raw, nil
 }
 
 func buildViper(flagSets *FlagSets) (*viper.Viper, []string, bool, error) {

--- a/internal/sizeparse/sizeparse.go
+++ b/internal/sizeparse/sizeparse.go
@@ -2,27 +2,37 @@ package sizeparse
 
 import (
 	"fmt"
-	"strconv"
+	"math"
+	"math/big"
 	"strings"
 	"unicode"
 )
 
-// Parse parses a size string with optional units (KB, MB, GB, etc.) or percentage (e.g., "10%")
-// and returns the numeric value. If the value represents a percentage, the returned bool is true
-// and the numeric value is the percentage. Otherwise the numeric value represents bytes.
-func Parse(input string) (float64, bool, error) {
+var maxUint64 = new(big.Int).SetUint64(math.MaxUint64)
+
+// Parse parses a size string with optional units (KB, MB, GB, etc.) or a percentage
+// (e.g., "10%") and returns the numeric value. If the value represents a
+// percentage, the returned bool is true and the numeric value is the percentage
+// as an integer. Otherwise the numeric value represents bytes.
+func Parse(input string) (uint64, bool, error) {
 	s := strings.TrimSpace(strings.ToUpper(input))
 	if s == "" {
 		return 0, false, fmt.Errorf("empty size")
 	}
+
 	if strings.HasSuffix(s, "%") {
 		num := strings.TrimSpace(strings.TrimSuffix(s, "%"))
-		f, err := strconv.ParseFloat(num, 64)
-		if err != nil {
+		r := new(big.Rat)
+		if _, ok := r.SetString(num); !ok || !r.IsInt() {
 			return 0, true, fmt.Errorf("invalid percentage value %q", input)
 		}
-		return f, true, nil
+		i := r.Num()
+		if i.Sign() < 0 || i.Cmp(maxUint64) > 0 {
+			return 0, true, fmt.Errorf("percentage value %q overflows uint64", input)
+		}
+		return i.Uint64(), true, nil
 	}
+
 	s = strings.ReplaceAll(s, " ", "")
 	idx := 0
 	for ; idx < len(s); idx++ {
@@ -33,28 +43,41 @@ func Parse(input string) (float64, bool, error) {
 	}
 	numStr := s[:idx]
 	unit := s[idx:]
-	f, err := strconv.ParseFloat(numStr, 64)
-	if err != nil {
+
+	r := new(big.Rat)
+	if _, ok := r.SetString(numStr); !ok {
 		return 0, false, fmt.Errorf("invalid size %q", input)
 	}
+
+	mult := new(big.Rat)
 	switch unit {
 	case "", "B":
-		return f, false, nil
+		mult.SetInt64(1)
 	case "K", "KB":
-		return f * 1e3, false, nil
+		mult.SetInt64(1e3)
 	case "M", "MB":
-		return f * 1e6, false, nil
+		mult.SetInt64(1e6)
 	case "G", "GB":
-		return f * 1e9, false, nil
+		mult.SetInt64(1e9)
 	case "T", "TB":
-		return f * 1e12, false, nil
+		mult.SetInt64(1e12)
 	case "P", "PB":
-		return f * 1e15, false, nil
+		mult.SetInt64(1e15)
 	case "E", "EB":
-		return f * 1e18, false, nil
+		mult.SetInt64(1e18)
 	default:
 		return 0, false, fmt.Errorf("unknown size suffix %q", unit)
 	}
+
+	r.Mul(r, mult)
+	if !r.IsInt() {
+		return 0, false, fmt.Errorf("size %q has fractional bytes", input)
+	}
+	i := r.Num()
+	if i.Sign() < 0 || i.Cmp(maxUint64) > 0 {
+		return 0, false, fmt.Errorf("size %q overflows uint64", input)
+	}
+	return i.Uint64(), false, nil
 }
 
 // FormatBytes returns a human readable string for the given number of bytes.

--- a/internal/sizeparse/sizeparse_test.go
+++ b/internal/sizeparse/sizeparse_test.go
@@ -1,20 +1,30 @@
 package sizeparse
 
-import "testing"
+import (
+	"math"
+	"strconv"
+	"testing"
+)
 
 func TestParse(t *testing.T) {
 	tests := []struct {
 		input   string
-		want    float64
+		want    uint64
 		percent bool
 		wantErr bool
 	}{
 		{"1KB", 1000, false, false},
 		{"1MB", 1e6, false, false},
-		{"1.5GB", 1.5e9, false, false},
+		{"1.5GB", 1500000000, false, false},
 		{"50%", 50, true, false},
 		{"bad", 0, false, true},
 		{"10XB", 0, false, true},
+		{strconv.FormatUint(math.MaxUint64, 10), math.MaxUint64, false, false},
+		{strconv.FormatUint(math.MaxUint64, 10) + "B", math.MaxUint64, false, false},
+		{"18.446744073709551615E", math.MaxUint64, false, false},
+		{"18446744073709551616", 0, false, true},
+		{"18446744073709551616B", 0, false, true},
+		{"18446744073709551615K", 0, false, true},
 	}
 	for _, tt := range tests {
 		got, pct, err := Parse(tt.input)

--- a/lvm/backend_cgo.go
+++ b/lvm/backend_cgo.go
@@ -24,11 +24,7 @@ func (b *cgoBackend) CreateSnapshot(_ context.Context, lvPath, snapshotName, siz
 	if percent {
 		return fmt.Errorf("percentage sizes not supported")
 	}
-	u := uint64(bytes)
-	if bytes < 0 || float64(u) != bytes {
-		return fmt.Errorf("size %q overflows uint64", size)
-	}
-	if err := b.lvm.CreateSnapshot(lvPath, snapshotName, u); err != nil {
+	if err := b.lvm.CreateSnapshot(lvPath, snapshotName, bytes); err != nil {
 		return fmt.Errorf("cgo create snapshot: %w", err)
 	}
 	return nil

--- a/lvm/backend_test.go
+++ b/lvm/backend_test.go
@@ -42,7 +42,7 @@ func TestBackend(t *testing.T) {
 	if err != nil || len(vgs) != 1 || vgs[0].Name != "vg1" || vgs[0].Free != 2048 {
 		t.Fatalf("unexpected filtered result: %#v err %v", vgs, err)
 	}
-	wantCreate := fmt.Sprintf("create:%s:%s:%d:ro", "/dev/vg0/origin", "snap", uint64(1<<30))
+	wantCreate := fmt.Sprintf("create:%s:%s:%d:ro", "/dev/vg0/origin", "snap", uint64(1000000000))
 	wantRemove := "remove:/dev/vg0/snap"
 	if len(mc.calls) != 2 || mc.calls[0] != wantCreate || mc.calls[1] != wantRemove {
 		t.Fatalf("calls = %v, want [%s %s]", mc.calls, wantCreate, wantRemove)

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -333,7 +333,7 @@ func ParseSnapshotSize(sizeStr, volumePath string, cache *FDCache, logger *zap.L
 	}
 
 	if isPercent {
-		if val <= 0 || val > 100 {
+		if val == 0 || val > 100 {
 			return 0, fmt.Errorf("percentage must be between 0 and 100, got %v", val)
 		}
 
@@ -342,9 +342,9 @@ func ParseSnapshotSize(sizeStr, volumePath string, cache *FDCache, logger *zap.L
 			return 0, fmt.Errorf("failed to get volume size for %q: %w", volumePath, err)
 		}
 
-		res := float64(volSize) * (val / 100.0)
+		res := float64(volSize) * (float64(val) / 100.0)
 		parsedSize := uint64(res)
-		if res < 0 || float64(parsedSize) != res {
+		if float64(parsedSize) != res {
 			return 0, fmt.Errorf("snapshot size %q overflows uint64", sizeStr)
 		}
 
@@ -355,16 +355,11 @@ func ParseSnapshotSize(sizeStr, volumePath string, cache *FDCache, logger *zap.L
 		return parsedSize, nil
 	}
 
-	parsedSize := uint64(val)
-	if val < 0 || float64(parsedSize) != val {
-		return 0, fmt.Errorf("snapshot size %q overflows uint64", sizeStr)
-	}
-
 	logger.Debug("parsed snapshot size",
 		zap.String("input", sizeStr),
-		zap.Uint64("bytes", parsedSize))
+		zap.Uint64("bytes", val))
 
-	return parsedSize, nil
+	return val, nil
 }
 
 func GetSnapshotDevicePath(snapshotName, volumeGroup string, logger *zap.Logger) string {

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -55,11 +55,10 @@ func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup Deduplicati
 		if err != nil || isPercent {
 			return nil, fmt.Errorf("invalid sync interval %q: %w", cfg.SyncInterval, err)
 		}
-		u := uint64(val)
-		if float64(u) != val || u > uint64(math.MaxInt) {
+		if val > uint64(math.MaxInt) {
 			return nil, fmt.Errorf("sync interval %q overflows int", cfg.SyncInterval)
 		}
-		cfg.SyncIntervalBytes = int(u)
+		cfg.SyncIntervalBytes = int(val)
 	}
 	bw := &blockWriter{
 		cfg:      cfg,


### PR DESCRIPTION
## Summary
- change sizeparse.Parse to return uint64 bytes or percentage flag
- remove float comparisons in LVM backend and other call sites
- add tests for size parsing around math.MaxUint64 and update expectations

## Testing
- `go test ./internal/sizeparse ./lvm`


------
https://chatgpt.com/codex/tasks/task_e_68a47f2c4cb0832387ad7511da6dd91b