### PR TITLE
test: send digest and add context timeout

### DIFF
--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -89,7 +89,8 @@ func TestHandleApplyDelta(t *testing.T) {
 	data := []byte("hello")
 	dev := &memDevice{buf: make([]byte, len(data))}
 	srv := newServer(t, dev, data)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	errCh := make(chan error, 1)
 	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
 
@@ -99,6 +100,9 @@ func TestHandleApplyDelta(t *testing.T) {
 	}
 	if err := cl.SendDelta(0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
+	}
+	if err := cl.SendDigest(digest.SHA256, srv.expect); err != nil {
+		t.Fatalf("SendDigest: %v", err)
 	}
 	c1.Close()
 	if err := <-errCh; err != nil {


### PR DESCRIPTION
## Summary
- ensure client sends digest before closing in TestHandleApplyDelta
- guard server goroutine with context timeout to avoid hangs

## Testing
- `go build ./...`
- `go test ./internal/rsyncserver -run TestHandleApplyDelta -count=1 -v` *(fails: signal interrupt)*
- `golangci-lint run` *(fails: numerous lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a659b78edc8323bcc2762378f8d84d