### PR TITLE
lvm: enforce non-nil logger in snapshot registry

### DIFF
--- a/lvm/snapshot_registry.go
+++ b/lvm/snapshot_registry.go
@@ -19,13 +19,14 @@ var (
 )
 
 // RegisterSnapshot adds the snapshot path to the cleanup registry and installs
-// a signal handler on first use.
+// a signal handler on first use. Callers must provide a non-nil logger;
+// use zap.NewNop() when logging is not desired.
 func RegisterSnapshot(path string, logger *zap.Logger) {
 	if path == "" {
 		return
 	}
 	if logger == nil {
-		logger = zap.NewNop()
+		panic("nil logger")
 	}
 	registryMu.Lock()
 	registry[path] = logger
@@ -74,14 +75,15 @@ func CleanupRegistered(ctx context.Context) {
 	}
 }
 
-// CleanupSnapshot removes a single snapshot, unregistering it first.
-// It logs success or failure and ignores nil paths.
+// CleanupSnapshot removes a single snapshot, unregistering it first. Callers
+// must supply a non-nil logger (use zap.NewNop() to disable logging). It logs
+// success or failure and ignores empty paths.
 func CleanupSnapshot(ctx context.Context, path string, logger *zap.Logger) {
 	if path == "" {
 		return
 	}
 	if logger == nil {
-		logger = zap.NewNop()
+		panic("nil logger")
 	}
 	UnregisterSnapshot(path)
 	if ctx == nil {

--- a/lvm/snapshot_registry_test.go
+++ b/lvm/snapshot_registry_test.go
@@ -1,0 +1,59 @@
+package lvm
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestRegisterSnapshotNilLoggerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	RegisterSnapshot("/dev/test", nil)
+}
+
+func TestRegisterSnapshotAddsSnapshot(t *testing.T) {
+	registryMu.Lock()
+	registry = make(map[string]*zap.Logger)
+	registryMu.Unlock()
+
+	RegisterSnapshot("/dev/test", zap.NewNop())
+
+	registryMu.Lock()
+	_, ok := registry["/dev/test"]
+	registry = make(map[string]*zap.Logger)
+	registryMu.Unlock()
+
+	if !ok {
+		t.Fatalf("snapshot not registered")
+	}
+}
+
+func TestCleanupSnapshotNilLoggerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	CleanupSnapshot(context.Background(), "/dev/test", nil)
+}
+
+func TestCleanupSnapshotCallsRemove(t *testing.T) {
+	var called bool
+	old := removeSnap
+	removeSnap = func(ctx context.Context, path string, logger *zap.Logger) error {
+		called = true
+		return nil
+	}
+	defer func() { removeSnap = old }()
+
+	CleanupSnapshot(context.Background(), "/dev/test", zap.NewNop())
+
+	if !called {
+		t.Fatalf("removeSnap not called")
+	}
+}


### PR DESCRIPTION
## Summary
- require callers to pass a non-nil logger to snapshot registry helpers
- cover nil logger cases with dedicated tests

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: TestEnsureAndDrop_WithSudo, TestEnsureAndDrop_NoSudo, TestEnsureRootOrReexec_RunnerExitCode)*
- `golangci-lint run` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5499510808323a3ab0828084f55ad