### PR TITLE
Add WAL resume tracking and crash recovery tests

### DIFF
--- a/device/wal.go
+++ b/device/wal.go
@@ -560,11 +560,22 @@ func (w *WAL) Append(r Range) error {
 		return err
 	}
 	w.f = nf
+	w.ranges = append(w.ranges, r)
 	return syncDirFunc(filepath.Dir(name))
 }
 
 // Ranges returns the ranges recorded in the WAL.
 func (w *WAL) Ranges() []Range { return append([]Range(nil), w.ranges...) }
+
+// Has reports whether the provided range is fully contained in the WAL.
+func (w *WAL) Has(start, end uint64) bool {
+	for _, r := range w.ranges {
+		if start >= r.Start && end <= r.End {
+			return true
+		}
+	}
+	return false
+}
 
 func (w *WAL) Close() error {
 	if w.f == nil {

--- a/device/wal_crash_test.go
+++ b/device/wal_crash_test.go
@@ -1,0 +1,81 @@
+package device
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWALCrashRecovery simulates crash scenarios and ensures WAL recovery.
+func TestWALCrashRecovery(t *testing.T) {
+	id := DeviceIdentity{SizeBytes: 128, KernelUUID: "k", GPTUUID: "g", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
+
+	t.Run("truncate_mid_entry", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "wal")
+		w, err := OpenWAL(path, id)
+		if err != nil {
+			t.Fatalf("open wal: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		f, err := os.OpenFile(path, os.O_WRONLY, 0)
+		if err != nil {
+			t.Fatalf("open file: %v", err)
+		}
+		if _, err := f.Seek(walHeaderSize, 0); err != nil {
+			t.Fatalf("seek: %v", err)
+		}
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], 64)
+		if _, err := f.Write(buf[:]); err != nil {
+			t.Fatalf("partial write: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close file: %v", err)
+		}
+		w2, err := OpenWAL(path, id)
+		if err != nil {
+			t.Fatalf("reopen wal: %v", err)
+		}
+		if len(w2.Ranges()) != 0 {
+			t.Fatalf("expected no ranges, got %#v", w2.Ranges())
+		}
+		w2.Close()
+	})
+
+	t.Run("omit_fsync", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "wal")
+		w, err := OpenWAL(path, id)
+		if err != nil {
+			t.Fatalf("open wal: %v", err)
+		}
+		if err := w.Append(Range{Start: 0, End: 64}); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		var entry [16]byte
+		binary.LittleEndian.PutUint64(entry[0:8], 64)
+		binary.LittleEndian.PutUint64(entry[8:16], 128)
+		if _, err := w.f.Write(entry[:]); err != nil {
+			t.Fatalf("write entry: %v", err)
+		}
+		if err := w.f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if err := os.Truncate(path, walHeaderSize+16); err != nil {
+			t.Fatalf("truncate: %v", err)
+		}
+		w2, err := OpenWAL(path, id)
+		if err != nil {
+			t.Fatalf("reopen wal: %v", err)
+		}
+		rs := w2.Ranges()
+		if len(rs) != 1 || rs[0].Start != 0 || rs[0].End != 64 {
+			t.Fatalf("unexpected ranges %#v", rs)
+		}
+		w2.Close()
+	})
+}

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -66,8 +66,8 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 	}
 	defer common.CloseWithErr(destFile, &err, "close destination device")
 
