### PR TITLE
test(device): handle truncated WAL entry

### DIFF
--- a/device/wal_crash_test.go
+++ b/device/wal_crash_test.go
@@ -105,4 +105,44 @@ func TestWALCrashRecovery(t *testing.T) {
 		}
 		w2.Close()
 	})
+
+	t.Run("truncate_within_entry", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "wal")
+		w, err := OpenWAL(path, id, zap.NewNop(), nil)
+		if err != nil {
+			t.Fatalf("open wal: %v", err)
+		}
+		if err := w.Append(Range{Start: 0, End: 64}); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		var entry [16]byte
+		binary.LittleEndian.PutUint64(entry[0:8], 64)
+		binary.LittleEndian.PutUint64(entry[8:16], 128)
+		if _, err := w.f.Write(entry[:]); err != nil {
+			t.Fatalf("write entry: %v", err)
+		}
+		if err := w.f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if err := os.Truncate(path, walHeaderSize+16+8); err != nil {
+			t.Fatalf("truncate: %v", err)
+		}
+		w2, err := OpenWAL(path, id, zap.NewNop(), nil)
+		if err != nil {
+			t.Fatalf("reopen wal: %v", err)
+		}
+		rs := w2.Ranges()
+		if len(rs) != 1 || rs[0].Start != 0 || rs[0].End != 64 {
+			t.Fatalf("unexpected ranges %#v", rs)
+		}
+		if err := w2.Append(Range{Start: 64, End: 128}); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		rs = w2.Ranges()
+		if len(rs) != 2 || rs[0].Start != 0 || rs[0].End != 64 || rs[1].Start != 64 || rs[1].End != 128 {
+			t.Fatalf("unexpected ranges after resume %#v", rs)
+		}
+		w2.Close()
+	})
 }


### PR DESCRIPTION
## Summary
- add test that truncates the WAL within an entry and verifies resuming does not duplicate ranges

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused-parameter, package-comments, redefines-builtin-id, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68a647f988888323982d72275ebb9f5b