### PR TITLE
device: separate kernel and filesystem UUID retrieval

### DIFF
--- a/device/identity_cmds.go
+++ b/device/identity_cmds.go
@@ -8,6 +8,7 @@ import (
 var (
 	blkidPath string
 	lvsPath   string
+	lsblkPath string
 )
 
 const identityTimeout = 5 * time.Second
@@ -15,4 +16,5 @@ const identityTimeout = 5 * time.Second
 func init() {
 	blkidPath, _ = exec.LookPath("blkid")
 	lvsPath, _ = exec.LookPath("lvs")
+	lsblkPath, _ = exec.LookPath("lsblk")
 }

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -103,5 +105,45 @@ func TestDeviceIdentityFormatParseOrder(t *testing.T) {
 	}
 	if parsed != id {
 		t.Fatalf("round-trip mismatch: got %+v want %+v", parsed, id)
+	}
+}
+
+func createEchoScript(t *testing.T, name, output string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	script := fmt.Sprintf("#!/bin/sh\necho %s\n", output)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return path
+}
+
+func TestRawIdentityKernelAndFSUUID(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	defer f.Close()
+	d := &RawDevice{f: f, logger: zap.NewNop()}
+
+	origLSBLK := lsblkPath
+	origBLKID := blkidPath
+	lsblkPath = createEchoScript(t, "lsblk", "kernel")
+	blkidPath = createEchoScript(t, "blkid", "fs")
+	defer func() {
+		lsblkPath = origLSBLK
+		blkidPath = origBLKID
+	}()
+
+	id, err := d.Identity(context.Background())
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if id.KernelUUID != "kernel" {
+		t.Fatalf("kernel uuid mismatch: %v", id.KernelUUID)
+	}
+	if id.FSUUID != "fs" {
+		t.Fatalf("fs uuid mismatch: %v", id.FSUUID)
 	}
 }

--- a/device/raw.go
+++ b/device/raw.go
@@ -190,6 +190,9 @@ func (d *RawDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
 	if blkidPath == "" {
 		return DeviceIdentity{}, fmt.Errorf("blkid not found")
 	}
+	if lsblkPath == "" {
+		return DeviceIdentity{}, fmt.Errorf("lsblk not found")
+	}
 	var st unix.Stat_t
 	if err := unix.Stat(d.Path(), &st); err != nil {
 		return DeviceIdentity{}, err
@@ -199,16 +202,22 @@ func (d *RawDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
 		Major:     uint32(unix.Major(uint64(st.Rdev))),
 		Minor:     uint32(unix.Minor(uint64(st.Rdev))),
 	}
-	out, err := exec.CommandContext(ctx, blkidPath, "-o", "value", "-s", "UUID", d.Path()).Output()
+	out, err := exec.CommandContext(ctx, lsblkPath, "--nodeps", "-no", "UUID", d.Path()).Output()
 	if err != nil {
 		if ctx.Err() != nil {
 			return DeviceIdentity{}, ctx.Err()
 		}
 		return DeviceIdentity{}, err
 	}
-	uuid := strings.TrimSpace(string(out))
-	id.KernelUUID = uuid
-	id.FSUUID = uuid
+	id.KernelUUID = strings.TrimSpace(string(out))
+	out, err = exec.CommandContext(ctx, blkidPath, "-o", "value", "-s", "UUID", d.Path()).Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return DeviceIdentity{}, ctx.Err()
+		}
+		return DeviceIdentity{}, err
+	}
+	id.FSUUID = strings.TrimSpace(string(out))
 	if gpt, mbr, err := readPartitionSignatures(d.Path()); err == nil {
 		id.GPTUUID = gpt
 		id.MBRSignature = mbr


### PR DESCRIPTION
## Summary
- retrieve kernel UUID using `lsblk` and filesystem UUID via `blkid`
- expand raw identity tests for different kernel and filesystem UUIDs

## Testing
- `go build ./...` *(fails: internal/privilege/runner.go:44:6: syntax error: unexpected name NewWithSanitize, expected ()*)
- `go test -coverprofile=coverage.out ./...` *(fails: internal/privilege/runner.go:44:6: syntax error: unexpected name NewWithSanitize, expected ()*)
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: internal/privilege/runner.go:44:6: syntax error: unexpected name NewWithSanitize, expected ()*)

------
https://chatgpt.com/codex/tasks/task_e_68a623bc2e84832387892d22b4398dba