### PR TITLE
cmd/dump: consolidate destination probing

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -47,12 +47,11 @@ type Runner struct {
 	detectDevice   func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error)
 	sumFile        func(string, string) ([32]byte, error)
 	streamToRemote func(context.Context, *config.Config, io.WriteCloser, string, string, string, *zap.Logger) error
-	probeDest      func(context.Context, *config.Config, string, *zap.Logger) (uint64, string, uint64, error)
+	probeDest      func(context.Context, *config.Config, string, *zap.Logger) (device.DeviceIdentity, error)
 	createLV       func(context.Context, string, string, uint64, *zap.Logger) error
 	parseLVPath    func(string) (string, string, error)
 	getVolumeSize  func(string, *lvm.FDCache, *zap.Logger) (uint64, error)
 	newFDC         func(*zap.Logger) (*lvm.FDCache, error)
-	probeDest      func(context.Context, *config.Config, string, *zap.Logger) (device.DeviceIdentity, error)
 }
 
 var (
@@ -383,28 +382,23 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 			return destType, err
 		}
 		if !exists {
-			cache, err := lvm.NewDeviceFDCache(logger)
-		if _, err := os.Stat(dest); errors.Is(err, os.ErrNotExist) {
-			vg, lv, err := r.parseLVPath(dest)
-			if err != nil {
-				return destType, err
-			}
-			cache, err := r.newFDC(logger)
-			if err != nil {
-				return destType, err
-			}
-			defer cache.Close()
-			size, err := lvm.GetVolumeSize(snapshotDevice, cache, logger)
-			if err != nil {
-				return destType, err
-			}
-			if err := devRunner.CreateLV(devCtx, dest, size, cfg.LVMEscalation); err != nil {
-			size, err := r.getVolumeSize(originDevice, cache, logger)
-			if err != nil {
-				return destType, err
-			}
-			if err := r.createLV(ctx, vg, lv, size, logger); err != nil {
-				return destType, err
+			if _, err := os.Stat(dest); errors.Is(err, os.ErrNotExist) {
+				vg, lv, err := r.parseLVPath(dest)
+				if err != nil {
+					return destType, err
+				}
+				cache, err := r.newFDC(logger)
+				if err != nil {
+					return destType, err
+				}
+				defer cache.Close()
+				size, err := r.getVolumeSize(originDevice, cache, logger)
+				if err != nil {
+					return destType, err
+				}
+				if err := r.createLV(ctx, vg, lv, size, logger); err != nil {
+					return destType, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- collapse duplicate probeDest field to a single DeviceIdentity-based helper
- simplify local LV creation to use injected helpers

## Testing
- `go build ./cmd/dump`
- `go build ./...`
- `go test -cover ./...` *(fails: expected '(' in device/identity_command_test.go:59)*
- `golangci-lint run` *(terminated: no output after 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a50866808323be70912db8eb6631