### PR TITLE
Fix SanitizeEnv precedence test

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -1,7 +1,7 @@
 | ENV | Flag | YAML | Description |
 | --- | ---- | ---- | ----------- |
 | LVMSYNC_ALLOW_INSECURE | `--allow-insecure` | `allow-insecure` | allow insecure connections (disable TLS and host key verification) |
-| LVMSYNC_ALLOW_OVERWRITE | `--allow-overwrite` | `allow-overwrite` | Allow overwriting existing data; requires `--yes-i-know` for non-interactive sessions |
+| LVMSYNC_ALLOW_OVERWRITE | `--allow-overwrite` | `allow-overwrite` | Allow overwriting existing data; requires --yes-i-know for non-interactive sessions |
 | LVMSYNC_BLOCK_SIZE | `--block-size` | `block-size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
 | LVMSYNC_BLOOM_ENTRIES | `--bloom-entries` | `bloom-entries` | Bloom filter entries |
 | LVMSYNC_BLOOM_FP_RATE | `--bloom-fp-rate` | `bloom-fp-rate` | Bloom filter false positive rate |
@@ -17,11 +17,7 @@
 | LVMSYNC_COMPRESS_THRESHOLD | `--compress-threshold` | `compress-threshold` | Skip compression when estimated ratio exceeds this value |
 | LVMSYNC_CONCURRENCY | `--concurrency` | `concurrency` | Number of concurrent connections |
 | LVMSYNC_CONFIG | `--config` | `config` | Path to config YAML file |
-
-| LVMSYNC_CREATE_DEST_LV | `--create-dest-lv` | `create-dest-lv` | Create destination logical volume if missing |
-
 | LVMSYNC_CREATE_DEST_LV | `--create-dest-lv` | `create-dest-lv` | Create destination logical volume when missing |
-
 | LVMSYNC_DEDUP | `--dedup` | `dedup` | Deduplication mode: [fixed cdc hybrid] |
 | LVMSYNC_DEDUP_STATE_FILE | `--dedup-state-file` | `dedup-state-file` | Path to deduplication state file |
 | LVMSYNC_DEDUP_STRATEGY | `--dedup-strategy` | `dedup-strategy` | Deduplication strategy: [none auto checksum rolling_hash bloom] |
@@ -59,7 +55,7 @@
 | LVMSYNC_REMOTE_PRE_SCRIPT | `--remote-pre-script` | `remote-pre-script` | Remote script to run before transfer |
 | LVMSYNC_RESUME | `--resume` | `resume` | Path to resume state file |
 | LVMSYNC_RETRY_DELAY | `--retry-delay` | `retry-delay` | Initial delay between retries |
-| LVMSYNC_SANITIZE_ENV | `--sanitize-env` | `sanitize-env` | Drop PATH, LANG, and unsafe variables before privilege escalation (set to `0`/`false` to disable) |
+| LVMSYNC_SANITIZE_ENV | `--sanitize-env` | `sanitize-env` | Drop PATH, LANG, and unsafe variables before privilege escalation (disable with --sanitize-env=false) |
 | LVMSYNC_SIG_CACHE_MAX | `--sig-cache-max` | `sig-cache-max` | Maximum LVM signature cache entries |
 | LVMSYNC_SIG_CACHE_TTL | `--sig-cache-ttl` | `sig-cache-ttl` | TTL for LVM signature cache entries |
 | LVMSYNC_SKIP_DISK_CHECK | `--skip-disk-check` | `skip-disk-check` | Skip disk space check |

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -307,8 +307,6 @@ func TestSanitizeEnvEnvOverridesYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
-	if cfg.SanitizeEnv {
-		t.Fatalf("SanitizeEnv=%v want false", cfg.SanitizeEnv)
 	if !cfg.SanitizeEnv {
 		t.Fatalf("SanitizeEnv=%v want true", cfg.SanitizeEnv)
 	}


### PR DESCRIPTION
## Summary
- simplify SanitizeEnv precedence test to only assert env var takes effect
- regenerate env var documentation for test parity

## Testing
- `go build ./...`
- `go test ./internal/config`
- `go test -cover ./...` *(fails: verify package error and escalate tests requiring sudo)*
- `golangci-lint run` *(fails: many lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b0aae87c83238ffca8a0ee546460