### PR TITLE
refactor: rename sync logger message

### DIFF
--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -277,9 +277,9 @@ func TestRunSyncsLoggerDryRun(t *testing.T) {
 	if syncs != 1 {
 		t.Fatalf("expected logger.Sync called once, got %d", syncs)
 	}
-	if logs.FilterMessage("Logger sync error").Len() != 1 {
-		t.Fatalf("expected sync error log")
-	}
+       if logs.FilterMessage("logger_sync_error").Len() != 1 {
+               t.Fatalf("expected sync error log")
+       }
 }
 
 func TestRunWritesVersion(t *testing.T) {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -109,9 +109,9 @@ func RegisterVerify(fn func([]string, *zap.Logger) error) {
 
 // SyncLogger flushes buffered log entries and logs if syncing fails.
 func SyncLogger(logger *zap.Logger) {
-	if err := logger.Sync(); err != nil {
-		logger.Error("Logger sync error", zap.Error(err))
-	}
+       if err := logger.Sync(); err != nil {
+               logger.Error("logger_sync_error", zap.Error(err))
+       }
 }
 
 // ConfigureWithEscalator loads configuration, ensures privileges via the provided

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -91,9 +91,9 @@ func TestRunSyncsLogger(t *testing.T) {
 	if syncs != 1 {
 		t.Fatalf("expected logger.Sync called once, got %d", syncs)
 	}
-	if logs.FilterMessage("Logger sync error").Len() != 1 {
-		t.Fatalf("expected sync error log")
-	}
+       if logs.FilterMessage("logger_sync_error").Len() != 1 {
+               t.Fatalf("expected sync error log")
+       }
 }
 
 func TestRunFlagOverridesEnvAndYAML(t *testing.T) {

--- a/error_handling_test.go
+++ b/error_handling_test.go
@@ -42,9 +42,9 @@ func TestSyncLoggerLogsError(t *testing.T) {
 	if len(logs) != 1 {
 		t.Fatalf("expected one log entry, got %d", len(logs))
 	}
-	if logs[0].Message != "Logger sync error" {
-		t.Fatalf("unexpected log message %q", logs[0].Message)
-	}
+       if logs[0].Message != "logger_sync_error" {
+               t.Fatalf("unexpected log message %q", logs[0].Message)
+       }
 	errStr, ok := logs[0].ContextMap()["error"].(string)
 	if !ok || errStr != syncErr.Error() {
 		t.Fatalf("expected error %q in log, got %v", syncErr.Error(), logs[0].ContextMap()["error"])

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -53,7 +53,7 @@ func TestMainLogsStructuredError(t *testing.T) {
 		t.Fatalf("expected one log entry, got %d", len(entries))
 	}
 
-	syncEntries := logs.FilterMessage("Logger sync error").All()
+       syncEntries := logs.FilterMessage("logger_sync_error").All()
 	if len(syncEntries) != 1 {
 		t.Fatalf("expected logger sync error entry, got %d", len(syncEntries))
 	}
@@ -95,7 +95,7 @@ func TestMainLogsConfigError(t *testing.T) {
 		t.Fatalf("expected one log entry, got %d", len(entries))
 	}
 
-	syncEntries := logs.FilterMessage("Logger sync error").All()
+       syncEntries := logs.FilterMessage("logger_sync_error").All()
 	if len(syncEntries) != 1 {
 		t.Fatalf("expected logger sync error entry, got %d", len(syncEntries))
 	}
@@ -135,7 +135,7 @@ func TestMainErrorsOnNonLinux(t *testing.T) {
 		t.Fatalf("expected one log entry, got %d", len(entries))
 	}
 
-	syncEntries := logs.FilterMessage("Logger sync error").All()
+       syncEntries := logs.FilterMessage("logger_sync_error").All()
 	if len(syncEntries) != 1 {
 		t.Fatalf("expected logger sync error entry, got %d", len(syncEntries))
 	}

--- a/transfer/sync_logger_error_test.go
+++ b/transfer/sync_logger_error_test.go
@@ -36,7 +36,7 @@ func TestDumpChangesLogsSyncError(t *testing.T) {
 	if err := tr.DumpChangesSequential(context.Background(), cfg, snapshot, src, &buf); err != nil {
 		t.Fatalf("DumpChangesSequential failed: %v", err)
 	}
-	logs := observed.FilterMessage("Logger sync error").All()
+       logs := observed.FilterMessage("logger_sync_error").All()
 	if len(logs) != 1 {
 		t.Fatalf("expected sync error log, got %d", len(logs))
 	}
@@ -56,7 +56,7 @@ func TestDumpChangesLogsSyncErrorOnEarlyFailure(t *testing.T) {
 	if err := tr.DumpChangesSequential(context.Background(), cfg, "snapshot", "/nonexistent", &buf); err == nil {
 		t.Fatalf("expected DumpChangesSequential error")
 	}
-	logs := observed.FilterMessage("Logger sync error").All()
+       logs := observed.FilterMessage("logger_sync_error").All()
 	if len(logs) != 1 {
 		t.Fatalf("expected sync error log, got %d", len(logs))
 	}


### PR DESCRIPTION
## Summary
- use `logger_sync_error` message in `SyncLogger`
- update tests expecting old sync logger message

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: ensure_root_or_reexec: sudo not found in PATH)*
- `golangci-lint run` *(fails: unused parameter, package comments, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a549973adc8323a9e9e18459d85301