### PR TITLE
Coalesce hole punching and verify sparse writes

### DIFF
--- a/integration/loopback.sh
+++ b/integration/loopback.sh
@@ -81,4 +81,23 @@ done
 # Verify-only
 "$BIN" run --verify-only /dev/vgsrc/snap /dev/vgd/dest
 
+# Sparse file handling verification
+SRC_SPARSE="$TMPDIR/src_sparse.img"
+dd if=/dev/zero of="$SRC_SPARSE" bs=1M count=1
+truncate -s 2M "$SRC_SPARSE"
+DST_SPARSE="$TMPDIR/dst_sparse.img"
+"$BIN" run "$SRC_SPARSE" "$DST_SPARSE"
+used=$(stat -c %b "$DST_SPARSE")
+if [ $((used*512)) -ge $((2*1024*1024)) ]; then
+  echo "hole punching failed"
+  exit 1
+fi
+DST_FULL="$TMPDIR/dst_full.img"
+"$BIN" run --sparse=never "$SRC_SPARSE" "$DST_FULL"
+used_full=$(stat -c %b "$DST_FULL")
+if [ $((used_full*512)) -lt $((2*1024*1024)) ]; then
+  echo "expected full allocation with sparse=never"
+  exit 1
+fi
+
 exit 0

--- a/transfer/block_coalesce_linux_test.go
+++ b/transfer/block_coalesce_linux_test.go
@@ -1,0 +1,72 @@
+package transfer
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"lvmsync_go/internal/config"
+)
+
+func TestBlockWriterCoalescesZeroBlocks(t *testing.T) {
+	cfg := &config.Config{BlockSize: 4096}
+	dest, err := os.CreateTemp(t.TempDir(), "dest")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(dest.Name())
+	defer dest.Close()
+
+	var stream bytes.Buffer
+	hdr := make([]byte, 16)
+	binary.BigEndian.PutUint64(hdr[0:8], 0)
+	binary.BigEndian.PutUint32(hdr[8:12], 0)
+	binary.BigEndian.PutUint32(hdr[12:16], 0)
+	stream.Write(hdr)
+	binary.BigEndian.PutUint64(hdr[0:8], uint64(cfg.BlockSize))
+	binary.BigEndian.PutUint32(hdr[8:12], 0)
+	binary.BigEndian.PutUint32(hdr[12:16], 0)
+	stream.Write(hdr)
+	data := bytes.Repeat([]byte{1}, cfg.BlockSize)
+	binary.BigEndian.PutUint64(hdr[0:8], uint64(cfg.BlockSize*2))
+	binary.BigEndian.PutUint32(hdr[8:12], uint32(cfg.BlockSize))
+	binary.BigEndian.PutUint32(hdr[12:16], crc32c(data))
+	stream.Write(hdr)
+	stream.Write(data)
+
+	bw, err := newBlockWriter(cfg, dest, nil, false, nil, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("newBlockWriter: %v", err)
+	}
+	orig := punchHoleFunc
+	var calls int
+	var length int
+	punchHoleFunc = func(f *os.File, off uint64, l int) error {
+		calls++
+		length = l
+		return orig(f, off, l)
+	}
+	defer func() { punchHoleFunc = orig }()
+
+	if _, err := bw.write(bufio.NewReader(bytes.NewReader(stream.Bytes()))); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if calls != 1 || length != cfg.BlockSize*2 {
+		t.Fatalf("expected one hole of %d bytes, got calls=%d len=%d", cfg.BlockSize*2, calls, length)
+	}
+	if !seekHoleSupported(dest) {
+		t.Skip("SEEK_HOLE not supported")
+	}
+	off, err := unix.Seek(int(dest.Fd()), 0, unix.SEEK_DATA)
+	if err != nil {
+		t.Fatalf("seek data: %v", err)
+	}
+	if off != int64(cfg.BlockSize*2) {
+		t.Fatalf("expected data offset %d, got %d", cfg.BlockSize*2, off)
+	}
+}

