### PR TITLE
Remove stray literals from snapshot registry tests

### DIFF
--- a/lvm/snapshot_registry_test.go
+++ b/lvm/snapshot_registry_test.go
@@ -132,11 +132,7 @@ func TestCleanupRegisteredMultiple(t *testing.T) {
 		t.Fatalf("registry not cleared: %v", registry)
 	}
 	registryMu.Unlock()
-
-	"testing"
-
-	"go.uber.org/zap"
-)
+}
 
 func TestRegisterSnapshotNilLoggerPanics(t *testing.T) {
 	defer func() {


### PR DESCRIPTION
## Summary
- fix leftover string literals in `snapshot_registry_test.go`
- ensure test compiles with proper closing brace

## Testing
- `go test ./lvm`
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestEnsureAndDrop_WithSudo: sudo not found)*
- `golangci-lint run` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a55427d9388323bb2141edf2ecb59b