### PR TITLE
Add context-aware rsyncwire stream

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -512,7 +512,7 @@ func (r *Runner) StreamToRemote(ctx context.Context, cfg *config.Config, remoteS
 
 	rw := writeOnlyReadWriter{remoteStdin}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, maxFrame))
-	if err := cl.SendDigest(alg, sum); err != nil {
+	if err := cl.SendDigest(ctx, alg, sum); err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("send digest: %w", err)
 	}
@@ -543,11 +543,11 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 		remoteStdin.Close()
 		return fmt.Errorf("stat origin: %w", err)
 	}
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
+	if err := cl.SendIdentity(ctx, device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("send identity: %w", err)
 	}
-	if _, err := cl.SendSignatures(orig); err != nil {
+	if _, err := cl.SendSignatures(ctx, orig); err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("send signatures: %w", err)
 	}
@@ -575,7 +575,7 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 					for i < n && bufSnap[i] != bufOrig[i] {
 						i++
 					}
-					if err := cl.SendDelta(off+int64(start), bufSnap[start:i]); err != nil {
+					if err := cl.SendDelta(ctx, off+int64(start), bufSnap[start:i]); err != nil {
 						remoteStdin.Close()
 						return fmt.Errorf("send delta: %w", err)
 					}
@@ -603,7 +603,7 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 		remoteStdin.Close()
 		return fmt.Errorf("compute digest: %w", err)
 	}
-	if err := cl.SendDigest(alg, sum); err != nil {
+	if err := cl.SendDigest(ctx, alg, sum); err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("send digest: %w", err)
 	}

