### PR TITLE
docs: clarify probe tuple

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,12 +9,8 @@ The controller orchestrates replication, validates parameters, and interacts wit
 ## Probe and verify modes
 
 Read-only operations can run without elevated privileges.
-`--probe-only` checks device metadata, validates privileges, and prints `size_bytes device_id manifest_epoch` so operators can capture the identity tuple before writing.
-`--verify-only` reads source and destination devices and reports mismatches.
-
-Read-only operations can run without elevated privileges.  
 `--probe-only` checks device metadata, validates privileges, and emits dry-run estimates. It prints `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` for confirmation.
-`--verify-only` reads source and destination devices and reports mismatches.  
+`--verify-only` reads source and destination devices and reports mismatches.
 
 Both commands exit `0` on success, return `60` for verification failures, and `10` when required capabilities are missing.
 
@@ -22,12 +18,12 @@ Example `--probe-only` output:
 
 ```sh
 lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
-# 10737418240 12345678-9abc-def0-1234-56789abcdef0 1700000000
+# 10737418240 12345678-9abc-def0-1234-56789abcdef0 01234567-89ab-cdef-0123-456789abcdef deadbeef-dead-beef-dead-beefdeadbeef 253 0 1700000000
 ```
 
 ## Device identity enforcement
 
-Each transfer records `(device_id, fs_uuid, size_bytes, major:minor, manifest_epoch)` and compares it with the destination and any resume state before writing. LVMSync refuses to resume when this tuple differs, preventing accidental or malicious overwrites.
+Each transfer records `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` and compares it with the destination and any resume state before writing. LVMSync refuses to resume when this tuple differs, preventing accidental or malicious overwrites.
 
 ## Required sudoers entries
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -37,8 +37,9 @@ lvmsync run --resume=statefile /dev/vg0/snap0 /dev/vg0/target
 1. Start transfers with `--resume statefile` so checkpoints persist.
 2. If the process is interrupted (for example, by `SIGKILL`), invoke the same
    command with `--resume statefile` to continue copying remaining blocks.
-3. LVMSync validates the device identity tuple `(device_id, fs_uuid, size_bytes,
-   major:minor)` against the resume file. Mismatches abort with a precondition
+3. LVMSync validates `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor,
+   manifest_epoch)` against the resume file. Use `--probe-only` to record this
+   space-separated tuple beforehand. Mismatches abort with a precondition
    failure to prevent accidental overwrites.
 4. After a successful resume the state file is removed; optionally run
    `lvmsync verify` to confirm both devices match.


### PR DESCRIPTION
## Summary
- ensure SECURITY.md and OPERATIONS.md reference the canonical `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` tuple
- drop duplicate description of `--probe-only` and update example output
- document how to capture the tuple via `--probe-only`

## Testing
- `go test ./...` *(fails: sudo not found in PATH and related escalate tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d8448d288323b50f0dc710d9c8b7