### PR TITLE
cmd/verify: fix output tests

### DIFF
--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -268,8 +268,8 @@ func TestRunOutputsJSON(t *testing.T) {
 	os.Stdout = w
 	errCh := make(chan error, 1)
 	go func() {
-		io.Copy(&buf, pr)
-		close(done)
+		_, err := io.Copy(&buf, pr)
+		errCh <- err
 	}()
 	r := newStubRunner()
 	if err := r.Run([]string{"--output", "json", src, dst}, zap.NewNop()); err != nil {
@@ -301,8 +301,8 @@ func TestRunOutputsYAML(t *testing.T) {
 	os.Stdout = w
 	errCh := make(chan error, 1)
 	go func() {
-		io.Copy(&buf, pr)
-		close(done)
+		_, err := io.Copy(&buf, pr)
+		errCh <- err
 	}()
 	r := newStubRunner()
 	if err := r.Run([]string{"--output", "yaml", src, dst}, zap.NewNop()); err != nil {


### PR DESCRIPTION
## Summary
- Fix TestRunOutputsJSON and TestRunOutputsYAML to use errCh for copy errors instead of closing an undefined done channel
- Ensure stdout capture goroutines report completion via error channels

## Testing
- `go test ./cmd/verify`


------
https://chatgpt.com/codex/tasks/task_e_68a4baf678008323afdec9b63f7ec825