### PR TITLE
Fix sizeparse percent tests

### DIFF
--- a/internal/sizeparse/sizeparse_test.go
+++ b/internal/sizeparse/sizeparse_test.go
@@ -65,6 +65,7 @@ func TestParsePercent(t *testing.T) {
 	cases := []struct {
 		in      string
 		want    uint64
+		percent bool
 		wantErr bool
 	}{
 		{"1KB", 1000, false, false},
@@ -74,12 +75,12 @@ func TestParsePercent(t *testing.T) {
 		{"1MiB", 1 << 20, false, false},
 		{"1.5GiB", 3 * (1 << 29), false, false},
 		{"50%", 50, true, false},
+		{"1%", 1, true, false},
+		{"1.5%", 0, true, true},
+		{"-10%", 0, true, true},
 		{"bad", 0, false, true},
 		{"10XB", 0, false, true},
-
 		{"-1G", 0, false, true},
-		{"-10%", 0, true, true},
-
 		{strconv.FormatUint(math.MaxUint64, 10), math.MaxUint64, false, false},
 		{strconv.FormatUint(math.MaxUint64, 10) + "B", math.MaxUint64, false, false},
 		{"18.446744073709551615E", math.MaxUint64, false, false},
@@ -87,37 +88,22 @@ func TestParsePercent(t *testing.T) {
 		{"18446744073709551616B", 0, false, true},
 		{"18446744073709551615K", 0, false, true},
 	}
-	for _, tt := range tests {
-		got, pct, err := Parse(tt.input)
-		if (err != nil) != tt.wantErr {
-			t.Fatalf("Parse(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
-		}
-		if err == nil {
-			if pct != tt.percent {
-				t.Fatalf("Parse(%q) percent = %v, want %v", tt.input, pct, tt.percent)
-			}
-			if got != tt.want {
-				t.Fatalf("Parse(%q) = %v, want %v", tt.input, got, tt.want)
-			}
-
-		{"50%", 50, false},
-		{"1%", 1, false},
-		{"1.5%", 0, true},
-		{"-10%", 0, true},
-	}
 	for _, tc := range cases {
 		got, pct, err := Parse(tc.in)
-		if (err != nil) != tc.wantErr {
-			t.Fatalf("Parse(%q) error=%v wantErr=%v", tc.in, err, tc.wantErr)
-		}
 		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("Parse(%q) expected error", tc.in)
+			}
 			continue
 		}
-		if !pct {
-			t.Fatalf("Parse(%q) percent flag = false", tc.in)
+		if err != nil {
+			t.Fatalf("Parse(%q) error = %v", tc.in, err)
+		}
+		if pct != tc.percent {
+			t.Fatalf("Parse(%q) percent = %v, want %v", tc.in, pct, tc.percent)
 		}
 		if got != tc.want {
-			t.Fatalf("Parse(%q) = %d want %d", tc.in, got, tc.want)
+			t.Fatalf("Parse(%q) = %d, want %d", tc.in, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- reconstruct sizeparse test cases for percent inputs
- validate percent parsing with unified loop

## Testing
- `go build ./...` *(fails: device/wal.go:403:14: w.f.Name undefined)*
- `go test -coverprofile=coverage.out ./...` *(fails: multiple packages build failed)*
- `go test ./internal/sizeparse`
- `golangci-lint run` *(fails: typecheck: w.f.Name undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a48eeddb548323a64cd6b4e1c4cc4f