### PR TITLE
refactor: add injectable runners

### DIFF
--- a/cmd/verify/resume_verify_integration_test.go
+++ b/cmd/verify/resume_verify_integration_test.go
@@ -83,7 +83,7 @@ func TestResumeVerifySuccess(t *testing.T) {
 		t.Fatalf("manifest close: %v", err)
 	}
 	resume := filepath.Join(dir, "resume.state")
-	w, _, err := transfer.OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0)
+	w, _, err := transfer.OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestResumeVerifyMismatch(t *testing.T) {
 		t.Fatalf("manifest close: %v", err)
 	}
 	resume := filepath.Join(dir, "resume.state")
-	w, _, err := transfer.OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0)
+	w, _, err := transfer.OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/device/detect.go
+++ b/device/detect.go
@@ -15,9 +15,6 @@ import (
 	"lvmsync_go/lvm"
 )
 
-// openRawFunc allows tests to stub OpenRaw.
-var openRawFunc = OpenRaw
-
 func verifyPartition(ctx context.Context, dev Device) error {
 	gpt, mbr := partitionSignaturesFromContext(ctx)
 	if gpt == "" && mbr == "" {
@@ -109,7 +106,7 @@ func detectRawDevice(
 			thawArgs = parts[1:]
 		}
 	}
-	dev, err := openRawFunc(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger, runner)
+	dev, err := runner.OpenRaw(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger)
 	if err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -109,21 +109,20 @@ func TestDetectLVMDeviceEscalationError(t *testing.T) {
 }
 
 func TestDetectRawDeviceSuccess(t *testing.T) {
-	orig := openRawFunc
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
+	runner := NewRunner()
+	runner.openRawOverride = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
 		f, err := os.CreateTemp(t.TempDir(), "raw")
 		if err != nil {
 			return nil, err
 		}
 		return &RawDevice{f: f, logger: logger}, nil
 	}
-	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := detectRawDevice(ctx, "/dev/test", true, "", "", 0, 0, fakeEsc{}, logger, NewRunner())
+	dev, err := detectRawDevice(ctx, "/dev/test", true, "", "", 0, 0, fakeEsc{}, logger, runner)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -153,24 +152,23 @@ func TestDetectRawDeviceError(t *testing.T) {
 }
 
 func TestDetectRawDeviceFreezeParseError(t *testing.T) {
-	orig := openRawFunc
+	runner := NewRunner()
 	called := false
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
+	runner.openRawOverride = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
-	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := detectRawDevice(ctx, "/dev/test", true, "/bin/echo \"unterminated", "", 0, 0, fakeEsc{}, logger, NewRunner())
+	_, err := detectRawDevice(ctx, "/dev/test", true, "/bin/echo \"unterminated", "", 0, 0, fakeEsc{}, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "invalid freeze command") {
 		t.Fatalf("expected freeze parse error, got %v", err)
 	}
 	if called {
-		t.Fatalf("openRawFunc should not be called on parse error")
+		t.Fatalf("OpenRaw should not be called on parse error")
 	}
 	entries := logs.FilterMessage("detect_device_failed").All()
 	if len(entries) != 1 {
@@ -182,24 +180,23 @@ func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 }
 
 func TestDetectRawDeviceThawParseError(t *testing.T) {
-	orig := openRawFunc
+	runner := NewRunner()
 	called := false
-	openRawFunc = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger, runner *Runner) (*RawDevice, error) {
+	runner.openRawOverride = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
-	defer func() { openRawFunc = orig }()
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := detectRawDevice(ctx, "/dev/test", true, "", "/bin/echo \"unterminated", 0, 0, fakeEsc{}, logger, NewRunner())
+	_, err := detectRawDevice(ctx, "/dev/test", true, "", "/bin/echo \"unterminated", 0, 0, fakeEsc{}, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "invalid thaw command") {
 		t.Fatalf("expected thaw parse error, got %v", err)
 	}
 	if called {
-		t.Fatalf("openRawFunc should not be called on parse error")
+		t.Fatalf("OpenRaw should not be called on parse error")
 	}
 	entries := logs.FilterMessage("detect_device_failed").All()
 	if len(entries) != 1 {

--- a/device/runner.go
+++ b/device/runner.go
@@ -3,10 +3,12 @@ package device
 import (
 	"context"
 	"os/exec"
+	"time"
 
 	"go.uber.org/zap"
 
 	"lvmsync_go/internal/lock"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/lvm"
 )
 
@@ -30,6 +32,7 @@ type Runner struct {
 	isMountedRW       func(context.Context, string) (bool, error)
 	lockAcquire       func(string, string) (*lock.Lock, error)
 	openLVMOverride   func(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error)
+	openRawOverride   func(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger) (*RawDevice, error)
 }
 
 // NewDeviceRunner returns a Runner using production dependencies and the provided Commander.
@@ -84,4 +87,24 @@ func defaultIsMountedRW(ctx context.Context, path string) (bool, error) {
 		defer cancel()
 	}
 	return defaultMountFunc(ctx, path)
+}
+
+// OpenRaw wraps the package-level OpenRaw allowing tests to override the implementation.
+func (r *Runner) OpenRaw(
+	ctx context.Context,
+	path string,
+	offline bool,
+	freezePath string,
+	freezeArgs []string,
+	thawPath string,
+	thawArgs []string,
+	freezeTimeout time.Duration,
+	thawTimeout time.Duration,
+	esc privilege.Escalator,
+	logger *zap.Logger,
+) (*RawDevice, error) {
+	if r.openRawOverride != nil {
+		return r.openRawOverride(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger)
+	}
+	return OpenRaw(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger, r)
 }

--- a/device/wal.go
+++ b/device/wal.go
@@ -82,11 +82,18 @@ type WAL struct {
 	f      walFile
 	header walHeader
 	ranges []Range
+	deps   *WALDeps
 }
 
-// syncDirFunc flushes a directory to stable storage. It is a variable to allow tests
-// to stub the implementation.
-var syncDirFunc = syncDir
+// WALDeps bundles filesystem interactions for WAL operations.
+type WALDeps struct {
+	syncDir func(string) error
+}
+
+// NewWALDeps returns production dependencies.
+func NewWALDeps() *WALDeps {
+	return &WALDeps{syncDir: syncDir}
+}
 
 func walHeaderMAC(h *walHeader) [32]byte {
 	var buf [8 + 8 + 8 + 4 + 4 + 64 + 64 + 64]byte
@@ -135,7 +142,10 @@ func walHeaderMACV0(h *walHeaderV0) [32]byte {
 // OpenWAL opens or creates a WAL at path for the given device identity. The
 // logger must be non-nil and is used to report metadata mismatches.
 // It verifies metadata on existing WALs and loads recorded ranges.
-func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger) (*WAL, error) {
+func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) (*WAL, error) {
+	if deps == nil {
+		deps = NewWALDeps()
+	}
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, err
@@ -145,7 +155,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger) (*WAL, error) {
 		f.Close()
 		return nil, err
 	}
-	w := &WAL{f: f}
+	w := &WAL{f: f, deps: deps}
 	if st.Size() < walHeaderV0Size {
 		if st.Size() > 0 {
 			if err := f.Truncate(0); err != nil {
@@ -188,7 +198,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger) (*WAL, error) {
 			f.Close()
 			return nil, err
 		}
-		if err := syncDirFunc(filepath.Dir(path)); err != nil {
+		if err := deps.syncDir(filepath.Dir(path)); err != nil {
 			f.Close()
 			return nil, err
 		}
@@ -607,7 +617,7 @@ func (w *WAL) Append(r Range) error {
 	}
 	w.f = nf
 	w.ranges = append(w.ranges, r)
-	return syncDirFunc(filepath.Dir(name))
+	return w.deps.syncDir(filepath.Dir(name))
 }
 
 // Ranges returns the ranges recorded in the WAL.
@@ -636,18 +646,7 @@ func (w *WAL) Close() error {
 		return err
 	}
 	w.f = nil
-	return syncDirFunc(filepath.Dir(name))
-}
-
-// SetSyncDirFunc overrides the directory sync implementation. It returns a restore function.
-func SetSyncDirFunc(fn func(string) error) func() {
-	orig := syncDirFunc
-	if fn == nil {
-		syncDirFunc = syncDir
-	} else {
-		syncDirFunc = fn
-	}
-	return func() { syncDirFunc = orig }
+	return w.deps.syncDir(filepath.Dir(name))
 }
 
 func syncDir(path string) error {

--- a/device/wal_crash_test.go
+++ b/device/wal_crash_test.go
@@ -28,7 +28,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
-		w, err := OpenWAL(path, id, zap.NewNop())
+		w, err := OpenWAL(path, id, zap.NewNop(), nil)
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}
@@ -41,7 +41,7 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("truncate_mid_entry", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, err := OpenWAL(path, id, zap.NewNop())
+		w, err := OpenWAL(path, id, zap.NewNop(), nil)
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -63,7 +63,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatalf("close file: %v", err)
 		}
-		w2, err := OpenWAL(path, id, zap.NewNop())
+		w2, err := OpenWAL(path, id, zap.NewNop(), nil)
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}
@@ -76,7 +76,7 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("omit_fsync", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, err := OpenWAL(path, id, zap.NewNop())
+		w, err := OpenWAL(path, id, zap.NewNop(), nil)
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -95,7 +95,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := os.Truncate(path, walHeaderSize+16); err != nil {
 			t.Fatalf("truncate: %v", err)
 		}
-		w2, err := OpenWAL(path, id, zap.NewNop())
+		w2, err := OpenWAL(path, id, zap.NewNop(), nil)
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -16,7 +16,7 @@ func TestWALIdentityMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id, zap.NewNop())
+	w, err := OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -24,27 +24,27 @@ func TestWALIdentityMismatch(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 	badID := DeviceIdentity{SizeBytes: 101, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected size mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev2", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected uuid mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs2", Major: 1, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected fs uuid mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 3, Minor: 2, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected major mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 4, ManifestEpoch: 1}
-	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected minor mismatch error")
 	}
 	badID = DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 2}
-	if _, err := OpenWAL(path, badID, zap.NewNop()); err == nil {
+	if _, err := OpenWAL(path, badID, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected epoch mismatch error")
 	}
 }
@@ -53,7 +53,7 @@ func TestWALIdentityMismatchLogging(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id, zap.NewNop())
+	w, err := OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestWALIdentityMismatchLogging(t *testing.T) {
 	}
 	badID := DeviceIdentity{SizeBytes: 101, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
 	core, logs := observer.New(zap.ErrorLevel)
-	_, err = OpenWAL(path, badID, zap.New(core))
+	_, err = OpenWAL(path, badID, zap.New(core), nil)
 	if err == nil {
 		t.Fatalf("expected error for identity mismatch")
 	}
@@ -89,7 +89,7 @@ func TestWALRecovery(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id, zap.NewNop())
+	w, err := OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestWALRecovery(t *testing.T) {
 		t.Fatalf("append: %v", err)
 	}
 	w.Close()
-	w, err = OpenWAL(path, id, zap.NewNop())
+	w, err = OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestWALVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id, zap.NewNop())
+	w, err := OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestWALVersionMismatch(t *testing.T) {
 		t.Fatalf("write header: %v", err)
 	}
 	f.Close()
-	if _, err := OpenWAL(path, id, zap.NewNop()); err == nil {
+	if _, err := OpenWAL(path, id, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected version mismatch error")
 	}
 }
@@ -178,7 +178,7 @@ func TestWALUpgrade(t *testing.T) {
 	}
 	f.Close()
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id, zap.NewNop())
+	w, err := OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -208,12 +208,11 @@ func TestWALSyncDirCreate(t *testing.T) {
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
 	stubErr := errors.New("syncdir fail")
 	var calls int
-	restore := SetSyncDirFunc(func(string) error {
+	deps := &WALDeps{syncDir: func(string) error {
 		calls++
 		return stubErr
-	})
-	defer restore()
-	if _, err := OpenWAL(path, id, zap.NewNop()); !errors.Is(err, stubErr) {
+	}}
+	if _, err := OpenWAL(path, id, zap.NewNop(), deps); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}
 	if calls != 1 {
@@ -225,17 +224,16 @@ func TestWALSyncDirClose(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id, zap.NewNop())
+	w, err := OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
 	stubErr := errors.New("syncdir fail")
 	var calls int
-	restore := SetSyncDirFunc(func(string) error {
+	w.deps = &WALDeps{syncDir: func(string) error {
 		calls++
 		return stubErr
-	})
-	defer restore()
+	}}
 	if err := w.Close(); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}
@@ -248,17 +246,16 @@ func TestWALSyncDirAppend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "", FSUUID: "f", Major: 1, Minor: 2}
-	w, err := OpenWAL(path, id, zap.NewNop())
+	w, err := OpenWAL(path, id, zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
 	stubErr := errors.New("syncdir fail")
 	var calls int
-	restore := SetSyncDirFunc(func(string) error {
+	w.deps = &WALDeps{syncDir: func(string) error {
 		calls++
 		return stubErr
-	})
-	defer restore()
+	}}
 	if err := w.Append(Range{Start: 0, End: 1}); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}

--- a/device/write_elision_linux_test.go
+++ b/device/write_elision_linux_test.go
@@ -13,15 +13,12 @@ import (
 	"golang.org/x/sys/unix"
 
 	"lvmsync_go/internal/config"
-	_ "lvmsync_go/transfer"
+	transfer "lvmsync_go/transfer"
 	_ "unsafe"
 )
 
 //go:linkname writeZeroBlock lvmsync_go/transfer.writeZeroBlock
-func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *zap.Logger) error
-
-//go:linkname punchHoleFunc lvmsync_go/transfer.punchHoleFunc
-var punchHoleFunc func(*os.File, uint64, int) error
+func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *zap.Logger, deps *transfer.Deps) error
 
 //go:linkname punchHoleDisabled lvmsync_go/transfer.punchHoleDisabled
 var punchHoleDisabled atomic.Bool
