### PR TITLE
feat: structured verify output

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--verify` | `LVMSYNC_VERIFY` | `verify` | Verification level: `full`, `sampled`, or `none` |
 | `--digest` | `LVMSYNC_DIGEST` | `digest` | Digest algorithm: `auto`, `blake3`, or `sha256` (`auto` selects `blake3` when AVX2, AVX-512, or NEON is available, otherwise `sha256`) |
 | `--progress` | `LVMSYNC_PROGRESS` | `progress` | Show progress during transfer |
-| `--output` | `LVMSYNC_OUTPUT` | `output` | Output format for progress: `text` or `json` |
+| `--output` | `LVMSYNC_OUTPUT` | `output` | Output format: `text`, `json`, or `yaml` |
 | `--delta` | `LVMSYNC_DELTA` | `delta` | Delta algorithm: `none` or `rsync` |
 | `--manifest-path` | `LVMSYNC_MANIFEST_PATH` | `manifest_path` | Path to manifest file |
 | `--manifest-progress-interval` | `LVMSYNC_MANIFEST_PROGRESS_INTERVAL` | `manifest_progress_interval` | Interval between progress logs during manifest rebuild |
@@ -978,7 +978,8 @@ mode: throughput
 ### Logging and progress
 
 Logs are emitted with [zap](https://github.com/uber-go/zap) to stderr. When `--output=text` (default), progress updates are
-logged to stderr when `--progress` is enabled. Set `--output=json` to emit progress events on stdout as line-delimited JSON
+logged to stderr when `--progress` is enabled. Set `--output=json` to emit progress events on stdout as line-delimited JSON.
+The `verify` subcommand and `--verify-only` mode support `--output=json` or `--output=yaml` to write structured verification results to stdout.
 objects while preserving the regular logs on stderr. Each object follows this schema:
 
 ```json

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -146,6 +146,17 @@ func NewRootCmd(logger *zap.Logger, r *Runner) *cobra.Command {
 				fs.Usage()
 				return fmt.Errorf("usage: lvmsync run [flags] <source> <dest>")
 			}
+			if cfg.VerifyOnly {
+				vArgs := []string{}
+				if cfg.Output != "" {
+					vArgs = append(vArgs, "--output", cfg.Output)
+				}
+				if cfg.DryRun {
+					vArgs = append(vArgs, "--dry-run")
+				}
+				vArgs = append(vArgs, remaining...)
+				return r.Verify(vArgs, logger)
+			}
 			if cfg.DryRun {
 				if err := estimateTransfer(remaining[0], cfg, logger); err != nil {
 					return err

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -219,6 +219,26 @@ func TestVerifyRoutes(t *testing.T) {
 	}
 }
 
+func TestRunVerifyOnlyOutput(t *testing.T) {
+	var got []string
+	r := NewRunnerWithDeps(nil, nil, func(a []string, _ *zap.Logger) error {
+		got = append([]string{}, a...)
+		return nil
+	})
+	if err := ExecuteWithRunner([]string{"run", "--verify-only", "--output", "json", "src", "dst"}, zap.NewNop(), r); err != nil {
+		t.Fatalf("execute run verify-only: %v", err)
+	}
+	exp := []string{"--output", "json", "src", "dst"}
+	if len(got) != len(exp) {
+		t.Fatalf("unexpected args %v", got)
+	}
+	for i := range exp {
+		if got[i] != exp[i] {
+			t.Fatalf("arg %d = %q want %q", i, got[i], exp[i])
+		}
+	}
+}
+
 func TestExecuteSyncsLogger(t *testing.T) {
 	t.Setenv("LVMSYNC_TRANSPORT_TRANSPORT", "ssh")
 	src := t.TempDir() + "/src"

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -3,6 +3,7 @@ package verify
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/internal/config"
@@ -86,7 +88,34 @@ func (r *Runner) Run(args []string, logger *zap.Logger) error {
 				logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
 				return nil
 			}
-			return r.verifyDevices(cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)
+			err = r.verifyDevices(cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)
+			if cfg.Output == "json" || cfg.Output == "yaml" {
+				out := struct {
+					Verified bool   `json:"verified" yaml:"verified"`
+					Error    string `json:"error,omitempty" yaml:"error,omitempty"`
+				}{Verified: err == nil}
+				if err != nil {
+					out.Error = err.Error()
+				}
+				switch cfg.Output {
+				case "json":
+					enc := json.NewEncoder(os.Stdout)
+					enc.SetIndent("", "  ")
+					if encErr := enc.Encode(out); encErr != nil {
+						return fmt.Errorf("encode json: %w", encErr)
+					}
+				case "yaml":
+					enc := yaml.NewEncoder(os.Stdout)
+					enc.SetIndent(2)
+					if encErr := enc.Encode(out); encErr != nil {
+						return fmt.Errorf("encode yaml: %w", encErr)
+					}
+					if closeErr := enc.Close(); closeErr != nil {
+						return fmt.Errorf("close yaml encoder: %w", closeErr)
+					}
+				}
+			}
+			return err
 		},
 	}
 	cmd.SetArgs(args)

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -3,7 +3,9 @@ package verify
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+	"gopkg.in/yaml.v3"
 
 	"lvmsync_go/internal/config"
 	manifestpkg "lvmsync_go/manifest"