+	var walRanges []Range
 	if cfg.ResumeState != "" {
-		var walRanges []Range
 		t.wal, walRanges, err = OpenWAL(cfg.ResumeState+".wal", size, id, epoch)
 		if err != nil {
 			return err
@@ -81,7 +81,7 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 
 	startTime := time.Now()
 	checksum := GetChecksumStrategy(cfg.ChecksumAlgorithm)
-	bw, err := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger, t.wal)
+	bw, err := newBlockWriter(cfg, destFile, dedup, verify, checksum, t.Logger, t.wal, walRanges)
 	var totalBytes int64
 	totalBytes, err = bw.write(reader)
 	if err != nil {

--- a/transfer/block_coalesce_linux_test.go
+++ b/transfer/block_coalesce_linux_test.go
@@ -39,7 +39,7 @@ func TestBlockWriterCoalescesZeroBlocks(t *testing.T) {
 	stream.Write(hdr)
 	stream.Write(data)
 
-	bw, err := newBlockWriter(cfg, dest, nil, false, nil, zap.NewNop(), nil)
+	bw, err := newBlockWriter(cfg, dest, nil, false, nil, zap.NewNop(), nil, nil)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}

--- a/transfer/block_sparse_linux_test.go
+++ b/transfer/block_sparse_linux_test.go
@@ -83,7 +83,7 @@ func TestIterateBlocksSkipsSparseRegions(t *testing.T) {
 	defer os.Remove(dest.Name())
 	defer dest.Close()
 
-	bw, err := newBlockWriter(cfg, dest, nil, false, nil, zap.NewNop(), nil)
+	bw, err := newBlockWriter(cfg, dest, nil, false, nil, zap.NewNop(), nil, nil)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -28,17 +28,18 @@ type blockWriter struct {
 	rt        *resumeTracker
 	deps      *Deps
 	wal       *WAL
+	applied   []Range
 }
 
 // newBlockWriter constructs a blockWriter, detecting the destination's physical
 // block size when the configured block size is "auto" (0) and parsing the
 // sync interval when provided as a string. It validates that the configured
 // block size is aligned to the underlying sector size.
-func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, wal *WAL) (*blockWriter, error) {
-	return newBlockWriterWithDeps(cfg, dest, dedup, verify, checksum, logger, wal, DefaultDeps)
+func newBlockWriter(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, wal *WAL, applied []Range) (*blockWriter, error) {
+	return newBlockWriterWithDeps(cfg, dest, dedup, verify, checksum, logger, wal, applied, DefaultDeps)
 }
 
-func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, wal *WAL, deps *Deps) (*blockWriter, error) {
+func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup DeduplicationStrategy, verify bool, checksum ChecksumStrategy, logger *zap.Logger, wal *WAL, applied []Range, deps *Deps) (*blockWriter, error) {
 	if cfg.BlockSize <= 0 || cfg.ODirect {
 		sector, err := DetectSectorSize(dest)
 		if err != nil {
@@ -69,11 +70,21 @@ func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup Deduplicati
 		logger:   logger,
 		deps:     deps,
 		wal:      wal,
+		applied:  applied,
 	}
 	if cfg.IntraDedup {
 		bw.intra = newChunkCache(intraCacheCapacity)
 	}
 	return bw, nil
+}
+
+func containsRange(rs []Range, start, end uint64) bool {
+	for _, r := range rs {
+		if start >= r.Start && end <= r.End {
+			return true
+		}
+	}
+	return false
 }
 
 // write consumes block records from reader and writes them to the destination
@@ -98,6 +109,18 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		}
 		if err != nil {
 			return total, err
+		}
+		end := offset + uint64(chunkSize)
+		if chunkSize == 0 {
+			end = offset + uint64(bw.cfg.BlockSize)
+		}
+		if containsRange(bw.applied, offset, end) {
+			if chunkSize > 0 {
+				if _, err := io.CopyN(io.Discard, reader, int64(chunkSize)); err != nil {
+					return total, err
+				}
+			}
+			continue
 		}
 		data, err := readBlockData(bw.cfg, reader, chunkSize)
 		if err == io.EOF {
@@ -131,9 +154,11 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 				zeroLen += zlen
 			} else {
 				if bw.wal != nil {
-					if err := bw.wal.Append(Range{Start: zeroStart, End: zeroStart + zeroLen}); err != nil {
+					r := Range{Start: zeroStart, End: zeroStart + zeroLen}
+					if err := bw.wal.Append(r); err != nil {
 						return total, err
 					}
+					bw.applied = append(bw.applied, r)
 				}
 				if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
 					return total, err
@@ -155,9 +180,11 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		}
 		if zeroLen > 0 {
 			if bw.wal != nil {
-				if err := bw.wal.Append(Range{Start: zeroStart, End: zeroStart + zeroLen}); err != nil {
+				r := Range{Start: zeroStart, End: zeroStart + zeroLen}
+				if err := bw.wal.Append(r); err != nil {
 					return total, err
 				}
+				bw.applied = append(bw.applied, r)
 			}
 			if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
 				return total, err
@@ -175,6 +202,10 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		}
 		saveResumeState(bw.cfg, bw.rt, offset, chunkID, int64(chunkSize), bw.logger)
 		if written {
+			if bw.wal != nil {
+				r := Range{Start: offset, End: offset + uint64(chunkSize)}
+				bw.applied = append(bw.applied, r)
+			}
 			total += int64(chunkSize)
 			bw.sinceSync += int64(chunkSize)
 			if bw.cfg.SyncIntervalBytes > 0 && bw.sinceSync >= int64(bw.cfg.SyncIntervalBytes) {

--- a/transfer/block_writer_apply_test.go
+++ b/transfer/block_writer_apply_test.go
@@ -48,7 +48,7 @@ func TestBlockWriterSyncInterval(t *testing.T) {
 		calls++
 		return nil
 	}}
-	bw, err := newBlockWriterWithDeps(cfg, f, nil, false, checksum, zap.NewNop(), nil, deps)
+	bw, err := newBlockWriterWithDeps(cfg, f, nil, false, checksum, zap.NewNop(), nil, nil, deps)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestBlockWriterMACVerification(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw, err := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop(), nil)
+	bw, err := newBlockWriter(cfg, f, nil, true, checksum, zap.NewNop(), nil, nil)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestBlockWriterCRCValidation(t *testing.T) {
 	}
 	defer f.Close()
 
-	bw, err := newBlockWriter(cfg, f, nil, false, nil, zap.NewNop(), nil)
+	bw, err := newBlockWriter(cfg, f, nil, false, nil, zap.NewNop(), nil, nil)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}

--- a/transfer/block_writer_test.go
+++ b/transfer/block_writer_test.go
@@ -25,7 +25,7 @@ func TestBlockWriterSyncIntervalTriggers(t *testing.T) {
 		calls++
 		return nil
 	}}
-	bw, err := newBlockWriterWithDeps(cfg, tmp, nil, false, nil, zap.NewNop(), nil, deps)
+	bw, err := newBlockWriterWithDeps(cfg, tmp, nil, false, nil, zap.NewNop(), nil, nil, deps)
 	if err != nil {
 		t.Fatalf("newBlockWriter: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestBlockWriterInvalidSyncInterval(t *testing.T) {
 	cases := []string{"bogus", "10%"}
 	for _, interval := range cases {
 		cfg := &config.Config{BlockSize: 4, SyncInterval: interval}
-		if _, err := newBlockWriter(cfg, tmp, nil, false, nil, zap.NewNop(), nil); err == nil {
+		if _, err := newBlockWriter(cfg, tmp, nil, false, nil, zap.NewNop(), nil, nil); err == nil {
 			t.Fatalf("newBlockWriter(%q) expected error", interval)
 		}
 	}

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -14,6 +14,8 @@ import (
 	"lvmsync_go/internal/config"
 )
 
+func resumeWALPath(path string) string { return path + ".wal" }
+
 // resumeState persists transfer checkpoints allowing interrupted transfers to resume.
 type resumeChunkState struct {
 	Offset uint64 `json:"offset"`
@@ -65,7 +67,7 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunk
 		return
 	}
 
-	walPath := path + ".wal"
+	walPath := resumeWALPath(path)
 	tmpPath := walPath + ".tmp"
 
 	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
@@ -129,7 +131,7 @@ func finalizeResumeState(cfg *config.Config, rt *resumeTracker, logger *zap.Logg
 	if err := os.Remove(cfg.ResumeState); err != nil && !os.IsNotExist(err) {
 		logger.Warn("Failed to remove resume state", zap.Error(err))
 	}
-	if err := os.Remove(cfg.ResumeState + ".wal"); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(resumeWALPath(cfg.ResumeState)); err != nil && !os.IsNotExist(err) {
 		logger.Warn("Failed to remove resume WAL", zap.Error(err))
 	}
 	rt.bytes = 0
@@ -145,7 +147,7 @@ func readResumeState(cfg *config.Config, logger *zap.Logger, size uint64, device
 		return resumeCheckpoint{}
 	}
 
-	if cp, ok := loadResumeState(cfg.ResumeState+".wal", cfg, size, deviceID, epoch, digest, logger); ok {
+	if cp, ok := loadResumeState(resumeWALPath(cfg.ResumeState), cfg, size, deviceID, epoch, digest, logger); ok {
 		return cp
 	}
 	if cp, ok := loadResumeState(cfg.ResumeState, cfg, size, deviceID, epoch, digest, logger); ok {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -398,5 +398,6 @@ func verifyWAL(cfg *config.Config, dest *os.File, ranges []Range, logger *zap.Lo
 			return fmt.Errorf("wal verification failed at offset %d", r.Start)
 		}
 	}
+	logger.Info("wal_resume", zap.Int("range_count", len(ranges)))
 	return nil
 }


### PR DESCRIPTION
## Summary
- track applied ranges in device WAL and expose Has
- skip already-applied WAL ranges during block writes
- add crash recovery tests for device WAL

## Testing
- `go build ./...` *(fails: cmd/dump/client.go:421:37: syntax error: unexpected name context in argument list; possibly missing comma or ))*
- `go test -cover ./...` *(fails: device/identity_command_test.go:59:6: expected '(', found TestRawIdentityIgnoresPATH)*
- `golangci-lint run` *(fails: cmd/dump/client.go:421:37: syntax error: unexpected name context in argument list; possibly missing comma or ))*

------
https://chatgpt.com/codex/tasks/task_e_68a4a50c980083238f076536d3b5a48e