### PR TITLE
docs: include manifest epoch in device identity tuple

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -8,9 +8,10 @@ This guide outlines exit codes, resume workflows, and common troubleshooting ste
 
 ```sh
 lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
+# 10737418240 12345678-9abc-def0-1234-56789abcdef0 1700000000
 ```
 
-Validates device identities and privileges and logs dry-run estimates without writing data.
+Validates device identities and privileges and prints `size_bytes device_id manifest_epoch` without writing data.
 
 ### `--resume`
 
@@ -46,6 +47,7 @@ lvmsync run --skip-snapshot-creation --force /dev/vg0/src /dev/vg0/target
 
    ```sh
    lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
+   # 10737418240 12345678-9abc-def0-1234-56789abcdef0 1700000000
    ```
 
 2. Verify existing blocks:
@@ -95,7 +97,7 @@ lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with e
 
 ## Troubleshooting
 
-- Compare source and destination identities; the device identity tuple `(device_id, fs_uuid, size_bytes, major:minor)` must match the resume file.
+- Compare source and destination identities; the device identity tuple `(device_id, fs_uuid, size_bytes, major:minor, manifest_epoch)` must match the resume file. LVMSync refuses to resume when the tuple differs.
 - Confirm the destination is not mounted read-write. Use `--force` only when intentionally overwriting.
 - Rerun with `--resume` after resolving issues to avoid re-copying completed blocks.
 - Review logs for detailed errors and ensure all configuration values follow the expected flag > environment variable > config file precedence.
@@ -135,7 +137,7 @@ lvmsync run --resume state /dev/vg0/snap0 /dev/vg0/target
 ### Identity Tuple Mismatch
 
 If the source or destination no longer matches the resume state, LVMSync exits with
-[`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) (`80`). Recreate the
+[`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) (`80`) and refuses to resume. Recreate the
 destination or regenerate the resume state before restarting.
 
 ## Failure Drills

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ For snapshot cleanup, resuming transfers, and verify-only rollback procedures, s
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers with verification enabled by default (use `--verify=none` to skip).
 - **Crash-Safe WAL**: Records committed ranges in a write-ahead log so interrupted runs can recover. See [WAL documentation](docs/wal.md) for layout and replay details.
-- **Probe and Verification Modes**: `--probe-only` validates devices and privileges without writing, while `--verify-only` scans both sides and reports mismatches.
+ - **Probe and Verification Modes**: `--probe-only` validates devices and privileges without writing and prints `size_bytes device_id manifest_epoch` to stdout, while `--verify-only` scans both sides and reports mismatches.
 - **Dry-run Estimates**: `--dry-run` samples the manifest to project bytes and ETA without transferring data.
 - **Planning**: `--plan` prints resolved configuration, transport order, estimated bytes, and compression decisions as JSON without transferring data.
-- **Device Identity Tuple**: Each run records `(device_id, fs_uuid, size_bytes, major:minor)` to prevent writing to the wrong destination.
+ - **Device Identity Tuple**: Each run records `(device_id, fs_uuid, size_bytes, major:minor, manifest_epoch)` to prevent writing to the wrong destination.
 - **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
 - **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it. Use `--sparse=never` to always write zeros instead.
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to a device's NUMA node (`--numa-pin`) or an explicit node (`--numa-node`).
@@ -53,7 +53,14 @@ For snapshot cleanup, resuming transfers, and verify-only rollback procedures, s
 
 ### Resume, verification, and safe overwrite flows
 
-Transfers store the device identity tuple `(device_id, fs_uuid, size_bytes, major:minor)` and compare it against the destination before writing. Mismatches abort the run to avoid accidental overwrites. Use `--force` to bypass this check when intentionally overwriting.
+Transfers store the device identity tuple `(device_id, fs_uuid, size_bytes, major:minor, manifest_epoch)` and compare it against the destination before writing. Mismatches abort the run and LVMSync refuses to resume when the tuple differs. Use `--force` to bypass this check when intentionally overwriting.
+
+Example `--probe-only` output showing `size_bytes device_id manifest_epoch`:
+
+```sh
+lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
+# 10737418240 12345678-9abc-def0-1234-56789abcdef0 1700000000
+```
 
 - `--resume=statefile` continues an interrupted run (verification runs unless `--verify=none`).
 - `--verify-only` reads both devices and reports mismatches without writing data.
@@ -691,7 +698,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Log estimated transfer bytes without sending data; uses manifest sampling when available |
 | `--plan` | `LVMSYNC_PLAN` | `plan` | Print configuration plan as JSON and exit |
 | `--verify-only` | `LVMSYNC_VERIFY_ONLY` | `verify_only` | Read source and destination and report mismatches without writing data |
-| `--probe-only` | `LVMSYNC_PROBE_ONLY` | `probe_only` | Validate devices and privileges and log estimates without transferring data |
+| `--probe-only` | `LVMSYNC_PROBE_ONLY` | `probe_only` | Validate devices and privileges and print `size_bytes device_id manifest_epoch` without transferring data |
 | `--sparse` | `LVMSYNC_SPARSE` | `sparse` | Sparse file handling: `auto` punches holes, `never` writes zero blocks |
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | `transport` | Ordered transports to try (e.g., `ssh,tcp+tls,h2,quic`) |
 | `--tcp-port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,21 @@ The controller orchestrates replication, validates parameters, and interacts wit
 
 ## Probe and verify modes
 
-Read-only operations can run without elevated privileges.  
-`--probe-only` checks device metadata, validates privileges, and emits dry-run estimates.  
-`--verify-only` reads source and destination devices and reports mismatches.  
+Read-only operations can run without elevated privileges.
+`--probe-only` checks device metadata, validates privileges, and prints `size_bytes device_id manifest_epoch` so operators can capture the identity tuple before writing.
+`--verify-only` reads source and destination devices and reports mismatches.
 Both commands exit `0` on success, return `60` for verification failures, and `10` when required capabilities are missing.
+
+Example `--probe-only` output:
+
+```sh
+lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
+# 10737418240 12345678-9abc-def0-1234-56789abcdef0 1700000000
+```
+
+## Device identity enforcement
+
+Each transfer records `(device_id, fs_uuid, size_bytes, major:minor, manifest_epoch)` and compares it with the destination and any resume state before writing. LVMSync refuses to resume when this tuple differs, preventing accidental or malicious overwrites.
 
 ## Required sudoers entries
 


### PR DESCRIPTION
## Summary
- document `manifest_epoch` in device identity tuple
- warn that mismatched tuples refuse resumes
- show probe-only output including `manifest_epoch`

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRawIdentityTimeout, TestLVMIdentityTimeout, sizeparse build, remote tests)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: typecheck in internal/sizeparse, missing git revision)*

------
https://chatgpt.com/codex/tasks/task_e_68a495e2dafc83238ee4852ddcaf2a4e