@@ -200,5 +203,63 @@ func TestVerifyDevicesRebuildsManifest(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("expected rebuild invoked")
+	}
+}
+
+func TestRunOutputsJSON(t *testing.T) {
+	src := createTestFile(t, 1024)
+	dst := createTestFile(t, 1024)
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	done := make(chan struct{})
+	go func() {
+		io.Copy(&buf, r)
+		close(done)
+	}()
+	if err := Run([]string{"--output", "json", src, dst}, zap.NewNop()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	w.Close()
+	<-done
+	os.Stdout = oldStdout
+	var out struct {
+		Verified bool `json:"verified"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.Verified {
+		t.Fatalf("expected verified true")
+	}
+}
+
+func TestRunOutputsYAML(t *testing.T) {
+	src := createTestFile(t, 1024)
+	dst := createTestFile(t, 1024)
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	done := make(chan struct{})
+	go func() {
+		io.Copy(&buf, r)
+		close(done)
+	}()
+	if err := Run([]string{"--output", "yaml", src, dst}, zap.NewNop()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	w.Close()
+	<-done
+	os.Stdout = oldStdout
+	var out struct {
+		Verified bool `yaml:"verified"`
+	}
+	if err := yaml.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.Verified {
+		t.Fatalf("expected verified true")
 	}
 }

--- a/docs/env.md
+++ b/docs/env.md
@@ -50,7 +50,7 @@
 | LVMSYNC_NUMA_PIN | `--numa-pin` | `numa-pin` | Pin worker goroutines to device NUMA node |
 | LVMSYNC_ODIRECT | `--odirect` | `odirect` | Use O_DIRECT for device I/O when possible |
 | LVMSYNC_OFFLINE | `--offline` | `offline` | Assume source raw device is offline |
-| LVMSYNC_OUTPUT | `--output` | `output` | Output format: text or json |
+| LVMSYNC_OUTPUT | `--output` | `output` | Output format: text, json, or yaml |
 | LVMSYNC_PARALLEL | `--parallel` | `parallel` | Number of concurrent workers |
 | LVMSYNC_PLAN | `--plan` | `plan` | Print configuration plan as JSON and exit |
 | LVMSYNC_PROBE_ONLY | `--probe-only` | `probe-only` | Output size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, and manifest_epoch without writing |

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -2,7 +2,9 @@
 
 `lvmsync verify` compares two devices and reports any blocks that differ.
 It reads both paths in chunks, computing BLAKE3 digests for each block. A
-non-zero exit status is returned when mismatches are detected.
+non-zero exit status is returned when mismatches are detected. Specify
+`--output=json` or `--output=yaml` to emit structured verification results
+to stdout.
 
 ## Examples
 

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -91,7 +91,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.String("verify", cfg.VerifyLevel, "Verification level: full, sampled, or none")
 	fs.String("digest", cfg.ChecksumAlgorithm, fmt.Sprintf("Digest algorithm: %v", SupportedChecksumAlgorithms))
 	fs.Bool("progress", cfg.Progress, "Show progress during transfer")
-	fs.String("output", cfg.Output, "Output format: text or json")
+	fs.String("output", cfg.Output, "Output format: text, json, or yaml")
 	return fs
 }
 

--- a/internal/config/output_test.go
+++ b/internal/config/output_test.go
@@ -15,4 +15,8 @@ func TestValidateOutput(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("validate json output: %v", err)
 	}
+	cfg.Output = "yaml"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate yaml output: %v", err)
+	}
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -30,8 +30,8 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 	if c.DestType != "" && c.DestType != "auto" && c.DestType != "file" && c.DestType != "raw" && c.DestType != "lvm" {
 		return fmt.Errorf("invalid dest type %q", c.DestType)
 	}
-	if c.Output != "" && c.Output != "text" && c.Output != "json" {
-		return fmt.Errorf("invalid output %q: must be \"text\" or \"json\"", c.Output)
+	if c.Output != "" && c.Output != "text" && c.Output != "json" && c.Output != "yaml" {
+		return fmt.Errorf("invalid output %q: must be \"text\", \"json\" or \"yaml\"", c.Output)
 	}
 	if c.Sparse != "" && c.Sparse != Auto && c.Sparse != "never" {
 		return fmt.Errorf("invalid sparse %q: must be %q or %q", c.Sparse, Auto, "never")


### PR DESCRIPTION
## Summary
- add json and yaml structured output to `verify`
- forward `--output` to `verify` when using `--verify-only`
- document new output formats

## Testing
- `go build ./...` *(fails: cmd/dump/client.go:421:37: syntax error: unexpected name context)*
- `go test -coverprofile=coverage.out ./...` *(fails: device/identity_command_test.go:59:6: expected '(')*
- `golangci-lint run` *(fails: cmd/dump/client.go:421:37: syntax error: unexpected name context in argument list; possibly missing comma or ))*
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68a4a512a2e083238f8873853e8ac4cb