### PR TITLE
feat: add force-offline safety flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--target-vgs` | `LVMSYNC_TARGET_VGS` | `target_vgs` | Candidate target volume groups for auto-selection |
 | `--create-dest-lv` | `LVMSYNC_CREATE_DEST_LV` | `create_dest_lv` | Create destination logical volume when missing (requires `--force` or confirmation) |
 | `--force` | `LVMSYNC_FORCE` | `force` | Override safety checks and proceed on mounted destination |
+| `--force-offline` | `LVMSYNC_FORCE_OFFLINE` | `force_offline` | Allow direct device writes; prompts for `double-confirm` when interactive (requires `--yes-i-know` otherwise) |
 | `--allow-overwrite` | `LVMSYNC_ALLOW_OVERWRITE` | `allow_overwrite` | Allow overwriting existing data; requires `--yes-i-know` for non-interactive sessions |
 | `--discard` | `LVMSYNC_DISCARD` | `discard` | Issue BLKDISCARD before writing blocks |
 | `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Log estimated transfer bytes without sending data; uses manifest sampling when available |

--- a/cmd/dump/force_offline_test.go
+++ b/cmd/dump/force_offline_test.go
@@ -1,0 +1,101 @@
+package dump
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"go.uber.org/zap"
+
+	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/internal/config"
+)
+
+func setupLoopDev(t *testing.T, size int64) (string, func()) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "loopback")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if err := f.Truncate(size); err != nil {
+		f.Close()
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+	out, err := exec.Command("losetup", "--show", "-f", f.Name()).Output()
+	if err != nil {
+		t.Skipf("losetup: %v", err)
+	}
+	loop := strings.TrimSpace(string(out))
+	loop = filepath.Clean(loop)
+	cleanup := func() { exec.Command("losetup", "-d", loop).Run() }
+	return loop, cleanup
+}
+
+func TestRunRefusesDeviceWithoutForceOffline(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoopDev(t, 1<<20)
+	defer cleanup()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.YesIKnow = true
+	deps := &rootcmd.Runner{}
+	setField := func(name string, fn any) {
+		v := reflect.ValueOf(deps).Elem().FieldByName(name)
+		reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().Set(reflect.ValueOf(fn))
+	}
+	setField("setupSignalHandleFn", func(ctx context.Context, cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
+		return make(chan os.Signal), make(chan error)
+	})
+	setField("prepareSnapshotFn", func(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+		return "snap", nil, func() {}, nil
+	})
+	setField("executeClientFn", func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
+		return nil
+	})
+	r := rootcmd.NewRunnerWithDeps(deps)
+	if err := r.Run(cfg, []string{loop, loop}, zap.NewNop()); err == nil || !strings.Contains(err.Error(), "--force-offline") {
+		t.Fatalf("expected --force-offline error, got %v", err)
+	}
+}
+
+func TestRunAllowsDeviceWithForceOffline(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoopDev(t, 1<<20)
+	defer cleanup()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.YesIKnow = true
+	cfg.ForceOffline = true
+	deps := &rootcmd.Runner{}
+	setField := func(name string, fn any) {
+		v := reflect.ValueOf(deps).Elem().FieldByName(name)
+		reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().Set(reflect.ValueOf(fn))
+	}
+	setField("setupSignalHandleFn", func(ctx context.Context, cfg *config.Config, snapshotPath *string, logger *zap.Logger) (chan os.Signal, chan error) {
+		return make(chan os.Signal), make(chan error)
+	})
+	setField("prepareSnapshotFn", func(ctx context.Context, cfg *config.Config, originalVolume string, logger *zap.Logger) (string, chan error, func(), error) {
+		return "snap", nil, func() {}, nil
+	})
+	setField("executeClientFn", func(context.Context, func(context.Context, string, string) error, string, string, chan error, chan error, *zap.Logger) error {
+		return nil
+	})
+	r := rootcmd.NewRunnerWithDeps(deps)
+	if err := r.Run(cfg, []string{loop, loop}, zap.NewNop()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -252,6 +253,31 @@ func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Lo
 	destPath := ""
 	if !cfg.StdoutMode {
 		destPath = args[1]
+	}
+	if destPath != "" && !cfg.StdoutMode && !strings.Contains(destPath, ":") {
+		resolved, err := filepath.EvalSymlinks(destPath)
+		if err == nil {
+			if info, err := os.Stat(resolved); err == nil && info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
+				if !cfg.ForceOffline {
+					cancel()
+					signal.Stop(signals)
+					return nil, nil, "", "", nil, nil, fmt.Errorf("direct device writes require --force-offline")
+				}
+				if term.IsTerminal(int(os.Stdin.Fd())) {
+					fmt.Fprint(os.Stderr, "Direct device writes may destroy data. Type 'double-confirm' to continue: ")
+					resp, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+					if strings.TrimSpace(resp) != "double-confirm" {
+						cancel()
+						signal.Stop(signals)
+						return nil, nil, "", "", nil, nil, fmt.Errorf("direct device write cancelled")
+					}
+				} else if !cfg.YesIKnow {
+					cancel()
+					signal.Stop(signals)
+					return nil, nil, "", "", nil, nil, fmt.Errorf("direct device writes require --yes-i-know flag when not run interactively")
+				}
+			}
+		}
 	}
 
 	snapPath, monitorErrCh, snapCleanup, err := r.prepareSnapshotFn(ctx, cfg, originalVolume, logger)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -10,6 +10,13 @@ an interactive TTY on stdin, it prompts for confirmation before proceeding. In
 non-interactive sessions the `--yes-i-know` flag (or `LVMSYNC_YES_I_KNOW`)
 must be supplied to bypass the prompt.
 
+## Direct device writes
+
+Writing directly to block devices bypasses filesystem safeguards and can
+destroy data. These operations require `--force-offline`. When stdin is a TTY,
+`lvmsync` prompts for the literal text `double-confirm`; non-interactive
+sessions must also provide `--yes-i-know`.
+
 ## Dry-run and plan output
 
 `--dry-run` and `lvmsync plan` report the estimated transfer parameters

--- a/docs/config_env.md
+++ b/docs/config_env.md
@@ -29,6 +29,7 @@
 | LVMSYNC_DISCARD | `--discard` | `discard` | Issue BLKDISCARD before writing blocks |
 | LVMSYNC_DRY_RUN | `--dry-run` | `dry-run` | Print actions without executing |
 | LVMSYNC_FORCE | `--force` | `force` | Override safety checks for offline raw access or filesystem freeze |
+| LVMSYNC_FORCE_OFFLINE | `--force-offline` | `force-offline` | Allow direct device writes; prompts for double-confirm |
 | LVMSYNC_FREEZE_TIMEOUT | `--freeze-timeout` | `freeze-timeout` | Timeout for filesystem freeze command |
 | LVMSYNC_FS_FREEZE_COMMAND | `--fs-freeze-command` | `fs-freeze-command` | Freeze command (absolute path, validated for NUL bytes, allowed characters, and existence) |
 | LVMSYNC_FS_THAW_COMMAND | `--fs-thaw-command` | `fs-thaw-command` | Thaw command (absolute path, validated for NUL bytes, allowed characters, and existence) |

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -35,6 +35,7 @@ type Config struct {
 	ProbeOnly                bool          `mapstructure:"probe_only"`
 	Plan                     bool          `mapstructure:"plan"`
 	Force                    bool          `mapstructure:"force"`
+	ForceOffline             bool          `mapstructure:"force_offline"`
 	AllowOverwrite           bool          `mapstructure:"allow_overwrite"`
 	StrictConfig             bool          `mapstructure:"strict_config"`
 	Discard                  bool          `mapstructure:"discard"`
@@ -182,6 +183,7 @@ func DefaultConfig() (*Config, error) {
 		ProbeOnly:                false,
 		Plan:                     false,
 		Force:                    false,
+		ForceOffline:             false,
 		AllowOverwrite:           false,
 		StrictConfig:             false,
 		Offline:                  false,

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -60,6 +60,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("probe-only", cfg.ProbeOnly, "Output size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, and manifest_epoch without writing")
 	fs.Bool("plan", cfg.Plan, "Print configuration plan as JSON and exit")
 	fs.Bool("force", cfg.Force, "Override safety checks for offline raw access or filesystem freeze")
+	fs.Bool("force-offline", cfg.ForceOffline, "Allow direct device writes; prompts for double-confirm")
 	fs.Bool("allow-overwrite", cfg.AllowOverwrite, "Allow overwriting existing data; requires --yes-i-know for non-interactive sessions")
 	fs.Bool("discard", cfg.Discard, "Issue BLKDISCARD before writing blocks")
 	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -124,6 +124,9 @@
     "force": {
       "type": "boolean"
     },
+    "force_offline": {
+      "type": "boolean"
+    },
     "freeze-timeout": {
       "type": "string"
     },


### PR DESCRIPTION
## Summary
- add `--force-offline` flag configurable via env and YAML
- require force-offline with double-confirm for direct device writes
- document risks and add tests for acceptance and refusal paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: thousands of lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a61a60d0708323a1f1dd57fa58f09d