### PR TITLE
Remove duplicate create-dest-lv flag

### DIFF
--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -166,8 +166,6 @@ func initLVMFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("target-volume-group", cfg.TargetVolumeGroup, "Target LVM volume group")
 	fs.StringSlice("target-vgs", cfg.TargetVGCandidates, "Candidate target VGs for volume selection")
 
-	fs.Bool("create-dest-lv", cfg.CreateDestLV, "Create destination logical volume if missing")
-
 	fs.Bool("create-dest-lv", cfg.CreateDestLV, "Create destination logical volume when missing")
 
 	return fs


### PR DESCRIPTION
## Summary
- remove duplicate `create-dest-lv` flag from LVM flag set

## Testing
- `go build ./...` (fails: syntax error in cmd/dump/client.go)
- `go test -cover ./...` (fails: syntax errors in multiple tests)
- `go test ./cmd/...` (fails: build error in cmd/dump)
- `golangci-lint run` (fails: syntax errors in cmd/dump and others)


------
https://chatgpt.com/codex/tasks/task_e_68a4a50878e88323b80c4ba6055a6604