### PR TITLE
refactor size parsing and expand tests

### DIFF
--- a/internal/sizeparse/sizeparse.go
+++ b/internal/sizeparse/sizeparse.go
@@ -19,7 +19,6 @@ func Parse(input string) (uint64, bool, error) {
 	if s == "" {
 		return 0, false, fmt.Errorf("empty size")
 	}
-	s = strings.ToUpper(s)
 
 	if strings.HasSuffix(s, "%") {
 		num := strings.TrimSpace(strings.TrimSuffix(s, "%"))
@@ -37,16 +36,17 @@ func Parse(input string) (uint64, bool, error) {
 		return i.Uint64(), true, nil
 	}
 
-	s = strings.ReplaceAll(s, " ", "")
-	idx := 0
-	for ; idx < len(s); idx++ {
-		r := rune(s[idx])
-		if !unicode.IsDigit(r) && r != '.' && !(idx == 0 && r == '-') {
+	s = strings.ReplaceAll(strings.ToUpper(s), " ", "")
+
+	numEnd := len(s)
+	for i, r := range s {
+		if !unicode.IsDigit(r) && r != '.' && !(i == 0 && r == '-') {
+			numEnd = i
 			break
 		}
 	}
-	numStr := s[:idx]
-	unit := s[idx:]
+	numStr := s[:numEnd]
+	unit := s[numEnd:]
 
 	r := new(big.Rat)
 	if _, ok := r.SetString(numStr); !ok {

--- a/internal/sizeparse/sizeparse_test.go
+++ b/internal/sizeparse/sizeparse_test.go
@@ -6,44 +6,121 @@ import (
 	"testing"
 )
 
-func TestParse(t *testing.T) {
-	tests := []struct {
-		input   string
+func TestParseUnits(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint64
+	}{
+		{"1KB", 1000},
+		{"1MB", 1e6},
+		{"1GB", 1e9},
+		{"1KiB", 1 << 10},
+		{"1MiB", 1 << 20},
+		{"1GiB", 1 << 30},
+	}
+	for _, tc := range cases {
+		got, pct, err := Parse(tc.in)
+		if err != nil {
+			t.Fatalf("Parse(%q) error = %v", tc.in, err)
+		}
+		if pct {
+			t.Fatalf("Parse(%q) reported percent", tc.in)
+		}
+		if got != tc.want {
+			t.Fatalf("Parse(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseFractional(t *testing.T) {
+	valid := []struct {
+		in   string
+		want uint64
+	}{
+		{"1.5KB", 1500},
+		{"1.5MiB", 1572864},
+	}
+	for _, tc := range valid {
+		got, pct, err := Parse(tc.in)
+		if err != nil {
+			t.Fatalf("Parse(%q) error = %v", tc.in, err)
+		}
+		if pct {
+			t.Fatalf("Parse(%q) reported percent", tc.in)
+		}
+		if got != tc.want {
+			t.Fatalf("Parse(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+
+	invalid := []string{"1.1B", "1.1MiB"}
+	for _, in := range invalid {
+		if _, _, err := Parse(in); err == nil {
+			t.Fatalf("Parse(%q) expected error", in)
+		}
+	}
+}
+
+func TestParsePercent(t *testing.T) {
+	cases := []struct {
+		in      string
 		want    uint64
-		percent bool
 		wantErr bool
 	}{
-		{"1KB", 1000, false, false},
-		{"1MB", 1000000, false, false},
-		{"1.5GB", uint64(1.5 * 1e9), false, false},
-		{"1KiB", 1 << 10, false, false},
-		{"1MiB", 1 << 20, false, false},
-		{"50%", 50, true, false},
-		{"bad", 0, false, true},
-		{"10XB", 0, false, true},
-
-		{"-1G", 0, false, true},
-		{"-10%", 0, true, true},
-
-		{strconv.FormatUint(math.MaxUint64, 10), math.MaxUint64, false, false},
-		{strconv.FormatUint(math.MaxUint64, 10) + "B", math.MaxUint64, false, false},
-		{"18.446744073709551615E", math.MaxUint64, false, false},
-		{"18446744073709551616", 0, false, true},
-		{"18446744073709551616B", 0, false, true},
-		{"18446744073709551615K", 0, false, true},
+		{"50%", 50, false},
+		{"1%", 1, false},
+		{"1.5%", 0, true},
+		{"-10%", 0, true},
 	}
-	for _, tt := range tests {
-		got, pct, err := Parse(tt.input)
-		if (err != nil) != tt.wantErr {
-			t.Fatalf("Parse(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+	for _, tc := range cases {
+		got, pct, err := Parse(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Fatalf("Parse(%q) error=%v wantErr=%v", tc.in, err, tc.wantErr)
 		}
-		if err == nil {
-			if pct != tt.percent {
-				t.Fatalf("Parse(%q) percent = %v, want %v", tt.input, pct, tt.percent)
-			}
-			if got != tt.want {
-				t.Fatalf("Parse(%q) = %v, want %v", tt.input, got, tt.want)
-			}
+		if tc.wantErr {
+			continue
+		}
+		if !pct {
+			t.Fatalf("Parse(%q) percent flag = false", tc.in)
+		}
+		if got != tc.want {
+			t.Fatalf("Parse(%q) = %d want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseOverflowAndNegative(t *testing.T) {
+	overflow := []string{
+		"18446744073709551616", // MaxUint64 + 1
+		"18446744073709551616B",
+		"18446744073709551615K",
+	}
+	for _, in := range overflow {
+		if _, _, err := Parse(in); err == nil {
+			t.Fatalf("Parse(%q) expected overflow error", in)
+		}
+	}
+
+	negative := []string{"-1", "-1B", "-1KB"}
+	for _, in := range negative {
+		if _, _, err := Parse(in); err == nil {
+			t.Fatalf("Parse(%q) expected negative error", in)
+		}
+	}
+}
+
+func TestParseMaxUint64(t *testing.T) {
+	maxStr := strconv.FormatUint(math.MaxUint64, 10)
+	for _, in := range []string{maxStr, maxStr + "B"} {
+		got, pct, err := Parse(in)
+		if err != nil {
+			t.Fatalf("Parse(%q) error=%v", in, err)
+		}
+		if pct {
+			t.Fatalf("Parse(%q) percent flag = true", in)
+		}
+		if got != math.MaxUint64 {
+			t.Fatalf("Parse(%q) = %d want %d", in, got, uint64(math.MaxUint64))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- use `big.Rat` to parse sizes and percent values
- support decimal and binary units via single switch mapping
- validate against fractional bytes, negatives, and `math.MaxUint64`
- expand unit tests for units, fractions, percentages, overflow, and negative inputs

## Testing
- `go test ./internal/sizeparse`


------
https://chatgpt.com/codex/tasks/task_e_68a48b2776ec8323bcbc3b9502199341