### PR TITLE
device: context-aware identity

### DIFF
--- a/cmd/dump/fake_device_test.go
+++ b/cmd/dump/fake_device_test.go
@@ -14,6 +14,8 @@ func (f *fakeDevice) BlockSize() uint64                                       { 
 func (f *fakeDevice) Snapshot(context.Context, string) (device.Device, error) { return f, nil }
 func (f *fakeDevice) Cleanup(context.Context) error                           { return nil }
 func (f *fakeDevice) Close() error                                            { return nil }
-func (f *fakeDevice) Identity() (device.DeviceIdentity, error)                { return device.DeviceIdentity{}, nil }
-func (f *fakeDevice) AppendWAL(r device.Range) error                          { return nil }
-func (f *fakeDevice) RecoverWAL(fn func(device.Range) error) error            { return nil }
+func (f *fakeDevice) Identity(context.Context) (device.DeviceIdentity, error) {
+	return device.DeviceIdentity{}, nil
+}
+func (f *fakeDevice) AppendWAL(r device.Range) error               { return nil }
+func (f *fakeDevice) RecoverWAL(fn func(device.Range) error) error { return nil }

--- a/cmd/verify/resume_verify_integration_test.go
+++ b/cmd/verify/resume_verify_integration_test.go
@@ -35,9 +35,11 @@ func (m *mockDevice) BlockSize() uint64                                       { 
 func (m *mockDevice) Close() error                                            { return nil }
 func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
 func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
-func (m *mockDevice) Identity() (device.DeviceIdentity, error)                { return device.DeviceIdentity{}, nil }
-func (m *mockDevice) AppendWAL(device.Range) error                            { return nil }
-func (m *mockDevice) RecoverWAL(func(device.Range) error) error               { return nil }
+func (m *mockDevice) Identity(context.Context) (device.DeviceIdentity, error) {
+	return device.DeviceIdentity{}, nil
+}
+func (m *mockDevice) AppendWAL(device.Range) error              { return nil }
+func (m *mockDevice) RecoverWAL(func(device.Range) error) error { return nil }
 
 func minimalStream(t *testing.T) []byte {
 	t.Helper()

--- a/device/device.go
+++ b/device/device.go
@@ -19,7 +19,7 @@ type Device interface {
 	// Close releases any resources associated with the device.
 	Close() error
 	// Identity gathers metadata describing the device.
-	Identity() (DeviceIdentity, error)
+	Identity(ctx context.Context) (DeviceIdentity, error)
 	// AppendWAL records an applied range in the device's WAL.
 	AppendWAL(r Range) error
 	// RecoverWAL replays ranges from the WAL using fn.

--- a/device/file.go
+++ b/device/file.go
@@ -63,7 +63,7 @@ func (d *FileDevice) SizeBytes() uint64 { return d.size }
 func (d *FileDevice) BlockSize() uint64 { return d.blockSize }
 
 // Identity returns size information for the file.
-func (d *FileDevice) Identity() (DeviceIdentity, error) {
+func (d *FileDevice) Identity(context.Context) (DeviceIdentity, error) {
 	return DeviceIdentity{SizeBytes: d.SizeBytes()}, nil
 }
 

--- a/device/identity_cmds.go
+++ b/device/identity_cmds.go
@@ -1,0 +1,18 @@
+package device
+
+import (
+	"os/exec"
+	"time"
+)
+
+var (
+	blkidPath string
+	lvsPath   string
+)
+
+const identityTimeout = 5 * time.Second
+
+func init() {
+	blkidPath, _ = exec.LookPath("blkid")
+	lvsPath, _ = exec.LookPath("lvs")
+}

--- a/device/identity_command_test.go
+++ b/device/identity_command_test.go
@@ -1,0 +1,111 @@
+package device
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func createSleepScript(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	script := "#!/bin/sh\nsleep 2\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return path
+}
+
+func createTouchScript(t *testing.T, dir, name, touch string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	script := "#!/bin/sh\ntouch " + touch + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return path
+}
+
+func TestRawIdentityTimeout(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	defer f.Close()
+	d := &RawDevice{f: f, logger: zap.NewNop()}
+	script := createSleepScript(t, "blkid")
+	orig := blkidPath
+	blkidPath = script
+	defer func() { blkidPath = orig }()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := d.Identity(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestRawIdentityIgnoresPATH(t *testing.T) {
+	if blkidPath == "" {
+		t.Skip("blkid not found")
+	}
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	defer f.Close()
+	d := &RawDevice{f: f, logger: zap.NewNop()}
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ran")
+	createTouchScript(t, dir, "blkid", marker)
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", dir)
+	defer os.Setenv("PATH", origPath)
+	_, _ = d.Identity(context.Background())
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatalf("malicious blkid executed")
+	}
+}
+
+func TestLVMIdentityTimeout(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	d := &LVMDevice{path: f.Name(), logger: zap.NewNop()}
+	script := createSleepScript(t, "lvs")
+	orig := lvsPath
+	lvsPath = script
+	defer func() { lvsPath = orig }()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := d.Identity(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestLVMIdentityIgnoresPATH(t *testing.T) {
+	if lvsPath == "" {
+		t.Skip("lvs not found")
+	}
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	d := &LVMDevice{path: f.Name(), logger: zap.NewNop()}
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ran")
+	createTouchScript(t, dir, "lvs", marker)
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", dir)
+	defer os.Setenv("PATH", origPath)
+	_, _ = d.Identity(context.Background())
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatalf("malicious lvs executed")
+	}
+}

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -43,7 +43,7 @@ func (s *identityStub) BlockSize() uint64                                { retur
 func (s *identityStub) Snapshot(context.Context, string) (Device, error) { return s, nil }
 func (s *identityStub) Cleanup(context.Context) error                    { return nil }
 func (s *identityStub) Close() error                                     { return nil }
-func (s *identityStub) Identity() (DeviceIdentity, error) {
+func (s *identityStub) Identity(context.Context) (DeviceIdentity, error) {
 	return DeviceIdentity{SizeBytes: s.size}, nil
 }
 func (s *identityStub) AppendWAL(r Range) error               { return nil }

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -528,7 +528,7 @@ func (s *stubDevice) BlockSize() uint64                                { return 
 func (s *stubDevice) Snapshot(context.Context, string) (Device, error) { return nil, nil }
 func (s *stubDevice) Cleanup(context.Context) error                    { return nil }
 func (s *stubDevice) Close() error                                     { return s.closeErr }
-func (s *stubDevice) Identity() (DeviceIdentity, error) {
+func (s *stubDevice) Identity(context.Context) (DeviceIdentity, error) {
 	return DeviceIdentity{SizeBytes: s.size}, nil
 }
 func (s *stubDevice) AppendWAL(r Range) error               { return nil }

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -105,7 +105,21 @@ func (d *LVMDevice) SizeBytes() uint64 { return d.size }
 func (d *LVMDevice) BlockSize() uint64 { return d.blockSize }
 
 // Identity gathers size, device numbers and UUID info for the logical volume.
-func (d *LVMDevice) Identity() (DeviceIdentity, error) {
+func (d *LVMDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, identityTimeout)
+		defer cancel()
+	}
+	if lvsPath == "" {
+		return DeviceIdentity{}, fmt.Errorf("lvs not found")
+	}
+	if blkidPath == "" {
+		return DeviceIdentity{}, fmt.Errorf("blkid not found")
+	}
 	var st unix.Stat_t
 	if err := unix.Stat(d.Path(), &st); err != nil {
 		return DeviceIdentity{}, err
@@ -115,16 +129,16 @@ func (d *LVMDevice) Identity() (DeviceIdentity, error) {
 		Major:     uint32(unix.Major(uint64(st.Rdev))),
 		Minor:     uint32(unix.Minor(uint64(st.Rdev))),
 	}
-	out, err := exec.Command("lvs", "--noheadings", "-o", "lv_uuid", d.Path()).Output()
+	out, err := exec.CommandContext(ctx, lvsPath, "--noheadings", "-o", "lv_uuid", d.Path()).Output()
 	if err != nil {
 		return DeviceIdentity{}, err
 	}
 	id.KernelUUID = strings.TrimSpace(string(out))
-	if out, err = exec.Command("blkid", "-o", "value", "-s", "UUID", d.Path()).Output(); err != nil {
+	if out, err = exec.CommandContext(ctx, blkidPath, "-o", "value", "-s", "UUID", d.Path()).Output(); err != nil {
 		return DeviceIdentity{}, err
 	}
 	id.FSUUID = strings.TrimSpace(string(out))
-	if out, err = exec.Command("blkid", "-o", "value", "-s", "PTUUID", d.Path()).Output(); err == nil {
+	if out, err = exec.CommandContext(ctx, blkidPath, "-o", "value", "-s", "PTUUID", d.Path()).Output(); err == nil {
 		id.GPTUUID = strings.TrimSpace(string(out))
 	}
 	return id, nil

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -34,7 +34,7 @@ func (r *Runner) OpenLVM(context.Context, string, *lvm.FDCache, string, *zap.Log
 func (d *LVMDevice) Path() string      { return "" }
 func (d *LVMDevice) SizeBytes() uint64 { return 0 }
 func (d *LVMDevice) BlockSize() uint64 { return 0 }
-func (d *LVMDevice) Identity() (DeviceIdentity, error) {
+func (d *LVMDevice) Identity(context.Context) (DeviceIdentity, error) {
 	return DeviceIdentity{}, fmt.Errorf("unsupported")
 }
 func (d *LVMDevice) AppendWAL(r Range) error               { return nil }

--- a/device/raw.go
+++ b/device/raw.go
@@ -183,7 +183,18 @@ func (d *RawDevice) SizeBytes() uint64 { return d.size }
 func (d *RawDevice) BlockSize() uint64 { return d.blockSize }
 
 // Identity gathers size, kernel uuid and GPT information for the device.
-func (d *RawDevice) Identity() (DeviceIdentity, error) {
+func (d *RawDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, identityTimeout)
+		defer cancel()
+	}
+	if blkidPath == "" {
+		return DeviceIdentity{}, fmt.Errorf("blkid not found")
+	}
 	var st unix.Stat_t
 	if err := unix.Stat(d.Path(), &st); err != nil {
 		return DeviceIdentity{}, err
@@ -193,14 +204,14 @@ func (d *RawDevice) Identity() (DeviceIdentity, error) {
 		Major:     uint32(unix.Major(uint64(st.Rdev))),
 		Minor:     uint32(unix.Minor(uint64(st.Rdev))),
 	}
-	out, err := exec.Command("blkid", "-o", "value", "-s", "UUID", d.Path()).Output()
+	out, err := exec.CommandContext(ctx, blkidPath, "-o", "value", "-s", "UUID", d.Path()).Output()
 	if err != nil {
 		return DeviceIdentity{}, err
 	}
 	uuid := strings.TrimSpace(string(out))
 	id.KernelUUID = uuid
 	id.FSUUID = uuid
-	if out, err = exec.Command("blkid", "-o", "value", "-s", "PTUUID", d.Path()).Output(); err == nil {
+	if out, err = exec.CommandContext(ctx, blkidPath, "-o", "value", "-s", "PTUUID", d.Path()).Output(); err == nil {
 		id.GPTUUID = strings.TrimSpace(string(out))
 	}
 	return id, nil

--- a/device/raw_nonlinux.go
+++ b/device/raw_nonlinux.go
@@ -23,7 +23,7 @@ func OpenRaw(context.Context, string, bool, string, []string, string, []string, 
 func (d *RawDevice) Path() string      { return "" }
 func (d *RawDevice) SizeBytes() uint64 { return 0 }
 func (d *RawDevice) BlockSize() uint64 { return 0 }
-func (d *RawDevice) Identity() (DeviceIdentity, error) {
+func (d *RawDevice) Identity(context.Context) (DeviceIdentity, error) {
 	return DeviceIdentity{}, fmt.Errorf("unsupported")
 }
 func (d *RawDevice) AppendWAL(r Range) error               { return nil }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -547,7 +547,7 @@ func Rebuild(
 	if err != nil {
 		return err
 	}
-	identity, err := dev.Identity()
+	identity, err := dev.Identity(ctx)
 	if err != nil {
 		return err
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -32,7 +32,7 @@ func (m *mockDevice) BlockSize() uint64                                       { 
 func (m *mockDevice) Close() error                                            { return nil }
 func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
 func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
-func (m *mockDevice) Identity() (device.DeviceIdentity, error) {
+func (m *mockDevice) Identity(context.Context) (device.DeviceIdentity, error) {
 	return device.DeviceIdentity{SizeBytes: m.size}, nil
 }
 func (m *mockDevice) AppendWAL(r device.Range) error               { return nil }

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -73,9 +73,11 @@ func (m *rdMockDevice) BlockSize() uint64 { return m.blockSize }
 func (m *rdMockDevice) Snapshot(ctx context.Context, snapshotSize string) (device.Device, error) {
 	return m, nil
 }
-func (m *rdMockDevice) Cleanup(ctx context.Context) error         { return nil }
-func (m *rdMockDevice) Close() error                              { return nil }
-func (m *rdMockDevice) Identity() (device.DeviceIdentity, error)  { return device.DeviceIdentity{}, nil }
+func (m *rdMockDevice) Cleanup(ctx context.Context) error { return nil }
+func (m *rdMockDevice) Close() error                      { return nil }
+func (m *rdMockDevice) Identity(context.Context) (device.DeviceIdentity, error) {
+	return device.DeviceIdentity{}, nil
+}
 func (m *rdMockDevice) AppendWAL(device.Range) error              { return nil }
 func (m *rdMockDevice) RecoverWAL(func(device.Range) error) error { return nil }
 

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -25,7 +25,7 @@ func (m *mockDevice) BlockSize() uint64                                       { 
 func (m *mockDevice) Close() error                                            { return nil }
 func (m *mockDevice) Snapshot(context.Context, string) (device.Device, error) { return m, nil }
 func (m *mockDevice) Cleanup(context.Context) error                           { return nil }
-func (m *mockDevice) Identity() (device.DeviceIdentity, error) {
+func (m *mockDevice) Identity(context.Context) (device.DeviceIdentity, error) {
 	return device.DeviceIdentity{SizeBytes: m.size}, nil
 }
 func (m *mockDevice) AppendWAL(r device.Range) error               { return nil }


### PR DESCRIPTION
## Summary
- add context-aware Identity methods with command timeouts and fixed path resolution
- ensure blkid and lvs binaries resolved once at startup
- test Identity for timeout handling and PATH tampering

## Testing
- `go build ./...` *(fails: undefined: f in internal/sizeparse/sizeparse.go)*
- `go test -coverprofile=coverage.out ./...` *(fails: undefined: f in internal/sizeparse/sizeparse.go)*
- `golangci-lint run` *(fails: undefined: f in internal/sizeparse/sizeparse.go)*

------
https://chatgpt.com/codex/tasks/task_e_68a485587cd08323a619b20f43332700