### PR TITLE
config: validate config against schema

### DIFF
--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -59,9 +59,14 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 			f.Changed = false
 		}
 	}
-	v, warns, allowInsecureYAML, err := buildViper(b.FlagSets)
+	v, warns, allowInsecureYAML, raw, err := buildViper(b.FlagSets)
 	if err != nil {
 		return nil, nil, warns, err
+	}
+	if len(raw) > 0 {
+		if err := validateSchema(raw); err != nil {
+			return nil, nil, warns, err
+		}
 	}
 	vb := &builder{v: v, defaults: b.defaults}
 	cfg, err := vb.Build()

--- a/internal/config/flagsets_bindings_test.go
+++ b/internal/config/flagsets_bindings_test.go
@@ -32,7 +32,7 @@ func TestFlagSetEnvBindings(t *testing.T) {
 		}
 		t.Setenv(tc.env, tc.val)
 	}
-	v, _, _, err := buildViper(flagSets)
+	v, _, _, _, err := buildViper(flagSets)
 	if err != nil {
 		t.Fatalf("buildViper: %v", err)
 	}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func TestSchemaValidationUnknownType(t *testing.T) {
+func TestSchemaValidationInvalidType(t *testing.T) {
 	defaults, _ := DefaultConfig()
 	b := NewBuilder(defaults)
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	// write temp config with wrong type for parallel (string instead of int)
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "cfg.yaml")
 	if err := os.WriteFile(cfgPath, []byte("parallel: 'nope'\n"), 0644); err != nil {
@@ -21,6 +20,24 @@ func TestSchemaValidationUnknownType(t *testing.T) {
 	_, _, _, err := b.Build(fs, []string{"--config", cfgPath})
 	if err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestSchemaValidationValid(t *testing.T) {
+	defaults, _ := DefaultConfig()
+	b := NewBuilder(defaults)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgPath, []byte("parallel: 5\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Parallel != 5 {
+		t.Fatalf("expected parallel 5, got %d", cfg.Parallel)
 	}
 }
 

--- a/internal/config/viper_builder.go
+++ b/internal/config/viper_builder.go
@@ -286,7 +286,7 @@ func (b *builder) parseBlockSize() (int, string, error) {
 	return int(val), raw, nil
 }
 
-func buildViper(flagSets *FlagSets) (*viper.Viper, []string, bool, error) {
+func buildViper(flagSets *FlagSets) (*viper.Viper, []string, bool, map[string]any, error) {
 	v := viper.New()
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")
@@ -297,7 +297,7 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, bool, error) {
 	var envErr error
 	for _, fs := range flagSets.All() {
 		if err := v.BindPFlags(fs); err != nil {
-			return nil, nil, false, err
+			return nil, nil, false, nil, err
 		}
 		fs.VisitAll(func(f *pflag.Flag) {
 			if envErr == nil {
@@ -310,37 +310,34 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, bool, error) {
 		})
 	}
 	if envErr != nil {
-		return nil, nil, false, envErr
+		return nil, nil, false, nil, envErr
 	}
 
 	if err := bindTransportEnv(flagSets.Transport, v); err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, nil, err
 	}
 	if err := bindDedupEnv(flagSets.Dedup, v); err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, nil, err
 	}
 	if err := bindCompressionEnv(flagSets.Compression, v); err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, nil, err
 	}
 	if err := bindLVMEnv(flagSets.LVM, v); err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, nil, err
 	}
 	var warnings []string
 	allowInsecureYAML := false
+	var raw map[string]any
 	if cfgFile := v.GetString("config"); cfgFile != "" {
 		data, err := os.ReadFile(cfgFile)
 		if err != nil {
-			return nil, nil, false, fmt.Errorf("error reading config file %q: %w", cfgFile, err)
+			return nil, nil, false, nil, fmt.Errorf("error reading config file %q: %w", cfgFile, err)
 		}
 		v.SetConfigFile(cfgFile)
 		if err := v.ReadConfig(bytes.NewReader(data)); err != nil {
-			return nil, nil, false, fmt.Errorf("error reading config file %q: %w", cfgFile, err)
+			return nil, nil, false, nil, fmt.Errorf("error reading config file %q: %w", cfgFile, err)
 		}
-		var raw map[string]any
 		if err := yaml.Unmarshal(data, &raw); err == nil {
-			if err := validateSchema(raw); err != nil {
-				return nil, nil, false, err
-			}
 			if v, ok := raw["allow_insecure"].(bool); ok && v {
 				allowInsecureYAML = true
 			}
@@ -366,7 +363,7 @@ func buildViper(flagSets *FlagSets) (*viper.Viper, []string, bool, error) {
 			}
 		}
 	}
-	return v, warnings, allowInsecureYAML, nil
+	return v, warnings, allowInsecureYAML, raw, nil
 }
 
 func knownConfigKeys() map[string]struct{} {


### PR DESCRIPTION
## Summary
- validate configuration files against the embedded JSON schema
- add tests ensuring invalid configs fail and valid configs pass

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/verify build failure, escalate tests require sudo)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(typecheck failure in cmd/verify)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bafada248323a378ae6f56e7b019