### PR TITLE
privilege: add timeout contexts

### DIFF
--- a/docs/sudoers.md
+++ b/docs/sudoers.md
@@ -6,6 +6,9 @@ See [../SECURITY.md](../SECURITY.md) for the overall model, assumptions, and
 risks. Adjust paths to match your distribution and test on non-production
 systems before enabling them in production.
 
+All command paths are validated by LVMSync at startup. Escalation commands
+must be specified explicitly and may not contain pipes or shell redirects.
+
 ## LVM administration
 
 Permit only the LVM utilities needed by LVMSync:

--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -28,6 +28,7 @@
 package escalate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +36,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -57,11 +59,12 @@ type Options struct {
 	Environ    func() []string                   // defaults to os.Environ
 	Geteuid    func() int                        // defaults to os.Geteuid
 	LookPath   func(file string) (string, error) // defaults to exec.LookPath
-	ExecRunner func(name string, args, env []string, stdin io.Reader, stdout, stderr io.Writer) error
+	ExecRunner func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error
 	Stdin      io.Reader     // defaults to nil (no prompting)
 	Stdout     io.Writer     // defaults to os.Stdout
 	Stderr     io.Writer     // defaults to os.Stderr
 	Sys        syscallFacade // defaults to real unix syscalls
+	Timeout    time.Duration // optional timeout for sudo escalation
 }
 
 // IsRoot reports whether the effective UID is 0.
