### PR TITLE
transport: require logger

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -52,10 +52,10 @@ type listener struct {
 	ctx context.Context
 }
 
-// New returns a new Transport. Logger is optional; a no-op logger is used when nil.
+// New returns a new Transport. Logger must be non-nil.
 func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		cfg.Logger = zap.NewNop()
+		return nil, fmt.Errorf("logger is required")
 	}
 	if cfg.Roots == nil && !cfg.AllowInsecure {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")

--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -654,9 +654,9 @@ func TestH2DialUnreachable(t *testing.T) {
 	}
 }
 
-func TestH2TransportLoggerOptional(t *testing.T) {
-	if _, err := New(transport.Config{AllowInsecure: true}); err != nil {
-		t.Fatalf("New: %v", err)
+func TestH2TransportRequiresLogger(t *testing.T) {
+	if _, err := New(transport.Config{AllowInsecure: true}); err == nil {
+		t.Fatalf("expected error when logger is nil")
 	}
 }
 

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -48,10 +48,10 @@ type listener struct {
 }
 
 // New constructs a Transport using the provided TLS roots, server certificate,
-// and client certificate. Logger is optional; a no-op logger is used when nil.
+// and client certificate. Logger must be non-nil.
 func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		cfg.Logger = zap.NewNop()
+		return nil, fmt.Errorf("logger is required")
 	}
 	if cfg.Roots == nil && !cfg.AllowInsecure {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")

--- a/transport/quic/quic_test.go
+++ b/transport/quic/quic_test.go
@@ -319,9 +319,9 @@ func TestQUICTransportAllowInsecureWarn(t *testing.T) {
 	}
 }
 
-func TestQUICTransportLoggerOptional(t *testing.T) {
-	if _, err := New(transport.Config{AllowInsecure: true}); err != nil {
-		t.Fatalf("New: %v", err)
+func TestQUICTransportRequiresLogger(t *testing.T) {
+	if _, err := New(transport.Config{AllowInsecure: true}); err == nil {
+		t.Fatalf("expected error when logger is nil")
 	}
 }
 

--- a/transport/rsyncwire/rsyncwire.go
+++ b/transport/rsyncwire/rsyncwire.go
@@ -23,10 +23,10 @@ type Transport struct {
 	logger *zap.Logger
 }
 
-// New constructs a Transport. Logger may be nil, in which case zap.NewNop() is used.
+// New constructs a Transport. Logger must be non-nil.
 func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		cfg.Logger = zap.NewNop()
+		return nil, fmt.Errorf("logger is required")
 	}
 	if !cfg.AllowInsecure {
 		return nil, fmt.Errorf("rsync transport requires AllowInsecure")

--- a/transport/rsyncwire/rsyncwire_test.go
+++ b/transport/rsyncwire/rsyncwire_test.go
@@ -15,6 +15,12 @@ func TestRequiresAllowInsecure(t *testing.T) {
 	}
 }
 
+func TestRequiresLogger(t *testing.T) {
+	if _, err := New(transport.Config{AllowInsecure: true}); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
+}
+
 func TestLogsPlaintextWarning(t *testing.T) {
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)

--- a/transport/ssh/basic_test.go
+++ b/transport/ssh/basic_test.go
@@ -11,8 +11,15 @@ import (
 )
 
 func TestNewRequiresUser(t *testing.T) {
-	if _, err := New(context.Background(), transport.Config{SSHPassword: "p"}); err == nil {
+	if _, err := New(context.Background(), transport.Config{Logger: zap.NewNop(), SSHPassword: "p"}); err == nil {
 		t.Fatalf("expected error for missing user")
+	}
+}
+
+func TestNewRequiresLogger(t *testing.T) {
+	cfg := transport.Config{SSHUser: "u", SSHPassword: "p", AllowInsecure: true}
+	if _, err := New(context.Background(), cfg); err == nil {
+		t.Fatalf("expected error when logger is nil")
 	}
 }
 

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -44,10 +44,11 @@ type Transport struct {
 	logger     *zap.Logger
 }
 
-// New returns a new Transport using username/password authentication. Logger is optional; a no-op logger is used when nil.
+// New returns a new Transport using username/password authentication.
+// Logger must be non-nil.
 func New(ctx context.Context, cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		cfg.Logger = zap.NewNop()
+		return nil, fmt.Errorf("logger is required")
 	}
 	if cfg.SSHUser == "" {
 		return nil, fmt.Errorf("ssh user is required")

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -922,9 +922,9 @@ func TestSSHTransportNegotiateTimeoutServer(t *testing.T) {
 	conn.Close()
 }
 
-func TestSSHTransportLoggerOptional(t *testing.T) {
-	if _, err := New(context.Background(), transport.Config{SSHUser: "u", SSHPassword: "p", AllowInsecure: true}); err != nil {
-		t.Fatalf("New: %v", err)
+func TestSSHTransportRequiresLogger(t *testing.T) {
+	if _, err := New(context.Background(), transport.Config{SSHUser: "u", SSHPassword: "p", AllowInsecure: true}); err == nil {
+		t.Fatalf("expected error when logger is nil")
 	}
 }
 

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -29,10 +29,10 @@ type Transport struct {
 }
 
 // New creates a Transport using provided TLS roots, server certificate, and
-// client certificate. Logger is optional; a no-op logger is used when nil.
+// client certificate. Logger must be non-nil.
 func New(cfg transport.Config) (transport.Interface, error) {
 	if cfg.Logger == nil {
-		cfg.Logger = zap.NewNop()
+		return nil, fmt.Errorf("logger is required")
 	}
 	if cfg.Roots == nil && !cfg.AllowInsecure {
 		return nil, fmt.Errorf("tls roots are required unless AllowInsecure is set")

--- a/transport/tcp_tls/tcp_tls_test.go
+++ b/transport/tcp_tls/tcp_tls_test.go
@@ -643,10 +643,10 @@ func TestTCPTLSTransportAllowInsecureWarn(t *testing.T) {
 	}
 }
 
-func TestTCPTLSTransportLoggerOptional(t *testing.T) {
+func TestTCPTLSTransportRequiresLogger(t *testing.T) {
 	cert, root := generateSelfSignedCert(t)
-	if _, err := New(transport.Config{Roots: root, ClientCert: cert, ServerCert: cert}); err != nil {
-		t.Fatalf("New: %v", err)
+	if _, err := New(transport.Config{Roots: root, ClientCert: cert, ServerCert: cert}); err == nil {
+		t.Fatalf("expected error when logger is nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
- require non-nil logger for SSH, QUIC, H2, TCP+TLS, and rsync transports
- add tests for nil logger constructor failures across transports

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: 1135 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a631d4a99c832387a6a1ec0b6eaf5d