### PR TITLE
test: verify rsync transport requires allow-insecure

### DIFF
--- a/integration/rsync_refusal.sh
+++ b/integration/rsync_refusal.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+cleanup(){
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+BIN="$TMPDIR/lvmsync"
+go build -o "$BIN" .
+
+SRC="$TMPDIR/src.img"
+DST_NEG="$TMPDIR/dst_neg.img"
+DST_POS="$TMPDIR/dst_pos.img"
+
+dd if=/dev/zero of="$SRC" bs=1M count=1
+cp "$SRC" "$DST_NEG"
+cp "$SRC" "$DST_POS"
+
+# Scenario A: rsync transport without allow-insecure should fail
+set +e
+"$BIN" --transport=rsync --force --allow-overwrite --yes-i-know "$SRC" "$DST_NEG" >"$TMPDIR/neg.log" 2>&1
+STATUS=$?
+set -e
+if [ "$STATUS" -eq 0 ]; then
+  echo "expected failure without --allow-insecure"
+  cat "$TMPDIR/neg.log"
+  exit 1
+fi
+if ! grep -q "unsupported transport" "$TMPDIR/neg.log"; then
+  echo "missing unsupported transport warning"
+  cat "$TMPDIR/neg.log"
+  exit 1
+fi
+
+# Scenario B: rsync transport with allow-insecure should succeed with plaintext warning
+"$BIN" --transport=rsync --allow-insecure --force --allow-overwrite --yes-i-know "$SRC" "$DST_POS" >"$TMPDIR/pos.log" 2>&1
+if ! grep -q "plaintext_connection" "$TMPDIR/pos.log"; then
+  echo "missing plaintext warning"
+  cat "$TMPDIR/pos.log"
+  exit 1
+fi
+
+exit 0

--- a/integration/rsync_refusal_test.go
+++ b/integration/rsync_refusal_test.go
@@ -1,0 +1,17 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestRsyncRefusal(t *testing.T) {
+	cmd := exec.Command("bash", "./integration/rsync_refusal.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("rsync refusal integration failed: %v\n%s", err, out)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test covering rsync refusal without --allow-insecure
- exercise success path when --allow-insecure is provided

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: lvm/snapshot_registry_test.go:139:1: expected statement, found ')')*
- `golangci-lint run` *(fails: syntax error in lvm/snapshot_registry_test.go)*
- `go tool cover -func=coverage.out | tail -n 1` *(total: 0.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68a55431696883239fd2940e6732de13