@@ -78,6 +81,8 @@ func IsRoot(opts Options) bool {
 // If already root, returns (false, nil).
 // If not root, re-execs the current binary through `sudo -n` and returns (true, err).
 // When (true, nil) is returned, the caller should exit immediately.
+const defaultTimeout = 5 * time.Second
+
 func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
 	argv := opts.Args
 	if argv == nil {
@@ -138,12 +143,22 @@ func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
 		stderr = os.Stderr
 	}
 
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	run := opts.ExecRunner
 	if run == nil {
 		run = defaultExecRunner
 	}
 
-	if err := run(sudoPath, args, env, stdin, stdout, stderr); err != nil {
+	if err := run(ctx, sudoPath, args, env, stdin, stdout, stderr); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
 		logger.Error("ensure_root_or_reexec", zap.String("action_id", actionID), zap.Strings("argv", argv), zap.String("hostname", host), zap.String("result", "error"), zap.Error(err))
 		return false, fmt.Errorf("sudo escalation failed: %w", err)
 	}
@@ -281,8 +296,8 @@ func (unixFacade) Setgroups(gids []int) error  { return unix.Setgroups(gids) }
 func (unixFacade) Setresgid(r, e, s int) error { return unix.Setresgid(r, e, s) }
 func (unixFacade) Setresuid(r, e, s int) error { return unix.Setresuid(r, e, s) }
 
-func defaultExecRunner(name string, args, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
-	cmd := exec.Command(name, args...)
+func defaultExecRunner(ctx context.Context, name string, args, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, name, args...)
 	if env != nil {
 		cmd.Env = env
 	}

--- a/escalate/escalate_integration_test.go
+++ b/escalate/escalate_integration_test.go
@@ -1,11 +1,14 @@
 package escalate
 
 import (
+	"context"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -26,7 +29,7 @@ func TestEnsureRootOrReexec_NoReexecWhenRoot(t *testing.T) {
 			lookCalled = true
 			return exec.LookPath(s)
 		},
-		ExecRunner: func(string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+		ExecRunner: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 			runCalled = true
 			return nil
 		},
@@ -63,6 +66,56 @@ func TestEnsureRootOrReexec_InvalidCommand(t *testing.T) {
 	}, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "sudo escalation failed") {
 		t.Fatalf("expected sudo escalation error, got %v", err)
+	}
+	if reexeced {
+		t.Fatalf("expected reexeced false, got true")
+	}
+}
+
+// TestEnsureRootOrReexec_PipedSleep verifies that piped commands do not hang
+// and respect timeouts.
+func TestEnsureRootOrReexec_PipedSleep(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	ctxTimeout := 100 * time.Millisecond
+	reexeced, err := EnsureRootOrReexec(Options{
+		Geteuid:  func() int { return 1 },
+		LookPath: func(string) (string, error) { return "/bin/sh", nil },
+		ExecRunner: func(ctx context.Context, _ string, _ []string, _ []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
+			return exec.CommandContext(ctx, "sh", "-c", "sleep 5 | true").Run()
+		},
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+		Timeout: ctxTimeout,
+	}, zap.NewNop())
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if reexeced {
+		t.Fatalf("expected reexeced false, got true")
+	}
+}
+
+// TestEnsureRootOrReexec_SleepTimeout verifies that long-running commands are
+// killed when exceeding the timeout.
+func TestEnsureRootOrReexec_SleepTimeout(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	ctxTimeout := 100 * time.Millisecond
+	reexeced, err := EnsureRootOrReexec(Options{
+		Geteuid:  func() int { return 1 },
+		LookPath: func(string) (string, error) { return "/bin/sh", nil },
+		ExecRunner: func(ctx context.Context, _ string, _ []string, _ []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
+			return exec.CommandContext(ctx, "sh", "-c", "sleep 5").Run()
+		},
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+		Timeout: ctxTimeout,
+	}, zap.NewNop())
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 	if reexeced {
 		t.Fatalf("expected reexeced false, got true")

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -2,6 +2,7 @@ package escalate
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -191,8 +192,8 @@ type execCall struct {
 	env  []string
 }
 
-func fakeRunner(rec *execCall, ret error) func(string, []string, []string, io.Reader, io.Writer, io.Writer) error {
-	return func(name string, args []string, env []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
+func fakeRunner(rec *execCall, ret error) func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+	return func(_ context.Context, name string, args []string, env []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
 		*rec = execCall{name: name, args: append([]string{}, args...), env: append([]string{}, env...)}
 		return ret
 	}
@@ -283,7 +284,7 @@ func TestEnsureRootOrReexec_RunnerExitCode(t *testing.T) {
 	_, err := EnsureRootOrReexec(Options{
 		Geteuid:  func() int { return 1000 },
 		LookPath: func(string) (string, error) { return "/usr/bin/sudo", nil },
-		ExecRunner: func(string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+		ExecRunner: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 			return exec.Command("sh", "-c", "exit 42").Run()
 		},
 	}, zap.NewNop())

--- a/internal/privilege/escalate.go
+++ b/internal/privilege/escalate.go
@@ -6,6 +6,7 @@ package privilege
 import (
 	"context"
 	"os/exec"
+	"time"
 )
 
 // Escalator validates privilege requirements and executes commands with
@@ -25,4 +26,5 @@ type sudoEscalator struct {
 	runner      *Runner
 	sanitizeEnv bool
 	environ     func() []string
+	timeout     time.Duration
 }

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -212,12 +212,9 @@ func TestCommandContextCanceled(t *testing.T) {
 
 func TestEnsureDefaultTimeout(t *testing.T) {
 	HasCaps = func() bool { return false }
-	orig := escalationTimeout
-	escalationTimeout = 10 * time.Millisecond
-	defer func() { escalationTimeout = orig }()
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
-	}), LookPath: fakeLookPath(nil)}
+	}), LookPath: fakeLookPath(nil), Timeout: 10 * time.Millisecond}
 	esc := NewWithRunner(context.Background(), r, zap.NewNop())
 	err := esc.Ensure(context.Background())
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -226,12 +223,9 @@ func TestEnsureDefaultTimeout(t *testing.T) {
 }
 
 func TestCommandDefaultTimeout(t *testing.T) {
-	orig := escalationTimeout
-	escalationTimeout = 10 * time.Millisecond
-	defer func() { escalationTimeout = orig }()
 	esc := &sudoEscalator{useSudo: false, runner: &Runner{Cmd: cmdFunc(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
-	}), Logger: zap.NewNop()}}
+	}), Logger: zap.NewNop()}, timeout: 10 * time.Millisecond}
 	cmd := esc.Command(context.Background(), "sleep", "10")
 	err := cmd.Run()
 	if !errors.Is(err, context.DeadlineExceeded) && err.Error() != "signal: killed" {

--- a/internal/privilege/runner.go
+++ b/internal/privilege/runner.go
@@ -1,10 +1,11 @@
 package privilege
 
 import (
-        "context"
-        "os/exec"
+	"context"
+	"os/exec"
+	"time"
 
-        "go.uber.org/zap"
+	"go.uber.org/zap"
 )
 
 // Commander abstracts exec.CommandContext for dependency injection.
@@ -23,58 +24,64 @@ type Runner struct {
 	Cmd      Commander
 	LookPath func(string) (string, error)
 	Logger   *zap.Logger
+	Timeout  time.Duration
 }
 
 // New returns an Escalator with production dependencies.
 // ctx is currently unused but reserved for future use.
 func New(ctx context.Context, logger *zap.Logger) Escalator {
-        return NewWithRunner(ctx, nil, logger)
+	return NewWithRunner(ctx, nil, logger)
 }
 
 // NewWithRunner constructs an Escalator with the provided Runner.
 // Nil fields default to exec.CommandContext and exec.LookPath.
 func NewWithRunner(ctx context.Context, r *Runner, logger *zap.Logger) Escalator {
-        if logger == nil {
-                logger = zap.NewNop()
-        }
-        if r == nil {
-                r = &Runner{Logger: logger}
-        } else if r.Logger == nil {
-                r.Logger = logger
-        }
-        return newEscalator(ctx, r, false)
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if r == nil {
+		r = &Runner{Logger: logger}
+	} else if r.Logger == nil {
+		r.Logger = logger
+	}
+	return newEscalator(ctx, r, false)
 }
 
 // NewWithSanitize constructs an Escalator that optionally sanitizes the
 // environment of executed commands.
 func NewWithSanitize(ctx context.Context, sanitize bool) Escalator {
-        return newEscalator(ctx, nil, sanitize)
+	return newEscalator(ctx, nil, sanitize)
 }
 
 // NewWithRunnerAndSanitize constructs an Escalator with the provided Runner
 // and optional environment sanitization.
 func NewWithRunnerAndSanitize(ctx context.Context, r *Runner, sanitize bool) Escalator {
-        return newEscalator(ctx, r, sanitize)
+	return newEscalator(ctx, r, sanitize)
 }
 
 func newEscalator(_ context.Context, r *Runner, sanitize bool) Escalator {
-        cmd := Commander(commanderFunc(exec.CommandContext))
-        lp := exec.LookPath
-        logger := zap.NewNop()
-        if r != nil {
-                if r.Cmd != nil {
-                        cmd = r.Cmd
-                }
-                if r.LookPath != nil {
-                        lp = r.LookPath
-                }
-                if r.Logger != nil {
-                        logger = r.Logger
-                }
-        }
-        return &sudoEscalator{
-                useSudo:     !HasCaps(),
-                runner:      &Runner{Cmd: cmd, LookPath: lp, Logger: logger},
-                sanitizeEnv: sanitize,
-        }
+	cmd := Commander(commanderFunc(exec.CommandContext))
+	lp := exec.LookPath
+	logger := zap.NewNop()
+	timeout := defaultEscalationTimeout
+	if r != nil {
+		if r.Cmd != nil {
+			cmd = r.Cmd
+		}
+		if r.LookPath != nil {
+			lp = r.LookPath
+		}
+		if r.Logger != nil {
+			logger = r.Logger
+		}
+		if r.Timeout > 0 {
+			timeout = r.Timeout
+		}
+	}
+	return &sudoEscalator{
+		useSudo:     !HasCaps(),
+		runner:      &Runner{Cmd: cmd, LookPath: lp, Logger: logger},
+		sanitizeEnv: sanitize,
+		timeout:     timeout,
+	}
 }

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -13,21 +13,25 @@ import (
 	"go.uber.org/zap"
 )
 
-// escalationTimeout limits how long privilege checks and escalated commands may run
-// when the caller does not provide a deadline.
-var escalationTimeout = 5 * time.Second
+// defaultEscalationTimeout limits how long privilege checks and escalated
+// commands may run when the caller does not provide a deadline.
+const defaultEscalationTimeout = 5 * time.Second
 
-func withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+func (s *sudoEscalator) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	if _, ok := ctx.Deadline(); ok {
 		return context.WithCancel(ctx)
 	}
-	return context.WithTimeout(ctx, escalationTimeout)
+	to := s.timeout
+	if to == 0 {
+		to = defaultEscalationTimeout
+	}
+	return context.WithTimeout(ctx, to)
 }
 
 // Ensure verifies that either the required capabilities are present or that
 // sudo is available when escalation is necessary.
 func (s *sudoEscalator) Ensure(ctx context.Context) error {
-	ctx, cancel := withTimeout(ctx)
+	ctx, cancel := s.withTimeout(ctx)
 	defer cancel()
 	if s.useSudo {
 		if _, err := s.runner.LookPath("sudo"); err != nil {
@@ -55,7 +59,7 @@ func (s *sudoEscalator) Ensure(ctx context.Context) error {
 // Command returns an *exec.Cmd that runs the given program. sudo -n is inserted
 // when capabilities are missing.
 func (s *sudoEscalator) Command(ctx context.Context, name string, args ...string) *exec.Cmd {
-	ctx, _ = withTimeout(ctx)
+	ctx, _ = s.withTimeout(ctx)
 	s.runner.Logger.Debug("exec_command",
 		zap.String("command", name),
 		zap.Strings("args", redactArgs(args)),
@@ -109,25 +113,25 @@ func sanitizeEnv(environ []string) []string {
 }
 
 func redactArgs(args []string) []string {
-        out := make([]string, len(args))
-        for i := 0; i < len(args); i++ {
-                a := args[i]
-                lower := strings.ToLower(a)
-                if strings.Contains(lower, "password") || strings.Contains(lower, "secret") ||
-                        strings.Contains(lower, "token") || strings.Contains(lower, "key") {
-                        if strings.Contains(a, "=") {
-                                parts := strings.SplitN(a, "=", 2)
-                                out[i] = parts[0] + "=[REDACTED]"
-                        } else {
-                                out[i] = a
-                                if i+1 < len(args) {
-                                        out[i+1] = "[REDACTED]"
-                                        i++
-                                }
-                        }
-                } else {
-                        out[i] = a
-                }
-        }
-        return out
+	out := make([]string, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		lower := strings.ToLower(a)
+		if strings.Contains(lower, "password") || strings.Contains(lower, "secret") ||
+			strings.Contains(lower, "token") || strings.Contains(lower, "key") {
+			if strings.Contains(a, "=") {
+				parts := strings.SplitN(a, "=", 2)
+				out[i] = parts[0] + "=[REDACTED]"
+			} else {
+				out[i] = a
+				if i+1 < len(args) {
+					out[i+1] = "[REDACTED]"
+					i++
+				}
+			}
+		} else {
+			out[i] = a
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
- enforce configurable context timeout in EnsureRootOrReexec
- propagate timeout handling through privilege escalator
- document validated command paths in sudoers

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameter warnings and other lint issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a6428e672083239c3f07e012018ec5