### PR TITLE
sizeparse: reject negative values

### DIFF
--- a/internal/sizeparse/sizeparse.go
+++ b/internal/sizeparse/sizeparse.go
@@ -21,13 +21,16 @@ func Parse(input string) (float64, bool, error) {
 		if err != nil {
 			return 0, true, fmt.Errorf("invalid percentage value %q", input)
 		}
+		if f < 0 {
+			return 0, true, fmt.Errorf("negative percentage value %q", input)
+		}
 		return f, true, nil
 	}
 	s = strings.ReplaceAll(s, " ", "")
 	idx := 0
 	for ; idx < len(s); idx++ {
 		r := rune(s[idx])
-		if !unicode.IsDigit(r) && r != '.' {
+		if !unicode.IsDigit(r) && r != '.' && !(idx == 0 && r == '-') {
 			break
 		}
 	}
@@ -36,6 +39,9 @@ func Parse(input string) (float64, bool, error) {
 	f, err := strconv.ParseFloat(numStr, 64)
 	if err != nil {
 		return 0, false, fmt.Errorf("invalid size %q", input)
+	}
+	if f < 0 {
+		return 0, false, fmt.Errorf("negative size %q", input)
 	}
 	switch unit {
 	case "", "B":

--- a/internal/sizeparse/sizeparse_test.go
+++ b/internal/sizeparse/sizeparse_test.go
@@ -15,6 +15,8 @@ func TestParse(t *testing.T) {
 		{"50%", 50, true, false},
 		{"bad", 0, false, true},
 		{"10XB", 0, false, true},
+		{"-1G", 0, false, true},
+		{"-10%", 0, true, true},
 	}
 	for _, tt := range tests {
 		got, pct, err := Parse(tt.input)


### PR DESCRIPTION
## Summary
- Reject negative numbers in size and percentage parsing
- Add tests for negative sizes and percentages

## Testing
- `go build ./...`
- `go test ./internal/sizeparse`
- `go test -coverprofile=coverage.out ./...` *(fails: lvm Backend tests)*
- `golangci-lint run` *(fails: many issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f2d64448323bbeb018f292b261a