### PR TITLE
docs: fix create-dest-lv duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,6 @@ Flags override environment variables, which override `config.yaml` values.
 | `--skip-snapshot-creation` | `LVMSYNC_SKIP_SNAPSHOT_CREATION` | `skip_snapshot_creation` | Skip automatic snapshot creation (requires `--force`) |
 | `--skip-disk-check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot-size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
-| `--create-dest-lv` | `LVMSYNC_LVM_CREATE_DEST_LV` | `create_dest_lv` | Create destination logical volume when missing |
 | `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; parsed with shell-style quoting and validated at startup |
 | `--sanitize-env` | `LVMSYNC_SANITIZE_ENV` | `sanitize_env` | Drop dangerous variables like `LD_PRELOAD` and remove `PATH`/`LANG` during escalation (disable with `--sanitize-env=false`) |
 | `--lvm-timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations and privilege checks |


### PR DESCRIPTION
## Summary
- remove duplicate create-dest-lv option from README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestEnsureAndDrop_* in escalate package)*
- `go tool cover -func=coverage.out | tail -n 1`
- `go test ./docs`
- `golangci-lint run` *(fails: 1107 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce7c98648323a21c95730ce44344