### PR TITLE
config: sort warnings for deterministic output

### DIFF
--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -16,7 +17,8 @@ import (
 // control which options are available.
 //
 // Build returns the populated Config, remaining CLI arguments, any warnings for
-// unknown YAML keys, and an error if parsing or validation fails.
+// unknown YAML keys, and an error if parsing or validation fails. The warnings
+// slice is sorted for stable output.
 //
 // Example:
 //
@@ -41,6 +43,7 @@ func NewBuilder(defaults *Config) *ConfigBuilder {
 }
 
 // Build parses the provided args using fs and returns the resulting Config.
+// Warnings are returned in sorted order for deterministic output.
 func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []string, []string, error) {
 	if fs == nil {
 		fs = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
@@ -120,6 +123,7 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 	} else if allowInsecureYAML {
 		return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow-insecure flag or LVMSYNC_ALLOW_INSECURE environment variable")
 	}
+	sort.Strings(warns)
 	if strict && len(warns) > 0 {
 		return nil, nil, warns, fmt.Errorf("%s", strings.Join(warns, "; "))
 	}

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -112,6 +112,34 @@ func TestUnboundEnvKeyWarns(t *testing.T) {
 	}
 }
 
+func TestWarningsSorted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	// Remove SSH flag bindings so multiple keys become unbound.
+	b.FlagSets.SSH = pflag.NewFlagSet("SSH Options", pflag.ExitOnError)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("ssh_host: example\nssh_user: root\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	_, _, warns, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	want := []string{
+		`unknown configuration key "ssh-host"`,
+		`unknown configuration key "ssh-user"`,
+	}
+	if len(warns) != len(want) || warns[0] != want[0] || warns[1] != want[1] {
+		t.Fatalf("warnings=%v", warns)
+	}
+}
+
 func TestStrictConfigYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()


### PR DESCRIPTION
## Summary
- sort accumulated configuration warnings before returning to callers
- document stable warning order and verify in tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: sudo escalation failed: exit status 1)*
- `golangci-lint run` *(fails: many lint errors)*
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a5499d163483238efd4916186fde3f