### PR TITLE
cmd/configdoc: handle errors without panic

### DIFF
--- a/cmd/configdoc/main.go
+++ b/cmd/configdoc/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -8,33 +10,48 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	defaults, err := cfg.DefaultConfig()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	doc := cfg.EnvDocHeader + cfg.EnvDoc(cfg.NewFlagSets(defaults))
-	if err := os.WriteFile(outputPath(), []byte(doc), 0o644); err != nil {
-		panic(err)
+	path, err := outputPath()
+	if err != nil {
+		return err
 	}
+	if err := os.WriteFile(path, []byte(doc), 0o644); err != nil {
+		return err
+	}
+	return nil
 }
 
-func outputPath() string {
-	root := findRepoRoot()
-	return filepath.Join(root, "docs", "config_env.md")
+func outputPath() (string, error) {
+	root, err := findRepoRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "docs", "config_env.md"), nil
 }
 
-func findRepoRoot() string {
+func findRepoRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	for {
 		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
+			return dir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			panic("go.mod not found")
+			return "", errors.New("go.mod not found")
 		}
 		dir = parent
 	}

--- a/cmd/configdoc/main_test.go
+++ b/cmd/configdoc/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunGeneratesDoc(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(tmp, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(oldwd)
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if err := run(); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	path := filepath.Join(tmp, "docs", "config_env.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected doc at %s: %v", path, err)
+	}
+}
+
+func TestRunMissingGoMod(t *testing.T) {
+	tmp := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(oldwd)
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if err := run(); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- replace panics in cmd/configdoc with explicit stderr error handling and deterministic exits
- add unit tests for doc generation and missing go.mod error path

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo escalation tests)*
- `go tool cover -func=coverage.out | tail -n 1`
- `go test ./cmd/configdoc`
- `golangci-lint run` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d838c0608323823a9469f62324c9