### PR TITLE
Disable env sanitization by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--skip-disk-check` | `LVMSYNC_SKIP_DISK_CHECK` | `skip_disk_check` | Skip disk space check before snapshot creation |
 | `--snapshot-size` | `LVMSYNC_SNAPSHOT_SIZE` | `snapshot_size` | Snapshot size (e.g., `20G` or `20%`) |
 | `--lvm-escalation` | `LVMSYNC_LVM_ESCALATION` | `lvm_escalation` | Command used to escalate privileges for LVM commands; parsed with shell-style quoting and validated at startup |
-| `--sanitize-env` | `LVMSYNC_SANITIZE_ENV` | `sanitize_env` | Drop dangerous variables like `LD_PRELOAD` and remove `PATH`/`LANG` during escalation (disable with `--sanitize-env=false`) |
+| `--sanitize-env` | `LVMSYNC_SANITIZE_ENV` | `sanitize_env` | Drop dangerous variables like `LD_PRELOAD` and remove `PATH`/`LANG` during escalation (disabled by default) |
 | `--lvm-timeout` | `LVMSYNC_LVM_TIMEOUT` | `lvm_timeout` | Timeout for LVM operations and privilege checks |
 | `--sig-cache-ttl` | `LVMSYNC_LVM_SIG_CACHE_TTL` | `sig-cache-ttl` | TTL for cached LVM signatures |
 | `--sig-cache-max` | `LVMSYNC_LVM_SIG_CACHE_MAX` | `sig-cache-max` | Maximum cached LVM signatures |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,13 +60,12 @@ complete destruction or disclosure of data across the entire disk.
 
 ## Environment sanitization
 
-By default the helper drops `PATH`, `LANG`, and dangerous variables such as
-`LD_PRELOAD` or `GCONV_PATH`, running with a minimal whitelisted environment.
-Disable this behavior with `--sanitize-env=false` or `LVMSYNC_SANITIZE_ENV=false`
-to forward the full environment. Because `PATH` is removed during escalation,
-`sudoers` entries must specify absolute command paths. After each privileged
-command the helper clears any ambient capability sets to minimise the time
-elevated rights remain active.
+The helper forwards the invoking environment unchanged. Supply
+`--sanitize-env` or set `LVMSYNC_SANITIZE_ENV=1` to drop `PATH`, `LANG`, and
+dangerous variables such as `LD_PRELOAD` or `GCONV_PATH`. When sanitization is
+enabled, `sudoers` entries must specify absolute command paths. After each
+privileged command the helper clears any ambient capability sets to minimise
+the time elevated rights remain active.
 
 ## Logging hygiene
 

--- a/docs/config_env.md
+++ b/docs/config_env.md
@@ -57,7 +57,7 @@
 | LVMSYNC_REMOTE_PRE_SCRIPT | `--remote-pre-script` | `remote-pre-script` | Remote script to run before transfer |
 | LVMSYNC_RESUME | `--resume` | `resume` | Path to resume state file |
 | LVMSYNC_RETRY_DELAY | `--retry-delay` | `retry-delay` | Initial delay between retries |
-| LVMSYNC_SANITIZE_ENV | `--sanitize-env` | `sanitize-env` | Drop PATH, LANG, and unsafe variables before privilege escalation (disable with --sanitize-env=false) |
+| LVMSYNC_SANITIZE_ENV | `--sanitize-env` | `sanitize-env` | Drop PATH, LANG, and unsafe variables before privilege escalation (enable with --sanitize-env) |
 | LVMSYNC_SIG_CACHE_MAX | `--sig-cache-max` | `sig-cache-max` | Maximum LVM signature cache entries |
 | LVMSYNC_SIG_CACHE_TTL | `--sig-cache-ttl` | `sig-cache-ttl` | TTL for LVM signature cache entries |
 | LVMSYNC_SKIP_DISK_CHECK | `--skip-disk-check` | `skip-disk-check` | Skip disk space check |

--- a/docs/privilege_escalation.md
+++ b/docs/privilege_escalation.md
@@ -28,11 +28,11 @@ lvmsync --check-escalation
 
 ## Environment Sanitization
 
-LVMSync drops `PATH`, `LANG`, and unsafe variables like `LD_PRELOAD` by default
-before invoking `sudo`. Disable this behavior with `--sanitize-env=false` or
-`LVMSYNC_SANITIZE_ENV=0` to forward the entire environment. The helper also
-clears any ambient capability sets after each privileged command to limit the
-window of elevated rights.
+LVMSync forwards the invoking environment unchanged. Use `--sanitize-env` or
+`LVMSYNC_SANITIZE_ENV=1` to drop `PATH`, `LANG`, and unsafe variables like
+`LD_PRELOAD` before invoking `sudo`. The helper also clears any ambient
+capability sets after each privileged command to limit the window of elevated
+rights.
 
 
 

--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -48,8 +48,8 @@ type Options struct {
 	// ExtraArgs, if set, are appended after the self path (e.g., a subcommand).
 	ExtraArgs []string
 	// SanitizeEnv controls environment sanitization for the re-execed child.
-	// When nil, sanitization is enabled by default. Set to pointer to false to
-	// forward the full environment.
+	// When nil, the full environment is forwarded. Set to pointer to true to
+	// drop PATH, LANG, and other unsafe variables.
 	SanitizeEnv *bool
 
 	// Dependency seams (optional; default to real OS functions):
@@ -114,18 +114,18 @@ func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
 	args = append(args, filterAllowed(argv[1:], opts.AllowedPassthrough)...)
 
 	var env []string
-	sanitize := true
+	sanitize := false
 	if opts.SanitizeEnv != nil {
 		sanitize = *opts.SanitizeEnv
 	}
+	environ := os.Environ
+	if opts.Environ != nil {
+		environ = opts.Environ
+	}
 	if sanitize {
-		environ := os.Environ
-		if opts.Environ != nil {
-			environ = opts.Environ
-		}
 		env = sanitizedChildEnv(environ())
-	} else if opts.Environ != nil {
-		env = opts.Environ()
+	} else {
+		env = environ()
 	}
 
 	stdin := opts.Stdin // nil by default (no TTY password prompts)

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -368,7 +368,7 @@ func TestEnsureRootOrReexec_SanitizedEnv(t *testing.T) {
 	}
 }
 
-func TestEnsureRootOrReexec_DefaultSanitizedEnv(t *testing.T) {
+func TestEnsureRootOrReexec_DefaultPassthroughEnv(t *testing.T) {
 	var got execCall
 	t.Setenv("LD_PRELOAD", "/tmp/x.so")
 	t.Setenv("PATH", "/usr/local/bin")
@@ -382,11 +382,8 @@ func TestEnsureRootOrReexec_DefaultSanitizedEnv(t *testing.T) {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)
 	}
 	joined := strings.Join(got.env, "\n")
-	if strings.Contains(joined, "LD_PRELOAD=") || strings.Contains(joined, "PATH=") {
-		t.Fatalf("unexpected vars present: %v", got.env)
-	}
-	if !strings.Contains(joined, "TERM=dumb") {
-		t.Fatalf("TERM missing: %v", got.env)
+	if !strings.Contains(joined, "LD_PRELOAD=/tmp/x.so") || !strings.Contains(joined, "PATH=/usr/local/bin") || !strings.Contains(joined, "TERM=dumb") {
+		t.Fatalf("env not forwarded: %v", got.env)
 	}
 }
 
@@ -464,7 +461,7 @@ func TestEnsureRootOrReexec_SanitizeEnvStripsPathLang(t *testing.T) {
 	}
 }
 
-func TestEnsureRootOrReexec_DefaultDropsDisallowedEnv(t *testing.T) {
+func TestEnsureRootOrReexec_DefaultPreservesDisallowedEnv(t *testing.T) {
 	var got execCall
 	env := []string{"LD_PRELOAD=/tmp/x.so", "GCONV_PATH=/bad", "PATH=/usr/local/bin", "LANG=C", "TERM=dumb"}
 	reexeced, err := EnsureRootOrReexec(Options{
@@ -476,12 +473,8 @@ func TestEnsureRootOrReexec_DefaultDropsDisallowedEnv(t *testing.T) {
 	if err != nil || !reexeced {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)
 	}
-	joined := strings.Join(got.env, "\n")
-	if strings.Contains(joined, "LD_PRELOAD=") || strings.Contains(joined, "GCONV_PATH=") || strings.Contains(joined, "PATH=") || strings.Contains(joined, "LANG=") {
-		t.Fatalf("disallowed vars present: %v", got.env)
-	}
-	if !strings.Contains(joined, "TERM=dumb") {
-		t.Fatalf("TERM missing: %v", got.env)
+	if !reflect.DeepEqual(got.env, env) {
+		t.Fatalf("env sanitized unexpectedly: %v", got.env)
 	}
 }
 
@@ -507,7 +500,7 @@ func TestEnsureRootOrReexec_SanitizeEnvDropsDisallowed(t *testing.T) {
 	}
 }
 
-func TestEnsureRootOrReexec_DefaultRunnerSanitizesEnv(t *testing.T) {
+func TestEnsureRootOrReexec_DefaultRunnerSanitizesEnvWhenEnabled(t *testing.T) {
 	dir := t.TempDir()
 	envFile := filepath.Join(dir, "env.txt")
 	script := filepath.Join(dir, "sudo.sh")
@@ -519,8 +512,9 @@ func TestEnsureRootOrReexec_DefaultRunnerSanitizesEnv(t *testing.T) {
 	t.Setenv("PATH", "/usr/local/bin")
 	t.Setenv("TERM", "dumb")
 	reexeced, err := EnsureRootOrReexec(Options{
-		Geteuid:  func() int { return 1000 },
-		LookPath: func(string) (string, error) { return script, nil },
+		Geteuid:     func() int { return 1000 },
+		LookPath:    func(string) (string, error) { return script, nil },
+		SanitizeEnv: boolPtr(true),
 	}, zap.NewNop())
 	if err != nil || !reexeced {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)
@@ -537,7 +531,7 @@ func TestEnsureRootOrReexec_DefaultRunnerSanitizesEnv(t *testing.T) {
 	}
 }
 
-func TestEnsureRootOrReexec_DefaultRunnerPreservesEnvWhenDisabled(t *testing.T) {
+func TestEnsureRootOrReexec_DefaultRunnerPreservesEnv(t *testing.T) {
 	dir := t.TempDir()
 	envFile := filepath.Join(dir, "env.txt")
 	script := filepath.Join(dir, "sudo.sh")
@@ -549,9 +543,8 @@ func TestEnsureRootOrReexec_DefaultRunnerPreservesEnvWhenDisabled(t *testing.T) 
 	t.Setenv("TERM", "dumb")
 	t.Setenv("PATH", "/usr/local/bin")
 	reexeced, err := EnsureRootOrReexec(Options{
-		Geteuid:     func() int { return 1000 },
-		LookPath:    func(string) (string, error) { return script, nil },
-		SanitizeEnv: boolPtr(false),
+		Geteuid:  func() int { return 1000 },
+		LookPath: func(string) (string, error) { return script, nil },
 	}, zap.NewNop())
 	if err != nil || !reexeced {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -190,7 +190,7 @@ func DefaultConfig() (*Config, error) {
 		FSThawCommand:            "",
 		FreezeTimeout:            10 * time.Second,
 		ThawTimeout:              10 * time.Second,
-		SanitizeEnv:              true,
+		SanitizeEnv:              false,
 		Parallel:                 4,
 		Concurrency:              0,
 		ZeroCopy:                 false,

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -63,7 +63,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("allow-overwrite", cfg.AllowOverwrite, "Allow overwriting existing data; requires --yes-i-know for non-interactive sessions")
 	fs.Bool("discard", cfg.Discard, "Issue BLKDISCARD before writing blocks")
 	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")
-	fs.Bool("sanitize-env", cfg.SanitizeEnv, "Drop PATH, LANG, and unsafe variables before privilege escalation (disable with --sanitize-env=false)")
+	fs.Bool("sanitize-env", cfg.SanitizeEnv, "Drop PATH, LANG, and unsafe variables before privilege escalation (enable with --sanitize-env)")
 	fs.String("sparse", cfg.Sparse, "Sparse file handling: auto or never")
 	fs.String("fs-freeze-command", cfg.FSFreezeCommand, "Command to freeze filesystem before reading raw source")
 	fs.String("fs-thaw-command", cfg.FSThawCommand, "Command to thaw filesystem after reading raw source")

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -251,14 +251,14 @@ func TestSanitizeEnvFlagOverridesEnvAndYAML(t *testing.T) {
 	if err := os.WriteFile(cfgFile, []byte("sanitize_env: false\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	t.Setenv("LVMSYNC_CREATE_DEST_LV", "true")
+	t.Setenv("LVMSYNC_SANITIZE_ENV", "0")
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--sanitize-env"})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
-	if !cfg.CreateDestLV {
-		t.Fatalf("CreateDestLV=%v want true", cfg.CreateDestLV)
+	if !cfg.SanitizeEnv {
+		t.Fatalf("SanitizeEnv=%v want true", cfg.SanitizeEnv)
 	}
 }
 
@@ -274,7 +274,7 @@ func TestSanitizeEnvFlagFalseOverridesEnvAndYAML(t *testing.T) {
 	if err := os.WriteFile(cfgFile, []byte("sanitize_env: true\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	t.Setenv("LVMSYNC_SANITIZE_ENV", "true")
+	t.Setenv("LVMSYNC_SANITIZE_ENV", "1")
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--sanitize-env=false"})
 	if err != nil {
@@ -294,14 +294,10 @@ func TestSanitizeEnvEnvOverridesYAML(t *testing.T) {
 	b := NewBuilder(defaults)
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "cfg.yaml")
-	if err := os.WriteFile(cfgFile, []byte("sanitize_env: true\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	t.Setenv("LVMSYNC_SANITIZE_ENV", "false")
 	if err := os.WriteFile(cfgFile, []byte("sanitize_env: false\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	t.Setenv("LVMSYNC_SANITIZE_ENV", "true")
+	t.Setenv("LVMSYNC_SANITIZE_ENV", "1")
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
 	if err != nil {


### PR DESCRIPTION
## Summary
- make `sanitize_env` opt-in
- adjust escalation helper to forward the current environment unless explicitly sanitized
- document new behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: lvm/snapshot_registry_test.go:139:1: expected statement, found ')')*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: lvm/snapshot_registry_test.go:139:1: syntax error: unexpected ), expected })*)

------
https://chatgpt.com/codex/tasks/task_e_68a554294aac8323b05cca855409b801