### PR TITLE
docs: remove duplicated destination creation section

### DIFF
--- a/docs/lvm.md
+++ b/docs/lvm.md
@@ -57,12 +57,6 @@ lvmsync run --create-dest-lv --force /dev/vg0/origin /dev/vg1/target
 
 Accidentally creating a volume in the wrong group can destroy data; verify the
 destination path and available space before using this option.
-=======
-## Destination Creation
-
-`--create-dest-lv` (or `LVMSYNC_LVM_CREATE_DEST_LV=true`) creates the
-destination logical volume when it does not exist. The new LV matches the source
-size and is ready for data before the transfer begins.
 
 ## Environment Example
 


### PR DESCRIPTION
## Summary
- remove stray delimiter and duplicate destination creation block from LVM docs
- ensure destination volume creation flows into environment example

## Testing
- `go build ./...`
- `go test ./docs`
- `go test -cover ./...` *(fails: failed to sufficiently increase receive buffer size)*
- `golangci-lint run` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce7e8b4883238298083a639057a8