### PR TITLE
Add transport fallback and SSH host key tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ no additional coordination.
 ## Transport Options
 
 LVMSync negotiates transports in the order provided by `--transport` (default
-`ssh,tcp+tls,h2,quic`). All transports require TLS 1.3 with mutual
+`ssh,tcp+tls,h2,quic`). If a transport fails to connect, the next transport is
+tried and each attempt is logged. All transports require TLS 1.3 with mutual
 authentication or SSH host key verification unless `--allow-insecure` is set.
 The `rsync` transport is plaintext and refuses to initialize unless
 `--allow-insecure` acknowledges the lack of encryption. Enabling this transport

--- a/cmd/dump/select_transport_test.go
+++ b/cmd/dump/select_transport_test.go
@@ -1,14 +1,23 @@
 package dump
 
 import (
+	"context"
+	"errors"
+	"net"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/common"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/transport"
 	_ "lvmsync_go/transport/rsyncwire"
 	_ "lvmsync_go/transport/ssh"
-
-	"go.uber.org/zap/zaptest"
 )
 
 func TestSelectTransportNoConfig(t *testing.T) {
@@ -66,5 +75,65 @@ func TestSelectTransportRsyncAllowInsecure(t *testing.T) {
 	}
 	if tr == nil || tr.Name() != "rsync" {
 		t.Fatalf("expected rsync transport, got %v", tr)
+	}
+}
+
+type stubTransport struct {
+	name    string
+	dialErr error
+}
+
+func (s *stubTransport) Name() string { return s.name }
+
+func (s *stubTransport) Dial(ctx context.Context, address string) (net.Conn, error) {
+	if s.dialErr != nil {
+		return nil, s.dialErr
+	}
+	c1, c2 := net.Pipe()
+	go c2.Close()
+	return c1, nil
+}
+
+func (s *stubTransport) Listen(ctx context.Context, address string) (net.Listener, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubTransport) Negotiate(ctx context.Context, conn net.Conn, role transport.Role, hs common.Handshake) (common.Handshake, error) {
+	return common.Handshake{}, errors.New("not implemented")
+}
+
+func TestDialWithFallbackLogsAttempts(t *testing.T) {
+	failErr := errors.New("dial failed")
+	if err := transport.Register("failssh", func(cfg transport.Config) (transport.Interface, error) {
+		return &stubTransport{name: "failssh", dialErr: failErr}, nil
+	}); err != nil {
+		t.Fatalf("register failssh: %v", err)
+	}
+	if err := transport.Register("oktcp", func(cfg transport.Config) (transport.Interface, error) { return &stubTransport{name: "oktcp"}, nil }); err != nil {
+		t.Fatalf("register oktcp: %v", err)
+	}
+	core, obs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	tr, conn, err := transport.DialWithFallback(ctx, "127.0.0.1:0", []string{"failssh", "oktcp"}, transport.Config{Logger: logger})
+	if err != nil {
+		t.Fatalf("DialWithFallback: %v", err)
+	}
+	conn.Close()
+	if tr.Name() != "oktcp" {
+		t.Fatalf("expected oktcp, got %s", tr.Name())
+	}
+	var seq []string
+	for _, e := range obs.All() {
+		if e.Message == "dial_attempt" {
+			if n, ok := e.ContextMap()["transport"].(string); ok {
+				seq = append(seq, n)
+			}
+		}
+	}
+	expected := []string{"failssh", "oktcp"}
+	if !reflect.DeepEqual(seq, expected) {
+		t.Fatalf("attempt sequence %v, expected %v", seq, expected)
 	}
 }

--- a/transport/ssh/unknown_host_test.go
+++ b/transport/ssh/unknown_host_test.go
@@ -1,0 +1,75 @@
+package ssh
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/transport"
+)
+
+func emptyKnownHosts(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "known_hosts")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestUnknownHostKeyFails(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	hostKeyPath := filepath.Join(dir, "host_key")
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyBytes := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyBytes})
+	if err := os.WriteFile(hostKeyPath, pemBytes, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	srvIface, err := New(ctx, transport.Config{Logger: zap.NewNop(), SSHUser: "u", SSHPassword: "p", HostKeyPath: hostKeyPath, AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("new server transport: %v", err)
+	}
+	srv := srvIface.(*Transport)
+	ln, err := srv.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	acceptErr := make(chan error, 1)
+	go func() {
+		_, err := ln.Accept()
+		acceptErr <- err
+	}()
+
+	kh := emptyKnownHosts(t)
+	cliIface, err := New(ctx, transport.Config{Logger: zap.NewNop(), SSHUser: "u", SSHPassword: "p", SSHKnownHosts: kh, HostKeyPath: hostKeyPath})
+	if err != nil {
+		t.Fatalf("new client transport: %v", err)
+	}
+	cli := cliIface.(*Transport)
+	dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+	_, err = cli.Dial(dialCtx, ln.Addr().String())
+	cancel()
+	if err == nil || !strings.Contains(err.Error(), "key is unknown") {
+		t.Fatalf("expected unknown host key error, got %v", err)
+	}
+	if err := <-acceptErr; err == nil {
+		t.Fatalf("expected server accept error")
+	}
+}


### PR DESCRIPTION
## Summary
- test fallback dialing order and logging for transports
- enforce strict SSH host key checking with unknown host test
- document transport fallback semantics in README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameters and other lint issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a642913dd883239d9d4900e7fce603