### PR TITLE
Enforce rsync device identity validation

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -141,6 +141,10 @@ lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with e
 
 Partition-table changes between runs also trigger this error when GPT or MBR signatures differ.
 
+When using the `rsync` transport, the client sends the destination device identity
+before writing. If the server's identity differs, the transfer aborts with
+[`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) (`80`).
+
 ## Troubleshooting
 
 - Compare source and destination identities; the device identity tuple `(size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` must match the resume file. LVMSync refuses to resume when the tuple differs.

--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ tried and each attempt is logged. All transports require TLS 1.3 with mutual
 authentication or SSH host key verification unless `--allow-insecure` is set.
 The `rsync` transport is plaintext and refuses to initialize unless
 `--allow-insecure` acknowledges the lack of encryption. Enabling this transport
-logs a warning noting the plaintext connection. See
-[docs/transports.md](docs/transports.md) for details.
+logs a warning noting the plaintext connection. The client sends the destination
+device identity and the server refuses to write if it differs, returning a
+precondition failure. See [docs/transports.md](docs/transports.md) for details.
 
 | Transport | Security defaults | Notes |
 |-----------|------------------|-------|
@@ -138,7 +139,7 @@ logs a warning noting the plaintext connection. See
 | `h2`      | TLS 1.3                | HTTP/2 streams |
 | `tcp+tls` | TLS 1.3                | Plain TCP wrapped in TLS |
 | `ssh`     | Host key verification  | Uses OpenSSH-style authentication |
-| `rsync`   | Plaintext, requires `--allow-insecure` | rsync wire protocol |
+| `rsync`   | Plaintext, requires `--allow-insecure` | rsync wire protocol, enforces destination identity |
 
 ### Examples
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -538,6 +538,15 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 
 	rw := writeOnlyReadWriter{remoteStdin}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, maxFrame))
+	info, err := orig.Stat()
+	if err != nil {
+		remoteStdin.Close()
+		return fmt.Errorf("stat origin: %w", err)
+	}
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
+		remoteStdin.Close()
+		return fmt.Errorf("send identity: %w", err)
+	}
 	if _, err := cl.SendSignatures(orig); err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("send signatures: %w", err)

--- a/cmd/dump/rsync_delta_integration_test.go
+++ b/cmd/dump/rsync_delta_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 	digestpkg "lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncserver"
@@ -104,3 +105,7 @@ func (m *rsyncserverMemDevice) ReadAt(p []byte, off int64) (int, error) {
 func (m *rsyncserverMemDevice) Size() int64 { return int64(len(m.buf)) }
 
 func (m *rsyncserverMemDevice) Sync() error { return nil }
+
+func (m *rsyncserverMemDevice) Identity(context.Context) (device.DeviceIdentity, error) {
+	return device.DeviceIdentity{SizeBytes: uint64(len(m.buf))}, nil
+}

--- a/integration/rsync_refusal.sh
+++ b/integration/rsync_refusal.sh
@@ -13,10 +13,12 @@ go build -o "$BIN" .
 SRC="$TMPDIR/src.img"
 DST_NEG="$TMPDIR/dst_neg.img"
 DST_POS="$TMPDIR/dst_pos.img"
+DST_MIS="$TMPDIR/dst_mis.img"
 
 dd if=/dev/zero of="$SRC" bs=1M count=1
 cp "$SRC" "$DST_NEG"
 cp "$SRC" "$DST_POS"
+cp "$SRC" "$DST_MIS"
 
 # Scenario A: rsync transport without allow-insecure should fail
 set +e
@@ -39,6 +41,24 @@ fi
 if ! grep -q "plaintext_connection" "$TMPDIR/pos.log"; then
   echo "missing plaintext warning"
   cat "$TMPDIR/pos.log"
+  exit 1
+fi
+
+# Scenario C: destination identity mismatch triggers precondition
+cp "$SRC" "$DST_MIS"
+set +e
+(sleep 0.1; truncate -s 0 "$DST_MIS") &
+"$BIN" --transport=rsync --allow-insecure --force --allow-overwrite --yes-i-know "$SRC" "$DST_MIS" >"$TMPDIR/mis.log" 2>&1
+STATUS=$?
+set -e
+if [ "$STATUS" -ne 80 ]; then
+  echo "expected precondition failure"
+  cat "$TMPDIR/mis.log"
+  exit 1
+fi
+if ! grep -q precondition "$TMPDIR/mis.log"; then
+  echo "missing precondition message"
+  cat "$TMPDIR/mis.log"
   exit 1
 fi
 

--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gokrazy/rsync"
 	"go.uber.org/zap"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncwire"
 	"lvmsync_go/internal/signaturecache"
@@ -25,6 +26,7 @@ type Device interface {
 	io.WriterAt
 	Sync() error
 	Size() int64
+	Identity(context.Context) (device.DeviceIdentity, error)
 }
 
 // Server applies incoming deltas to the Device.
@@ -56,6 +58,7 @@ func New(dev Device, logger *zap.Logger, cache *signaturecache.Cache, vg, lv str
 // Handle consumes frames from the Stream until EOF, applying any delta frames to
 // the Device. On graceful EOF the Device is fsynced.
 func (s *Server) Handle(ctx context.Context, stream *rsyncwire.Stream) error {
+	var idOK bool
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -81,7 +84,24 @@ func (s *Server) Handle(ctx context.Context, stream *rsyncwire.Stream) error {
 			}
 			s.sigHead = &head
 			continue
+		case 'I':
+			var id device.DeviceIdentity
+			if _, err := fmt.Fscan(bytes.NewReader(frame[1:]), &id.SizeBytes, &id.KernelUUID, &id.GPTUUID, &id.MBRSignature, &id.FSUUID, &id.Major, &id.Minor, &id.ManifestEpoch); err != nil {
+				return err
+			}
+			local, err := s.dev.Identity(ctx)
+			if err != nil {
+				return err
+			}
+			if local != id {
+				return fmt.Errorf("precondition: device identity mismatch")
+			}
+			idOK = true
+			continue
 		case 'D':
+			if !idOK {
+				return fmt.Errorf("precondition: missing identity")
+			}
 			if len(frame) < 9 {
 				return fmt.Errorf("delta frame too short")
 			}

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncwire"
 	"lvmsync_go/internal/signaturecache"
@@ -28,6 +29,7 @@ type memDevice struct {
 	buf   []byte
 	sync  bool
 	short bool
+	id    device.DeviceIdentity
 }
 
 func (m *memDevice) WriteAt(p []byte, off int64) (int, error) {
@@ -60,6 +62,13 @@ func (m *memDevice) Size() int64 { return int64(len(m.buf)) }
 
 func (m *memDevice) Sync() error { m.sync = true; return nil }
 
+func (m *memDevice) Identity(context.Context) (device.DeviceIdentity, error) {
+	if (m.id != device.DeviceIdentity{}) {
+		return m.id, nil
+	}
+	return device.DeviceIdentity{SizeBytes: uint64(len(m.buf))}, nil
+}
+
 func newServer(t *testing.T, dev *memDevice, data []byte) *Server {
 	t.Helper()
 	srv := New(dev, zap.NewNop(), nil, "", "")
@@ -85,6 +94,9 @@ func TestHandleApplyDelta(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
 	if err := cl.SendDelta(0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
@@ -112,6 +124,9 @@ func TestHandleShortWrite(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
 	if err := cl.SendDelta(0, []byte("hi")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
@@ -216,7 +231,11 @@ func TestHandleCacheMissUpdates(t *testing.T) {
 	if err := stream.Send(gbuf.Bytes()); err != nil {
 		t.Fatalf("Send digest: %v", err)
 	}
-	if err := rsyncwire.NewClient(stream).SendDelta(0, data); err != nil {
+	cl := rsyncwire.NewClient(stream)
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
+	if err := cl.SendDelta(0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	c1.Close()
@@ -364,6 +383,9 @@ func TestHandleDeltaOutOfBounds(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
 	if err := cl.SendDelta(9, []byte("ab")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
@@ -425,6 +447,9 @@ func TestHandleDigestMismatch(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
 	data := []byte("hi")
 	if err := cl.SendDelta(0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
@@ -458,5 +483,48 @@ func TestHandleDigestMismatch(t *testing.T) {
 	}
 	if v, ok := ctxMap["actual_digest"].(string); !ok || v != fmt.Sprintf("%x", actual) {
 		t.Fatalf("unexpected actual_digest %v", ctxMap["actual_digest"])
+	}
+}
+
+func TestHandleMissingIdentity(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	dev := &memDevice{buf: make([]byte, 1)}
+	srv := New(dev, zap.NewNop(), nil, "", "")
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
+
+	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	if err := cl.SendDelta(0, []byte("a")); err != nil {
+		t.Fatalf("SendDelta: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err == nil || !strings.Contains(err.Error(), "precondition") {
+		t.Fatalf("expected precondition error, got %v", err)
+	}
+}
+
+func TestHandleIdentityMismatch(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	dev := &memDevice{buf: make([]byte, 1)}
+	srv := New(dev, zap.NewNop(), nil, "", "")
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
+
+	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	// Send mismatched identity (size 2 instead of 1).
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: 2}); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err == nil || !strings.Contains(err.Error(), "precondition") {
+		t.Fatalf("expected precondition error, got %v", err)
 	}
 }

--- a/internal/rsyncwire/client_test.go
+++ b/internal/rsyncwire/client_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/gokrazy/rsync"
+
+	"lvmsync_go/device"
 )
 
 const maxFrame = 1 << 20
@@ -86,6 +88,33 @@ func TestClientSendSignatures(t *testing.T) {
 	}
 	if err := <-errCh; err != nil {
 		t.Fatalf("verify: %v", err)
+	}
+}
+
+func TestClientSendIdentity(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	client := NewClient(NewStream(c1, maxFrame))
+	srv := NewStream(c2, maxFrame)
+	id := device.DeviceIdentity{SizeBytes: 1, KernelUUID: "k"}
+	if err := client.SendIdentity(id); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
+	frame, err := srv.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if frame[0] != 'I' {
+		t.Fatalf("unexpected frame type %q", frame[0])
+	}
+	var got device.DeviceIdentity
+	if _, err := fmt.Fscan(bytes.NewReader(frame[1:]), &got.SizeBytes, &got.KernelUUID, &got.GPTUUID, &got.MBRSignature, &got.FSUUID, &got.Major, &got.Minor, &got.ManifestEpoch); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != id {
+		t.Fatalf("identity mismatch: %+v != %+v", got, id)
 	}
 }
 

--- a/internal/rsyncwire/wire.go
+++ b/internal/rsyncwire/wire.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/gokrazy/rsync"
 	"github.com/mmcloughlin/md4"
+
+	"lvmsync_go/device"
 )
 
 var crcTable = crc32.MakeTable(crc32.Castagnoli)
@@ -95,6 +97,14 @@ type Client struct {
 
 // NewClient constructs a Client using the provided Stream.
 func NewClient(stream *Stream) *Client { return &Client{stream: stream} }
+
+// SendIdentity transmits a device identity frame prefixed with 'I'.
+func (c *Client) SendIdentity(id device.DeviceIdentity) error {
+	var buf bytes.Buffer
+	buf.WriteByte('I')
+	fmt.Fprintf(&buf, "%d %s %s %s %s %d %d %d", id.SizeBytes, id.KernelUUID, id.GPTUUID, id.MBRSignature, id.FSUUID, id.Major, id.Minor, id.ManifestEpoch)
+	return c.stream.Send(buf.Bytes())
+}
 
 // SendSignatures reads from r incrementally, computes rsync signatures block
 // by block and sends them as a single frame prefixed with 'S'. It returns the

--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -11,6 +11,7 @@ import (
 
 	"lvmsync_go/common"
 	"lvmsync_go/dedup"
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 	digestpkg "lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncwire"
@@ -41,6 +42,14 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 
 	rw := writeOnlyReadWriter{out}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, rsyncMaxFrame))
+	// Send destination identity based on the origin size.
+	info, err := orig.Stat()
+	if err != nil {
+		return fmt.Errorf("stat origin: %w", err)
+	}
+	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
+		return fmt.Errorf("send identity: %w", err)
+	}
 	if _, err := cl.SendSignatures(orig); err != nil {
 		return fmt.Errorf("send signatures: %w", err)
 	}

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -61,6 +61,10 @@ func (m *rsyncserverMemDevice) Size() int64 { return int64(len(m.buf)) }
 
 func (m *rsyncserverMemDevice) Sync() error { return nil }
 
+func (m *rsyncserverMemDevice) Identity(context.Context) (device.DeviceIdentity, error) {
+	return device.DeviceIdentity{SizeBytes: uint64(len(m.buf))}, nil
+}
+
 type rdMockDevice struct {
 	path      string
 	size      uint64


### PR DESCRIPTION
## Summary
- validate destination device identity before applying rsync deltas
- send device identity frame from rsync clients
- document rsync identity enforcement and add test for mismatch

## Testing
- `go build ./...`
- `go test -cover ./...` *(fails: interrupt during cmd/dump tests)*
- `golangci-lint run` *(fails: numerous lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a647f12f9c8323bf4ca36e4850ecd5