### PR TITLE
privilege: add optional env sanitization

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,12 +60,14 @@ complete destruction or disclosure of data across the entire disk.
 
 ## Environment sanitization
 
-The helper forwards the invoking environment unchanged. Supply
-`--sanitize-env` or set `LVMSYNC_SANITIZE_ENV=1` to drop `PATH`, `LANG`, and
-dangerous variables such as `LD_PRELOAD` or `GCONV_PATH`. When sanitization is
-enabled, `sudoers` entries must specify absolute command paths. After each
-privileged command the helper clears any ambient capability sets to minimise
-the time elevated rights remain active.
+The privilege layer forwards the invoking environment unchanged unless
+sanitization is requested. Supply `--sanitize-env` or set
+`LVMSYNC_SANITIZE_ENV=1` to run all privileged commands with a minimal
+environment. In this mode `PATH`, `LANG`, and unsafe variables such as
+`LD_PRELOAD` or `GCONV_PATH` are removed, leaving only `LC_ALL`, `LC_CTYPE`,
+and `TERM`. When sanitization is enabled, `sudoers` entries must specify
+absolute command paths. After each privileged command the helper clears any
+ambient capability sets to minimise the time elevated rights remain active.
 
 ## Logging hygiene
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -305,7 +305,7 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 		cfg.LVMEscalation,
 		cfg.FreezeTimeout,
 		cfg.ThawTimeout,
-		privilege.New(ctx),
+		privilege.NewWithSanitize(ctx, cfg.SanitizeEnv),
 		logger,
 		device.NewRunner(),
 	)
