### PR TITLE
test: add freeze and thaw timeout log tests

### DIFF
--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -329,6 +329,32 @@ func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 	}
 }
 
+func TestOpenRawFreezeTimeoutErrorLogs(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	helper := helperCommand(t)
+	runner := NewDeviceRunner(cmdFunc(fakeExecCommandContext))
+	ctx := WithForce(context.Background(), true)
+	ctx = WithAllowOverwrite(ctx, true)
+	ctx = WithYesIKnow(ctx, true)
+	_, err := OpenRaw(ctx, "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, fakeEsc{}, logger, runner)
+	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("expected freeze timeout, got %v", err)
+	}
+	if logs.FilterMessage("fs_freeze_start").Len() != 1 {
+		t.Fatalf("expected fs_freeze_start log")
+	}
+	if logs.FilterMessage("fs_freeze_failed").Len() != 1 {
+		t.Fatalf("expected fs_freeze_failed log")
+	}
+	if logs.FilterMessage("fs_freeze_complete").Len() != 0 {
+		t.Fatalf("unexpected fs_freeze_complete log")
+	}
+	if logs.FilterMessage("fs_thaw_start").Len() != 0 || logs.FilterMessage("fs_thaw_complete").Len() != 0 {
+		t.Fatalf("unexpected fs_thaw_* logs, got %v", logs.All())
+	}
+}
+
 func TestOpenRawThawFailure(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
@@ -440,6 +466,32 @@ func TestRawDeviceCleanupThawTimeoutLogs(t *testing.T) {
 	}
 	if logs.FilterMessage("fs_thaw_failed").Len() != 1 {
 		t.Fatalf("expected fs_thaw_failed log")
+	}
+}
+
+func TestRawDeviceCleanupThawTimeoutErrorLogs(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	helper := helperCommand(t)
+	d := &RawDevice{
+		freezeIssued: true,
+		thawCmdPath:  helper,
+		thawCmdArgs:  []string{"thaw-timeout"},
+		thawTimeout:  100 * time.Millisecond,
+		logger:       logger,
+		runner:       NewDeviceRunner(cmdFunc(fakeExecCommandContext)),
+	}
+	if err := d.Cleanup(context.Background()); err == nil || !strings.Contains(err.Error(), "killed") {
+		t.Fatalf("expected thaw command to be killed, got %v", err)
+	}
+	if logs.FilterMessage("fs_thaw_start").Len() != 1 {
+		t.Fatalf("expected fs_thaw_start log")
+	}
+	if logs.FilterMessage("fs_thaw_failed").Len() != 1 {
+		t.Fatalf("expected fs_thaw_failed log")
+	}
+	if logs.FilterMessage("fs_thaw_complete").Len() != 0 {
+		t.Fatalf("unexpected fs_thaw_complete log")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add regression tests for filesystem freeze timeout without thaw
- add regression tests for hung thaw scripts during cleanup

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: identity_command_test.go: expected deadline exceeded)*
- `golangci-lint run` *(fails: 1132 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a62a493d208323a33d804fc608b9a8