### PR TITLE
Run rsync delta tests with concurrent client/server

### DIFF
--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -101,7 +101,7 @@ func TestHandleApplyDelta(t *testing.T) {
 	if err := cl.SendDelta(context.Background(), 0, data); err != nil {
 		t.Fatalf("SendDelta: %v", err)
 	}
-	if err := cl.SendDigest(digest.SHA256, srv.expect); err != nil {
+	if err := cl.SendDigest(context.Background(), digest.SHA256, srv.expect); err != nil {
 		t.Fatalf("SendDigest: %v", err)
 	}
 	c1.Close()

--- a/internal/rsyncwire/client_test.go
+++ b/internal/rsyncwire/client_test.go
@@ -113,10 +113,10 @@ func TestClientSendIdentity(t *testing.T) {
 	defer cancel()
 
 	id := device.DeviceIdentity{SizeBytes: 1, KernelUUID: "k"}
-	if err := client.SendIdentity(context.Background(), id); err != nil {
+	if err := client.SendIdentity(ctx, id); err != nil {
 		t.Fatalf("SendIdentity: %v", err)
 	}
-	frame, err := srv.Recv(context.Background())
+	frame, err := srv.Recv(ctx)
 	if err != nil {
 		t.Fatalf("Recv: %v", err)
 	}
@@ -129,42 +129,6 @@ func TestClientSendIdentity(t *testing.T) {
 	}
 	if got != id {
 		t.Fatalf("identity mismatch: %+v != %+v", got, id)
-
-
-	errCh := make(chan error, 1)
-	go func() {
-		frame, err := srv.Recv()
-		if err != nil {
-			errCh <- fmt.Errorf("Recv: %w", err)
-			return
-		}
-		if frame[0] != 'I' {
-			errCh <- fmt.Errorf("unexpected frame type %q", frame[0])
-			return
-		}
-		var got device.DeviceIdentity
-		if _, err := fmt.Fscan(bytes.NewReader(frame[1:]), &got.SizeBytes, &got.KernelUUID, &got.GPTUUID, &got.MBRSignature, &got.FSUUID, &got.Major, &got.Minor, &got.ManifestEpoch); err != nil {
-			errCh <- fmt.Errorf("parse: %w", err)
-			return
-		}
-		if got != id {
-			errCh <- fmt.Errorf("identity mismatch: %+v != %+v", got, id)
-			return
-		}
-		errCh <- nil
-	}()
-
-	if err := client.SendIdentity(id); err != nil {
-		t.Fatalf("SendIdentity: %v", err)
-	}
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("verify: %v", err)
-		}
-	case <-ctx.Done():
-		t.Fatal("timeout waiting for Recv")
 	}
 }
 

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -124,18 +125,40 @@ func TestDumpChangesRsyncDelta(t *testing.T) {
 	copy(dev.buf, originData)
 	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
 
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	c1, c2 := net.Pipe()
 	cc := &countingConn{Conn: c1}
-	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(context.Background(), rsyncwire.NewStream(c2, rsyncMaxFrame)) }()
+	var wg sync.WaitGroup
+	serverReady := make(chan struct{})
+	var srvErr, clientErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(serverReady)
+		srvErr = srv.Handle(ctx, rsyncwire.NewStream(c2, rsyncMaxFrame))
+	}()
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
-	if err := tr.DumpChangesSequential(context.Background(), cfg, snapPath, origPath, cc); err != nil {
-		t.Fatalf("DumpChangesSequential: %v", err)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer c1.Close()
+		<-serverReady
+		clientErr = tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
+	}()
+
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context: %v", err)
 	}
-	c1.Close()
-	if err := <-errCh; err != nil {
-		t.Fatalf("Handle: %v", err)
+	if clientErr != nil {
+		t.Fatalf("DumpChangesSequential: %v", clientErr)
+	}
+	if srvErr != nil {
+		t.Fatalf("Handle: %v", srvErr)
 	}
 	if !bytes.Equal(dev.buf, snapshotData) {
 		t.Fatalf("device mismatch")
@@ -177,18 +200,40 @@ func TestRsyncDeltaCDCShift(t *testing.T) {
 	copy(dev.buf, originData)
 	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
 
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	c1, c2 := net.Pipe()
 	cc := &countingConn{Conn: c1}
-	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(context.Background(), rsyncwire.NewStream(c2, rsyncMaxFrame)) }()
+	var wg sync.WaitGroup
+	serverReady := make(chan struct{})
+	var srvErr, clientErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(serverReady)
+		srvErr = srv.Handle(ctx, rsyncwire.NewStream(c2, rsyncMaxFrame))
+	}()
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
-	if err := tr.DumpChangesSequential(context.Background(), cfg, snapPath, origPath, cc); err != nil {
-		t.Fatalf("DumpChangesSequential: %v", err)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer c1.Close()
+		<-serverReady
+		clientErr = tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
+	}()
+
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context: %v", err)
 	}
-	c1.Close()
-	if err := <-errCh; err != nil {
-		t.Fatalf("Handle: %v", err)
+	if clientErr != nil {
+		t.Fatalf("DumpChangesSequential: %v", clientErr)
+	}
+	if srvErr != nil {
+		t.Fatalf("Handle: %v", srvErr)
 	}
 	if !bytes.Equal(dev.buf, snapshotData) {
 		t.Fatalf("device mismatch")
@@ -231,18 +276,40 @@ func TestRsyncDeltaCDCMutate(t *testing.T) {
 	copy(dev.buf, originData)
 	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
 
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	c1, c2 := net.Pipe()
 	cc := &countingConn{Conn: c1}
-	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Handle(context.Background(), rsyncwire.NewStream(c2, rsyncMaxFrame)) }()
+	var wg sync.WaitGroup
+	serverReady := make(chan struct{})
+	var srvErr, clientErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(serverReady)
+		srvErr = srv.Handle(ctx, rsyncwire.NewStream(c2, rsyncMaxFrame))
+	}()
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
-	if err := tr.DumpChangesSequential(context.Background(), cfg, snapPath, origPath, cc); err != nil {
-		t.Fatalf("DumpChangesSequential: %v", err)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer c1.Close()
+		<-serverReady
+		clientErr = tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
+	}()
+
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context: %v", err)
 	}
-	c1.Close()
-	if err := <-errCh; err != nil {
-		t.Fatalf("Handle: %v", err)
+	if clientErr != nil {
+		t.Fatalf("DumpChangesSequential: %v", clientErr)
+	}
+	if srvErr != nil {
+		t.Fatalf("Handle: %v", srvErr)
 	}
 	if !bytes.Equal(dev.buf, snapshotData) {
 		t.Fatalf("device mismatch")


### PR DESCRIPTION
## Summary
- run rsync delta server and client in separate goroutines with a WaitGroup
- guard rsync delta tests with context timeouts to surface deadlocks
- update tests for rsync client/server helpers to pass context to identity and digest calls

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many lint errors such as redefines-builtin-id and unused-parameter)*

------
https://chatgpt.com/codex/tasks/task_e_68a659bb16f0832388c49edd3aa714a0