### PR TITLE
docs: clarify identity tuple in troubleshooting

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -126,10 +126,7 @@ lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with e
 
 ## Troubleshooting
 
-- Compare source and destination identities; the device identity tuple `(device_id, fs_uuid, size_bytes, major:minor, manifest_epoch)` must match the resume file. LVMSync refuses to resume when the tuple differs.
-
-- Compare source and destination identities; the device identity tuple `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` must match the resume file.
-
+- Compare source and destination identities; the device identity tuple `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` must match the resume file. LVMSync refuses to resume when the tuple differs.
 - Confirm the destination is not mounted read-write. Use `--force` only when intentionally overwriting.
 - Rerun with `--resume` after resolving issues to avoid re-copying completed blocks.
 - Review logs for detailed errors and ensure all configuration values follow the expected flag > environment variable > config file precedence.


### PR DESCRIPTION
## Summary
- clarify device identity tuple in operations troubleshooting docs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo escalation failed: exec: "sh": executable file not found in $PATH)*
- `go test ./docs`
- `golangci-lint run` *(fails: 1107 issues: errcheck, gocritic, revive, staticcheck, unused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce7d895c8323bfc1310bb6e9c3e7