### PR TITLE
Stub lsblk and blkid in raw identity timeout test

### DIFF
--- a/device/identity_command_test.go
+++ b/device/identity_command_test.go
@@ -41,9 +41,14 @@ func TestRawIdentityTimeout(t *testing.T) {
 	defer f.Close()
 	d := &RawDevice{f: f, logger: zap.NewNop()}
 	script := createSleepScript(t, "blkid")
-	orig := blkidPath
+	origBLKID := blkidPath
+	origLSBLK := lsblkPath
 	blkidPath = script
-	defer func() { blkidPath = orig }()
+	lsblkPath = script
+	defer func() {
+		blkidPath = origBLKID
+		lsblkPath = origLSBLK
+	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	if _, err := d.Identity(ctx); err == nil || !(errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "signal: killed")) {


### PR DESCRIPTION
## Summary
- ensure RawDevice timeout test stubs both lsblk and blkid commands
- restore original command paths after the test

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1132 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a62a44b25883239adb7314cdf6151c