### PR TITLE
docs: note OS-specific command paths

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ Tight `sudoers` rules limit what the helper may execute. LVMSync assumes the
 controlling user can invoke **only** the following commands via `sudo`; any
 broadly scoped or wildcard entries break the least-privilege model and may give
 the user full root access. See [docs/sudoers.md](docs/sudoers.md) for
-command-specific guidance:
+command-specific guidance and distribution-specific paths:
 
 ```sudoers
 # Allow LVM administration commands
@@ -52,10 +52,12 @@ lvmsync ALL=(root) NOPASSWD: \\
     /usr/local/bin/lvmsync-helper discard
 
 # Enable direct blkdiscard when the helper is unavailable
-lvmsync ALL=(root) NOPASSWD: /usr/sbin/blkdiscard
+lvmsync ALL=(root) NOPASSWD: /sbin/blkdiscard
 ```
 
-Adjust paths to match your distribution.
+Debian packages place `lvm*` and `blkdiscard` under `/sbin`, while AlmaLinux
+uses `/usr/sbin` for the same binaries. Refer to the distribution sections in
+[docs/sudoers.md](docs/sudoers.md) for exact paths.
 
 ## Least-privilege assumptions and risks
 

--- a/docs/sudoers.md
+++ b/docs/sudoers.md
@@ -30,7 +30,7 @@ Cmnd_Alias LVMSYNC_HELPER = \
     /usr/local/bin/lvmsync-helper write, \
     /usr/local/bin/lvmsync-helper discard
 
-Cmnd_Alias LVMSYNC_BLKDISCARD = /usr/sbin/blkdiscard
+Cmnd_Alias LVMSYNC_BLKDISCARD = /sbin/blkdiscard
 
 # Allow the "lvmsync" user to run the aliases without a password and block
 # shell escapes and environment injection
@@ -60,3 +60,39 @@ grep lvmsync-helper /var/log/auth.log
 ```
 
 Review these logs regularly to confirm the helper and LVM commands execute as intended.
+
+## Distribution-specific paths
+
+### AlmaLinux
+
+AlmaLinux installs LVM utilities and `blkdiscard` under `/usr/sbin`:
+
+```sudoers
+Cmnd_Alias LVMSYNC_LVM = \
+    /usr/sbin/lvm, \
+    /usr/sbin/lvcreate, \
+    /usr/sbin/lvremove, \
+    /usr/sbin/lvs, \
+    /usr/sbin/pvs, \
+    /usr/sbin/vgs
+
+Cmnd_Alias LVMSYNC_BLKDISCARD = /usr/sbin/blkdiscard
+```
+
+### Debian
+
+Debian packages place these binaries in `/sbin`:
+
+```sudoers
+Cmnd_Alias LVMSYNC_LVM = \
+    /sbin/lvm, \
+    /sbin/lvcreate, \
+    /sbin/lvremove, \
+    /sbin/lvs, \
+    /sbin/pvs, \
+    /sbin/vgs
+
+Cmnd_Alias LVMSYNC_BLKDISCARD = /sbin/blkdiscard
+```
+
+`lvmsync-helper` remains at `/usr/local/bin/lvmsync-helper` on both distributions.


### PR DESCRIPTION
## Summary
- document AlmaLinux and Debian command locations for sudoers rules
- mention distribution-specific paths in SECURITY.md

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: many revive/staticcheck issues)*
- `go tool cover -func=coverage.out | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68a647f7284c8323b434e72e78564ac0