### PR TITLE
docs: document exit codes

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -114,6 +114,7 @@ committed ranges.
 | [`exitcode.OK`](internal/exitcode/exitcode.go) | `0`  | Success | None |
 | [`exitcode.ErrCapability`](internal/exitcode/exitcode.go) | `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
 | [`exitcode.ErrDevice`](internal/exitcode/exitcode.go) | `20` | Device error | Verify device paths and snapshot health. |
+| [`exitcode.ErrSnapshotExhausted`](internal/exitcode/exitcode.go) | `25` | Snapshot space exhausted | Grow or recreate the snapshot before resuming. |
 | [`exitcode.ErrPlatform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform | Run on a supported Linux platform. |
 | [`exitcode.ErrConfig`](internal/exitcode/exitcode.go) | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
 | [`exitcode.ErrRuntime`](internal/exitcode/exitcode.go) | `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,13 +12,21 @@ Read-only operations can run without elevated privileges.
 `--probe-only` checks device metadata, validates privileges, and emits dry-run estimates. It prints `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` for confirmation.
 `--verify-only` reads source and destination devices and reports mismatches.
 
-Both commands exit `0` on success, return `60` for verification failures, and `10` when required capabilities are missing.
+Both commands exit `0` on success, return `60` for verification failures, and `10` when required capabilities are missing. See [exit code meanings](OPERATIONS.md#exit-codes-and-recovery) for all codes.
 
 Example `--probe-only` output:
 
 ```sh
 lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target
 # 10737418240 12345678-9abc-def0-1234-56789abcdef0 9abcdef0-1234-5678-90ab-cdef12345678 0fedcba9-8765-4321-0fed-cba987654321 253 0 1700000000
+```
+
+When privileges are missing:
+
+```sh
+lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target || \
+  echo "probe failed with exit $?; run as root or adjust --lvm-escalation"
+# probe failed with exit 10; run as root or adjust --lvm-escalation
 ```
 
 ## Device identity enforcement


### PR DESCRIPTION
## Summary
- map internal exit codes to their meanings in the operations guide
- link probe and verify modes to the exit code table and show non-zero exit example

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRawIdentityTimeout expected deadline exceeded, got exit status 32)*
- `golangci-lint run` *(fails: 1132 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a62a58ad048323a127c8cad7c1df10