### PR TITLE
privilege: add logger and command logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Override detection with `--source-type` and `--dest-type` when necessary.
 Internally, `device.Detect` delegates to dedicated helpers:
 
 ```go
-dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, privilege.New(ctx), logger, device.NewRunner())
+dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 // detectFileDevice, detectLVMDevice, or detectRawDevice is selected based on the path.
 ```
 
@@ -1562,7 +1562,7 @@ can stub command execution:
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 defer cancel()
-esc := privilege.New(ctx)
+esc := privilege.New(ctx, zap.NewNop())
 if err := esc.Ensure(ctx); err != nil {
     // handle missing capabilities or sudo
 }

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -305,7 +305,7 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 		cfg.LVMEscalation,
 		cfg.FreezeTimeout,
 		cfg.ThawTimeout,
-		privilege.New(ctx),
+		privilege.New(ctx, logger),
 		logger,
 		device.NewRunner(),
 	)
@@ -377,7 +377,7 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 		return destType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, io.Discard, logger)
 	}
 	if destType == "auto" {
-		if dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx), logger, devRunner); err == nil {
+		if dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx, logger), logger, devRunner); err == nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {

--- a/cmd/dump/probe.go
+++ b/cmd/dump/probe.go
@@ -22,7 +22,7 @@ const firstBlockDigestSize = 1 << 20
 
 func realProbeDestination(ctx context.Context, cfg *config.Config, dest string, logger *zap.Logger) (device.DeviceIdentity, error) {
 	info := device.NewInfo()
-	dev, err := device.Detect(ctx, dest, true, "", "", "", "", 0, 0, privilege.New(ctx), logger, device.NewRunner())
+	dev, err := device.Detect(ctx, dest, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 	if err != nil {
 		return device.DeviceIdentity{}, err
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -143,7 +143,7 @@ func ConfigureWithEscalator(esc privilege.Escalator) (*config.Config, []string, 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.LVMTimeout)
 	defer cancel()
 	if esc == nil {
-		esc = privilege.New(ctx)
+		esc = privilege.New(ctx, zap.NewNop())
 	}
 	if err = esc.Ensure(ctx); err != nil {
 		return nil, nil, nil, fmt.Errorf("privilege check failed: %w", err)

--- a/device/info.go
+++ b/device/info.go
@@ -186,7 +186,7 @@ func (i *Info) SizeBytes(ctx context.Context, path string) (size uint64, err err
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	dev, err := i.detectFunc(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx), zap.NewNop(), NewRunner())
+	dev, err := i.detectFunc(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
 	if err != nil {
 		return 0, err
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -129,7 +129,7 @@ func OpenRaw(
 	runner *Runner,
 ) (_ *RawDevice, err error) {
 	if esc == nil {
-		esc = privilege.New(ctx)
+		esc = privilege.New(ctx, logger)
 	}
 	if err := esc.Ensure(ctx); err != nil {
 		return nil, err

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 
+	"go.uber.org/zap"
+
 	"lvmsync_go/internal/privilege"
 	lvmlib "lvmsync_go/lvm"
 )
@@ -54,10 +56,13 @@ type agent struct {
 
 // NewAgent constructs an Agent that delegates LVM operations to the provided
 // lvmAPI and ensures privileges using the given Escalator. When esc is nil,
-// privilege.New(context.Background()) supplies a default implementation.
-func NewAgent(lvm lvmAPI, esc privilege.Escalator) Agent {
+// privilege.New(context.Background(), logger) supplies a default implementation.
+func NewAgent(lvm lvmAPI, esc privilege.Escalator, logger *zap.Logger) Agent {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	if esc == nil {
-		esc = privilege.New(context.Background())
+		esc = privilege.New(context.Background(), logger)
 	}
 	return &agent{esc: esc, lvm: lvm}
 }
@@ -65,11 +70,11 @@ func NewAgent(lvm lvmAPI, esc privilege.Escalator) Agent {
 // NewSudoAgent wraps the public LVM API with a privilege-enforcing Agent. The
 // sudoPath and ensureRoot parameters are retained for compatibility but are
 // currently unused.
-func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error) Agent { //nolint:revive // sudoPath kept for future use
+func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error, logger *zap.Logger) Agent { //nolint:revive // sudoPath kept for future use
 	_ = sudoPath
 	_ = ensureRoot
 	api, _ := l.(lvmAPI)
-	return NewAgent(api, nil)
+	return NewAgent(api, nil, logger)
 }
 
 func (a *agent) Lock(ctx context.Context, volume, requester string) error {

--- a/internal/lvm/agent_test.go
+++ b/internal/lvm/agent_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os/exec"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 type fakeEsc struct{ err error }
@@ -82,7 +84,7 @@ func (m *mockLVM) IsMounted(_ context.Context, _ string) (bool, error) {
 func TestAgentLock(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	if err := a.Lock(ctx, "vol", "req"); err != nil {
 		t.Fatalf("lock failed: %v", err)
 	}
@@ -95,7 +97,7 @@ func TestAgentLock(t *testing.T) {
 func TestAgentUnlock(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	if err := a.Unlock(ctx, "vol", "req"); err != nil {
 		t.Fatalf("unlock failed: %v", err)
 	}
@@ -109,7 +111,7 @@ func TestAgentGetMetadata(t *testing.T) {
 	ctx := context.Background()
 	expected := VolumeMetadata{VolumeName: "vol", SizeBytes: 1, ChunkSize: 2}
 	mock := &mockLVM{md: expected}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	md, err := a.GetMetadata(ctx, "vol")
 	if err != nil {
 		t.Fatalf("get metadata failed: %v", err)
@@ -126,7 +128,7 @@ func TestAgentGetMetadata(t *testing.T) {
 func TestAgentSendMetadata(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	md := VolumeMetadata{VolumeName: "vol"}
 	if err := a.SendMetadata(ctx, md); err != nil {
 		t.Fatalf("send metadata failed: %v", err)
@@ -143,7 +145,7 @@ func TestAgentSendMetadata(t *testing.T) {
 func TestAgentStartTransferSession(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	if err := a.StartTransferSession(ctx, "vol", "req"); err != nil {
 		t.Fatalf("start transfer failed: %v", err)
 	}
@@ -156,7 +158,7 @@ func TestAgentStartTransferSession(t *testing.T) {
 func TestAgentFinalizeSync(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	if err := a.FinalizeSync(ctx, "vol", "req"); err != nil {
 		t.Fatalf("finalize sync failed: %v", err)
 	}
@@ -169,7 +171,7 @@ func TestAgentFinalizeSync(t *testing.T) {
 func TestAgentGetStatus(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{status: "ok"}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	status, err := a.GetStatus(ctx, "vol", "req")
 	if err != nil {
 		t.Fatalf("get status failed: %v", err)
@@ -186,7 +188,7 @@ func TestAgentGetStatus(t *testing.T) {
 func TestAgentVolumeExists(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{exists: true}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	ok, err := a.VolumeExists(ctx, "vol")
 	if err != nil || !ok {
 		t.Fatalf("volume exists check failed: %v %v", ok, err)
@@ -200,7 +202,7 @@ func TestAgentVolumeExists(t *testing.T) {
 func TestAgentAutoExtendEnabled(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{autoExtend: true}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	ok, err := a.AutoExtendEnabled(ctx, "vol")
 	if err != nil || !ok {
 		t.Fatalf("auto extend check failed: %v %v", ok, err)
@@ -214,7 +216,7 @@ func TestAgentAutoExtendEnabled(t *testing.T) {
 func TestAgentDiscardEnabled(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{discard: true}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	ok, err := a.DiscardEnabled(ctx, "vol")
 	if err != nil || !ok {
 		t.Fatalf("discard check failed: %v %v", ok, err)
@@ -228,7 +230,7 @@ func TestAgentDiscardEnabled(t *testing.T) {
 func TestAgentIsMounted(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{mounted: true}
-	a := NewAgent(mock, fakeEsc{})
+	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	ok, err := a.IsMounted(ctx, "vol")
 	if err != nil || !ok {
 		t.Fatalf("mount check failed: %v %v", ok, err)

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -3,11 +3,16 @@ package privilege
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type cmdFunc func(context.Context, string, ...string) *exec.Cmd
@@ -23,7 +28,7 @@ func fakeLookPath(err error) func(string) (string, error) {
 
 func TestEnsureWithCaps(t *testing.T) {
 	HasCaps = func() bool { return true }
-	esc := New(context.Background()).(*sudoEscalator)
+	esc := New(context.Background(), zap.NewNop()).(*sudoEscalator)
 	if esc.useSudo {
 		t.Fatalf("expected capabilities to be used")
 	}
@@ -37,7 +42,7 @@ func TestEnsureWithSudo(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(context.Background(), r).(*sudoEscalator)
+	esc := NewWithRunner(context.Background(), r, zap.NewNop()).(*sudoEscalator)
 	if !esc.useSudo {
 		t.Fatalf("expected sudo usage")
 	}
@@ -48,7 +53,7 @@ func TestEnsureWithSudo(t *testing.T) {
 
 func TestEnsureNoSudo(t *testing.T) {
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(context.Background(), &Runner{LookPath: fakeLookPath(errors.New("missing"))}).(*sudoEscalator)
+	esc := NewWithRunner(context.Background(), &Runner{LookPath: fakeLookPath(errors.New("missing"))}, zap.NewNop()).(*sudoEscalator)
 	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -56,16 +61,34 @@ func TestEnsureNoSudo(t *testing.T) {
 
 func TestCommand(t *testing.T) {
 	HasCaps = func() bool { return false }
-	esc := New(context.Background())
+	esc := New(context.Background(), zap.NewNop())
 	cmd := esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] != "sudo" {
 		t.Fatalf("expected sudo prefix")
 	}
 	HasCaps = func() bool { return true }
-	esc = New(context.Background())
+	esc = New(context.Background(), zap.NewNop())
 	cmd = esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] == "sudo" {
 		t.Fatalf("unexpected sudo prefix")
+	}
+}
+
+func TestCommandLogs(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	esc := New(context.Background(), logger)
+	esc.Command(context.Background(), "cmd", "--password=foo", "--token", "bar")
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if fields["command"] != "cmd" {
+		t.Fatalf("command = %v", fields["command"])
+	}
+	if fmt.Sprint(fields["args"]) != "[--password=[REDACTED] --token [REDACTED]]" {
+		t.Fatalf("args = %v", fields["args"])
 	}
 }
 
@@ -74,7 +97,7 @@ func TestEnsureSudoFailure(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(context.Background(), r).(*sudoEscalator)
+	esc := NewWithRunner(context.Background(), r, zap.NewNop()).(*sudoEscalator)
 	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -105,7 +128,7 @@ func TestSudoSuccess(t *testing.T) {
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
-	})})
+	})}, zap.NewNop())
 	cmd := esc.Command(context.Background(), "echo")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -117,7 +140,7 @@ func TestSudoPermissionDenied(t *testing.T) {
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
-	})})
+	})}, zap.NewNop())
 	cmd := esc.Command(context.Background(), "echo")
 	err := cmd.Run()
 	if err == nil {
@@ -133,7 +156,7 @@ func TestSudoCommandNotFound(t *testing.T) {
 	HasCaps = func() bool { return false }
 	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(127)(name, args...)
-	})})
+	})}, zap.NewNop())
 	cmd := esc.Command(context.Background(), "echo")
 	err := cmd.Run()
 	if err == nil {
@@ -165,7 +188,7 @@ func TestEnsureContextCanceled(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(context.Background(), r)
+	esc := NewWithRunner(context.Background(), r, zap.NewNop())
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	err := esc.Ensure(ctx)
@@ -177,7 +200,7 @@ func TestEnsureContextCanceled(t *testing.T) {
 func TestCommandContextCanceled(t *testing.T) {
 	esc := &sudoEscalator{useSudo: false, runner: &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
-	})}}
+	}), Logger: zap.NewNop()}}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	cmd := esc.Command(ctx, "sleep", "10")
@@ -195,7 +218,7 @@ func TestEnsureDefaultTimeout(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(context.Background(), r)
+	esc := NewWithRunner(context.Background(), r, zap.NewNop())
 	err := esc.Ensure(context.Background())
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
@@ -208,7 +231,7 @@ func TestCommandDefaultTimeout(t *testing.T) {
 	defer func() { escalationTimeout = orig }()
 	esc := &sudoEscalator{useSudo: false, runner: &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
-	})}}
+	}), Logger: zap.NewNop()}}
 	cmd := esc.Command(context.Background(), "sleep", "10")
 	err := cmd.Run()
 	if !errors.Is(err, context.DeadlineExceeded) && err.Error() != "signal: killed" {

--- a/internal/privilege/runner.go
+++ b/internal/privilege/runner.go
@@ -3,6 +3,8 @@ package privilege
 import (
 	"context"
 	"os/exec"
+
+	"go.uber.org/zap"
 )
 
 // Commander abstracts exec.CommandContext for dependency injection.
@@ -20,15 +22,21 @@ func (f commanderFunc) CommandContext(ctx context.Context, name string, args ...
 type Runner struct {
 	Cmd      Commander
 	LookPath func(string) (string, error)
+	Logger   *zap.Logger
 }
 
 // New returns an Escalator with production dependencies.
 // ctx is currently unused but reserved for future use.
-func New(ctx context.Context) Escalator { return NewWithRunner(ctx, nil) }
+func New(ctx context.Context, logger *zap.Logger) Escalator {
+	return NewWithRunner(ctx, nil, logger)
+}
 
 // NewWithRunner constructs an Escalator with the provided Runner.
 // Nil fields default to exec.CommandContext and exec.LookPath.
-func NewWithRunner(_ context.Context, r *Runner) Escalator {
+func NewWithRunner(_ context.Context, r *Runner, logger *zap.Logger) Escalator {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	cmd := Commander(commanderFunc(exec.CommandContext))
 	lp := exec.LookPath
 	if r != nil {
@@ -38,6 +46,9 @@ func NewWithRunner(_ context.Context, r *Runner) Escalator {
 		if r.LookPath != nil {
 			lp = r.LookPath
 		}
+		if r.Logger != nil {
+			logger = r.Logger
+		}
 	}
-	return &sudoEscalator{useSudo: !HasCaps(), runner: &Runner{Cmd: cmd, LookPath: lp}}
+	return &sudoEscalator{useSudo: !HasCaps(), runner: &Runner{Cmd: cmd, LookPath: lp, Logger: logger}}
 }

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // escalationTimeout limits how long privilege checks and escalated commands may run
@@ -44,9 +47,37 @@ func (s *sudoEscalator) Ensure(ctx context.Context) error {
 // when capabilities are missing.
 func (s *sudoEscalator) Command(ctx context.Context, name string, args ...string) *exec.Cmd {
 	ctx, _ = withTimeout(ctx)
+	s.runner.Logger.Debug("exec_command",
+		zap.String("command", name),
+		zap.Strings("args", redactArgs(args)),
+	)
 	if s.useSudo {
 		all := append([]string{"-n", name}, args...)
 		return s.runner.Cmd.CommandContext(ctx, "sudo", all...)
 	}
 	return s.runner.Cmd.CommandContext(ctx, name, args...)
+}
+
+func redactArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		lower := strings.ToLower(a)
+		if strings.Contains(lower, "password") || strings.Contains(lower, "secret") ||
+			strings.Contains(lower, "token") || strings.Contains(lower, "key") {
+			if strings.Contains(a, "=") {
+				parts := strings.SplitN(a, "=", 2)
+				out[i] = parts[0] + "=[REDACTED]"
+			} else {
+				out[i] = a
+				if i+1 < len(args) {
+					out[i+1] = "[REDACTED]"
+					i++
+				}
+			}
+		} else {
+			out[i] = a
+		}
+	}
+	return out
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -91,7 +91,7 @@ func defaultIndexOptions() indexOptions {
 			ctx = device.WithForce(ctx, true)
 			ctx = device.WithAllowOverwrite(ctx, true)
 			ctx = device.WithYesIKnow(ctx, true)
-			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx), logger, device.NewRunner())
+			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 		},
 		closeHook: func() error { return nil },
 		info:      device.NewInfo(),


### PR DESCRIPTION
## Summary
- add `*zap.Logger` to `privilege.Runner` and require it via constructors
- log command path and redacted args before execution
- plumb loggers through callers and test command logging

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many existing lint issues)*


------
https://chatgpt.com/codex/tasks/task_e_68a61a622b7c8323a7c92ebff16b09ab