### PR TITLE
Log WAL identity mismatches

### DIFF
--- a/device/wal.go
+++ b/device/wal.go
@@ -2,13 +2,16 @@ package device
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
 )
 
 const (
@@ -71,6 +74,10 @@ type walFile interface {
 	Name() string
 }
 
+// ErrWALMetadataMismatch indicates the WAL header identity does not match the
+// provided device identity.
+var ErrWALMetadataMismatch = errors.New("wal metadata mismatch")
+
 type WAL struct {
 	f      walFile
 	header walHeader
@@ -125,9 +132,10 @@ func walHeaderMACV0(h *walHeaderV0) [32]byte {
 	return blake3.Sum256(buf[:])
 }
 
-// OpenWAL opens or creates a WAL at path for the given device identity.
+// OpenWAL opens or creates a WAL at path for the given device identity. The
+// logger must be non-nil and is used to report metadata mismatches.
 // It verifies metadata on existing WALs and loads recorded ranges.
-func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
+func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger) (*WAL, error) {
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, err
@@ -209,7 +217,34 @@ func OpenWAL(path string, id DeviceIdentity) (*WAL, error) {
 			string(hdr.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
 			string(hdr.FS[:len(id.FSUUID)]) != id.FSUUID {
 			f.Close()
-			return nil, fmt.Errorf("wal: metadata mismatch")
+			hdrID := DeviceIdentity{
+				SizeBytes:     hdr.Size,
+				KernelUUID:    strings.TrimRight(string(hdr.Kernel[:]), "\x00"),
+				GPTUUID:       strings.TrimRight(string(hdr.GPT[:]), "\x00"),
+				FSUUID:        strings.TrimRight(string(hdr.FS[:]), "\x00"),
+				Major:         hdr.Major,
+				Minor:         hdr.Minor,
+				ManifestEpoch: hdr.Epoch,
+			}
+			err := fmt.Errorf("precondition: %w", ErrWALMetadataMismatch)
+			logger.Error("wal metadata mismatch",
+				zap.Uint64("header_size_bytes", hdrID.SizeBytes),
+				zap.Uint64("header_manifest_epoch", hdrID.ManifestEpoch),
+				zap.Uint32("header_major", hdrID.Major),
+				zap.Uint32("header_minor", hdrID.Minor),
+				zap.String("header_kernel_uuid", hdrID.KernelUUID),
+				zap.String("header_gpt_uuid", hdrID.GPTUUID),
+				zap.String("header_fs_uuid", hdrID.FSUUID),
+				zap.Uint64("identity_size_bytes", id.SizeBytes),
+				zap.Uint64("identity_manifest_epoch", id.ManifestEpoch),
+				zap.Uint32("identity_major", id.Major),
+				zap.Uint32("identity_minor", id.Minor),
+				zap.String("identity_kernel_uuid", id.KernelUUID),
+				zap.String("identity_gpt_uuid", id.GPTUUID),
+				zap.String("identity_fs_uuid", id.FSUUID),
+				zap.Error(err),
+			)
+			return nil, err
 		}
 		w.header = hdr
 		off := int64(walHeaderSize)

--- a/device/wal_crash_test.go
+++ b/device/wal_crash_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 // TestWALCrashRecovery simulates crash scenarios and ensures WAL recovery.
@@ -14,7 +16,7 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("truncate_mid_entry", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, err := OpenWAL(path, id)
+		w, err := OpenWAL(path, id, zap.NewNop())
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -36,7 +38,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatalf("close file: %v", err)
 		}
-		w2, err := OpenWAL(path, id)
+		w2, err := OpenWAL(path, id, zap.NewNop())
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}
@@ -49,7 +51,7 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("omit_fsync", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, err := OpenWAL(path, id)
+		w, err := OpenWAL(path, id, zap.NewNop())
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -68,7 +70,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := os.Truncate(path, walHeaderSize+16); err != nil {
 			t.Fatalf("truncate: %v", err)
 		}
-		w2, err := OpenWAL(path, id)
+		w2, err := OpenWAL(path, id, zap.NewNop())
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -6,13 +6,17 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"strings"
 )
 
 func TestWALIdentityMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id)
+	w, err := OpenWAL(path, id, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -20,28 +24,64 @@ func TestWALIdentityMismatch(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 	badID := DeviceIdentity{SizeBytes: 101, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
 		t.Fatalf("expected size mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev2", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
 		t.Fatalf("expected uuid mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs2", Major: 1, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
 		t.Fatalf("expected fs uuid mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 3, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
 		t.Fatalf("expected major mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 4, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
 		t.Fatalf("expected minor mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 2}
-	if _, err := OpenWAL(path, badID); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
 		t.Fatalf("expected epoch mismatch error")
+	}
+}
+
+func TestWALIdentityMismatchLogging(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, err := OpenWAL(path, id, zap.NewNop())
+	if err != nil {
+		t.Fatalf("open wal: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	badID := DeviceIdentity{SizeBytes: 101, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	core, logs := observer.New(zap.ErrorLevel)
+	_, err = OpenWAL(path, badID, zap.New(core))
+	if err == nil {
+		t.Fatalf("expected error for identity mismatch")
+	}
+	if !errors.Is(err, ErrWALMetadataMismatch) {
+		t.Fatalf("expected ErrWALMetadataMismatch, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "precondition") {
+		t.Fatalf("expected precondition error, got %v", err)
+	}
+	entries := logs.FilterMessage("wal metadata mismatch").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected wal metadata mismatch log, got %v", logs.All())
+	}
+	fields := entries[0].ContextMap()
+	if fields["header_size_bytes"].(uint64) != 100 || fields["identity_size_bytes"].(uint64) != 101 {
+		t.Fatalf("unexpected size fields: %v", fields)
+	}
+	if fields["header_kernel_uuid"].(string) != "dev" || fields["identity_kernel_uuid"].(string) != "dev" {
+		t.Fatalf("unexpected kernel uuid fields: %v", fields)
 	}
 }
 
@@ -49,7 +89,7 @@ func TestWALRecovery(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id)
+	w, err := OpenWAL(path, id, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -57,7 +97,7 @@ func TestWALRecovery(t *testing.T) {
 		t.Fatalf("append: %v", err)
 	}
 	w.Close()
-	w, err = OpenWAL(path, id)
+	w, err = OpenWAL(path, id, zap.NewNop())
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -72,7 +112,7 @@ func TestWALVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id)
+	w, err := OpenWAL(path, id, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -103,7 +143,7 @@ func TestWALVersionMismatch(t *testing.T) {
 		t.Fatalf("write header: %v", err)
 	}
 	f.Close()
-	if _, err := OpenWAL(path, id); err == nil {
+	if _, err := OpenWAL(path, id, zap.NewNop()); err == nil {
 		t.Fatalf("expected version mismatch error")
 	}
 }
@@ -138,7 +178,7 @@ func TestWALUpgrade(t *testing.T) {
 	}
 	f.Close()
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id)
+	w, err := OpenWAL(path, id, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -173,7 +213,7 @@ func TestWALSyncDirCreate(t *testing.T) {
 		return stubErr
 	})
 	defer restore()
-	if _, err := OpenWAL(path, id); !errors.Is(err, stubErr) {
+	if _, err := OpenWAL(path, id, zap.NewNop()); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}
 	if calls != 1 {
@@ -185,7 +225,7 @@ func TestWALSyncDirClose(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id)
+	w, err := OpenWAL(path, id, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -208,7 +248,7 @@ func TestWALSyncDirAppend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", FSUUID: "f", Major: 1, Minor: 2}
-	w, err := OpenWAL(path, id)
+	w, err := OpenWAL(path, id, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}


### PR DESCRIPTION
## Summary
- require a logger for WAL operations and return a sentinel precondition error when metadata mismatches
- log both WAL header and provided device identity for easier debugging
- add a unit test ensuring mismatched identities emit structured logs and a precondition error

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo not found)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1109 issues)*


------
https://chatgpt.com/codex/tasks/task_e_68a4d7e9524883239af7c78f82361b61