### PR TITLE
test(verify): check io.Copy error

### DIFF
--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -213,16 +213,18 @@ func TestRunOutputsJSON(t *testing.T) {
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
-	done := make(chan struct{})
+	errCh := make(chan error, 1)
 	go func() {
-		io.Copy(&buf, r)
-		close(done)
+		_, err := io.Copy(&buf, r)
+		errCh <- err
 	}()
 	if err := Run([]string{"--output", "json", src, dst}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	w.Close()
-	<-done
+	if err := <-errCh; err != nil {
+		t.Fatalf("copy: %v", err)
+	}
 	os.Stdout = oldStdout
 	var out struct {
 		Verified bool `json:"verified"`
@@ -242,16 +244,18 @@ func TestRunOutputsYAML(t *testing.T) {
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
-	done := make(chan struct{})
+	errCh := make(chan error, 1)
 	go func() {
-		io.Copy(&buf, r)
-		close(done)
+		_, err := io.Copy(&buf, r)
+		errCh <- err
 	}()
 	if err := Run([]string{"--output", "yaml", src, dst}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	w.Close()
-	<-done
+	if err := <-errCh; err != nil {
+		t.Fatalf("copy: %v", err)
+	}
 	os.Stdout = oldStdout
 	var out struct {
 		Verified bool `yaml:"verified"`


### PR DESCRIPTION
## Summary
- fail verify output tests if stdout copy errors

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: rebuild manifest exit status 2; sudo not found)*
- `golangci-lint run` *(fails: syntax errors in internal/config/precedence_test.go)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0af21c88323a47c0d58cb4ca363