### PR TITLE
device: fsync wal directory

### DIFF
--- a/device/wal.go
+++ b/device/wal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/zeebo/blake3"
 )
@@ -49,6 +50,10 @@ type WAL struct {
 	header walHeader
 	ranges []Range
 }
+
+// syncDirFunc flushes a directory to stable storage. It is a variable to allow tests
+// to stub the implementation.
+var syncDirFunc = syncDir
 
 func walHeaderMAC(h *walHeader) [32]byte {
 	var buf [8 + 8 + 4 + 4 + 64 + 64 + 64]byte
@@ -118,6 +123,10 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 			return nil, err
 		}
 		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if err := syncDirFunc(filepath.Dir(path)); err != nil {
 			f.Close()
 			return nil, err
 		}
@@ -353,8 +362,37 @@ func (w *WAL) Append(r Range) error {
 func (w *WAL) Ranges() []Range { return append([]Range(nil), w.ranges...) }
 
 func (w *WAL) Close() error {
-	if w.f != nil {
-		return w.f.Close()
+	if w.f == nil {
+		return nil
 	}
-	return nil
+	if err := w.f.Sync(); err != nil {
+		w.f.Close()
+		return err
+	}
+	name := w.f.Name()
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	w.f = nil
+	return syncDirFunc(filepath.Dir(name))
+}
+
+// SetSyncDirFunc overrides the directory sync implementation. It returns a restore function.
+func SetSyncDirFunc(fn func(string) error) func() {
+	orig := syncDirFunc
+	if fn == nil {
+		syncDirFunc = syncDir
+	} else {
+		syncDirFunc = fn
+	}
+	return func() { syncDirFunc = orig }
+}
+
+func syncDir(path string) error {
+	d, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"encoding/binary"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -150,5 +151,47 @@ func TestWALUpgrade(t *testing.T) {
 	}
 	if want := int64(walHeaderSize + 16); info.Size() != want {
 		t.Fatalf("expected size %d got %d", want, info.Size())
+	}
+}
+
+func TestWALSyncDirCreate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", FSUUID: "f", Major: 1, Minor: 2}
+	stubErr := errors.New("syncdir fail")
+	var calls int
+	restore := SetSyncDirFunc(func(string) error {
+		calls++
+		return stubErr
+	})
+	defer restore()
+	if _, err := OpenWAL(path, id); !errors.Is(err, stubErr) {
+		t.Fatalf("expected %v got %v", stubErr, err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected syncDir called once, got %d", calls)
+	}
+}
+
+func TestWALSyncDirClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", FSUUID: "f", Major: 1, Minor: 2}
+	w, err := OpenWAL(path, id)
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	stubErr := errors.New("syncdir fail")
+	var calls int
+	restore := SetSyncDirFunc(func(string) error {
+		calls++
+		return stubErr
+	})
+	defer restore()
+	if err := w.Close(); !errors.Is(err, stubErr) {
+		t.Fatalf("expected %v got %v", stubErr, err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected syncDir called once, got %d", calls)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure WAL creation and close fsync the parent directory
- add SetSyncDirFunc for tests and cover directory fsync errors
- add tests for directory fsync failures

## Testing
- `go build ./...` *(fails: internal/sizeparse package has undefined identifiers)*
- `go test -coverprofile=coverage.out ./...` *(fails: internal/sizeparse package has undefined identifiers)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: internal/sizeparse package has undefined identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_68a485579df48323829bc1c0fcbf0d02