### PR TITLE
device: rely on caller to ensure privilege

### DIFF
--- a/device/raw.go
+++ b/device/raw.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 
-	"lvmsync_go/escalate"
 	"lvmsync_go/internal/privilege"
 	"lvmsync_go/remote"
 )
@@ -83,12 +82,8 @@ func prepareFreeze(
 }
 
 // openDevice ensures the path is a block device and opens it for reading and writing.
-func openDevice(path string, logger *zap.Logger) (*os.File, error) {
-	if reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{}, logger); err != nil {
-		return nil, err
-	} else if reexeced {
-		return nil, fmt.Errorf("re-exec requested for root")
-	}
+// Callers must ensure the necessary privilege before invoking this function.
+func openDevice(path string) (*os.File, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -158,7 +153,7 @@ func OpenRaw(
 			}
 		}()
 	}
-	f, err := openDevice(path, logger)
+	f, err := openDevice(path)
 	if err != nil {
 		return nil, err
 	}

--- a/device/raw_helpers_test.go
+++ b/device/raw_helpers_test.go
@@ -48,7 +48,7 @@ func TestOpenDeviceSuccess(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	f, err := openDevice(loop, zap.NewNop())
+	f, err := openDevice(loop)
 	if err != nil {
 		t.Fatalf("openDevice: %v", err)
 	}
@@ -61,18 +61,9 @@ func TestOpenDeviceFailure(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := openDevice(f.Name(), zap.NewNop()); err == nil {
+	if _, err := openDevice(f.Name()); err == nil {
 		t.Fatalf("expected error for non-block device")
 	}
-}
-
-func TestOpenDeviceNilLoggerPanics(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	openDevice("", nil)
 }
 
 func TestQueryDeviceInfoSuccess(t *testing.T) {
@@ -81,7 +72,7 @@ func TestQueryDeviceInfoSuccess(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	f, err := openDevice(loop, zap.NewNop())
+	f, err := openDevice(loop)
 	if err != nil {
 		t.Fatalf("openDevice: %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove automatic privilege escalation from `openDevice`
- update raw device tests for the simplified helper
- note that callers must ensure privilege before invoking `openDevice`

## Testing
- `go build ./...` *(fails: undefined: f, duplicate cases in internal/sizeparse/sizeparse.go)*
- `go test -coverprofile=coverage.out ./...` *(fails: undefined: f, duplicate cases in internal/sizeparse/sizeparse.go)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: undefined: f, duplicate cases in internal/sizeparse/sizeparse.go)*

------
https://chatgpt.com/codex/tasks/task_e_68a4855b01e4832398499694a028a387