### PR TITLE
device: test overwrite flags for identity mismatch

### DIFF
--- a/device/identity_mismatch_overwrite_test.go
+++ b/device/identity_mismatch_overwrite_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package device
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestIdentityMismatchRequiresOverwriteFlags(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	srcLoop, cleanupSrc := setupLoop(t, 1<<20)
+	defer cleanupSrc()
+	dstLoop, cleanupDst := setupLoop(t, 2<<20)
+	defer cleanupDst()
+
+	ctx := WithForce(context.Background(), true)
+	if _, err := OpenRaw(ctx, dstLoop, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "--allow-overwrite") {
+		t.Fatalf("expected allow-overwrite error, got %v", err)
+	}
+	ctx = WithAllowOverwrite(ctx, true)
+	if _, err := OpenRaw(ctx, dstLoop, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "--yes-i-know") {
+		t.Fatalf("expected yes-i-know error, got %v", err)
+	}
+	ctx = WithYesIKnow(ctx, true)
+	dev, err := OpenRaw(ctx, dstLoop, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+	if err != nil {
+		t.Fatalf("OpenRaw: %v", err)
+	}
+	dev.Close()
+
+	info := NewInfo()
+	if err := verifyIdentity(context.Background(), info, srcLoop, dstLoop); err == nil || !strings.Contains(err.Error(), "size mismatch") {
+		t.Fatalf("expected size mismatch error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add linux-only test that creates two loopback devices with different sizes
- ensure non-interactive writes require `--allow-overwrite` and `--yes-i-know`
- verify identity checks detect size mismatches

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo escalation failed, verify: rebuild manifest: exit status 2)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: could not read git repo: error executing "git diff --color=never --no-ext-diff --default-prefix --relative origin/main --": exit status 128)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b0b008888323b153fa3978645965