### PR TITLE
device: skip CreateLV tests without escalation

### DIFF
--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -139,6 +139,9 @@ func TestRunLVMFailure(t *testing.T) {
 }
 
 func TestCreateLV(t *testing.T) {
+	if err := lvm.VerifyEscalationCommand(""); err != nil {
+		t.Skipf("requires root or --lvm-escalation: %v", err)
+	}
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
@@ -168,6 +171,9 @@ func TestCreateLV(t *testing.T) {
 }
 
 func TestCreateLVRequiresForce(t *testing.T) {
+	if err := lvm.VerifyEscalationCommand(""); err != nil {
+		t.Skipf("requires root or --lvm-escalation: %v", err)
+	}
 	cmd := cmdFunc(func(ctx context.Context, n string, a ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "true")
 	})
@@ -178,6 +184,9 @@ func TestCreateLVRequiresForce(t *testing.T) {
 }
 
 func TestCreateLVRunLVMError(t *testing.T) {
+	if err := lvm.VerifyEscalationCommand(""); err != nil {
+		t.Skipf("requires root or --lvm-escalation: %v", err)
+	}
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)


### PR DESCRIPTION
## Summary
- skip CreateLV tests when root or LVM escalation isn't available

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: internal/config/precedence_test.go: expected '(')*
- `go test ./device`
- `golangci-lint run` *(fails: internal/config/precedence_test.go: syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b0ad4f04832393dd39355f3d443e