### PR TITLE
Add CreateDestLV and SanitizeEnv precedence tests

### DIFF
--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -193,10 +193,7 @@ func TestPlanEnvOverridesYAML(t *testing.T) {
 	}
 }
 
-
 func TestCreateDestLVFlagOverridesEnvAndYAML(t *testing.T) {
-
-func TestSanitizeEnvFlagOverridesEnvAndYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -220,7 +217,37 @@ func TestSanitizeEnvFlagOverridesEnvAndYAML(t *testing.T) {
 }
 
 func TestCreateDestLVEnvOverridesYAML(t *testing.T) {
-=======
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("create_dest_lv: false\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_CREATE_DEST_LV", "true")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !cfg.CreateDestLV {
+		t.Fatalf("CreateDestLV=%v want true", cfg.CreateDestLV)
+	}
+}
+
+func TestSanitizeEnvFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
 	if err := os.WriteFile(cfgFile, []byte("sanitize_env: false\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -244,29 +271,17 @@ func TestSanitizeEnvEnvOverridesYAML(t *testing.T) {
 	b := NewBuilder(defaults)
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "cfg.yaml")
-
-	if err := os.WriteFile(cfgFile, []byte("create_dest_lv: false\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	t.Setenv("LVMSYNC_CREATE_DEST_LV", "true")
-
 	if err := os.WriteFile(cfgFile, []byte("sanitize_env: false\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Setenv("LVMSYNC_SANITIZE_ENV", "true")
-
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
-
-	if !cfg.CreateDestLV {
-		t.Fatalf("CreateDestLV=%v want true", cfg.CreateDestLV)
-
 	if !cfg.SanitizeEnv {
 		t.Fatalf("SanitizeEnv=%v want true", cfg.SanitizeEnv)
-
 	}
 }
 


### PR DESCRIPTION
## Summary
- test CreateDestLV config precedence
- test SanitizeEnv config precedence

## Testing
- `go build ./...` *(fails: cmd/dump/client.go syntax error)*
- `go test -coverprofile=coverage.out ./...` *(fails: device/identity_command_test.go syntax errors, create-dest-lv flag redefined, cmd/dump/client.go syntax error)*
- `golangci-lint run` *(fails: syntax errors in cmd/dump/client.go, device tests, sizeparse tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a514230483239ba604bbf2770862