### PR TITLE
test: add verify exit code integration

### DIFF
--- a/cmd/verify/verify_command_integration_test.go
+++ b/cmd/verify/verify_command_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package verify
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"lvmsync_go/internal/exitcode"
+)
+
+func setupLoop(t *testing.T, path string) string {
+	t.Helper()
+	out, err := exec.Command("losetup", "--find", "--show", path).CombinedOutput()
+	if err != nil {
+		t.Skipf("losetup %s: %v: %s", path, err, out)
+	}
+	loop := strings.TrimSpace(string(out))
+	t.Cleanup(func() { _ = exec.Command("losetup", "-d", loop).Run() })
+	return loop
+}
+
+func TestVerifyCommandMismatchExitCode(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src.img")
+	dstFile := filepath.Join(dir, "dst.img")
+
+	block := bytes.Repeat([]byte{1}, 4096)
+	if err := os.WriteFile(srcFile, block, 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dstData := append([]byte{}, block...)
+	dstData[0] = 2
+	if err := os.WriteFile(dstFile, dstData, 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	srcLoop := setupLoop(t, srcFile)
+	dstLoop := setupLoop(t, dstFile)
+
+	bin := filepath.Join(dir, "lvmsync")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = filepath.Join("..", "..")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build lvmsync: %v\n%s", err, out)
+	}
+
+	manifest := filepath.Join(dir, "src.manifest")
+	cmd := exec.Command(bin, "verify", "--manifest-path", manifest, srcLoop, dstLoop)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected verify to fail")
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("verify: %v", err)
+	}
+	if exitErr.ExitCode() != exitcode.ErrVerify {
+		t.Fatalf("expected exit code %d, got %d", exitcode.ErrVerify, exitErr.ExitCode())
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test that runs `lvmsync verify` on loopback devices and expects exit code 60 when data differ

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo escalation failed: exec: "sh": executable file not found in $PATH)*
- `golangci-lint run` *(fails: 1109 issues: errcheck, gocritic, revive, staticcheck, unused)*
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a4d7ebdb848323ad38beb47949333f