### PR TITLE
Handle snapshot cleanup failures

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -47,7 +47,6 @@ type Runner struct {
 	detectDevice   func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error)
 	sumFile        func(string, string) ([32]byte, error)
 	streamToRemote func(context.Context, *config.Config, io.WriteCloser, string, string, string, *zap.Logger) error
-	probeDest      func(context.Context, *config.Config, string, *zap.Logger) (uint64, string, uint64, error)
 	createLV       func(context.Context, string, string, uint64, *zap.Logger) error
 	parseLVPath    func(string) (string, string, error)
 	getVolumeSize  func(string, *lvm.FDCache, *zap.Logger) (uint64, error)
@@ -333,8 +332,9 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 	}
 	snapshotDevice := snapDev.Path()
 	originDevice := dev.Path()
+	lvm.RegisterSnapshot(snapshotDevice, logger)
+	defer lvm.CleanupSnapshot(ctx, snapshotDevice, logger)
 	defer func() {
-		snapDev.Cleanup(ctx)
 		snapDev.Close()
 		if snapDev != dev {
 			dev.Cleanup(ctx)
@@ -383,28 +383,36 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 			return destType, err
 		}
 		if !exists {
-			cache, err := lvm.NewDeviceFDCache(logger)
-		if _, err := os.Stat(dest); errors.Is(err, os.ErrNotExist) {
-			vg, lv, err := r.parseLVPath(dest)
-			if err != nil {
-				return destType, err
-			}
-			cache, err := r.newFDC(logger)
-			if err != nil {
-				return destType, err
-			}
-			defer cache.Close()
-			size, err := lvm.GetVolumeSize(snapshotDevice, cache, logger)
-			if err != nil {
-				return destType, err
-			}
-			if err := devRunner.CreateLV(devCtx, dest, size, cfg.LVMEscalation); err != nil {
-			size, err := r.getVolumeSize(originDevice, cache, logger)
-			if err != nil {
-				return destType, err
-			}
-			if err := r.createLV(ctx, vg, lv, size, logger); err != nil {
-				return destType, err
+			if _, err := os.Stat(dest); errors.Is(err, os.ErrNotExist) {
+				vg, lv, err := r.parseLVPath(dest)
+				if err != nil {
+					return destType, err
+				}
+				cache, err := r.newFDC(logger)
+				if err != nil {
+					return destType, err
+				}
+				defer cache.Close()
+				size, err := r.getVolumeSize(originDevice, cache, logger)
+				if err != nil {
+					return destType, err
+				}
+				if err := r.createLV(ctx, vg, lv, size, logger); err != nil {
+					return destType, err
+				}
+			} else {
+				cache, err := lvm.NewDeviceFDCache(logger)
+				if err != nil {
+					return destType, err
+				}
+				defer cache.Close()
+				size, err := lvm.GetVolumeSize(snapshotDevice, cache, logger)
+				if err != nil {
+					return destType, err
+				}
+				if err := devRunner.CreateLV(devCtx, dest, size, cfg.LVMEscalation); err != nil {
+					return destType, err
+				}
 			}
 		}
 	}

--- a/integration/snapshot_failure_test.go
+++ b/integration/snapshot_failure_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package integration
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func run(t *testing.T, cmd *exec.Cmd) string {
+	t.Helper()
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%v failed: %v\n%s", cmd.Args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestSnapshotCleanupOnFailure(t *testing.T) {
+	for _, tool := range []string{"losetup", "pvcreate", "vgcreate", "lvcreate", "dd"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available", tool)
+		}
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("root required")
+	}
+
+	tmpDir := t.TempDir()
+	bin := filepath.Join(tmpDir, "lvmsync")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = ".."
+	run(t, build)
+
+	img := filepath.Join(tmpDir, "disk.img")
+	run(t, exec.Command("dd", "if=/dev/zero", "of="+img, "bs=1M", "count=128"))
+	loop := run(t, exec.Command("losetup", "--find", "--show", img))
+
+	cleanup := func() {
+		exec.Command("bash", "-c", "lvremove -f vgfail/* >/dev/null 2>&1").Run()
+		exec.Command("vgremove", "-f", "vgfail").Run()
+		exec.Command("pvremove", "-ff", loop).Run()
+		exec.Command("losetup", "-d", loop).Run()
+	}
+	defer cleanup()
+
+	run(t, exec.Command("pvcreate", "-ffy", loop))
+	run(t, exec.Command("vgcreate", "vgfail", loop))
+	run(t, exec.Command("lvcreate", "-n", "origin", "-L", "32M", "vgfail"))
+	run(t, exec.Command("dd", "if=/dev/urandom", "of=/dev/vgfail/origin", "bs=1M", "count=32"))
+
+	cmd := exec.Command(bin, "run", "--speed=1M", "--snapshot-size=1M", "--create-dest-lv", "/dev/vgfail/origin", "/dev/vgmissing/dest")
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected exit error, got %v", err)
+	}
+
+	out := run(t, exec.Command("lvs", "--noheadings", "-o", "lv_name", "vgfail"))
+	fields := strings.Fields(out)
+	if len(fields) != 1 || fields[0] != "origin" {
+		t.Fatalf("unexpected volumes: %v", fields)
+	}
+}

--- a/lvm/snapshot_registry.go
+++ b/lvm/snapshot_registry.go
@@ -73,3 +73,25 @@ func CleanupRegistered(ctx context.Context) {
 		cancel()
 	}
 }
+
+// CleanupSnapshot removes a single snapshot, unregistering it first.
+// It logs success or failure and ignores nil paths.
+func CleanupSnapshot(ctx context.Context, path string, logger *zap.Logger) {
+	if path == "" {
+		return
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	UnregisterSnapshot(path)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rmCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := removeSnap(rmCtx, path, logger); err != nil {
+		logger.Warn("failed to remove snapshot", zap.String("snapshot", path), zap.Error(err))
+	} else {
+		logger.Info("snapshot removed", zap.String("snapshot", path))
+	}
+}


### PR DESCRIPTION
## Summary
- ensure dump snapshot creation registers cleanup and defers removal
- add CleanupSnapshot helper in lvm to unregister and remove snapshots
- integration test verifies snapshots are removed on command failure

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: expected '(' found TestRawIdentityIgnoresPATH)*
- `golangci-lint run` *(fails: can't prepare diff by revgrep: fatal: bad revision 'origin/main')*

------
https://chatgpt.com/codex/tasks/task_e_68a4a510434083238ebe72d5b3022b13