--- a/transfer/block_sparse_linux_test.go
+++ b/transfer/block_sparse_linux_test.go
@@ -7,8 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/binary"
-	"io"
 	"os"
 	"testing"
 
@@ -85,28 +83,12 @@ func TestIterateBlocksSkipsSparseRegions(t *testing.T) {
 	defer os.Remove(dest.Name())
 	defer dest.Close()
 
-	rd := bytes.NewReader(buf.Bytes())
-	header := make([]byte, 16)
-	for {
-		if _, err := io.ReadFull(rd, header); err != nil {
-			if err == io.EOF {
-				break
-			}
-			t.Fatalf("read header: %v", err)
-		}
-		off := binary.BigEndian.Uint64(header[0:8])
-		size := binary.BigEndian.Uint32(header[8:12])
-		crc := binary.BigEndian.Uint32(header[12:16])
-		var block []byte
-		if size > 0 {
-			block = make([]byte, size)
-			if _, err := io.ReadFull(rd, block); err != nil {
-				t.Fatalf("read block: %v", err)
-			}
-		}
-		if _, err := processBlock(cfg, dest, nil, nil, false, nil, off, crc, nil, block, size, zap.NewNop(), nil); err != nil {
-			t.Fatalf("processBlock: %v", err)
-		}
+	bw, err := newBlockWriter(cfg, dest, nil, false, nil, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("newBlockWriter: %v", err)
+	}
+	if _, err := bw.write(bufio.NewReader(bytes.NewReader(buf.Bytes()))); err != nil {
+		t.Fatalf("write: %v", err)
 	}
 
 	if !seekHoleSupported(dest) {

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -88,6 +88,9 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 	}
 	headerBuf := make([]byte, headerLen)
 	var total int64
+	var zeroStart uint64
+	var zeroLen uint64
+	var holes []Range
 	for {
 		offset, chunkSize, crc, transmitted, err := readBlockHeader(reader, headerBuf, bw.verify, bw.checksum)
 		if err == io.EOF {
@@ -109,7 +112,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		} else {
 			chunkID = zeroHash(int(chunkSize))
 		}
-		written, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.intra, bw.verify, bw.checksum, offset, crc, transmitted, data, chunkSize, bw.logger, bw.wal)
+		written, zlen, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.intra, bw.verify, bw.checksum, offset, crc, transmitted, data, chunkSize, bw.logger, bw.wal)
 		if bw.cfg.ODirect {
 			if data != nil {
 				putAlignedBlockBuffer(data)
@@ -120,6 +123,56 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		if err != nil {
 			return total, err
 		}
+		if zlen > 0 {
+			if zeroLen == 0 {
+				zeroStart = offset
+				zeroLen = zlen
+			} else if offset == zeroStart+zeroLen {
+				zeroLen += zlen
+			} else {
+				if bw.wal != nil {
+					if err := bw.wal.Append(Range{Start: zeroStart, End: zeroStart + zeroLen}); err != nil {
+						return total, err
+					}
+				}
+				if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
+					return total, err
+				}
+				holes = append(holes, Range{Start: zeroStart, End: zeroStart + zeroLen})
+				total += int64(zeroLen)
+				bw.sinceSync += int64(zeroLen)
+				if bw.cfg.SyncIntervalBytes > 0 && bw.sinceSync >= int64(bw.cfg.SyncIntervalBytes) {
+					if err := bw.deps.FdatasyncFile(bw.dest); err != nil {
+						return total, err
+					}
+					bw.sinceSync = 0
+				}
+				zeroStart = offset
+				zeroLen = zlen
+			}
+			saveResumeState(bw.cfg, bw.rt, offset, chunkID, int64(zlen), bw.logger)
+			continue
+		}
+		if zeroLen > 0 {
+			if bw.wal != nil {
+				if err := bw.wal.Append(Range{Start: zeroStart, End: zeroStart + zeroLen}); err != nil {
+					return total, err
+				}
+			}
+			if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
+				return total, err
+			}
+			holes = append(holes, Range{Start: zeroStart, End: zeroStart + zeroLen})
+			total += int64(zeroLen)
+			bw.sinceSync += int64(zeroLen)
+			if bw.cfg.SyncIntervalBytes > 0 && bw.sinceSync >= int64(bw.cfg.SyncIntervalBytes) {
+				if err := bw.deps.FdatasyncFile(bw.dest); err != nil {
+					return total, err
+				}
+				bw.sinceSync = 0
+			}
+			zeroLen = 0
+		}
 		saveResumeState(bw.cfg, bw.rt, offset, chunkID, int64(chunkSize), bw.logger)
 		if written {
 			total += int64(chunkSize)
@@ -129,6 +182,36 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 					return total, err
 				}
 				bw.sinceSync = 0
+			}
+		}
+	}
+	if zeroLen > 0 {
+		if bw.wal != nil {
+			if err := bw.wal.Append(Range{Start: zeroStart, End: zeroStart + zeroLen}); err != nil {
+				return total, err
+			}
+		}
+		if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
+			return total, err
+		}
+		holes = append(holes, Range{Start: zeroStart, End: zeroStart + zeroLen})
+		total += int64(zeroLen)
+		bw.sinceSync += int64(zeroLen)
+		if bw.cfg.SyncIntervalBytes > 0 && bw.sinceSync >= int64(bw.cfg.SyncIntervalBytes) {
+			if err := bw.deps.FdatasyncFile(bw.dest); err != nil {
+				return total, err
+			}
+			bw.sinceSync = 0
+		}
+	}
+	if bw.cfg.Sparse != "never" && seekHoleSupported(bw.dest) {
+		for _, h := range holes {
+			off, err := nextDataOffset(bw.dest, int64(h.Start))
+			if err != nil {
+				return total, err
+			}
+			if off != -1 && off < int64(h.End) {
+				return total, fmt.Errorf("hole verification failed at offset %d", h.Start)
 			}
 		}
 	}

