### PR TITLE
Handle partial WAL header recovery

### DIFF
--- a/device/wal.go
+++ b/device/wal.go
@@ -146,7 +146,17 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger) (*WAL, error) {
 		return nil, err
 	}
 	w := &WAL{f: f}
-	if st.Size() == 0 {
+	if st.Size() < walHeaderV0Size {
+		if st.Size() > 0 {
+			if err := f.Truncate(0); err != nil {
+				f.Close()
+				return nil, err
+			}
+			if _, err := f.Seek(0, 0); err != nil {
+				f.Close()
+				return nil, err
+			}
+		}
 		var hdr walHeader
 		hdr.Version = walVersion
 		hdr.Size = id.SizeBytes

--- a/device/wal_crash_test.go
+++ b/device/wal_crash_test.go
@@ -13,6 +13,31 @@ import (
 func TestWALCrashRecovery(t *testing.T) {
 	id := DeviceIdentity{SizeBytes: 128, KernelUUID: "k", GPTUUID: "g", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
 
+	t.Run("partial_header", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "wal")
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], walVersion)
+		if _, err := f.Write(buf[:]); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		w, err := OpenWAL(path, id, zap.NewNop())
+		if err != nil {
+			t.Fatalf("reopen wal: %v", err)
+		}
+		if len(w.Ranges()) != 0 {
+			t.Fatalf("expected no ranges, got %#v", w.Ranges())
+		}
+		w.Close()
+	})
+
 	t.Run("truncate_mid_entry", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")


### PR DESCRIPTION
## Summary
- recover from incomplete WAL headers by truncating and reinitializing
- test WAL recovery when file is created but header write crashes

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many issues, e.g. 1115, due to missing upstream reference)*

------
https://chatgpt.com/codex/tasks/task_e_68a558c0f3288323851094b00c7c6c3f