### PR TITLE
Log compression algorithm in dry-run output

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -37,6 +37,19 @@ var ErrRemoteCommand = errors.New("remote command error")
 
 const maxFrame = 1 << 20
 
+func chooseCompression(chunkLen int, compress string) string {
+	if compress != transfer.StrategyAuto && compress != "" {
+		return compress
+	}
+	if chunkLen > 0 && chunkLen < 256*1024 {
+		return "lz4"
+	}
+	if cpufeatures.HasAVX2() || cpufeatures.HasNEON() {
+		return "zstd"
+	}
+	return "lz4"
+}
+
 // Runner manages external interactions for dump operations.
 type Runner struct {
 	dumpSeq        func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error
@@ -310,10 +323,12 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 	if cfg.DryRun {
 		size := int64(dev.SizeBytes())
 		durMs, bwBps := transfer.Estimate(size, cfg.SpeedLimit)
+		algo := chooseCompression(cfg.BlockSize, cfg.Compress)
 		logger.Info("dry run",
 			zap.Int64("size_bytes", size),
 			zap.Int64("estimated_duration_ms", durMs),
 			zap.Int64("estimated_bandwidth_bps", bwBps),
+			zap.String("compression", algo),
 		)
 		dev.Cleanup(ctx)
 		dev.Close()
@@ -353,11 +368,11 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 
 // RunLocalDump dumps changes to a local destination device and returns the detected destination type.
 func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
-       destType := cfg.DestType
-       devCtx := device.WithForce(context.Background(), cfg.Force)
-       devCtx = device.WithAllowOverwrite(devCtx, cfg.AllowOverwrite)
-       devCtx = device.WithYesIKnow(devCtx, cfg.YesIKnow)
-       devRunner := device.NewRunner()
+	destType := cfg.DestType
+	devCtx := device.WithForce(context.Background(), cfg.Force)
+	devCtx = device.WithAllowOverwrite(devCtx, cfg.AllowOverwrite)
+	devCtx = device.WithYesIKnow(devCtx, cfg.YesIKnow)
+	devRunner := device.NewRunner()
 	if cfg.DryRun {
 		return destType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, io.Discard, logger)
 	}

--- a/cmd/dump/probe_only_test.go
+++ b/cmd/dump/probe_only_test.go
@@ -8,11 +8,19 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 	"lvmsync_go/internal/privilege"
 )
+
+type sizedDevice struct {
+	fakeDevice
+	size uint64
+}
+
+func (d *sizedDevice) SizeBytes() uint64 { return d.size }
 
 func TestProbeOnlyNoSideEffects(t *testing.T) {
 	cfg, err := config.DefaultConfig()
@@ -55,5 +63,35 @@ func TestProbeOnlyNoSideEffects(t *testing.T) {
 	expected := "123 k g f 1 2 456\n"
 	if string(out) != expected {
 		t.Fatalf("expected %q, got %q", expected, string(out))
+	}
+}
+
+func TestDryRunLogsCompression(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	cfg.DryRun = true
+	cfg.BlockSize = 128 * 1024
+
+	core, observed := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	r := NewRunnerWithDeps(&Runner{
+		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+			return &sizedDevice{fakeDevice{path: "/dev/snap"}, 1024}, nil
+		},
+	})
+
+	if _, err := r.Run(context.Background(), cfg, "/dev/snap", "", logger); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	logs := observed.FilterMessage("dry run").All()
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logs))
+	}
+	if _, ok := logs[0].ContextMap()["compression"]; !ok {
+		t.Fatalf("compression field missing: %#v", logs[0].ContextMap())
 	}
 }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -10,6 +10,13 @@ an interactive TTY on stdin, it prompts for confirmation before proceeding. In
 non-interactive sessions the `--yes-i-know` flag (or `LVMSYNC_YES_I_KNOW`)
 must be supplied to bypass the prompt.
 
+## Dry-run and plan output
+
+`--dry-run` and `lvmsync plan` report the estimated transfer parameters
+without copying data. The JSON log entry includes `size_bytes`,
+`estimated_duration_ms`, `estimated_bandwidth_bps`, and `compression`
+showing the selected compression algorithm.
+
 ## Snapshot Creation and Cleanup Flow
 
 1. `lvmsync run` validates the source and destination.

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pierrec/lz4/v4"
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -118,10 +119,16 @@ func (t *Transfer) dumpChangesCore(ctx context.Context, cfg *config.Config, snap
 			return err
 		}
 		durationMs, bandwidthBps := Estimate(int64(size), cfg.SpeedLimit)
+		lz4Level := int(lz4.Level1)
+		if strings.ToLower(cfg.LZ4Level) == "hc" {
+			lz4Level = int(lz4.Level9)
+		}
+		algo, _ := selectAlgorithm(cfg.BlockSize, cfg.Compress, lz4Level, cfg.ZstdLevel)
 		t.Logger.Info("dry run",
 			zap.Int64("size_bytes", int64(size)),
 			zap.Int64("estimated_duration_ms", durationMs),
 			zap.Int64("estimated_bandwidth_bps", bandwidthBps),
+			zap.String("compression", algo),
 		)
 		return nil
 	}


### PR DESCRIPTION
## Summary
- call compression selector in transfer dry-run and log chosen algorithm
- surface compression field in dump command dry-run output
- document compression field in dry-run/plan output

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run --new-from-rev=HEAD`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a558bc832c8323bb2668a803f42181