@@ -377,7 +377,7 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 		return destType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, io.Discard, logger)
 	}
 	if destType == "auto" {
-		if dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx), logger, devRunner); err == nil {
+		if dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.NewWithSanitize(devCtx, cfg.SanitizeEnv), logger, devRunner); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/probe.go
+++ b/cmd/dump/probe.go
@@ -22,7 +22,7 @@ const firstBlockDigestSize = 1 << 20
 
 func realProbeDestination(ctx context.Context, cfg *config.Config, dest string, logger *zap.Logger) (device.DeviceIdentity, error) {
 	info := device.NewInfo()
-	dev, err := device.Detect(ctx, dest, true, "", "", "", "", 0, 0, privilege.New(ctx), logger, device.NewRunner())
+	dev, err := device.Detect(ctx, dest, true, "", "", "", "", 0, 0, privilege.NewWithSanitize(ctx, cfg.SanitizeEnv), logger, device.NewRunner())
 	if err != nil {
 		return device.DeviceIdentity{}, err
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -143,7 +143,7 @@ func ConfigureWithEscalator(esc privilege.Escalator) (*config.Config, []string, 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.LVMTimeout)
 	defer cancel()
 	if esc == nil {
-		esc = privilege.New(ctx)
+		esc = privilege.NewWithSanitize(ctx, cfg.SanitizeEnv)
 	}
 	if err = esc.Ensure(ctx); err != nil {
 		return nil, nil, nil, fmt.Errorf("privilege check failed: %w", err)

--- a/internal/privilege/escalate.go
+++ b/internal/privilege/escalate.go
@@ -21,6 +21,8 @@ type Escalator interface {
 // sudoEscalator implements Escalator using Linux capabilities when present
 // and sudo -n as a fallback.
 type sudoEscalator struct {
-	useSudo bool
-	runner  *Runner
+	useSudo     bool
+	runner      *Runner
+	sanitizeEnv bool
+	environ     func() []string
 }

--- a/internal/privilege/runner.go
+++ b/internal/privilege/runner.go
@@ -2,6 +2,7 @@ package privilege
 
 import (
 	"context"
+	"os"
 	"os/exec"
 )
 
@@ -24,11 +25,27 @@ type Runner struct {
 
 // New returns an Escalator with production dependencies.
 // ctx is currently unused but reserved for future use.
-func New(ctx context.Context) Escalator { return NewWithRunner(ctx, nil) }
+func New(ctx context.Context) Escalator { return newEscalator(ctx, nil, false) }
 
 // NewWithRunner constructs an Escalator with the provided Runner.
 // Nil fields default to exec.CommandContext and exec.LookPath.
-func NewWithRunner(_ context.Context, r *Runner) Escalator {
+func NewWithRunner(ctx context.Context, r *Runner) Escalator {
+	return newEscalator(ctx, r, false)
+}
+
+// NewWithSanitize constructs an Escalator that optionally sanitizes the
+// environment of executed commands.
+func NewWithSanitize(ctx context.Context, sanitize bool) Escalator {
+	return newEscalator(ctx, nil, sanitize)
+}
+
+// NewWithRunnerAndSanitize constructs an Escalator with the provided Runner
+// and optional environment sanitization.
+func NewWithRunnerAndSanitize(ctx context.Context, r *Runner, sanitize bool) Escalator {
+	return newEscalator(ctx, r, sanitize)
+}
+
+func newEscalator(_ context.Context, r *Runner, sanitize bool) Escalator {
 	cmd := Commander(commanderFunc(exec.CommandContext))
 	lp := exec.LookPath
 	if r != nil {
@@ -39,5 +56,10 @@ func NewWithRunner(_ context.Context, r *Runner) Escalator {
 			lp = r.LookPath
 		}
 	}
-	return &sudoEscalator{useSudo: !HasCaps(), runner: &Runner{Cmd: cmd, LookPath: lp}}
+	return &sudoEscalator{
+		useSudo:     !HasCaps(),
+		runner:      &Runner{Cmd: cmd, LookPath: lp},
+		sanitizeEnv: sanitize,
+		environ:     os.Environ,
+	}
 }

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -5,7 +5,9 @@ package privilege
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -29,7 +31,15 @@ func (s *sudoEscalator) Ensure(ctx context.Context) error {
 		if _, err := s.runner.LookPath("sudo"); err != nil {
 			return fmt.Errorf("sudo not found: %w", err)
 		}
-		if err := s.runner.Cmd.CommandContext(ctx, "sudo", "-n", "true").Run(); err != nil {
+		cmd := s.runner.Cmd.CommandContext(ctx, "sudo", "-n", "true")
+		if s.sanitizeEnv {
+			environ := os.Environ
+			if s.environ != nil {
+				environ = s.environ
+			}
+			cmd.Env = sanitizeEnv(environ())
+		}
+		if err := cmd.Run(); err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return fmt.Errorf("sudo escalation failed: %w", ctxErr)
 			}
@@ -46,7 +56,48 @@ func (s *sudoEscalator) Command(ctx context.Context, name string, args ...string
 	ctx, _ = withTimeout(ctx)
 	if s.useSudo {
 		all := append([]string{"-n", name}, args...)
-		return s.runner.Cmd.CommandContext(ctx, "sudo", all...)
+		cmd := s.runner.Cmd.CommandContext(ctx, "sudo", all...)
+		if s.sanitizeEnv {
+			environ := os.Environ
+			if s.environ != nil {
+				environ = s.environ
+			}
+			cmd.Env = sanitizeEnv(environ())
+		}
+		return cmd
 	}
-	return s.runner.Cmd.CommandContext(ctx, name, args...)
+	cmd := s.runner.Cmd.CommandContext(ctx, name, args...)
+	if s.sanitizeEnv {
+		environ := os.Environ
+		if s.environ != nil {
+			environ = s.environ
+		}
+		cmd.Env = sanitizeEnv(environ())
+	}
+	return cmd
+}
+
+// sanitizeEnv drops unsafe variables like PATH, LANG, and anything starting
+// with LD_. Only a small whitelist of locale-related variables is preserved.
+func sanitizeEnv(environ []string) []string {
+	whitelist := map[string]bool{
+		"LC_ALL":   true,
+		"LC_CTYPE": true,
+		"TERM":     true,
+	}
+	out := make([]string, 0, len(environ))
+	for _, kv := range environ {
+		if strings.HasPrefix(kv, "LD_") || strings.HasPrefix(kv, "GCONV_PATH=") {
+			continue
+		}
+		i := strings.IndexByte(kv, '=')
+		if i <= 0 {
+			continue
+		}
+		k := kv[:i]
+		if whitelist[k] {
+			out = append(out, kv)
+		}
+	}
+	return out
 }

--- a/internal/privilege/sudo_env_test.go
+++ b/internal/privilege/sudo_env_test.go
@@ -1,0 +1,70 @@
+package privilege
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// dummy commander to avoid executing real commands
+func noopCmd(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "echo")
+}
+
+func TestSanitizeEnv(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"LANG=en_US.UTF-8",
+		"LC_ALL=C",
+		"TERM=xterm",
+		"LD_PRELOAD=evil.so",
+		"GCONV_PATH=/tmp",
+		"FOO=bar",
+	}
+	got := sanitizeEnv(env)
+	for _, bad := range []string{"PATH=", "LANG=", "LD_PRELOAD=", "GCONV_PATH=", "FOO="} {
+		for _, kv := range got {
+			if strings.HasPrefix(kv, bad) {
+				t.Fatalf("unexpected variable %s in sanitized env", bad)
+			}
+		}
+	}
+	want := map[string]bool{"LC_ALL=C": true, "TERM=xterm": true}
+	for _, kv := range got {
+		if !want[kv] {
+			t.Fatalf("unexpected variable %s", kv)
+		}
+		delete(want, kv)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing variables %v", want)
+	}
+}
+
+func TestCommandAppliesSanitizedEnv(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	t.Setenv("LANG", "en_US.UTF-8")
+	t.Setenv("LC_ALL", "C")
+	t.Setenv("TERM", "xterm")
+	t.Setenv("LD_PRELOAD", "evil.so")
+	esc := &sudoEscalator{sanitizeEnv: true, runner: &Runner{Cmd: commanderFunc(noopCmd)}}
+	cmd := esc.Command(context.Background(), "true")
+	for _, kv := range cmd.Env {
+		if strings.HasPrefix(kv, "PATH=") || strings.HasPrefix(kv, "LANG=") || strings.HasPrefix(kv, "LD_PRELOAD=") {
+			t.Fatalf("unsanitized variable %s", kv)
+		}
+	}
+	if !contains(cmd.Env, "LC_ALL=C") || !contains(cmd.Env, "TERM=xterm") {
+		t.Fatalf("expected LC_ALL and TERM in env: %v", cmd.Env)
+	}
+}
+
+func contains(env []string, v string) bool {
+	for _, e := range env {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add configurable environment sanitization for sudo commands
- pass sanitize-env from root and dump commands to privilege layer
- document and test sanitized PATH/LANG removal

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: 1116 issues)*
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_68a61a63acd48323b872df3a34088fe5