--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -63,7 +63,7 @@ func (s *Server) Handle(ctx context.Context, stream *rsyncwire.Stream) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		frame, err := stream.Recv()
+		frame, err := stream.Recv(ctx)
 		if err == io.EOF {
 			if err := s.dev.Sync(); err != nil {
 				return err

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -94,10 +94,10 @@ func TestHandleApplyDelta(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+	if err := cl.SendIdentity(context.Background(), device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
-	if err := cl.SendDelta(0, data); err != nil {
+	if err := cl.SendDelta(context.Background(), 0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	c1.Close()
@@ -124,10 +124,10 @@ func TestHandleShortWrite(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+	if err := cl.SendIdentity(context.Background(), device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
-	if err := cl.SendDelta(0, []byte("hi")); err != nil {
+	if err := cl.SendDelta(context.Background(), 0, []byte("hi")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	c1.Close()
@@ -158,7 +158,7 @@ func TestHandleRejectsOversizedSignatures(t *testing.T) {
 	buf.WriteByte(0)
 	binary.Write(&buf, binary.LittleEndian, int32(0))
 	buf.WriteByte(0)
-	if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+	if err := rsyncwire.NewStream(c1, maxFrame).Send(context.Background(), buf.Bytes()); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -193,7 +193,7 @@ func TestHandleCacheHit(t *testing.T) {
 	buf.WriteByte(byte(len(digest.SHA256)))
 	buf.WriteString(digest.SHA256)
 	buf.Write(dgst[:])
-	if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+	if err := rsyncwire.NewStream(c1, maxFrame).Send(context.Background(), buf.Bytes()); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -228,14 +228,14 @@ func TestHandleCacheMissUpdates(t *testing.T) {
 	gbuf.WriteByte(byte(len(digest.SHA256)))
 	gbuf.WriteString(digest.SHA256)
 	gbuf.Write(dgst[:])
-	if err := stream.Send(gbuf.Bytes()); err != nil {
+	if err := stream.Send(context.Background(), gbuf.Bytes()); err != nil {
 		t.Fatalf("Send digest: %v", err)
 	}
 	cl := rsyncwire.NewClient(stream)
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+	if err := cl.SendIdentity(context.Background(), device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
-	if err := cl.SendDelta(0, data); err != nil {
+	if err := cl.SendDelta(context.Background(), 0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	c1.Close()
@@ -278,7 +278,7 @@ func TestHandleCacheTTLExpiry(t *testing.T) {
 	buf.WriteByte(byte(len(digest.SHA256)))
 	buf.WriteString(digest.SHA256)
 	buf.Write(dgst[:])
-	if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+	if err := rsyncwire.NewStream(c1, maxFrame).Send(context.Background(), buf.Bytes()); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -310,7 +310,7 @@ func TestHandleCacheLRUEviction(t *testing.T) {
 		buf.WriteByte(byte(len(digest.SHA256)))
 		buf.WriteString(digest.SHA256)
 		buf.Write(dgst[:])
-		if err := rsyncwire.NewStream(c1, maxFrame).Send(buf.Bytes()); err != nil {
+		if err := rsyncwire.NewStream(c1, maxFrame).Send(context.Background(), buf.Bytes()); err != nil {
 			t.Fatalf("Send: %v", err)
 		}
 		c1.Close()
@@ -346,7 +346,7 @@ func TestHandleDeltaOffsetOverflow(t *testing.T) {
 	buf.WriteByte('D')
 	binary.Write(&buf, binary.BigEndian, uint64(math.MaxInt64)+1)
 	buf.WriteByte(0x1)
-	if err := stream.Send(buf.Bytes()); err != nil {
+	if err := stream.Send(context.Background(), buf.Bytes()); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -383,10 +383,10 @@ func TestHandleDeltaOutOfBounds(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+	if err := cl.SendIdentity(context.Background(), device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
-	if err := cl.SendDelta(9, []byte("ab")); err != nil {
+	if err := cl.SendDelta(context.Background(), 9, []byte("ab")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	c1.Close()
@@ -424,7 +424,7 @@ func TestHandleUnknownFrameType(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
-	if err := rsyncwire.NewStream(c1, maxFrame).Send([]byte{'X'}); err != nil {
+	if err := rsyncwire.NewStream(c1, maxFrame).Send(context.Background(), []byte{'X'}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	c1.Close()
@@ -447,18 +447,18 @@ func TestHandleDigestMismatch(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
+	if err := cl.SendIdentity(context.Background(), device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))}); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
 	data := []byte("hi")
-	if err := cl.SendDelta(0, data); err != nil {
+	if err := cl.SendDelta(context.Background(), 0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	bad, err := digest.SumReader(bytes.NewReader([]byte("ho")), digest.SHA256)
 	if err != nil {
 		t.Fatalf("digest: %v", err)
 	}
-	if err := cl.SendDigest(digest.SHA256, bad); err != nil {
+	if err := cl.SendDigest(context.Background(), digest.SHA256, bad); err != nil {
 		t.Fatalf("SendDigest: %v", err)
 	}
 	c1.Close()
@@ -498,7 +498,7 @@ func TestHandleMissingIdentity(t *testing.T) {
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
-	if err := cl.SendDelta(0, []byte("a")); err != nil {
+	if err := cl.SendDelta(context.Background(), 0, []byte("a")); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
 	c1.Close()
@@ -520,7 +520,7 @@ func TestHandleIdentityMismatch(t *testing.T) {
 
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
 	// Send mismatched identity (size 2 instead of 1).
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: 2}); err != nil {
+	if err := cl.SendIdentity(context.Background(), device.DeviceIdentity{SizeBytes: 2}); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
 	c1.Close()

--- a/internal/rsyncwire/client_test.go
+++ b/internal/rsyncwire/client_test.go
@@ -2,6 +2,7 @@ package rsyncwire
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -28,7 +29,7 @@ func TestClientSendSignatures(t *testing.T) {
 	headExpect := sumSizesSqroot(int64(len(data)))
 	errCh := make(chan error)
 	go func() {
-		frame, err := srv.Recv()
+		frame, err := srv.Recv(context.Background())
 		if err != nil {
 			errCh <- err
 			return
@@ -83,7 +84,7 @@ func TestClientSendSignatures(t *testing.T) {
 		errCh <- nil
 	}()
 
-	if _, err := client.SendSignatures(bytes.NewReader(data)); err != nil {
+	if _, err := client.SendSignatures(context.Background(), bytes.NewReader(data)); err != nil {
 		t.Fatalf("SendSignatures: %v", err)
 	}
 	if err := <-errCh; err != nil {
@@ -99,10 +100,10 @@ func TestClientSendIdentity(t *testing.T) {
 	client := NewClient(NewStream(c1, maxFrame))
 	srv := NewStream(c2, maxFrame)
 	id := device.DeviceIdentity{SizeBytes: 1, KernelUUID: "k"}
-	if err := client.SendIdentity(id); err != nil {
+	if err := client.SendIdentity(context.Background(), id); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
-	frame, err := srv.Recv()
+	frame, err := srv.Recv(context.Background())
 	if err != nil {
 		t.Fatalf("Recv: %v", err)
 	}
@@ -129,7 +130,7 @@ func TestClientSendSignaturesLargeInput(t *testing.T) {
 	// Consume the frame so the client can write without blocking.
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := srv.Recv()
+		_, err := srv.Recv(context.Background())
 		errCh <- err
 	}()
 
@@ -142,7 +143,7 @@ func TestClientSendSignaturesLargeInput(t *testing.T) {
 	runtime.GC()
 	var m1 runtime.MemStats
 	runtime.ReadMemStats(&m1)
-	if _, err := client.SendSignatures(r); err != nil {
+	if _, err := client.SendSignatures(context.Background(), r); err != nil {
 		t.Fatalf("SendSignatures: %v", err)
 	}
 	runtime.GC()
@@ -180,7 +181,7 @@ func TestStreamBadCRC(t *testing.T) {
 		}
 		errCh <- c1.Close()
 	}()
-	if _, err := s.Recv(); err == nil {
+	if _, err := s.Recv(context.Background()); err == nil {
 		t.Fatalf("expected CRC error")
 	}
 	if err := <-errCh; err != nil {

--- a/internal/rsyncwire/stream_test.go
+++ b/internal/rsyncwire/stream_test.go
@@ -2,11 +2,14 @@ package rsyncwire
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"errors"
 	"hash/crc32"
 	"net"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStreamRecvWithinLimit(t *testing.T) {
@@ -20,12 +23,12 @@ func TestStreamRecvWithinLimit(t *testing.T) {
 
 	payload := []byte("test")
 	go func() {
-		if err := sender.Send(payload); err != nil {
+		if err := sender.Send(context.Background(), payload); err != nil {
 			t.Errorf("Send: %v", err)
 		}
 	}()
 
-	frame, err := recv.Recv()
+	frame, err := recv.Recv(context.Background())
 	if err != nil {
 		t.Fatalf("Recv: %v", err)
 	}
@@ -50,7 +53,7 @@ func TestStreamRecvTooLarge(t *testing.T) {
 		c1.Write(hdr[:])
 	}()
 
-	if _, err := recv.Recv(); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+	if _, err := recv.Recv(context.Background()); err == nil || !strings.Contains(err.Error(), "exceeds max") {
 		t.Fatalf("expected size limit error, got %v", err)
 	}
 }
@@ -60,7 +63,7 @@ func TestStreamSendTooLarge(t *testing.T) {
 	const max = 4
 	s := NewStream(&buf, max)
 	payload := []byte("hello")
-	if err := s.Send(payload); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+	if err := s.Send(context.Background(), payload); err == nil || !strings.Contains(err.Error(), "exceeds max") {
 		t.Fatalf("expected size limit error, got %v", err)
 	}
 	if buf.Len() != 0 {
@@ -88,7 +91,7 @@ func TestStreamSendShortWrites(t *testing.T) {
 	srw := &shortReadWriter{max: limit}
 	s := NewStream(srw, 1<<20)
 	payload := []byte("hello world")
-	if err := s.Send(payload); err != nil {
+	if err := s.Send(context.Background(), payload); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	expectedLen := 8 + len(payload)
@@ -109,4 +112,38 @@ func TestStreamSendShortWrites(t *testing.T) {
 	if srw.calls != expectedCalls {
 		t.Fatalf("expected %d writes, got %d", expectedCalls, srw.calls)
 	}
+}
+
+func TestStreamRecvTimeout(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	recv := NewStream(c2, 1<<20)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	if _, err := recv.Recv(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestStreamSendTimeout(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	sender := NewStream(c1, 1<<20)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		payload := bytes.Repeat([]byte("a"), 1<<20)
+		errCh <- sender.Send(ctx, payload)
+	}()
+	if err := <-errCh; !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	_ = c2.Close()
 }

--- a/internal/rsyncwire/wire.go
+++ b/internal/rsyncwire/wire.go
@@ -5,11 +5,14 @@ package rsyncwire
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
 	"io"
 	"math"
+	"net"
+	"time"
 
 	"github.com/gokrazy/rsync"
 	"github.com/mmcloughlin/md4"
@@ -33,32 +36,52 @@ func NewStream(rw io.ReadWriter, max uint32) *Stream { return &Stream{rw: rw, ma
 
 // Send writes a single frame to the underlying stream, prefixing the
 // payload with its length and CRC32C checksum. It retries short writes so the
-// header and payload are fully written unless an error occurs.
-func (s *Stream) Send(p []byte) error {
+// header and payload are fully written unless an error occurs. The write
+// respects context cancellation and deadlines.
+func (s *Stream) Send(ctx context.Context, p []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if uint32(len(p)) > s.max {
 		return fmt.Errorf("frame %d exceeds max %d", len(p), s.max)
 	}
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(p)))
 	binary.BigEndian.PutUint32(hdr[4:8], crc32.Checksum(p, crcTable))
-	if err := writeFull(s.rw, hdr[:]); err != nil {
+
+	if err := withDeadline(ctx, s.rw); err != nil {
+		return err
+	}
+	if err := writeFull(ctx, s.rw, hdr[:]); err != nil {
 		return err
 	}
 	if len(p) > 0 {
-		if err := writeFull(s.rw, p); err != nil {
+		if err := writeFull(ctx, s.rw, p); err != nil {
 			return err
 		}
 	}
-	return nil
+	return ctx.Err()
 }
 
-func writeFull(w io.Writer, buf []byte) error {
+func writeFull(ctx context.Context, w io.Writer, buf []byte) error {
 	for len(buf) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		n, err := w.Write(buf)
 		if n > 0 {
 			buf = buf[n:]
 		}
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				return context.DeadlineExceeded
+			}
 			return err
 		}
 		if n == 0 {
@@ -69,10 +92,17 @@ func writeFull(w io.Writer, buf []byte) error {
 }
 
 // Recv reads the next frame from the stream, verifying the CRC32C value.
-// It returns io.EOF when the underlying stream is exhausted.
-func (s *Stream) Recv() ([]byte, error) {
+// It returns io.EOF when the underlying stream is exhausted. The read respects
+// context cancellation and deadlines.
+func (s *Stream) Recv(ctx context.Context) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := withDeadline(ctx, s.rw); err != nil {
+		return nil, err
+	}
 	var hdr [8]byte
-	if _, err := io.ReadFull(s.rw, hdr[:]); err != nil {
+	if err := readFull(ctx, s.rw, hdr[:]); err != nil {
 		return nil, err
 	}
 	n := binary.BigEndian.Uint32(hdr[0:4])
@@ -81,13 +111,73 @@ func (s *Stream) Recv() ([]byte, error) {
 	}
 	expected := binary.BigEndian.Uint32(hdr[4:8])
 	buf := make([]byte, n)
-	if _, err := io.ReadFull(s.rw, buf); err != nil {
+	if err := readFull(ctx, s.rw, buf); err != nil {
 		return nil, err
 	}
 	if crc32.Checksum(buf, crcTable) != expected {
 		return nil, fmt.Errorf("crc32c mismatch")
 	}
-	return buf, nil
+	return buf, ctx.Err()
+}
+
+func readFull(ctx context.Context, r io.Reader, buf []byte) error {
+	for len(buf) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, err := r.Read(buf)
+		if n > 0 {
+			buf = buf[n:]
+		}
+		if err != nil {
+			if err == io.EOF && len(buf) == 0 {
+				return nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				return context.DeadlineExceeded
+			}
+			if err == io.EOF {
+				return io.ErrUnexpectedEOF
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// withDeadline applies the context deadline to conn if it supports deadlines
+// and ensures it is cleared when the context completes. For contexts without a
+// deadline it sets a deadline when the context is cancelled.
+func withDeadline(ctx context.Context, rw io.ReadWriter) error {
+	conn, ok := rw.(net.Conn)
+	if !ok {
+		return nil
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(dl); err != nil {
+			return err
+		}
+		if done := ctx.Done(); done != nil {
+			go func() {
+				<-done
+				_ = conn.SetDeadline(time.Time{})
+			}()
+		}
+		return nil
+	}
+	if done := ctx.Done(); done != nil {
+		go func() {
+			<-done
+			_ = conn.SetDeadline(time.Now())
+		}()
+	}
+	return nil
 }
 
 // Client transmits rsync signatures and deltas over a Stream.
@@ -99,18 +189,18 @@ type Client struct {
 func NewClient(stream *Stream) *Client { return &Client{stream: stream} }
 
 // SendIdentity transmits a device identity frame prefixed with 'I'.
-func (c *Client) SendIdentity(id device.DeviceIdentity) error {
+func (c *Client) SendIdentity(ctx context.Context, id device.DeviceIdentity) error {
 	var buf bytes.Buffer
 	buf.WriteByte('I')
 	fmt.Fprintf(&buf, "%d %s %s %s %s %d %d %d", id.SizeBytes, id.KernelUUID, id.GPTUUID, id.MBRSignature, id.FSUUID, id.Major, id.Minor, id.ManifestEpoch)
-	return c.stream.Send(buf.Bytes())
+	return c.stream.Send(ctx, buf.Bytes())
 }
 
 // SendSignatures reads from r incrementally, computes rsync signatures block
 // by block and sends them as a single frame prefixed with 'S'. It returns the
 // generated SumHead. The reader must be seekable so the total length can be
 // determined without buffering the entire input.
-func (c *Client) SendSignatures(r io.Reader) (rsync.SumHead, error) {
+func (c *Client) SendSignatures(ctx context.Context, r io.Reader) (rsync.SumHead, error) {
 	seeker, ok := r.(io.Seeker)
 	if !ok {
 		return rsync.SumHead{}, fmt.Errorf("SendSignatures requires seekable reader")
@@ -141,6 +231,9 @@ func (c *Client) SendSignatures(r io.Reader) (rsync.SumHead, error) {
 	block := make([]byte, head.BlockLength)
 	offset := int64(0)
 	for i := int32(0); i < head.ChecksumCount; i++ {
+		if err := ctx.Err(); err != nil {
+			return rsync.SumHead{}, err
+		}
 		blen := int(head.BlockLength)
 		if i == head.ChecksumCount-1 && head.RemainderLength != 0 {
 			blen = int(head.RemainderLength)
@@ -166,7 +259,7 @@ func (c *Client) SendSignatures(r io.Reader) (rsync.SumHead, error) {
 	}
 
 	payload := append([]byte{'S'}, buf.Bytes()...)
-	if err := c.stream.Send(payload); err != nil {
+	if err := c.stream.Send(ctx, payload); err != nil {
 		return rsync.SumHead{}, err
 	}
 	return head, nil
@@ -174,18 +267,18 @@ func (c *Client) SendSignatures(r io.Reader) (rsync.SumHead, error) {
 
 // SendDelta sends a delta frame indicating data to be written at the provided
 // offset. The frame is prefixed with 'D'.
-func (c *Client) SendDelta(offset int64, data []byte) error {
+func (c *Client) SendDelta(ctx context.Context, offset int64, data []byte) error {
 	var buf bytes.Buffer
 	buf.WriteByte('D')
 	binary.Write(&buf, binary.BigEndian, uint64(offset))
 	buf.Write(data)
-	return c.stream.Send(buf.Bytes())
+	return c.stream.Send(ctx, buf.Bytes())
 }
 
 // SendDigest transmits a digest frame prefixed with 'G'. The frame contains the
 // length of the algorithm name followed by the UTF-8 algorithm string and the
 // 32-byte digest sum.
-func (c *Client) SendDigest(alg string, sum [32]byte) error {
+func (c *Client) SendDigest(ctx context.Context, alg string, sum [32]byte) error {
 	if len(alg) > 255 {
 		return fmt.Errorf("algorithm name too long")
 	}
@@ -194,7 +287,7 @@ func (c *Client) SendDigest(alg string, sum [32]byte) error {
 	buf.WriteByte(byte(len(alg)))
 	buf.WriteString(alg)
 	buf.Write(sum[:])
-	return c.stream.Send(buf.Bytes())
+	return c.stream.Send(ctx, buf.Bytes())
 }
 
 // sumSizesSqroot mirrors rsync's block size and count calculation.

--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -47,10 +47,10 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 	if err != nil {
 		return fmt.Errorf("stat origin: %w", err)
 	}
-	if err := cl.SendIdentity(device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
+	if err := cl.SendIdentity(ctx, device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
 		return fmt.Errorf("send identity: %w", err)
 	}
-	if _, err := cl.SendSignatures(orig); err != nil {
+	if _, err := cl.SendSignatures(ctx, orig); err != nil {
 		return fmt.Errorf("send signatures: %w", err)
 	}
 	if _, err := orig.Seek(0, io.SeekStart); err != nil {
@@ -91,7 +91,7 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 			}
 			sum := blake3.Sum256(c.Data[:c.Length])
 			if _, ok := digests[sum]; !ok {
-				if err := cl.SendDelta(off, c.Data[:c.Length]); err != nil {
+				if err := cl.SendDelta(ctx, off, c.Data[:c.Length]); err != nil {
 					return fmt.Errorf("send delta: %w", err)
 				}
 			}
@@ -123,7 +123,7 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 						for i < n && bufSnap[i] != bufOrig[i] {
 							i++
 						}
-						if err := cl.SendDelta(off+int64(start), bufSnap[start:i]); err != nil {
+						if err := cl.SendDelta(ctx, off+int64(start), bufSnap[start:i]); err != nil {
 							return fmt.Errorf("send delta: %w", err)
 						}
 					} else {
@@ -148,7 +148,7 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 	if err != nil {
 		return fmt.Errorf("compute digest: %w", err)
 	}
-	if err := cl.SendDigest(cfg.ChecksumAlgorithm, sum); err != nil {
+	if err := cl.SendDigest(ctx, cfg.ChecksumAlgorithm, sum); err != nil {
 		return fmt.Errorf("send digest: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- add context to rsyncwire streams and clients
- cancel Send/Recv operations via deadlines
- test send/recv timeouts

## Testing
- `go build ./...`
- `go test ./internal/rsyncwire -run TestStreamSendTimeout -count=1`
- `golangci-lint run ./internal/rsyncwire` *(fails: errcheck, revive, gocritic)*

------
https://chatgpt.com/codex/tasks/task_e_68a659bc315c83238bd967331c417ae5