### PR TITLE
track bloom filter stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1445,6 +1445,7 @@ dedup_state_file: ~/.lvmsync_state
 ```
 
 LVMSync automatically reloads this state file on startup. Delete it to reset deduplication: `rm ~/.lvmsync_dedup`.
+When saving Bloom filter state, LVMSync logs `dedup_bloom_stats` with `entries`, `configured_fp_rate`, and `observed_fp_rate`.
 
 #### Compression
 

--- a/transfer/dedup.go
+++ b/transfer/dedup.go
@@ -65,6 +65,8 @@ type BloomFilterDedup struct {
 	strategy  ChecksumStrategy
 	logger    *zap.Logger
 	deps      *Deps
+	lookups   uint64
+	misses    uint64
 }
 
 // RollingHashDedup computes a rolling hash for block comparison.
@@ -329,9 +331,13 @@ func (r *RollingHashDedup) loadState() error {
 func (b *BloomFilterDedup) ShouldTransfer(_ int64, data []byte) bool {
 	// offset is ignored because the Bloom filter only tracks data hashes.
 	sum := b.strategy.Compute(data)
-	b.mu.RLock()
+	b.mu.Lock()
+	b.lookups++
 	ok := !b.filter.Test(sum)
-	b.mu.RUnlock()
+	if ok {
+		b.misses++
+	}
+	b.mu.Unlock()
 	return ok
 }
 
@@ -345,6 +351,17 @@ func (b *BloomFilterDedup) RecordTransfer(_ int64, data []byte) {
 func (b *BloomFilterDedup) SaveState() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.logger != nil {
+		var observed float64
+		if b.lookups > 0 {
+			observed = float64(b.lookups-b.misses) / float64(b.lookups)
+		}
+		b.logger.Info("dedup_bloom_stats",
+			zap.Uint("entries", uint(b.filter.ApproximatedSize())),
+			zap.Float64("configured_fp_rate", b.fpRate),
+			zap.Float64("observed_fp_rate", observed),
+		)
+	}
 	return saveStateFile(b.deps, b.logger, b.stateFile, func(file io.Writer) error {
 		_, err := b.filter.WriteTo(file)
 		return err

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/device"
 	manifestpkg "lvmsync_go/manifest"
@@ -38,6 +39,45 @@ func TestBloomFilterDedupPersistence(t *testing.T) {
 
 	if d2.ShouldTransfer(0, data) {
 		t.Fatalf("expected bloom filter to persist state")
+	}
+}
+
+func TestBloomFilterDedupStatsLog(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state")
+	core, observed := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	d := &BloomFilterDedup{
+		filter:    bloom.NewWithEstimates(10, 0.01),
+		stateFile: stateFile,
+		entries:   10,
+		fpRate:    0.01,
+		strategy:  &SHA256Checksum{},
+		logger:    logger,
+		deps:      DefaultDeps,
+	}
+	blocks := [][]byte{[]byte("a"), []byte("b")}
+	for i, b := range blocks {
+		if !d.ShouldTransfer(int64(i), b) {
+			t.Fatalf("first transfer should be allowed")
+		}
+		d.RecordTransfer(int64(i), b)
+	}
+	if err := d.SaveState(); err != nil {
+		t.Fatalf("failed to save state: %v", err)
+	}
+	logs := observed.FilterMessage("dedup_bloom_stats").All()
+	if len(logs) != 1 {
+		t.Fatalf("expected stats log, got %d", len(logs))
+	}
+	fields := logs[0].ContextMap()
+	if entries, ok := fields["entries"].(uint64); !ok || entries != 2 {
+		t.Fatalf("entries: got %v", fields["entries"])
+	}
+	if fp, ok := fields["configured_fp_rate"].(float64); !ok || fp != 0.01 {
+		t.Fatalf("configured_fp_rate: got %v", fields["configured_fp_rate"])
+	}
+	if obs, ok := fields["observed_fp_rate"].(float64); !ok || obs != 0 {
+		t.Fatalf("observed_fp_rate: got %v", fields["observed_fp_rate"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- track lookups and misses in BloomFilterDedup and log dedup_bloom_stats with false-positive metrics
- cover logging with unit test
- document dedup_bloom_stats log output

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a558b2f6fc8323a63e04dbe5e88786