### PR TITLE
test: add xfs freeze/thaw scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docs-check:
 test-race:
 > go test -race ./...
 
-integration:
+integration: integration/offline_enforcement.sh
 > go test -tags=integration ./...
 
 release:

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -179,6 +179,8 @@ Example scripts in this repository:
 - [fsfreeze-freeze.sh](fsfreeze-freeze.sh)
 - [fsfreeze-thaw.sh](fsfreeze-thaw.sh)
 
+Integration tests run these hooks on both ext4 and XFS loopback filesystems.
+
 Use them together:
 
 ```sh

--- a/integration/offline_enforcement.sh
+++ b/integration/offline_enforcement.sh
@@ -2,17 +2,7 @@
 set -euo pipefail
 
 TMPDIR=$(mktemp -d)
-IMG="$TMPDIR/src.img"
-MNT="$TMPDIR/mnt"
-LOOP=""
 cleanup() {
-  set +e
-  if mountpoint -q "$MNT"; then
-    umount "$MNT" >/dev/null 2>&1
-  fi
-  if [ -n "$LOOP" ]; then
-    losetup -d "$LOOP" >/dev/null 2>&1
-  fi
   rm -rf "$TMPDIR"
 }
 trap cleanup EXIT
@@ -20,31 +10,66 @@ trap cleanup EXIT
 BIN="$TMPDIR/lvmsync"
 go build -o "$BIN" .
 
-dd if=/dev/zero of="$IMG" bs=1M count=16
-LOOP=$(losetup --find --show "$IMG")
-mkfs.ext4 -q "$LOOP"
-mkdir "$MNT"
-mount "$LOOP" "$MNT"
-DEST="$TMPDIR/dest.img"
-truncate -s 16M "$DEST"
+run_fs() (
+  set -euo pipefail
+  FS="$1"
+  IMG="$TMPDIR/src-${FS}.img"
+  MNT="$TMPDIR/mnt-${FS}"
+  LOOP=""
+  cleanup_fs() {
+    set +e
+    if mountpoint -q "$MNT"; then
+      umount "$MNT" >/dev/null 2>&1
+    fi
+    if [ -n "$LOOP" ]; then
+      losetup -d "$LOOP" >/dev/null 2>&1
+    fi
+    rm -f "$IMG"
+    rmdir "$MNT" 2>/dev/null || true
+  }
+  trap cleanup_fs EXIT
 
-# Scenario A: no freeze/thaw commands, expect ErrPrecondition exit code
-set +e
-"$BIN" --dry-run --transport=rsync "$LOOP" "$DEST" >/tmp/offline_a.log 2>&1
-STATUS=$?
-set -e
-if [ "$STATUS" -ne 80 ]; then
-  echo "expected exit code 80, got $STATUS"
-  cat /tmp/offline_a.log
-  exit 1
-fi
+  dd if=/dev/zero of="$IMG" bs=1M count=16
+  LOOP=$(losetup --find --show "$IMG")
+  case "$FS" in
+    ext4)
+      mkfs.ext4 -q "$LOOP"
+      ;;
+    xfs)
+      mkfs.xfs -f -q "$LOOP"
+      ;;
+    *)
+      echo "unsupported fs: $FS" >&2
+      exit 1
+      ;;
+  esac
 
-# Scenario B: provide freeze and thaw commands, expect success
-FREEZE_CMD="$(pwd)/docs/fsfreeze-freeze.sh $MNT"
-THAW_CMD="$(pwd)/docs/fsfreeze-thaw.sh $MNT"
-"$BIN" --dry-run --transport=rsync --force --allow-overwrite --yes-i-know \
-  --fs-freeze-command "$FREEZE_CMD" \
-  --fs-thaw-command "$THAW_CMD" \
-  "$LOOP" "$DEST"
+  mkdir "$MNT"
+  mount "$LOOP" "$MNT"
+  DEST="$TMPDIR/dest-${FS}.img"
+  truncate -s 16M "$DEST"
+
+  # Scenario A: no freeze/thaw commands, expect ErrPrecondition exit code
+  set +e
+  "$BIN" --dry-run --transport=rsync "$LOOP" "$DEST" >/tmp/offline_${FS}_a.log 2>&1
+  STATUS=$?
+  set -e
+  if [ "$STATUS" -ne 80 ]; then
+    echo "expected exit code 80, got $STATUS for $FS"
+    cat /tmp/offline_${FS}_a.log
+    exit 1
+  fi
+
+  # Scenario B: provide freeze and thaw commands, expect success
+  FREEZE_CMD="$(pwd)/docs/fsfreeze-freeze.sh $MNT"
+  THAW_CMD="$(pwd)/docs/fsfreeze-thaw.sh $MNT"
+  "$BIN" --dry-run --transport=rsync --force --allow-overwrite --yes-i-know \
+    --fs-freeze-command "$FREEZE_CMD" \
+    --fs-thaw-command "$THAW_CMD" \
+    "$LOOP" "$DEST"
+)
+
+run_fs ext4
+run_fs xfs
 
 exit 0


### PR DESCRIPTION
## Summary
- extend offline enforcement test to exercise xfs loop devices
- run integration tests via updated Makefile target
- document ext4 and xfs coverage

## Testing
- `go test -tags=integration ./...` *(fails: run redeclared)*
- `go test -tags=integration ./integration/offline_enforcement_test.go` *(fails: mount permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a188f5c8323b6fe06b424a3035a