### PR TITLE
Add Name to walFile interface

### DIFF
--- a/device/wal.go
+++ b/device/wal.go
@@ -55,6 +55,7 @@ type walFile interface {
 	Truncate(int64) error
 	Close() error
 	Stat() (fs.FileInfo, error)
+	Name() string
 }
 
 type WAL struct {

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -2,9 +2,9 @@ package device
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
 	"io/fs"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -166,13 +166,14 @@ func (s *shortWriteFile) Sync() error                              { return nil 
 func (s *shortWriteFile) Truncate(int64) error                     { return nil }
 func (s *shortWriteFile) Close() error                             { return nil }
 func (s *shortWriteFile) Stat() (fs.FileInfo, error)               { return nil, nil }
+func (s *shortWriteFile) Name() string                             { return "" }
 
 func TestWALAppendShortWrite(t *testing.T) {
 	w := &WAL{f: &shortWriteFile{}}
 	err := w.Append(Range{Start: 0, End: 1})
 	if err == nil {
 		t.Fatalf("expected error on short write")
-  }
+	}
 }
 
 func TestWALSyncDirCreate(t *testing.T) {


### PR DESCRIPTION
## Summary
- include Name() in walFile interface so WAL can close and sync parent directory
- update shortWriteFile test stub with Name method

## Testing
- `go build ./device`
- `go test ./device` *(fails: expected deadline exceeded, got signal: killed)*
- `go test ./device -run TestWAL -v`
- `golangci-lint run ./device...` *(fails: multiple warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a48eeef3ec8323aa8bf10d4ccc5ba2