### PR TITLE
Restore missing test function bodies

### DIFF
--- a/device/identity_command_test.go
+++ b/device/identity_command_test.go
@@ -46,12 +46,7 @@ func TestRawIdentityTimeout(t *testing.T) {
 	defer func() { blkidPath = orig }()
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	if _, err := d.Identity(ctx); err == nil || (!errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "signal: killed")) {
-
-	if _, err := d.Identity(ctx); err == nil || (!errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "killed")) {
-
 	if _, err := d.Identity(ctx); err == nil || !(errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "signal: killed")) {
-
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }
@@ -90,12 +85,7 @@ func TestLVMIdentityTimeout(t *testing.T) {
 	defer func() { lvsPath = orig }()
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	if _, err := d.Identity(ctx); err == nil || (!errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "signal: killed")) {
-
-	if _, err := d.Identity(ctx); err == nil || (!errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "killed")) {
-
 	if _, err := d.Identity(ctx); err == nil || !(errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "signal: killed")) {
-
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -193,10 +193,7 @@ func TestPlanEnvOverridesYAML(t *testing.T) {
 	}
 }
 
-
 func TestCreateDestLVFlagOverridesEnvAndYAML(t *testing.T) {
-
-func TestSanitizeEnvFlagOverridesEnvAndYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -220,7 +217,37 @@ func TestSanitizeEnvFlagOverridesEnvAndYAML(t *testing.T) {
 }
 
 func TestCreateDestLVEnvOverridesYAML(t *testing.T) {
-=======
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("create_dest_lv: false\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_CREATE_DEST_LV", "true")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !cfg.CreateDestLV {
+		t.Fatalf("CreateDestLV=%v want true", cfg.CreateDestLV)
+	}
+}
+
+func TestSanitizeEnvFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
 	if err := os.WriteFile(cfgFile, []byte("sanitize_env: false\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -244,29 +271,17 @@ func TestSanitizeEnvEnvOverridesYAML(t *testing.T) {
 	b := NewBuilder(defaults)
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "cfg.yaml")
-
-	if err := os.WriteFile(cfgFile, []byte("create_dest_lv: false\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	t.Setenv("LVMSYNC_CREATE_DEST_LV", "true")
-
 	if err := os.WriteFile(cfgFile, []byte("sanitize_env: false\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Setenv("LVMSYNC_SANITIZE_ENV", "true")
-
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
-
-	if !cfg.CreateDestLV {
-		t.Fatalf("CreateDestLV=%v want true", cfg.CreateDestLV)
-
 	if !cfg.SanitizeEnv {
 		t.Fatalf("SanitizeEnv=%v want true", cfg.SanitizeEnv)
-
 	}
 }
 

--- a/internal/sizeparse/sizeparse_test.go
+++ b/internal/sizeparse/sizeparse_test.go
@@ -62,6 +62,34 @@ func TestParseFractional(t *testing.T) {
 }
 
 func TestParsePercent(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    uint64
+		wantErr bool
+	}{
+		{"50%", 50, false},
+		{"1%", 1, false},
+		{"1.5%", 0, true},
+		{"-10%", 0, true},
+		{strconv.FormatUint(math.MaxUint64, 10) + "0%", 0, true},
+	}
+	for _, tc := range cases {
+		got, pct, err := Parse(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Fatalf("Parse(%q) error=%v wantErr=%v", tc.in, err, tc.wantErr)
+		}
+		if tc.wantErr {
+			continue
+		}
+		if !pct {
+			t.Fatalf("Parse(%q) percent flag = false", tc.in)
+		}
+		if got != tc.want {
+			t.Fatalf("Parse(%q) = %d want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestParse(t *testing.T) {
 
 	cases := []struct {
@@ -117,33 +145,6 @@ func TestParse(t *testing.T) {
 			t.Fatalf("Parse(%q) = %d, want %d", tc.in, got, tc.want)
 		}
 	}
-
-	pctCases := []struct {
-		in      string
-		want    uint64
-		wantErr bool
-	}{
-		{"50%", 50, false},
-		{"1%", 1, false},
-		{"1.5%", 0, true},
-		{"-10%", 0, true},
-	}
-	for _, tc := range pctCases {
-		got, pct, err := Parse(tc.in)
-		if (err != nil) != tc.wantErr {
-			t.Fatalf("Parse(%q) error=%v wantErr=%v", tc.in, err, tc.wantErr)
-		}
-		if tc.wantErr {
-			continue
-		}
-		if !pct {
-			t.Fatalf("Parse(%q) percent flag = false", tc.in)
-		}
-		if got != tc.want {
-			t.Fatalf("Parse(%q) = %d want %d", tc.in, got, tc.want)
-		}
-	}
-
 }
 
 func TestParseOverflowAndNegative(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix RawDevice and LVM device identity timeout tests
- add configuration precedence tests for create-dest-lv and sanitize-env
- restore size parsing percent tests

## Testing
- `go test ./device`
- `go test ./internal/config` (fails: LVM Options flag redefined: create-dest-lv)
- `go test ./internal/sizeparse`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5096fe883239757c84e1c445ab3