### PR TITLE
Log deadline clear errors in transports and test handshake failure

### DIFF
--- a/transport/quic/deadline_test.go
+++ b/transport/quic/deadline_test.go
@@ -1,0 +1,54 @@
+package quic
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+)
+
+type failingConn struct{}
+
+func (f failingConn) Read(b []byte) (int, error)  { return 0, io.EOF }
+func (f failingConn) Write(b []byte) (int, error) { return 0, io.ErrClosedPipe }
+func (f failingConn) Close() error                { return nil }
+func (f failingConn) LocalAddr() net.Addr         { return dummyAddr{} }
+func (f failingConn) RemoteAddr() net.Addr        { return dummyAddr{} }
+func (f failingConn) SetDeadline(t time.Time) error {
+	if t.IsZero() {
+		return errors.New("boom")
+	}
+	return nil
+}
+func (f failingConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f failingConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "tcp" }
+func (dummyAddr) String() string  { return "dummy" }
+
+func TestNegotiateClearDeadlineFailure(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	tr := &Transport{logger: zap.New(core)}
+	conn := failingConn{}
+	if _, err := tr.Negotiate(context.Background(), conn, transport.Client, common.Handshake{}); err == nil {
+		t.Fatalf("expected negotiate error")
+	}
+	entries := logs.FilterMessage("clear_deadline_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 clear_deadline_failed log, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -238,16 +238,16 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
-			clearDeadline(conn)
+			clearDeadline(conn, t.logger)
 			return peer, err
 		}
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 
 		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		if err != nil {
 			return peer, err
 		}
@@ -261,7 +261,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		if err != nil {
 			return peer, err
 		}
@@ -273,10 +273,10 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
-			clearDeadline(conn)
+			clearDeadline(conn, t.logger)
 			return peer, err
 		}
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		return peer, nil
 	default:
 		return peer, nil
@@ -290,8 +290,10 @@ func setDeadline(ctx context.Context, conn net.Conn) error {
 	return nil
 }
 
-func clearDeadline(conn net.Conn) {
-	_ = conn.SetDeadline(time.Time{})
+func clearDeadline(conn net.Conn, logger *zap.Logger) {
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		logger.Error("clear_deadline_failed", zap.Error(err))
+	}
 }
 
 // Datagram APIs.

--- a/transport/ssh/deadline_test.go
+++ b/transport/ssh/deadline_test.go
@@ -1,0 +1,54 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+)
+
+type failingConn struct{}
+
+func (f failingConn) Read(b []byte) (int, error)  { return 0, io.EOF }
+func (f failingConn) Write(b []byte) (int, error) { return 0, io.ErrClosedPipe }
+func (f failingConn) Close() error                { return nil }
+func (f failingConn) LocalAddr() net.Addr         { return dummyAddr{} }
+func (f failingConn) RemoteAddr() net.Addr        { return dummyAddr{} }
+func (f failingConn) SetDeadline(t time.Time) error {
+	if t.IsZero() {
+		return errors.New("boom")
+	}
+	return nil
+}
+func (f failingConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f failingConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "tcp" }
+func (dummyAddr) String() string  { return "dummy" }
+
+func TestNegotiateClearDeadlineFailure(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	tr := &Transport{logger: zap.New(core)}
+	conn := failingConn{}
+	if _, err := tr.Negotiate(context.Background(), conn, transport.Client, common.Handshake{}); err == nil {
+		t.Fatalf("expected negotiate error")
+	}
+	entries := logs.FilterMessage("clear_deadline_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 clear_deadline_failed log, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -352,16 +352,16 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
-			clearDeadline(conn)
+			clearDeadline(conn, t.logger)
 			return peer, err
 		}
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 
 		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		if err != nil {
 			return peer, err
 		}
@@ -375,7 +375,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		if err != nil {
 			return peer, err
 		}
@@ -387,10 +387,10 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
-			clearDeadline(conn)
+			clearDeadline(conn, t.logger)
 			return peer, err
 		}
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		return peer, nil
 	default:
 		return peer, nil
@@ -513,6 +513,8 @@ func setDeadline(ctx context.Context, conn net.Conn) error {
 	return nil
 }
 
-func clearDeadline(conn net.Conn) {
-	_ = conn.SetDeadline(time.Time{})
+func clearDeadline(conn net.Conn, logger *zap.Logger) {
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		logger.Error("clear_deadline_failed", zap.Error(err))
+	}
 }

--- a/transport/tcp_tls/deadline_test.go
+++ b/transport/tcp_tls/deadline_test.go
@@ -1,0 +1,54 @@
+package tcp_tls
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+)
+
+type failingConn struct{}
+
+func (f failingConn) Read(b []byte) (int, error)  { return 0, io.EOF }
+func (f failingConn) Write(b []byte) (int, error) { return 0, io.ErrClosedPipe }
+func (f failingConn) Close() error                { return nil }
+func (f failingConn) LocalAddr() net.Addr         { return dummyAddr{} }
+func (f failingConn) RemoteAddr() net.Addr        { return dummyAddr{} }
+func (f failingConn) SetDeadline(t time.Time) error {
+	if t.IsZero() {
+		return errors.New("boom")
+	}
+	return nil
+}
+func (f failingConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f failingConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "tcp" }
+func (dummyAddr) String() string  { return "dummy" }
+
+func TestNegotiateClearDeadlineFailure(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	tr := &Transport{logger: zap.New(core)}
+	conn := failingConn{}
+	if _, err := tr.Negotiate(context.Background(), conn, transport.Client, common.Handshake{}); err == nil {
+		t.Fatalf("expected negotiate error")
+	}
+	entries := logs.FilterMessage("clear_deadline_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 clear_deadline_failed log, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -280,16 +280,16 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
-			clearDeadline(conn)
+			clearDeadline(conn, t.logger)
 			return peer, err
 		}
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 
 		if err = setDeadline(ctx, conn); err != nil {
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		if err != nil {
 			return peer, err
 		}
@@ -303,7 +303,7 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		peer, err = common.ReadHandshake(bufio.NewReader(conn))
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		if err != nil {
 			return peer, err
 		}
@@ -315,10 +315,10 @@ func (t *Transport) Negotiate(ctx context.Context, conn net.Conn, role transport
 			return peer, err
 		}
 		if err = common.WriteHandshake(conn, hs); err != nil {
-			clearDeadline(conn)
+			clearDeadline(conn, t.logger)
 			return peer, err
 		}
-		clearDeadline(conn)
+		clearDeadline(conn, t.logger)
 		return peer, nil
 	default:
 		return peer, fmt.Errorf("invalid role %v", role)
@@ -332,6 +332,8 @@ func setDeadline(ctx context.Context, conn net.Conn) error {
 	return nil
 }
 
-func clearDeadline(conn net.Conn) {
-	_ = conn.SetDeadline(time.Time{})
+func clearDeadline(conn net.Conn, logger *zap.Logger) {
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		logger.Error("clear_deadline_failed", zap.Error(err))
+	}
 }


### PR DESCRIPTION
## Summary
- log errors when clearing deadlines in SSH, QUIC, and TCP+TLS transports
- test handshake failure paths emit `clear_deadline_failed`

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1169 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a648001c888323bec0ef79069ddbb6