### PR TITLE
ci: enable arm64 integration tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Go test (race + cover)
         run: go test -race -coverprofile=coverage.out ./...
 
-      - name: Integration tests (PR, amd64 only)
-        if: github.event_name == 'pull_request' && startsWith(matrix.os, 'ubuntu-') && !contains(matrix.os, 'arm64')
+      - name: Integration tests (PR)
+        if: github.event_name == 'pull_request' && startsWith(matrix.os, 'ubuntu-')
         run: |
           if [ -f Makefile ] && grep -q '^integration:' Makefile; then
             make integration

--- a/.github/workflows/loopback-integration.yml
+++ b/.github/workflows/loopback-integration.yml
@@ -14,7 +14,10 @@ permissions:
 
 jobs:
   loopback:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm64]
+    runs-on: ${{ matrix.os }}
     container:
       image: ubuntu:24.04
       options: --cap-add SYS_ADMIN


### PR DESCRIPTION
## Summary
- run go integration tests on both amd64 and arm64 runners
- run loopback integration workflow on arm64 as well

## Testing
- `go build ./...` *(fails: timed out)*
- `go test -coverprofile=coverage.out ./...` *(fails: timed out)*
- `golangci-lint run` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a1644f08323ba5de746ab62e004