### PR TITLE
privilege: remove duplicate argument redaction helper

### DIFF
--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -131,27 +131,3 @@ func redactArgs(args []string) []string {
 	}
 	return out
 }
-
-func redactArgs(args []string) []string {
-	out := make([]string, len(args))
-	for i := 0; i < len(args); i++ {
-		a := args[i]
-		lower := strings.ToLower(a)
-		if strings.Contains(lower, "password") || strings.Contains(lower, "secret") ||
-			strings.Contains(lower, "token") || strings.Contains(lower, "key") {
-			if strings.Contains(a, "=") {
-				parts := strings.SplitN(a, "=", 2)
-				out[i] = parts[0] + "=[REDACTED]"
-			} else {
-				out[i] = a
-				if i+1 < len(args) {
-					out[i+1] = "[REDACTED]"
-					i++
-				}
-			}
-		} else {
-			out[i] = a
-		}
-	}
-	return out
-}


### PR DESCRIPTION
## Summary
- remove redundant `redactArgs` helper from sudo escalation

## Testing
- `go build ./...` *(fails: internal/privilege/runner.go syntax errors)*
- `go test ./internal/privilege -count=1` *(fails: internal/privilege/runner.go syntax errors)*
- `golangci-lint run` *(fails: syntax errors in internal/privilege/runner.go)*

------
https://chatgpt.com/codex/tasks/task_e_68a623bb557c8323bd95f3ebe1636eeb