--- a/transfer/discard_test.go
+++ b/transfer/discard_test.go
@@ -28,7 +28,7 @@ func TestProcessBlockDiscard(t *testing.T) {
 	defer restore()
 	data := []byte("abcd")
 	crc := crc32c(data)
-	if written, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil || !written {
+	if written, _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil || !written {
 		t.Fatalf("processBlock: %v written=%v", err, written)
 	}
 	if !called {
@@ -51,7 +51,7 @@ func TestProcessBlockDiscardDisabled(t *testing.T) {
 	defer restore()
 	data := []byte("abcd")
 	crc := crc32c(data)
-	if _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil {
+	if _, _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil {
 		t.Fatalf("processBlock: %v", err)
 	}
 	if called {

--- a/transfer/intra_dedup_test.go
+++ b/transfer/intra_dedup_test.go
@@ -43,11 +43,11 @@ func TestProcessBlockIntraDedup(t *testing.T) {
 	defer os.Remove(f.Name())
 	data := []byte("data")
 	crc := crc32c(data)
-	written, err := processBlock(cfg, f, nil, cache, false, nil, 0, crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
+	written, _, err := processBlock(cfg, f, nil, cache, false, nil, 0, crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
 	if err != nil || !written {
 		t.Fatalf("first write %v %v", written, err)
 	}
-	written, err = processBlock(cfg, f, nil, cache, false, nil, uint64(len(data)), crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
+	written, _, err = processBlock(cfg, f, nil, cache, false, nil, uint64(len(data)), crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("second write err %v", err)
 	}

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -137,40 +137,35 @@ func processBlock(
 	chunkSize uint32,
 	logger *zap.Logger,
 	wal *WAL,
-) (bool, error) {
+) (bool, uint64, error) {
 	if offset > math.MaxInt64 {
-		return false, fmt.Errorf("offset %d overflows int64", offset)
+		return false, 0, fmt.Errorf("offset %d overflows int64", offset)
 	}
 	if err := verifyCRC(crc, data, offset); err != nil {
-		return false, err
+		return false, 0, err
 	}
 	if err := verifyChecksum(verify, checksum, data, transmitted, offset); err != nil {
-		return false, err
+		return false, 0, err
 	}
-	if chunkSize == 0 || isAllZero(data) {
-		if wal != nil {
-			if err := wal.Append(Range{Start: offset, End: offset + uint64(chunkSize)}); err != nil {
-				return false, err
-			}
-		}
-		if err := writeZeroBlock(cfg, destFile, offset, logger); err != nil {
-			return false, err
-		}
-		return true, nil
+	if chunkSize == 0 {
+		return false, uint64(cfg.BlockSize), nil
+	}
+	if isAllZero(data) {
+		return false, uint64(chunkSize), nil
 	}
 	if dedup != nil {
 		intOffset := int64(offset)
 		if !dedup.ShouldTransfer(intOffset, data) {
-			return false, nil
+			return false, 0, nil
 		}
 		dedup.RecordTransfer(intOffset, data)
 	}
 	if intra != nil && intra.Seen(data) {
-		return false, nil
+		return false, 0, nil
 	}
 	if wal != nil {
 		if err := wal.Append(Range{Start: offset, End: offset + uint64(chunkSize)}); err != nil {
-			return false, err
+			return false, 0, err
 		}
 	}
 	if cfg.Discard {
@@ -179,7 +174,7 @@ func processBlock(
 		}
 	}
 	if err := writeData(destFile, offset, data, logger); err != nil {
-		return false, err
+		return false, 0, err
 	}
-	return true, nil
+	return true, 0, nil
 }

--- a/transfer/zero.go
+++ b/transfer/zero.go
@@ -78,3 +78,45 @@ func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *za
 	}
 	return nil
 }
+
+// writeZeroRange attempts to punch a sparse hole spanning length bytes starting
+// at offset. When hole punching is unsupported, it falls back to writing zeros
+// for the entire range using a reusable buffer.
+func writeZeroRange(cfg *config.Config, dest *os.File, offset uint64, length uint64, logger *zap.Logger) error {
+	if length == 0 {
+		return nil
+	}
+	if cfg.Sparse != "never" && !punchHoleDisabled.Load() {
+		if err := punchHoleFunc(dest, offset, int(length)); err == nil {
+			return nil
+		} else if errors.Is(err, unix.ENOTSUP) {
+			if punchHoleDisabled.CompareAndSwap(false, true) {
+				logger.Warn("hole punching unsupported; disabling", zap.Error(err))
+			}
+		} else {
+			return err
+		}
+	}
+	var zero []byte
+	if cfg.ODirect {
+		zero = getAlignedBlockBuffer(cfg.BlockSize)
+		defer putAlignedBlockBuffer(zero)
+	} else {
+		zero = getBlockBuffer(cfg.BlockSize)
+		defer putBlockBuffer(zero)
+	}
+	remaining := length
+	cur := offset
+	for remaining > 0 {
+		n := cfg.BlockSize
+		if remaining < uint64(n) {
+			n = int(remaining)
+		}
+		if err := writeData(dest, cur, zero[:n], logger); err != nil {
+			return err
+		}
+		remaining -= uint64(n)
+		cur += uint64(n)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- coalesce consecutive zero blocks into a single punched hole and verify holes after transfer
- add unit tests for hole punching and update loopback script for sparse verification

## Testing
- `go build ./...`
- `go test -cover ./transfer`
- `go test -cover ./...` *(fails: TestRawIdentityTimeout, TestLVMIdentityTimeout, sizeparse build error)*
- `golangci-lint run` *(fails: sizeparse typecheck, missing origin/main)*

------
https://chatgpt.com/codex/tasks/task_e_68a495df8eb8832385f32d996f0293fb