### PR TITLE
verify: propagate manifest timeout

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -139,6 +140,9 @@ func (r *Runner) verifyDevices(cfg *config.Config, src, dst, manifestPath string
 				hybridFixed = uint32(cfg.BlockSize)
 			}
 			if err := r.Rebuild(ctx, src, manifestPath, logger, cfg.ManifestProgressInterval, cfg.ManifestAllowMounted, uint32(cfg.CDCMin), uint32(cfg.CDCAvg), uint32(cfg.CDCMax), hybridFixed); err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return err
+				}
 				return fmt.Errorf("rebuild manifest: %w", err)
 			}
 		} else {

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -203,6 +204,27 @@ func TestVerifyDevicesRebuildsManifest(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("expected rebuild invoked")
+	}
+}
+
+func TestVerifyDevicesTimeout(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("foo"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("foo"), 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	cfg := &config.Config{ManifestTimeout: time.Millisecond}
+	err := r.verifyDevices(cfg, src, dst, "", zap.NewNop())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected timeout error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- return manifest rebuild timeout directly in verifyDevices
- test verifyDevices returns context deadline exceeded on manifest rebuild delay

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: internal/config/precedence_test.go syntax errors)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: internal/config/precedence_test.go syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b0b13d088323919347db1b5e2fe7