### PR TITLE
feat: structure configuration warnings

### DIFF
--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -140,7 +141,18 @@ func NewRootCmd(logger *zap.Logger, r *Runner) *cobra.Command {
 				return err
 			}
 			for _, w := range warns {
-				logger.Warn(w)
+				fields := []zap.Field{zap.String("message", w)}
+				switch {
+				case strings.HasPrefix(w, "unknown configuration key "):
+					key := strings.Trim(strings.TrimPrefix(w, "unknown configuration key "), "\"")
+					fields = append(fields,
+						zap.String("config_key", key),
+						zap.String("reason", "unknown_config_key"),
+					)
+				case strings.Contains(w, "allow_insecure enabled"):
+					fields = append(fields, zap.String("reason", "allow_insecure_enabled"))
+				}
+				logger.Warn("configuration_warning", fields...)
 			}
 			if len(remaining) != 2 {
 				fs.Usage()
@@ -205,7 +217,18 @@ func NewRootCmd(logger *zap.Logger, r *Runner) *cobra.Command {
 				return err
 			}
 			for _, w := range warns {
-				logger.Warn(w)
+				fields := []zap.Field{zap.String("message", w)}
+				switch {
+				case strings.HasPrefix(w, "unknown configuration key "):
+					key := strings.Trim(strings.TrimPrefix(w, "unknown configuration key "), "\"")
+					fields = append(fields,
+						zap.String("config_key", key),
+						zap.String("reason", "unknown_config_key"),
+					)
+				case strings.Contains(w, "allow_insecure enabled"):
+					fields = append(fields, zap.String("reason", "allow_insecure_enabled"))
+				}
+				logger.Warn("configuration_warning", fields...)
 			}
 			if len(remaining) != 1 {
 				fs.Usage()

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -159,6 +159,28 @@ func TestRunCommandInvalidOutput(t *testing.T) {
 	}
 }
 
+func TestRunCommandLogsWarnings(t *testing.T) {
+	src := t.TempDir() + "/src"
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := t.TempDir() + "/dst"
+	r := NewRunnerWithDeps(func(src, dst string, opts RunOptions, logger *zap.Logger) error { return nil }, nil, nil)
+	core, obs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	if err := ExecuteWithRunner([]string{"run", "--allow-insecure", "--dry-run", src, dst}, logger, r); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	entries := obs.FilterMessage("configuration_warning").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected configuration warning, got %d", len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	if v, ok := ctx["reason"].(string); !ok || v != "allow_insecure_enabled" {
+		t.Fatalf("unexpected reason: %v", ctx["reason"])
+	}
+}
+
 func TestRunCommandInvalidConfig(t *testing.T) {
 	called := false
 	r := NewRunnerWithDeps(func(src, dst string, opts RunOptions, logger *zap.Logger) error {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -156,7 +156,18 @@ func ConfigureWithEscalator(esc privilege.Escalator) (*config.Config, []string, 
 		return nil, nil, nil, fmt.Errorf("logger initialization error: %w", err)
 	}
 	for _, w := range warns {
-		logger.Warn(w)
+		fields := []zap.Field{zap.String("message", w)}
+		switch {
+		case strings.HasPrefix(w, "unknown configuration key "):
+			key := strings.Trim(strings.TrimPrefix(w, "unknown configuration key "), "\"")
+			fields = append(fields,
+				zap.String("config_key", key),
+				zap.String("reason", "unknown_config_key"),
+			)
+		case strings.Contains(w, "allow_insecure enabled"):
+			fields = append(fields, zap.String("reason", "allow_insecure_enabled"))
+		}
+		logger.Warn("configuration_warning", fields...)
 	}
 	logger.Info("Effective configuration",
 		zap.String("block_size", cfg.HumanBlockSize()),

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -70,7 +70,18 @@ func (r *Runner) Run(args []string, logger *zap.Logger) error {
 				return err
 			}
 			for _, w := range warns {
-				logger.Warn(w)
+				fields := []zap.Field{zap.String("message", w)}
+				switch {
+				case strings.HasPrefix(w, "unknown configuration key "):
+					key := strings.Trim(strings.TrimPrefix(w, "unknown configuration key "), "\"")
+					fields = append(fields,
+						zap.String("config_key", key),
+						zap.String("reason", "unknown_config_key"),
+					)
+				case strings.Contains(w, "allow_insecure enabled"):
+					fields = append(fields, zap.String("reason", "allow_insecure_enabled"))
+				}
+				logger.Warn("configuration_warning", fields...)
 			}
 			if len(remaining) != 2 {
 				fs.Usage()

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -96,6 +96,35 @@ func TestRunSyncsLogger(t *testing.T) {
 	}
 }
 
+func TestRunLogsConfigurationWarning(t *testing.T) {
+	src := t.TempDir() + "/src"
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := t.TempDir() + "/dst"
+	if err := os.WriteFile(dst, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	t.Setenv("LVMSYNC_SSH_HOST", "example")
+	r := newStubRunner()
+	core, obs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	if err := r.Run([]string{"--dry-run", src, dst}, logger); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries := obs.FilterMessage("configuration_warning").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected configuration warning, got %d", len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	if v, ok := ctx["config_key"].(string); !ok || v != "ssh-host" {
+		t.Fatalf("unexpected config_key: %v", ctx["config_key"])
+	}
+	if v, ok := ctx["reason"].(string); !ok || v != "unknown_config_key" {
+		t.Fatalf("unexpected reason: %v", ctx["reason"])
+	}
+}
+
 func TestRunFlagOverridesEnvAndYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	src := t.TempDir() + "/src"


### PR DESCRIPTION
## Summary
- log configuration warnings with structured fields for unknown keys and insecure options
- update verify and CLI tests to assert structured warning fields

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo not found)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: revive, staticcheck, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a54999e7188323a35bfe6fb180081f