### PR TITLE
Warn on plaintext rsync transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ LVMSync negotiates transports in the order provided by `--transport` (default
 `ssh,tcp+tls,h2,quic`). All transports require TLS 1.3 with mutual
 authentication or SSH host key verification unless `--allow-insecure` is set.
 The `rsync` transport is plaintext and refuses to initialize unless
-`--allow-insecure` acknowledges the lack of encryption. See
+`--allow-insecure` acknowledges the lack of encryption. Enabling this transport
+logs a warning noting the plaintext connection. See
 [docs/transports.md](docs/transports.md) for details.
 
 | Transport | Security defaults | Notes |

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -125,4 +125,5 @@ lvmsyncd --listen quic://:12000 --server-cert cert.pem --server-key key.pem --cl
 - Interoperates with upstream `rsyncd` implementations (e.g., OpenRSYNC on macOS 15)
 - Known issue: macOS 15 ships OpenRSYNC 0.6 which may abort large transfers; verify with upstream rsync if issues arise
 - Security: traffic is unencrypted and unauthenticated. `--allow-insecure` must be set and connections should only run on trusted networks or within secure tunnels
+- Enabling the transport logs a warning noting the plaintext connection
 - Flags: `--transport rsync` selects this transport and requires `--allow-insecure`

--- a/transport/rsyncwire/rsyncwire.go
+++ b/transport/rsyncwire/rsyncwire.go
@@ -31,6 +31,11 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if !cfg.AllowInsecure {
 		return nil, fmt.Errorf("rsync transport requires AllowInsecure")
 	}
+	cfg.Logger.Warn(
+		"plaintext_connection",
+		zap.String("transport", "rsync"),
+		zap.String("docs", "docs/transports.md"),
+	)
 	return &Transport{logger: cfg.Logger}, nil
 }
 

--- a/transport/rsyncwire/rsyncwire_test.go
+++ b/transport/rsyncwire/rsyncwire_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/transport"
 )
@@ -11,5 +12,23 @@ import (
 func TestRequiresAllowInsecure(t *testing.T) {
 	if _, err := New(transport.Config{Logger: zap.NewNop()}); err == nil {
 		t.Fatalf("expected error when AllowInsecure is false")
+	}
+}
+
+func TestLogsPlaintextWarning(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	if _, err := New(transport.Config{Logger: logger, AllowInsecure: true}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries := logs.TakeAll()
+	if len(entries) == 0 {
+		t.Fatalf("expected warning log")
+	}
+	if entries[0].Message != "plaintext_connection" {
+		t.Fatalf("unexpected message: %s", entries[0].Message)
+	}
+	if entries[0].ContextMap()["docs"] != "docs/transports.md" {
+		t.Fatalf("missing docs field: %v", entries[0].ContextMap()["docs"])
 	}
 }


### PR DESCRIPTION
## Summary
- warn that rsync transport is plaintext
- test that enabling rsync logs plaintext warning
- document plaintext warning in README and docs/transports.md

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestEnsureAndDrop_WithSudo, see logs)*
- `golangci-lint run` *(fails: multiple revive/errcheck issues across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d7ea9e588323a26076c2d2cd1c2d