### PR TITLE
serve: use structured logger

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/internal/logging"
 	_ "lvmsync_go/transport/rsyncwire"
 )
 
@@ -26,7 +27,14 @@ func newRunner() *runner {
 		run:        run,
 		syncLogger: rootcmd.SyncLogger,
 		exit:       os.Exit,
-		newLogger:  func() *zap.Logger { return zap.NewExample() },
+		newLogger: func() *zap.Logger {
+			// Deprecated command, but keep logger consistent across commands.
+			logger, err := logging.NewLogger(nil, "serve")
+			if err != nil {
+				return zap.NewNop()
+			}
+			return logger
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
- use logging.NewLogger in deprecated serve command with zap.NewNop fallback
- document deprecated status while keeping logging consistent

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run --new-from-rev=HEAD~1`


------
https://chatgpt.com/codex/tasks/task_e_68a631d7fe908323a73948af968af625