### PR TITLE
Warn on unbound config keys

### DIFF
--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -47,6 +47,17 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 		fs.SetOutput(io.Discard)
 	}
 	registerFlags(b.FlagSets, fs)
+
+	// Track which configuration keys are bound to flags. Viper will accept
+	// environment variables or YAML keys even when a flag binding is
+	// missing, leading to silent ignores. Collect all flag names so we can
+	// warn about any keys that are present but unbound.
+	bound := make(map[string]struct{})
+	fs.VisitAll(func(f *pflag.Flag) {
+		name := strings.ReplaceAll(f.Name, "_", "-")
+		bound[name] = struct{}{}
+	})
+
 	if err := fs.Parse(args); err != nil {
 		return nil, nil, nil, err
 	}
@@ -67,6 +78,22 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	cfg, err := vb.Build()
 	if err != nil {
 		return nil, nil, warns, err
+	}
+
+	// Emit warnings for any keys present in Viper that aren't bound to a
+	// known flag. These may originate from environment variables or YAML
+	// configuration intended for other commands.
+	unused := make(map[string]struct{})
+	for k := range v.AllSettings() {
+		norm := strings.ReplaceAll(k, "_", "-")
+		if _, ok := bound[norm]; ok {
+			continue
+		}
+		if _, seen := unused[norm]; seen {
+			continue
+		}
+		unused[norm] = struct{}{}
+		warns = append(warns, fmt.Sprintf("unknown configuration key %q", norm))
 	}
 	if resumeVerify {
 		cfg.ResumeVerify = true

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -66,3 +66,48 @@ func TestAllowInsecureFlagWarns(t *testing.T) {
 		t.Fatalf("warnings=%v", warns)
 	}
 }
+
+func TestUnboundConfigKeyWarns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	// Remove SSH flag bindings so ssh_host becomes unbound.
+	b.FlagSets.SSH = pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("ssh_host: example\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	_, _, warns, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	want := `unknown configuration key "ssh-host"`
+	if len(warns) != 1 || warns[0] != want {
+		t.Fatalf("warnings=%v", warns)
+	}
+}
+
+func TestUnboundEnvKeyWarns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LVMSYNC_SSH_HOST", "example")
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	b.FlagSets.SSH = pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	_, _, warns, err := b.Build(fs, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	want := `unknown configuration key "ssh-host"`
+	if len(warns) != 1 || warns[0] != want {
+		t.Fatalf("warnings=%v", warns)
+	}
+}


### PR DESCRIPTION
## Summary
- warn when configuration contains keys without corresponding flags
- surface warnings for stray config/environment keys in tests

## Testing
- `go build ./...`
- `go test -cover ./internal/config`
- `go test -cover ./...` *(fails: cmd/verify undefined: done, escalate requires sudo)*
- `golangci-lint run` *(fails: undefined: done in cmd/verify tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4baf99d148323abbdf85bcb45d99b