@@ -40,7 +37,7 @@ func TestWriteElisionFallocateSupported(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), zap.NewNop()); err != nil {
+	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), zap.NewNop(), transfer.DefaultDeps); err != nil {
 		t.Fatalf("writeZeroBlock: %v", err)
 	}
 
@@ -63,27 +60,24 @@ func TestWriteElisionFallocateUnsupported(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	orig := punchHoleFunc
 	var calls int
-	punchHoleFunc = func(*os.File, uint64, int) error {
+	deps := *transfer.DefaultDeps
+	deps.PunchHole = func(*os.File, uint64, int) error {
 		calls++
 		return unix.ENOTSUP
 	}
 	punchHoleDisabled.Store(false)
-	defer func() {
-		punchHoleFunc = orig
-		punchHoleDisabled.Store(false)
-	}()
+	defer punchHoleDisabled.Store(false)
 
-	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), zap.NewNop()); err != nil {
+	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), zap.NewNop(), &deps); err != nil {
 		t.Fatalf("writeZeroBlock: %v", err)
 	}
-	if err := writeZeroBlock(cfg, f, 0, zap.NewNop()); err != nil {
+	if err := writeZeroBlock(cfg, f, 0, zap.NewNop(), &deps); err != nil {
 		t.Fatalf("writeZeroBlock: %v", err)
 	}
 
 	if calls != 1 {
-		t.Fatalf("expected punchHoleFunc called once, got %d", calls)
+		t.Fatalf("expected PunchHole called once, got %d", calls)
 	}
 
 	buf := make([]byte, cfg.BlockSize)

--- a/lvm/create_lv_test.go
+++ b/lvm/create_lv_test.go
@@ -24,23 +24,17 @@ func (m *createLVBackend) CreateLogicalVolume(context.Context, string, string, u
 }
 
 func TestCreateLogicalVolume(t *testing.T) {
-	restorePriv := SetPrivilegeChecker(func() error { return nil })
-	t.Cleanup(restorePriv)
 	b := &createLVBackend{}
-	restore := SetBackend(b)
-	t.Cleanup(restore)
-	if err := CreateLogicalVolume(context.Background(), "vg", "lv", 1024, zap.NewNop()); err != nil {
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, b, "")
+	if err := r.CreateLogicalVolume(context.Background(), "vg", "lv", 1024, zap.NewNop()); err != nil {
 		t.Fatalf("CreateLogicalVolume error: %v", err)
 	}
 }
 
 func TestCreateLogicalVolumeError(t *testing.T) {
-	restorePriv := SetPrivilegeChecker(func() error { return nil })
-	t.Cleanup(restorePriv)
 	b := &createLVBackend{err: errors.New("fail")}
-	restore := SetBackend(b)
-	t.Cleanup(restore)
-	if err := CreateLogicalVolume(context.Background(), "vg", "lv", 1024, zap.NewNop()); err == nil {
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, b, "")
+	if err := r.CreateLogicalVolume(context.Background(), "vg", "lv", 1024, zap.NewNop()); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/lvm/lvcreate.go
+++ b/lvm/lvcreate.go
@@ -9,13 +9,18 @@ import (
 
 // CreateLogicalVolume creates a logical volume of the specified size in bytes.
 func CreateLogicalVolume(ctx context.Context, vgName, lvName string, sizeBytes uint64, logger *zap.Logger) error {
-	if err := checkPrivs(); err != nil {
+	return defaultRunner.CreateLogicalVolume(ctx, vgName, lvName, sizeBytes, logger)
+}
+
+// CreateLogicalVolume creates a logical volume using the provided Runner.
+func (r *Runner) CreateLogicalVolume(ctx context.Context, vgName, lvName string, sizeBytes uint64, logger *zap.Logger) error {
+	if err := r.checkPrivs(); err != nil {
 		return err
 	}
 	if vgName == "" || lvName == "" || sizeBytes == 0 {
 		return fmt.Errorf("invalid parameters")
 	}
-	if err := backend.CreateLogicalVolume(ctx, vgName, lvName, sizeBytes); err != nil {
+	if err := r.backend.CreateLogicalVolume(ctx, vgName, lvName, sizeBytes); err != nil {
 		return fmt.Errorf("failed to create logical volume %s/%s: %w", vgName, lvName, err)
 	}
 	logger.Info("logical volume created", zap.String("volume_group", vgName), zap.String("logical_volume", lvName), zap.Uint64("size_bytes", sizeBytes))

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -21,11 +21,54 @@ const (
 	BLKGETSIZE64 = 0x80081272
 )
 
-var statfsFunc = unix.Statfs
+// Runner bundles dependencies for LVM operations.
+type Runner struct {
+	statfs         func(string, *unix.Statfs_t) error
+	checkPrivs     func() error
+	ioctlGetUint64 func(int, uint) (uint64, error)
+	backend        lvmBackend
+	sysBlockPath   string
+}
 
-var checkPrivs = checkRootPrivileges
+// NewRunner returns a Runner using production dependencies.
+func NewRunner() *Runner {
+	return &Runner{
+		statfs:         unix.Statfs,
+		checkPrivs:     checkRootPrivileges,
+		ioctlGetUint64: ioctlGetUint64,
+		backend:        newLVMBackend(),
+		sysBlockPath:   "/sys/block",
+	}
+}
 
-var ioctlGetUint64Func = ioctlGetUint64
+// NewRunnerWithDeps constructs a Runner with custom dependencies.
+func NewRunnerWithDeps(
+	statfs func(string, *unix.Statfs_t) error,
+	checkPrivs func() error,
+	ioctlGetUint64 func(int, uint) (uint64, error),
+	backend lvmBackend,
+	sysBlockPath string,
+) *Runner {
+	r := NewRunner()
+	if statfs != nil {
+		r.statfs = statfs
+	}
+	if checkPrivs != nil {
+		r.checkPrivs = checkPrivs
+	}
+	if ioctlGetUint64 != nil {
+		r.ioctlGetUint64 = ioctlGetUint64
+	}
+	if backend != nil {
+		r.backend = backend
+	}
+	if sysBlockPath != "" {
+		r.sysBlockPath = sysBlockPath
+	}
+	return r
+}
+
+var defaultRunner = NewRunner()
 
 func checkRootPrivileges() error {
 	if os.Geteuid() != 0 {
@@ -34,114 +77,88 @@ func checkRootPrivileges() error {
 	return nil
 }
 
-// SetPrivilegeChecker overrides the default privilege check function. It
-// returns a restore function to reset the original behavior.
-func SetPrivilegeChecker(fn func() error) func() {
-	orig := checkPrivs
-	if fn == nil {
-		checkPrivs = checkRootPrivileges
-	} else {
-		checkPrivs = fn
-	}
-	return func() { checkPrivs = orig }
-}
-
-// backend is used to execute LVM operations. It can be overridden for tests.
-var backend = newLVMBackend()
-
-// SetBackend overrides the LVM backend. It returns a restore function to reset the original behavior.
-func SetBackend(b lvmBackend) func() {
-	orig := backend
-	if b == nil {
-		backend = newLVMBackend()
-	} else {
-		backend = b
-	}
-	return func() { backend = orig }
-}
-
 func CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string, logger *zap.Logger) error {
-	if err := checkPrivs(); err != nil {
+	return defaultRunner.CreateSnapshot(ctx, lvPath, snapshotName, size, logger)
+}
+
+func (r *Runner) CreateSnapshot(ctx context.Context, lvPath, snapshotName, size string, logger *zap.Logger) error {
+	if err := r.checkPrivs(); err != nil {
 		return err
 	}
-
 	if lvPath == "" || snapshotName == "" || size == "" {
 		return fmt.Errorf("invalid parameters: lvPath, snapshotName, and size must be non-empty")
 	}
-
-	if err := backend.CreateSnapshot(ctx, lvPath, snapshotName, size); err != nil {
+	if err := r.backend.CreateSnapshot(ctx, lvPath, snapshotName, size); err != nil {
 		return fmt.Errorf("failed to create snapshot [%s] for LV %s with size %s: %w",
 			snapshotName, lvPath, size, err)
 	}
-
 	logger.Info("snapshot created successfully",
 		zap.String("lv_path", lvPath),
 		zap.String("snapshot_name", snapshotName),
 		zap.String("size", size))
-
 	return nil
 }
 
 func RemoveSnapshot(ctx context.Context, snapshotPath string, logger *zap.Logger) error {
-	if err := checkPrivs(); err != nil {
+	return defaultRunner.RemoveSnapshot(ctx, snapshotPath, logger)
+}
+
+func (r *Runner) RemoveSnapshot(ctx context.Context, snapshotPath string, logger *zap.Logger) error {
+	if err := r.checkPrivs(); err != nil {
 		return err
 	}
-
 	if snapshotPath == "" {
 		return fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
-
-	if err := backend.RemoveSnapshot(ctx, snapshotPath); err != nil {
+	if err := r.backend.RemoveSnapshot(ctx, snapshotPath); err != nil {
 		return fmt.Errorf("failed to remove snapshot [%s]: %w", snapshotPath, err)
 	}
-
 	logger.Info("snapshot removed successfully",
 		zap.String("snapshot_path", snapshotPath))
-
 	return nil
 }
 
 func GetSnapshotUsage(ctx context.Context, snapshotPath string, logger *zap.Logger) (float64, error) {
-	if err := checkPrivs(); err != nil {
+	return defaultRunner.GetSnapshotUsage(ctx, snapshotPath, logger)
+}
+
+func (r *Runner) GetSnapshotUsage(ctx context.Context, snapshotPath string, logger *zap.Logger) (float64, error) {
+	if err := r.checkPrivs(); err != nil {
 		return 0, err
 	}
-
 	if snapshotPath == "" {
 		return 0, fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
-
-	usage, err := backend.GetSnapshotUsage(ctx, snapshotPath)
+	usage, err := r.backend.GetSnapshotUsage(ctx, snapshotPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get snapshot usage for %s: %w", snapshotPath, err)
 	}
-
 	logger.Info("snapshot usage retrieved",
 		zap.String("snapshot", snapshotPath),
 		zap.Float64("usage_percent", usage))
-
 	return usage, nil
 }
 
 func MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64, interval time.Duration, logger *zap.Logger) error {
-	if err := checkPrivs(); err != nil {
+	return defaultRunner.MonitorSnapshot(ctx, snapshotPath, threshold, interval, logger)
+}
+
+func (r *Runner) MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64, interval time.Duration, logger *zap.Logger) error {
+	if err := r.checkPrivs(); err != nil {
 		return err
 	}
-
 	if snapshotPath == "" {
 		return fmt.Errorf("invalid parameter: snapshotPath must be non-empty")
 	}
-
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-
 	for {
 		select {
 		case <-ticker.C:
-			usage, err := GetSnapshotUsage(ctx, snapshotPath, logger)
+			usage, err := r.GetSnapshotUsage(ctx, snapshotPath, logger)
 			if err != nil {
 				return err
 			}
-
 			if usage >= threshold {
 				logger.Error("snapshot exhausted",
 					zap.String("snapshot", snapshotPath),
@@ -157,20 +174,21 @@ func MonitorSnapshot(ctx context.Context, snapshotPath string, threshold float64
 }
 
 func CheckDiskSpace(mountPoint string, logger *zap.Logger) (uint64, error) {
+	return defaultRunner.CheckDiskSpace(mountPoint, logger)
+}
+
+func (r *Runner) CheckDiskSpace(mountPoint string, logger *zap.Logger) (uint64, error) {
 	var stat unix.Statfs_t
-	if err := statfsFunc(mountPoint, &stat); err != nil {
+	if err := r.statfs(mountPoint, &stat); err != nil {
 		return 0, fmt.Errorf("failed to get disk stats for %q: %w", mountPoint, err)
 	}
-
 	if stat.Bsize < 0 {
 		return 0, fmt.Errorf("negative block size for %q: %d", mountPoint, stat.Bsize)
 	}
-
 	available := stat.Bavail * uint64(stat.Bsize)
 	logger.Debug("disk space check",
 		zap.String("mount_point", mountPoint),
 		zap.Uint64("available_bytes", available))
-
 	return available, nil
 }
 
@@ -184,6 +202,10 @@ func ioctlGetUint64(fd int, req uint) (uint64, error) {
 }
 
 func GetVolumeSize(volumePath string, cache *FDCache, logger *zap.Logger) (uint64, error) {
+	return defaultRunner.GetVolumeSize(volumePath, cache, logger)
+}
+
+func (r *Runner) GetVolumeSize(volumePath string, cache *FDCache, logger *zap.Logger) (uint64, error) {
 	if cache == nil {
 		return 0, fmt.Errorf("fd cache is nil")
 	}
@@ -194,8 +216,7 @@ func GetVolumeSize(volumePath string, cache *FDCache, logger *zap.Logger) (uint6
 	if err != nil {
 		return 0, err
 	}
-
-	size, err := ioctlGetUint64Func(fd, BLKGETSIZE64)
+	size, err := r.ioctlGetUint64(fd, BLKGETSIZE64)
 	if err != nil {
 		if err == unix.ENOTTY {
 			info, statErr := os.Stat(volumePath)
@@ -211,19 +232,14 @@ func GetVolumeSize(volumePath string, cache *FDCache, logger *zap.Logger) (uint6
 			return 0, fmt.Errorf("ioctl BLKGETSIZE64 failed on %q: %w", volumePath, err)
 		}
 	}
-
 	logger.Debug("volume size retrieved",
 		zap.String("volume_path", volumePath),
 		zap.Uint64("size_bytes", size))
-
 	return size, nil
 }
 
-var sysBlockPath = "/sys/block"
-
-func SetSysBlockPath(path string) {
-	sysBlockPath = path
-}
+// SetSysBlockPath overrides the sysfs base path.
+func (r *Runner) SetSysBlockPath(path string) { r.sysBlockPath = path }
 
 type VolumeAttributes struct {
 	Major     int
@@ -277,16 +293,16 @@ func readBoolAttr(sysfsPath, name string, logger *zap.Logger) (bool, error) {
 }
 
 func GetVolumeAttributes(volumePath string, logger *zap.Logger) (*VolumeAttributes, error) {
-	devName := filepath.Base(volumePath)
-	sysfsPath := filepath.Join(sysBlockPath, devName)
+	return defaultRunner.GetVolumeAttributes(volumePath, logger)
+}
 
+func (r *Runner) GetVolumeAttributes(volumePath string, logger *zap.Logger) (*VolumeAttributes, error) {
+	devName := filepath.Base(volumePath)
+	sysfsPath := filepath.Join(r.sysBlockPath, devName)
 	if _, err := os.Stat(sysfsPath); err != nil {
 		return nil, fmt.Errorf("device %s not found in sysfs: %w", devName, err)
 	}
-
 	attrs := &VolumeAttributes{}
-
-	// dev: major:minor
 	if data, err := os.ReadFile(filepath.Join(sysfsPath, "dev")); err == nil {
 		parts := strings.Split(strings.TrimSpace(string(data)), ":")
 		if len(parts) == 2 {
@@ -305,60 +321,49 @@ func GetVolumeAttributes(volumePath string, logger *zap.Logger) (*VolumeAttribut
 			zap.String("attribute", "dev"),
 			zap.Error(err))
 	}
-
-	// size
 	if size, err := readUintAttr(sysfsPath, "size", logger); err == nil {
 		attrs.Size = size
 	}
-
-	// read-only flag
 	if ro, err := readBoolAttr(sysfsPath, "ro", logger); err == nil {
 		attrs.ReadOnly = ro
 	}
-
-	// removable flag
 	if removable, err := readBoolAttr(sysfsPath, "removable", logger); err == nil {
 		attrs.Removable = removable
 	}
-
 	return attrs, nil
 }
 
 func ParseSnapshotSize(sizeStr, volumePath string, cache *FDCache, logger *zap.Logger) (uint64, error) {
-	sizeStr = strings.TrimSpace(sizeStr)
+	return defaultRunner.ParseSnapshotSize(sizeStr, volumePath, cache, logger)
+}
 
+func (r *Runner) ParseSnapshotSize(sizeStr, volumePath string, cache *FDCache, logger *zap.Logger) (uint64, error) {
+	sizeStr = strings.TrimSpace(sizeStr)
 	val, isPercent, err := sizeparse.Parse(sizeStr)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse snapshot size %q: %w", sizeStr, err)
 	}
-
 	if isPercent {
 		if val == 0 || val > 100 {
 			return 0, fmt.Errorf("percentage must be between 0 and 100, got %v", val)
 		}
-
-		volSize, err := GetVolumeSize(volumePath, cache, logger)
+		volSize, err := r.GetVolumeSize(volumePath, cache, logger)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get volume size for %q: %w", volumePath, err)
 		}
-
 		res := float64(volSize) * (float64(val) / 100.0)
 		parsedSize := uint64(res)
 		if float64(parsedSize) != res {
 			return 0, fmt.Errorf("snapshot size %q overflows uint64", sizeStr)
 		}
-
 		logger.Debug("parsed snapshot size from percentage",
 			zap.String("input", sizeStr),
 			zap.Uint64("calculated_bytes", parsedSize))
-
 		return parsedSize, nil
 	}
-
 	logger.Debug("parsed snapshot size",
 		zap.String("input", sizeStr),
 		zap.Uint64("bytes", val))
-
 	return val, nil
 }
 
@@ -381,11 +386,14 @@ func GetVolumeGroupName(lvPath string) (string, error) {
 }
 
 func GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
-	if err := checkPrivs(); err != nil {
+	return defaultRunner.GetVolumeGroupFreeSpace(ctx, vgName)
+}
+
+func (r *Runner) GetVolumeGroupFreeSpace(ctx context.Context, vgName string) (uint64, error) {
+	if err := r.checkPrivs(); err != nil {
 		return 0, err
 	}
-
-	size, err := backend.GetVolumeGroupFreeSpace(ctx, vgName)
+	size, err := r.backend.GetVolumeGroupFreeSpace(ctx, vgName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get free space for VG %s: %w", vgName, err)
 	}
@@ -400,11 +408,14 @@ type VolumeGroup struct {
 
 // ListVolumeGroups returns information about all available volume groups.
 func ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
-	if err := checkPrivs(); err != nil {
+	return defaultRunner.ListVolumeGroups(ctx)
+}
+
+func (r *Runner) ListVolumeGroups(ctx context.Context) ([]VolumeGroup, error) {
+	if err := r.checkPrivs(); err != nil {
 		return nil, err
 	}
-
-	vgs, err := backend.ListVolumeGroups(ctx, nil)
+	vgs, err := r.backend.ListVolumeGroups(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list volume groups: %w", err)
 	}
@@ -419,13 +430,17 @@ type VolumeGroupSelector func([]VolumeGroup) (VolumeGroup, error)
 // selector strategy. If candidates is non-empty, only those volume groups are
 // considered.
 func SelectVolumeGroup(ctx context.Context, candidates []string, selector VolumeGroupSelector) (VolumeGroup, error) {
+	return defaultRunner.SelectVolumeGroup(ctx, candidates, selector)
+}
+
+func (r *Runner) SelectVolumeGroup(ctx context.Context, candidates []string, selector VolumeGroupSelector) (VolumeGroup, error) {
 	if selector == nil {
 		return VolumeGroup{}, fmt.Errorf("selector must not be nil")
 	}
-	if err := checkPrivs(); err != nil {
+	if err := r.checkPrivs(); err != nil {
 		return VolumeGroup{}, err
 	}
-	vgs, err := backend.ListVolumeGroups(ctx, candidates)
+	vgs, err := r.backend.ListVolumeGroups(ctx, candidates)
 	if err != nil {
 		return VolumeGroup{}, err
 	}
@@ -478,9 +493,13 @@ func ByFreeSpaceFit(required uint64) VolumeGroupSelector {
 // that has at least the required amount of free space. If required is zero it
 // behaves like SelectVolumeGroup with ByFreeSpace.
 func SelectVolumeGroupForSize(ctx context.Context, candidates []string, required uint64) (VolumeGroup, error) {
+	return defaultRunner.SelectVolumeGroupForSize(ctx, candidates, required)
+}
+
+func (r *Runner) SelectVolumeGroupForSize(ctx context.Context, candidates []string, required uint64) (VolumeGroup, error) {
 	selector := ByFreeSpace
 	if required > 0 {
 		selector = ByFreeSpaceFit(required)
 	}
-	return SelectVolumeGroup(ctx, candidates, selector)
+	return r.SelectVolumeGroup(ctx, candidates, selector)
 }

--- a/lvm/lvm_test.go
+++ b/lvm/lvm_test.go
@@ -120,18 +120,13 @@ func TestGetVolumeSizeIoctlLarge(t *testing.T) {
 	}
 
 	fiveGiB := uint64(5) * 1024 * 1024 * 1024
-	orig := ioctlGetUint64Func
-	ioctlGetUint64Func = func(fd int, req uint) (uint64, error) {
-		return fiveGiB, nil
-	}
-	defer func() { ioctlGetUint64Func = orig }()
-
+	runner := NewRunnerWithDeps(nil, nil, func(fd int, req uint) (uint64, error) { return fiveGiB, nil }, nil, "")
 	cache, err := NewDeviceFDCache(zap.NewNop())
 	if err != nil {
 		t.Fatalf("NewDeviceFDCache: %v", err)
 	}
 	defer cache.Close()
-	size, err := GetVolumeSize(tmpFile, cache, zap.NewNop())
+	size, err := runner.GetVolumeSize(tmpFile, cache, zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetVolumeSize failed: %v", err)
 	}
@@ -142,8 +137,8 @@ func TestGetVolumeSizeIoctlLarge(t *testing.T) {
 
 func TestGetVolumeAttributes(t *testing.T) {
 	tmpDir := t.TempDir()
-	SetSysBlockPath(tmpDir)
-	defer SetSysBlockPath("/sys/block")
+	runner := NewRunner()
+	runner.SetSysBlockPath(tmpDir)
 
 	devDir := filepath.Join(tmpDir, "testdev")
 	if err := os.Mkdir(devDir, 0755); err != nil {
@@ -163,7 +158,7 @@ func TestGetVolumeAttributes(t *testing.T) {
 		}
 	}
 
-	got, err := GetVolumeAttributes("/dev/testdev", zap.NewNop())
+	got, err := runner.GetVolumeAttributes("/dev/testdev", zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetVolumeAttributes failed: %v", err)
 	}

--- a/lvm/snapshot_pressure_test.go
+++ b/lvm/snapshot_pressure_test.go
@@ -44,8 +44,9 @@ func TestSnapshotPressureAbortCleanup(t *testing.T) {
 	cfg.SnapshotSize = "1G"
 
 	removed := false
+	lRunner := lvm.NewRunnerWithDeps(nil, func() error { return nil }, nil, &pressureBackend{usage: 90}, "")
 	monitor := func(ctx context.Context, path string, threshold float64, _ time.Duration, logger *zap.Logger) error {
-		return lvm.MonitorSnapshot(ctx, path, threshold, 10*time.Millisecond, logger)
+		return lRunner.MonitorSnapshot(ctx, path, threshold, 10*time.Millisecond, logger)
 	}
 	r := client.NewRunnerWithDeps(
 		func(string, string, *lvm.FDCache, *zap.Logger) (uint64, error) { return 1024, nil },
@@ -56,11 +57,6 @@ func TestSnapshotPressureAbortCleanup(t *testing.T) {
 		func(context.Context, string, *zap.Logger) error { removed = true; return nil },
 		nil,
 	)
-
-	restoreBackend := lvm.SetBackend(&pressureBackend{usage: 90})
-	t.Cleanup(restoreBackend)
-	restorePriv := lvm.SetPrivilegeChecker(func() error { return nil })
-	t.Cleanup(restorePriv)
 
 	logger := zap.NewNop()
 	snap, monitorCh, cleanup, err := r.PrepareSnapshot(context.Background(), cfg, "/dev/vg/origin", logger)

--- a/lvm/snapshot_test.go
+++ b/lvm/snapshot_test.go
@@ -47,24 +47,19 @@ func (f *mockBackend) CreateLogicalVolume(context.Context, string, string, uint6
 }
 
 func TestCreateAndRemoveSnapshot(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
-
 	fb := &mockBackend{}
-	restore := SetBackend(fb)
-	t.Cleanup(restore)
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
 
 	lvPath := "/dev/vg0/origin"
 	snapName := "snap"
 	size := "1G"
 
 	logger := zap.NewNop()
-	if err := CreateSnapshot(context.Background(), lvPath, snapName, size, logger); err != nil {
+	if err := r.CreateSnapshot(context.Background(), lvPath, snapName, size, logger); err != nil {
 		t.Fatalf("CreateSnapshot failed: %v", err)
 	}
 	snapPath := "/dev/vg0/" + snapName
-	if err := RemoveSnapshot(context.Background(), snapPath, logger); err != nil {
+	if err := r.RemoveSnapshot(context.Background(), snapPath, logger); err != nil {
 		t.Fatalf("RemoveSnapshot failed: %v", err)
 	}
 
@@ -80,25 +75,17 @@ func TestCreateAndRemoveSnapshot(t *testing.T) {
 }
 
 func TestCreateSnapshotPrivilegeError(t *testing.T) {
-	orig := checkPrivs
 	errPriv := errors.New("privileges required")
-	checkPrivs = func() error { return errPriv }
-	t.Cleanup(func() { checkPrivs = orig })
-
-	err := CreateSnapshot(context.Background(), "/dev/vg0/origin", "snap", "1G", zap.NewNop())
+	r := NewRunnerWithDeps(nil, func() error { return errPriv }, nil, nil, "")
+	err := r.CreateSnapshot(context.Background(), "/dev/vg0/origin", "snap", "1G", zap.NewNop())
 	if !errors.Is(err, errPriv) {
 		t.Fatalf("expected privilege error, got %v", err)
 	}
 }
 
 func TestCreateSnapshotContextCancel(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
-
 	fb := &mockBackend{}
-	restore := SetBackend(fb)
-	t.Cleanup(restore)
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
@@ -107,7 +94,7 @@ func TestCreateSnapshotContextCancel(t *testing.T) {
 	snapName := "snap"
 	size := "1G"
 
-	err := CreateSnapshot(ctx, lvPath, snapName, size, zap.NewNop())
+	err := r.CreateSnapshot(ctx, lvPath, snapName, size, zap.NewNop())
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}

--- a/lvm/snapshot_usage_test.go
+++ b/lvm/snapshot_usage_test.go
@@ -30,15 +30,9 @@ func (f *usageBackend) CreateLogicalVolume(context.Context, string, string, uint
 }
 
 func TestGetSnapshotUsage(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
-
 	fb := &usageBackend{usage: 75.5}
-	restore := SetBackend(fb)
-	t.Cleanup(restore)
-
-	usage, err := GetSnapshotUsage(context.Background(), "/dev/vg0/snap", zap.NewNop())
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
+	usage, err := r.GetSnapshotUsage(context.Background(), "/dev/vg0/snap", zap.NewNop())
 	if err != nil {
 		t.Fatalf("GetSnapshotUsage failed: %v", err)
 	}
@@ -48,30 +42,21 @@ func TestGetSnapshotUsage(t *testing.T) {
 }
 
 func TestMonitorSnapshot(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
-
 	fb := &usageBackend{usage: 90}
-	restore := SetBackend(fb)
-	t.Cleanup(restore)
-
-	err := MonitorSnapshot(context.Background(), "/dev/vg0/snap", 80, 10*time.Millisecond, zap.NewNop())
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
+	err := r.MonitorSnapshot(context.Background(), "/dev/vg0/snap", 80, 10*time.Millisecond, zap.NewNop())
 	if err == nil {
 		t.Fatalf("MonitorSnapshot expected error, got nil")
 	}
 }
 
 func TestCheckDiskSpace(t *testing.T) {
-	orig := statfsFunc
-	statfsFunc = func(_ string, stat *unix.Statfs_t) error {
+	r := NewRunnerWithDeps(func(_ string, stat *unix.Statfs_t) error {
 		stat.Bavail = 100
 		stat.Bsize = 4096
 		return nil
-	}
-	defer func() { statfsFunc = orig }()
-
-	available, err := CheckDiskSpace("/mnt", zap.NewNop())
+	}, nil, nil, nil, "")
+	available, err := r.CheckDiskSpace("/mnt", zap.NewNop())
 	if err != nil {
 		t.Fatalf("CheckDiskSpace failed: %v", err)
 	}

--- a/lvm/vg_select_test.go
+++ b/lvm/vg_select_test.go
@@ -43,14 +43,9 @@ func (f *vgBackend) ListVolumeGroups(_ context.Context, candidates []string) ([]
 func (f *vgBackend) CreateLogicalVolume(context.Context, string, string, uint64) error { return nil }
 
 func TestSelectVolumeGroup(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
 	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
-	restore := SetBackend(fb)
-	defer restore()
-
-	vg, err := SelectVolumeGroup(context.Background(), nil, ByFreeSpace)
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
+	vg, err := r.SelectVolumeGroup(context.Background(), nil, ByFreeSpace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,7 +53,7 @@ func TestSelectVolumeGroup(t *testing.T) {
 		t.Fatalf("expected vg1 with 200, got %s with %d", vg.Name, vg.Free)
 	}
 
-	vg, err = SelectVolumeGroup(context.Background(), []string{"vg0"}, ByFreeSpace)
+	vg, err = r.SelectVolumeGroup(context.Background(), []string{"vg0"}, ByFreeSpace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,20 +61,16 @@ func TestSelectVolumeGroup(t *testing.T) {
 		t.Fatalf("expected vg0 with 100, got %s with %d", vg.Name, vg.Free)
 	}
 
-	if _, err := SelectVolumeGroup(context.Background(), []string{"vg2"}, ByFreeSpace); err == nil {
+	if _, err := r.SelectVolumeGroup(context.Background(), []string{"vg2"}, ByFreeSpace); err == nil {
 		t.Fatalf("expected error for unknown vg")
 	}
 }
 
 func TestSelectVolumeGroupQueriesCandidates(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
 	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
-	restore := SetBackend(fb)
-	defer restore()
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
 
-	if _, err := SelectVolumeGroup(context.Background(), []string{"vg0"}, ByFreeSpace); err != nil {
+	if _, err := r.SelectVolumeGroup(context.Background(), []string{"vg0"}, ByFreeSpace); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !reflect.DeepEqual(fb.lastArgs, []string{"vg0"}) {
@@ -88,12 +79,8 @@ func TestSelectVolumeGroupQueriesCandidates(t *testing.T) {
 }
 
 func TestSelectVolumeGroupCustomSelector(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
 	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
-	restore := SetBackend(fb)
-	defer restore()
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
 
 	selector := func(vgs []VolumeGroup) (VolumeGroup, error) {
 		for _, vg := range vgs {
@@ -104,7 +91,7 @@ func TestSelectVolumeGroupCustomSelector(t *testing.T) {
 		return VolumeGroup{}, fmt.Errorf("no suitable volume group")
 	}
 
-	vg, err := SelectVolumeGroup(context.Background(), nil, selector)
+	vg, err := r.SelectVolumeGroup(context.Background(), nil, selector)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,14 +101,10 @@ func TestSelectVolumeGroupCustomSelector(t *testing.T) {
 }
 
 func TestSelectVolumeGroupForSize(t *testing.T) {
-	orig := checkPrivs
-	checkPrivs = func() error { return nil }
-	t.Cleanup(func() { checkPrivs = orig })
 	fb := &vgBackend{vgs: []VolumeGroup{{Name: "vg0", Free: 100}, {Name: "vg1", Free: 200}}}
-	restore := SetBackend(fb)
-	defer restore()
+	r := NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
 
-	vg, err := SelectVolumeGroupForSize(context.Background(), nil, 150)
+	vg, err := r.SelectVolumeGroupForSize(context.Background(), nil, 150)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -129,7 +112,7 @@ func TestSelectVolumeGroupForSize(t *testing.T) {
 		t.Fatalf("expected vg1, got %s", vg.Name)
 	}
 
-	if _, err := SelectVolumeGroupForSize(context.Background(), nil, 250); err == nil {
+	if _, err := r.SelectVolumeGroupForSize(context.Background(), nil, 250); err == nil {
 		t.Fatalf("expected error when no vg has enough space")
 	}
 }

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -68,7 +68,7 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 
 	var walRanges []Range
 	if cfg.ResumeState != "" {
-		t.wal, walRanges, err = OpenWAL(cfg.ResumeState+".wal", size, id, epoch)
+		t.wal, walRanges, err = OpenWAL(cfg.ResumeState+".wal", size, id, epoch, nil)
 		if err != nil {
 			return err
 		}

--- a/transfer/block_coalesce_linux_test.go
+++ b/transfer/block_coalesce_linux_test.go
@@ -39,19 +39,19 @@ func TestBlockWriterCoalescesZeroBlocks(t *testing.T) {
 	stream.Write(hdr)
 	stream.Write(data)
 
-	bw, err := newBlockWriter(cfg, dest, nil, false, nil, zap.NewNop(), nil, nil)
-	if err != nil {
-		t.Fatalf("newBlockWriter: %v", err)
-	}
-	orig := punchHoleFunc
+	deps := *DefaultDeps
+	orig := deps.PunchHole
 	var calls int
 	var length int
-	punchHoleFunc = func(f *os.File, off uint64, l int) error {
+	deps.PunchHole = func(f *os.File, off uint64, l int) error {
 		calls++
 		length = l
 		return orig(f, off, l)
 	}
-	defer func() { punchHoleFunc = orig }()
+	bw, err := newBlockWriterWithDeps(cfg, dest, nil, false, nil, zap.NewNop(), nil, nil, &deps)
+	if err != nil {
+		t.Fatalf("newBlockWriter: %v", err)
+	}
 
 	if _, err := bw.write(bufio.NewReader(bytes.NewReader(stream.Bytes()))); err != nil {
 		t.Fatalf("write: %v", err)

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -160,7 +160,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 					}
 					bw.applied = append(bw.applied, r)
 				}
-				if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
+				if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger, bw.deps); err != nil {
 					return total, err
 				}
 				holes = append(holes, Range{Start: zeroStart, End: zeroStart + zeroLen})
@@ -186,7 +186,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 				}
 				bw.applied = append(bw.applied, r)
 			}
-			if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
+			if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger, bw.deps); err != nil {
 				return total, err
 			}
 			holes = append(holes, Range{Start: zeroStart, End: zeroStart + zeroLen})
@@ -222,7 +222,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 				return total, err
 			}
 		}
-		if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger); err != nil {
+		if err := writeZeroRange(bw.cfg, bw.dest, zeroStart, zeroLen, bw.logger, bw.deps); err != nil {
 			return total, err
 		}
 		holes = append(holes, Range{Start: zeroStart, End: zeroStart + zeroLen})

--- a/transfer/chunk_reader_test.go
+++ b/transfer/chunk_reader_test.go
@@ -90,31 +90,28 @@ func TestPunchHoleENOTSUPDisables(t *testing.T) {
 	}
 	defer f.Close()
 
-	orig := punchHoleFunc
 	var calls int
-	punchHoleFunc = func(_ *os.File, _ uint64, _ int) error {
+	deps := *DefaultDeps
+	deps.PunchHole = func(_ *os.File, _ uint64, _ int) error {
 		calls++
 		return unix.ENOTSUP
 	}
 	punchHoleDisabled.Store(false)
-	defer func() {
-		punchHoleFunc = orig
-		punchHoleDisabled.Store(false)
-	}()
+	defer punchHoleDisabled.Store(false)
 
 	cfg := &config.Config{BlockSize: 4096}
 	core, obs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 
-	if err := writeZeroBlock(cfg, f, 0, logger); err != nil {
+	if err := writeZeroBlock(cfg, f, 0, logger, &deps); err != nil {
 		t.Fatalf("writeZeroBlock: %v", err)
 	}
-	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), logger); err != nil {
+	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), logger, &deps); err != nil {
 		t.Fatalf("writeZeroBlock: %v", err)
 	}
 
 	if calls != 1 {
-		t.Fatalf("expected punchHoleFunc called once, got %d", calls)
+		t.Fatalf("expected PunchHole called once, got %d", calls)
 	}
 	if obs.Len() != 1 {
 		t.Fatalf("expected one warning, got %d", obs.Len())

--- a/transfer/deps.go
+++ b/transfer/deps.go
@@ -11,6 +11,7 @@ type Deps struct {
 	CreateStateFile    func(string) (io.WriteCloser, error)
 	DetectBestStrategy func() string
 	FdatasyncFile      func(*os.File) error
+	PunchHole          func(*os.File, uint64, int) error
 }
 
 func defaultCreateStateFile(name string) (io.WriteCloser, error) {
@@ -37,4 +38,5 @@ var DefaultDeps = &Deps{
 	CreateStateFile:    defaultCreateStateFile,
 	DetectBestStrategy: detectBestStrategy,
 	FdatasyncFile:      fdatasync,
+	PunchHole:          punchHole,
 }

--- a/transfer/resume_verify_integration_test.go
+++ b/transfer/resume_verify_integration_test.go
@@ -31,7 +31,7 @@ func TestResumeVerifyMismatch(t *testing.T) {
 	man := filepath.Join(dir, "dest.man")
 	buildManifest(t, dest, man, "uuid", uint64(len(data)))
 	resume := filepath.Join(dir, "resume.state")
-	w, _, err := OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0)
+	w, _, err := OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/resume_wal_integration_test.go
+++ b/transfer/resume_wal_integration_test.go
@@ -148,7 +148,7 @@ func TestResumeMidTransfer(t *testing.T) {
 	}
 
 	// Ensure WAL contains two sequential entries.
-	w, ranges, err := OpenWAL(walPath, uint64(2*blockSize), "uuid", 0)
+	w, ranges, err := OpenWAL(walPath, uint64(2*blockSize), "uuid", 0, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/sparse_never_linux_test.go
+++ b/transfer/sparse_never_linux_test.go
@@ -74,7 +74,7 @@ func TestSparseNeverLoopback(t *testing.T) {
 				t.Fatalf("write prefix: %v", err)
 			}
 			cfg := &config.Config{BlockSize: bs, Sparse: "never"}
-			if err := writeZeroBlock(cfg, dest, uint64(bs), zap.NewNop()); err != nil {
+			if err := writeZeroBlock(cfg, dest, uint64(bs), zap.NewNop(), DefaultDeps); err != nil {
 				t.Fatalf("writeZeroBlock: %v", err)
 			}
 			off, err := unix.Seek(int(dest.Fd()), int64(bs), unix.SEEK_DATA)

--- a/transfer/wal.go
+++ b/transfer/wal.go
@@ -56,11 +56,18 @@ type walFile interface {
 type WAL struct {
 	f      walFile
 	header walHeader
+	deps   *WALDeps
 }
 
-// syncDirFunc flushes a directory to stable storage. It is a variable to allow tests
-// to stub the implementation.
-var syncDirFunc = syncDir
+// WALDeps bundles filesystem helpers for the WAL.
+type WALDeps struct {
+	syncDir func(string) error
+}
+
+// NewWALDeps returns production dependencies.
+func NewWALDeps() *WALDeps {
+	return &WALDeps{syncDir: syncDir}
+}
 
 func walHeaderMAC(h *walHeader) [32]byte {
 	var buf [8 + 8 + 8 + 64]byte
@@ -83,7 +90,10 @@ func walHeaderMACV0(h *walHeaderV0) [32]byte {
 // returns any fully committed ranges. If a crash left a partially written
 // entry, the WAL is truncated to the last complete record and positioned for
 // further appends.
-func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []Range, error) {
+func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALDeps) (*WAL, []Range, error) {
+	if deps == nil {
+		deps = NewWALDeps()
+	}
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, nil, err
@@ -93,7 +103,7 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []R
 		f.Close()
 		return nil, nil, err
 	}
-	w := &WAL{f: f}
+	w := &WAL{f: f, deps: deps}
 	if st.Size() == 0 {
 		w.header.Version = walVersion
 		w.header.Size = size
@@ -121,7 +131,7 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64) (*WAL, []R
 			f.Close()
 			return nil, nil, err
 		}
-		if err := syncDirFunc(filepath.Dir(path)); err != nil {
+		if err := deps.syncDir(filepath.Dir(path)); err != nil {
 			f.Close()
 			return nil, nil, err
 		}
@@ -319,7 +329,7 @@ func (w *WAL) Append(r Range) error {
 		return err
 	}
 	w.f = nf
-	return syncDirFunc(filepath.Dir(name))
+	return w.deps.syncDir(filepath.Dir(name))
 }
 
 // Sync flushes the WAL to stable storage.
@@ -345,7 +355,7 @@ func (w *WAL) Close() error {
 		return err
 	}
 	w.f = nil
-	return syncDirFunc(filepath.Dir(name))
+	return w.deps.syncDir(filepath.Dir(name))
 }
 
 func syncDir(path string) error {
@@ -355,15 +365,4 @@ func syncDir(path string) error {
 	}
 	defer d.Close()
 	return d.Sync()
-}
-
-// SetSyncDirFunc overrides the directory sync implementation. It returns a restore function.
-func SetSyncDirFunc(fn func(string) error) func() {
-	orig := syncDirFunc
-	if fn == nil {
-		syncDirFunc = syncDir
-	} else {
-		syncDirFunc = fn
-	}
-	return func() { syncDirFunc = orig }
 }

--- a/transfer/wal_crash_test.go
+++ b/transfer/wal_crash_test.go
@@ -12,7 +12,7 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("truncate_mid_entry", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, _, err := OpenWAL(path, 128, "dev", 1)
+		w, _, err := OpenWAL(path, 128, "dev", 1, nil)
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -34,7 +34,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatalf("close file: %v", err)
 		}
-		w2, ranges, err := OpenWAL(path, 128, "dev", 1)
+		w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}
@@ -47,7 +47,7 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("omit_fsync", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, _, err := OpenWAL(path, 128, "dev", 1)
+		w, _, err := OpenWAL(path, 128, "dev", 1, nil)
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -66,7 +66,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := os.Truncate(path, walHeaderSize+16); err != nil {
 			t.Fatalf("truncate: %v", err)
 		}
-		w2, ranges, err := OpenWAL(path, 128, "dev", 1)
+		w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}

--- a/transfer/wal_resume_test.go
+++ b/transfer/wal_resume_test.go
@@ -16,7 +16,7 @@ import (
 func TestWALCommitFsync(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1)
+	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestWALCommitFsync(t *testing.T) {
 	if err := w.f.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	w2, ranges, err := OpenWAL(path, 128, "dev", 1)
+	w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestResumeValidation(t *testing.T) {
 func TestWALHeaderCorruption(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1)
+	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestWALHeaderCorruption(t *testing.T) {
 		t.Fatalf("corrupt header: %v", err)
 	}
 	f.Close()
-	if _, _, err := OpenWAL(path, 128, "dev", 1); err == nil {
+	if _, _, err := OpenWAL(path, 128, "dev", 1, nil); err == nil {
 		t.Fatalf("expected header corruption error")
 	}
 }
@@ -93,7 +93,7 @@ func TestWALHeaderCorruption(t *testing.T) {
 func TestWALDeviceIDCorruption(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1)
+	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestWALDeviceIDCorruption(t *testing.T) {
 		t.Fatalf("corrupt device id: %v", err)
 	}
 	f.Close()
-	if _, _, err := OpenWAL(path, 128, "dev", 1); err == nil {
+	if _, _, err := OpenWAL(path, 128, "dev", 1, nil); err == nil {
 		t.Fatalf("expected device id corruption error")
 	}
 }
@@ -117,7 +117,7 @@ func TestWALDeviceIDCorruption(t *testing.T) {
 func TestWALDetectsUnsyncedEntry(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1)
+	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestWALDetectsUnsyncedEntry(t *testing.T) {
 	if err := w.f.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	w2, ranges, err := OpenWAL(path, 128, "dev", 1)
+	w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}

--- a/transfer/wal_test.go
+++ b/transfer/wal_test.go
@@ -11,18 +11,18 @@ import (
 func TestWALMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1)
+	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
 	w.Close()
-	if _, _, err := OpenWAL(path, 101, "dev", 1); err == nil {
+	if _, _, err := OpenWAL(path, 101, "dev", 1, nil); err == nil {
 		t.Fatalf("expected size mismatch error")
 	}
-	if _, _, err := OpenWAL(path, 100, "dev2", 1); err == nil {
+	if _, _, err := OpenWAL(path, 100, "dev2", 1, nil); err == nil {
 		t.Fatalf("expected device mismatch error")
 	}
-	if _, _, err := OpenWAL(path, 100, "dev", 2); err == nil {
+	if _, _, err := OpenWAL(path, 100, "dev", 2, nil); err == nil {
 		t.Fatalf("expected epoch mismatch error")
 	}
 }
@@ -30,7 +30,7 @@ func TestWALMismatch(t *testing.T) {
 func TestWALRecovery(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1)
+	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestWALRecovery(t *testing.T) {
 		t.Fatalf("append: %v", err)
 	}
 	w.Close()
-	w, ranges, err := OpenWAL(path, 100, "dev", 1)
+	w, ranges, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestWALRecovery(t *testing.T) {
 func TestWALTruncatedHeader(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1)
+	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestWALTruncatedHeader(t *testing.T) {
 	if err := os.Truncate(path, 10); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
-	if _, _, err := OpenWAL(path, 100, "dev", 1); err == nil {
+	if _, _, err := OpenWAL(path, 100, "dev", 1, nil); err == nil {
 		t.Fatalf("expected truncated header error")
 	}
 }
@@ -72,7 +72,7 @@ func TestWALTruncatedHeader(t *testing.T) {
 func TestWALPartialWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1)
+	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestWALPartialWrite(t *testing.T) {
 	if err := f.Close(); err != nil {
 		t.Fatalf("close file: %v", err)
 	}
-	w2, ranges, err := OpenWAL(path, 100, "dev", 1)
+	w2, ranges, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -116,17 +116,16 @@ func TestWALPartialWrite(t *testing.T) {
 func TestWALSyncDirAppend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1)
+	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
 	stubErr := errors.New("syncdir fail")
 	var calls int
-	restore := SetSyncDirFunc(func(string) error {
+	w.deps = &WALDeps{syncDir: func(string) error {
 		calls++
 		return stubErr
-	})
-	defer restore()
+	}}
 	if err := w.Append(Range{Start: 0, End: 1}); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -52,7 +52,7 @@ func TestWALVerifySuccess(t *testing.T) {
 	man := filepath.Join(dir, "man")
 	buildManifest(t, dev, man, "uuid", uint64(len(data)))
 	walPath := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0)
+	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestWALVerifyMismatch(t *testing.T) {
 	man := filepath.Join(dir, "man")
 	buildManifest(t, dev, man, "uuid", uint64(len(data)))
 	walPath := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0)
+	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/wal_version_test.go
+++ b/transfer/wal_version_test.go
@@ -10,7 +10,7 @@ import (
 func TestWALVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1)
+	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestWALVersionMismatch(t *testing.T) {
 		t.Fatalf("write header: %v", err)
 	}
 	f.Close()
-	if _, _, err := OpenWAL(path, 100, "dev", 1); err == nil {
+	if _, _, err := OpenWAL(path, 100, "dev", 1, nil); err == nil {
 		t.Fatalf("expected version mismatch error")
 	}
 }
@@ -69,7 +69,7 @@ func TestWALUpgrade(t *testing.T) {
 		t.Fatalf("write entry: %v", err)
 	}
 	f.Close()
-	w, ranges, err := OpenWAL(path, 100, "dev", 1)
+	w, ranges, err := OpenWAL(path, 100, "dev", 1, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/zero.go
+++ b/transfer/zero.go
@@ -21,9 +21,6 @@ var zeroBufCache sync.Map // map[int][]byte
 // zeroHashCache stores BLAKE3 hashes of zero-filled buffers keyed by size.
 var zeroHashCache sync.Map // map[int][32]byte
 
-// punchHoleFunc allows tests to stub punchHole behavior.
-var punchHoleFunc = punchHole
-
 // punchHoleDisabled marks whether punchHole should be skipped after ENOTSUP.
 var punchHoleDisabled atomic.Bool
 
@@ -55,9 +52,12 @@ func isAllZero(b []byte) bool {
 // cfg.Sparse is "never". If the filesystem does not support hole punching it
 // falls back to writing a zero filled buffer. The buffer respects the O_DIRECT
 // setting by using aligned allocations when necessary.
-func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *zap.Logger) error {
+func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *zap.Logger, deps *Deps) error {
+	if deps == nil {
+		deps = DefaultDeps
+	}
 	if cfg.Sparse != "never" && !punchHoleDisabled.Load() {
-		if err := punchHoleFunc(dest, offset, cfg.BlockSize); err == nil {
+		if err := deps.PunchHole(dest, offset, cfg.BlockSize); err == nil {
 			return nil
 		} else if errors.Is(err, unix.ENOTSUP) {
 			if punchHoleDisabled.CompareAndSwap(false, true) {
@@ -82,12 +82,15 @@ func writeZeroBlock(cfg *config.Config, dest *os.File, offset uint64, logger *za
 // writeZeroRange attempts to punch a sparse hole spanning length bytes starting
 // at offset. When hole punching is unsupported, it falls back to writing zeros
 // for the entire range using a reusable buffer.
-func writeZeroRange(cfg *config.Config, dest *os.File, offset uint64, length uint64, logger *zap.Logger) error {
+func writeZeroRange(cfg *config.Config, dest *os.File, offset uint64, length uint64, logger *zap.Logger, deps *Deps) error {
 	if length == 0 {
 		return nil
 	}
+	if deps == nil {
+		deps = DefaultDeps
+	}
 	if cfg.Sparse != "never" && !punchHoleDisabled.Load() {
-		if err := punchHoleFunc(dest, offset, int(length)); err == nil {
+		if err := deps.PunchHole(dest, offset, int(length)); err == nil {
 			return nil
 		} else if errors.Is(err, unix.ENOTSUP) {
 			if punchHoleDisabled.CompareAndSwap(false, true) {

--- a/transfer/zero_test.go
+++ b/transfer/zero_test.go
@@ -54,7 +54,7 @@ func TestWriteZeroBlockPunchesHole(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), zap.NewNop()); err != nil {
+	if err := writeZeroBlock(cfg, f, uint64(cfg.BlockSize), zap.NewNop(), DefaultDeps); err != nil {
 		t.Fatalf("writeZeroBlock: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- refactor device detection to use Runner for raw opens
- pass WAL and zero helpers through structs for testable dependencies
- wrap LVM operations in a Runner with injectable backends

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused-parameter, package-comments, etc.)*
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_68a631d6e3588323b4510c22e67e36df