### PR TITLE
Use structured logging for configdoc and serve commands

### DIFF
--- a/cmd/configdoc/main.go
+++ b/cmd/configdoc/main.go
@@ -2,19 +2,59 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
+	"go.uber.org/zap"
+	rootcmd "lvmsync_go/cmd/root"
 	cfg "lvmsync_go/internal/config"
 )
 
-func main() {
-	if err := run(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+type runner struct {
+	run        func() error
+	syncLogger func(*zap.Logger)
+	exit       func(int)
+	newLogger  func() *zap.Logger
+}
+
+func newRunner() *runner {
+	return &runner{
+		run:        run,
+		syncLogger: rootcmd.SyncLogger,
+		exit:       os.Exit,
+		newLogger:  func() *zap.Logger { return zap.NewExample() },
 	}
 }
+
+func newRunnerWithDeps(runFunc func() error, syncFunc func(*zap.Logger), exitFunc func(int), loggerFunc func() *zap.Logger) *runner {
+	r := newRunner()
+	if runFunc != nil {
+		r.run = runFunc
+	}
+	if syncFunc != nil {
+		r.syncLogger = syncFunc
+	}
+	if exitFunc != nil {
+		r.exit = exitFunc
+	}
+	if loggerFunc != nil {
+		r.newLogger = loggerFunc
+	}
+	return r
+}
+
+func (r *runner) Run() {
+	logger := r.newLogger()
+	defer r.syncLogger(logger)
+	if err := r.run(); err != nil {
+		logger.Error("run_failed", zap.Error(err))
+		r.exit(1)
+		return
+	}
+	r.exit(0)
+}
+
+func main() { newRunner().Run() }
 
 func run() error {
 	defaults, err := cfg.DefaultConfig()

--- a/cmd/configdoc/main_test.go
+++ b/cmd/configdoc/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestRunGeneratesDoc(t *testing.T) {
@@ -43,5 +48,28 @@ func TestRunMissingGoMod(t *testing.T) {
 	}
 	if err := run(); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestMainLogsAndSyncs(t *testing.T) {
+	syncCalled := false
+	exitCode := 0
+	core, logs := observer.New(zapcore.ErrorLevel)
+	r := newRunnerWithDeps(
+		func() error { return errors.New("fail") },
+		func(*zap.Logger) { syncCalled = true },
+		func(c int) { exitCode = c },
+		func() *zap.Logger { return zap.New(core) },
+	)
+	r.Run()
+	if exitCode != 1 {
+		t.Fatalf("exit code: got %d want 1", exitCode)
+	}
+	entries := logs.FilterMessage("run_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if !syncCalled {
+		t.Fatalf("expected SyncLogger to be called")
 	}
 }

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -1,43 +1,83 @@
+// Package main contains the deprecated serve command.
 package main
 
 import (
 	"errors"
-	"fmt"
-	"io"
 	"os"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	rootcmd "lvmsync_go/cmd/root"
 	_ "lvmsync_go/transport/rsyncwire"
 )
 
 const deprecationMsg = "serve command deprecated; use lvmsyncd instead"
 
-func newCommand() *cobra.Command {
+type runner struct {
+	run        func([]string, *zap.Logger) int
+	syncLogger func(*zap.Logger)
+	exit       func(int)
+	newLogger  func() *zap.Logger
+}
+
+func newRunner() *runner {
+	return &runner{
+		run:        run,
+		syncLogger: rootcmd.SyncLogger,
+		exit:       os.Exit,
+		newLogger:  func() *zap.Logger { return zap.NewExample() },
+	}
+}
+
+func newRunnerWithDeps(runFunc func([]string, *zap.Logger) int, syncFunc func(*zap.Logger), exitFunc func(int), loggerFunc func() *zap.Logger) *runner {
+	r := newRunner()
+	if runFunc != nil {
+		r.run = runFunc
+	}
+	if syncFunc != nil {
+		r.syncLogger = syncFunc
+	}
+	if exitFunc != nil {
+		r.exit = exitFunc
+	}
+	if loggerFunc != nil {
+		r.newLogger = loggerFunc
+	}
+	return r
+}
+
+func (r *runner) Run(args []string) {
+	logger := r.newLogger()
+	defer r.syncLogger(logger)
+	code := r.run(args, logger)
+	r.exit(code)
+}
+
+func newCommand(logger *zap.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Deprecated server command",
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
+			logger.Error("command_deprecated", zap.String("replacement", "lvmsyncd"))
 			return errors.New(deprecationMsg)
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		fmt.Fprintln(cmd.OutOrStdout(), deprecationMsg)
+	cmd.SetHelpFunc(func(_ *cobra.Command, _ []string) {
+		logger.Warn(deprecationMsg)
 	})
 	return cmd
 }
 
-func run(args []string, w io.Writer) int {
-	cmd := newCommand()
+func run(args []string, logger *zap.Logger) int {
+	cmd := newCommand(logger)
 	cmd.SetArgs(args)
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(w, deprecationMsg)
 		return 1
 	}
 	return 0
 }
 
-func main() {
-	os.Exit(run(os.Args[1:], os.Stderr))
-}
+func main() { newRunner().Run(os.Args[1:]) }

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -1,18 +1,36 @@
 package main
 
 import (
-	"bytes"
-	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestServeCommandDeprecated(t *testing.T) {
-	var buf bytes.Buffer
-	code := run(nil, &buf)
-	if code == 0 {
+	syncCalled := false
+	exitCode := 0
+	core, logs := observer.New(zapcore.ErrorLevel)
+	r := newRunnerWithDeps(
+		nil,
+		func(*zap.Logger) { syncCalled = true },
+		func(c int) { exitCode = c },
+		func() *zap.Logger { return zap.New(core) },
+	)
+	r.Run(nil)
+	if exitCode == 0 {
 		t.Fatalf("expected non-zero exit code")
 	}
-	if !strings.Contains(buf.String(), "lvmsyncd") {
-		t.Fatalf("expected message to mention lvmsyncd, got %q", buf.String())
+	entries := logs.FilterMessage("command_deprecated").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	replacement, ok := entries[0].ContextMap()["replacement"].(string)
+	if !ok || replacement != "lvmsyncd" {
+		t.Fatalf("expected replacement lvmsyncd, got %v", entries[0].ContextMap()["replacement"])
+	}
+	if !syncCalled {
+		t.Fatalf("expected SyncLogger to be called")
 	}
 }


### PR DESCRIPTION
## Summary
- replace direct printing in `configdoc` and `serve` with `zap` structured logs
- flush logs on exit via `rootcmd.SyncLogger`
- add tests ensuring logs are emitted and `SyncLogger` is invoked

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo not found in PATH)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1109 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dedb8f7c8323955b5d827ed9d704