### PR TITLE
docs: add sudoers example and CI validation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,3 +96,18 @@ jobs:
         run: |
           pct=$(go tool cover -func=coverage.out | tail -n 1 | awk '{print $3}' | tr -d '%')
           awk -v p="$pct" 'BEGIN { if (p < 50) { printf("coverage %.2f%% is below 50%%\n", p); exit 1 } }'
+
+  visudo:
+    runs-on: ubuntu-latest
+    container: debian:stable-slim
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install sudo
+        run: apt-get update && apt-get install -y sudo
+
+      - name: Validate sudoers file
+        run: visudo -cf docs/sudoers.d/lvmsync

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,13 @@ staticcheck ./...
 ```
 
 These commands are enforced in CI via the Go workflows.
+
+## Sudoers file validation
+
+CI also checks the syntax of the sample sudoers rules:
+
+```sh
+visudo -cf docs/sudoers.d/lvmsync
+```
+
+Run this locally when modifying sudoers entries to ensure they parse correctly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,8 @@ Tight `sudoers` rules limit what the helper may execute. LVMSync assumes the
 controlling user can invoke **only** the following commands via `sudo`; any
 broadly scoped or wildcard entries break the least-privilege model and may give
 the user full root access. See [docs/sudoers.md](docs/sudoers.md) for
-command-specific guidance and distribution-specific paths:
+command-specific guidance and distribution-specific paths, and
+[docs/sudoers.d/lvmsync](docs/sudoers.d/lvmsync) for a minimal include file:
 
 ```sudoers
 # Allow LVM administration commands

--- a/docs/sudoers.d/lvmsync
+++ b/docs/sudoers.d/lvmsync
@@ -1,0 +1,7 @@
+# Minimal sudoers entries for lvmsync helper commands.
+Cmnd_Alias LVMSYNC_HELPER = \
+    /usr/local/bin/lvmsync-helper open, \
+    /usr/local/bin/lvmsync-helper write, \
+    /usr/local/bin/lvmsync-helper discard
+
+lvmsync ALL=(root) NOPASSWD:NOEXEC: LVMSYNC_HELPER


### PR DESCRIPTION
## Summary
- add minimal sudoers include for lvmsync helper commands
- validate sudoers file in CI
- document sudoers check in CONTRIBUTING

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: 1180 issues)*
- `visudo -cf docs/sudoers.d/lvmsync`


------
https://chatgpt.com/codex/tasks/task_e_68a64ec19668832389dbaa550f6091eb