### PR TITLE
reports: track size parser compile failure

### DIFF
--- a/reports/gaps.json
+++ b/reports/gaps.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "type": "bug",
+    "component": "internal/sizeparse",
+    "evidence": "go build ./internal/sizeparse fails to compile",
+    "impact": "size parsing unavailable; blocks builds relying on byte size parsing",
+    "fix": "correct the compiler errors and add tests",
+    "priority": "high"
+  }
+]

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -1,4 +1,4 @@
 | Type | Component | Evidence | Impact | Fix | Priority |
 |------|-----------|----------|--------|-----|----------|
-<!-- no outstanding gaps -->
 
+| bug | internal/sizeparse | `go build ./internal/sizeparse` fails to compile | size parsing unavailable; blocks builds relying on byte size parsing | correct the compiler errors and add tests | high |


### PR DESCRIPTION
## Summary
- document size parser compile failure in gap reports to keep CI red

## Testing
- `go test ./reports` (fails: found 1 unresolved gap)
- `go build ./...` (fails: w.f.Name undefined)
- `go test -cover ./...` (fails: w.f.Name undefined)
- `golangci-lint run` (fails: w.f.Name undefined)


------
https://chatgpt.com/codex/tasks/task_e_68a48b28de888323acf9554e11965437