### PR TITLE
Validate dedup mode when loading resume state

### DIFF
--- a/integration/resume_dedup_mismatch.sh
+++ b/integration/resume_dedup_mismatch.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+SRC_LOOP=""
+DST_LOOP=""
+cleanup() {
+  set +e
+  lvremove -f vgsrc/snap vgsrc/origin vgd/dest >/dev/null 2>&1
+  vgremove -f vgsrc vgd >/dev/null 2>&1
+  if [ -n "$SRC_LOOP" ]; then
+    pvremove -ff "$SRC_LOOP" >/dev/null 2>&1
+    losetup -d "$SRC_LOOP" >/dev/null 2>&1
+  fi
+  if [ -n "$DST_LOOP" ]; then
+    pvremove -ff "$DST_LOOP" >/dev/null 2>&1
+    losetup -d "$DST_LOOP" >/dev/null 2>&1
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+BIN="$TMPDIR/lvmsync"
+go build -o "$BIN" .
+
+# Prepare source LV
+SRC_IMG="$TMPDIR/src.img"
+dd if=/dev/urandom of="$SRC_IMG" bs=1M count=64
+SRC_LOOP=$(losetup --find --show "$SRC_IMG")
+pvcreate -ffy "$SRC_LOOP"
+vgcreate vgsrc "$SRC_LOOP"
+lvcreate -n origin -L 32M vgsrc
+dd if=/dev/urandom of=/dev/vgsrc/origin bs=1M count=32
+lvcreate -s -n snap -L 32M vgsrc/origin
+
+# Prepare destination LV
+DST_IMG="$TMPDIR/dst.img"
+dd if=/dev/zero of="$DST_IMG" bs=1M count=64
+DST_LOOP=$(losetup --find --show "$DST_IMG")
+pvcreate -ffy "$DST_LOOP"
+vgcreate vgd "$DST_LOOP"
+lvcreate -n dest -L 32M vgd
+
+STATE="$TMPDIR/state.json"
+"$BIN" run --speed=1M --output=json --resume="$STATE" --dedup=fixed /dev/vgsrc/snap /dev/vgd/dest >"$TMPDIR/first.log" 2>&1 &
+PID=$!
+sleep 1
+kill -9 $PID || true
+if [ ! -f "$STATE" ]; then
+  echo "resume state missing"
+  exit 1
+fi
+
+set +e
+"$BIN" run --speed=1M --output=json --resume="$STATE" --dedup=cdc /dev/vgsrc/snap /dev/vgd/dest >"$TMPDIR/mismatch.log" 2>&1
+STATUS=$?
+set -e
+if [ $STATUS -eq 0 ]; then
+  echo "expected resume to fail due to dedup mode mismatch"
+  exit 1
+fi
+if [ $STATUS -ne 80 ]; then
+  echo "expected exit code 80, got $STATUS"
+  exit 1
+fi
+if ! grep -q precondition "$TMPDIR/mismatch.log"; then
+  echo "missing precondition error"
+  exit 1
+fi
+exit 0

--- a/integration/resume_dedup_mismatch_test.go
+++ b/integration/resume_dedup_mismatch_test.go
@@ -1,0 +1,17 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestResumeDedupMismatch(t *testing.T) {
+	cmd := exec.Command("bash", "./integration/resume_dedup_mismatch.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dedup mismatch integration failed: %v\n%s", err, out)
+	}
+}

--- a/transfer/resume.go
+++ b/transfer/resume.go
@@ -19,6 +19,7 @@ type resumeChunks struct {
 // resumeCheckpoint represents the last processed chunk recorded on disk.
 type resumeCheckpoint struct {
 	resumeChunks
+	DedupMode string
 }
 
 // resumeTracker tracks checkpoint progress for an ongoing transfer.

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -171,9 +171,10 @@ func loadResumeState(path string, cfg *config.Config, size uint64, deviceID stri
 	if err := json.Unmarshal(data, &rs); err != nil {
 		return out, false
 	}
-	if rs.Transport != cfg.Transport || rs.Compress != cfg.Compress || rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm {
+	if rs.Transport != cfg.Transport || rs.Compress != cfg.Compress || rs.ChecksumAlgorithm != cfg.ChecksumAlgorithm || rs.DedupMode != cfg.DedupMode {
 		return out, false
 	}
+	out.DedupMode = rs.DedupMode
 	if (rs.DeviceID != "" && deviceID != "" && rs.DeviceID != deviceID) ||
 		(rs.SizeBytes != 0 && size != 0 && rs.SizeBytes != size) ||
 		(rs.Epoch != 0 && epoch != 0 && rs.Epoch != epoch) {

--- a/transfer/resume_state_test.go
+++ b/transfer/resume_state_test.go
@@ -65,6 +65,28 @@ func TestReadResumeStateDigestMismatch(t *testing.T) {
 	}
 }
 
+func TestReadResumeStateDedupModeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{
+		Transport:         "ssh",
+		Compress:          "none",
+		ChecksumAlgorithm: "blake3",
+		ResumeState:       path,
+		DedupMode:         "fixed",
+		CheckpointBytes:   4,
+		FirstBlockDigest:  hex.EncodeToString(dig[:]),
+	}
+	rt := &resumeTracker{}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cfg.DedupMode = "cdc"
+	cp := readResumeState(cfg, zap.NewNop(), 0, "", 0, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on dedup mode mismatch")
+	}
+}
+
 // TestResumeStateWALRecovery verifies that a WAL left behind after a crash is
 // preferred over the stale resume state file.
 func TestResumeStateWALRecovery(t *testing.T) {


### PR DESCRIPTION
## Summary
- compare dedup mode in resume state against current config
- record dedup mode in `resumeCheckpoint`
- add unit and integration tests for dedup mode mismatch during resume

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1145 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a6428c3fc083238fa719a337504fa9