### PR TITLE
test: close pipes and guard waitgroups

### DIFF
--- a/cmd/dump/rsync_delta_integration_test.go
+++ b/cmd/dump/rsync_delta_integration_test.go
@@ -68,17 +68,34 @@ func TestStreamToRemoteRsyncDelta(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer c2.Close()
 		srvErr = srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame))
+		if srvErr != nil {
+			cancel()
+		}
 	}()
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer c1.Close()
 		cliErr = StreamToRemote(ctx, cfg, cc, snapPath, origPath, digestpkg.SHA256, zap.NewNop())
-		c1.Close()
+		if cliErr != nil {
+			cancel()
+		}
 	}()
 
-	wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("wg.Wait(): timeout")
+	}
 
 	if cliErr != nil {
 		t.Fatalf("StreamToRemote: %v", cliErr)

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -137,8 +137,12 @@ func TestDumpChangesRsyncDelta(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer c2.Close()
 		close(serverReady)
 		srvErr = srv.Handle(ctx, rsyncwire.NewStream(c2, rsyncMaxFrame))
+		if srvErr != nil {
+			cancel()
+		}
 	}()
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
@@ -148,17 +152,31 @@ func TestDumpChangesRsyncDelta(t *testing.T) {
 		defer c1.Close()
 		<-serverReady
 		clientErr = tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
+		if clientErr != nil {
+			cancel()
+		}
 	}()
 
-	wg.Wait()
-	if err := ctx.Err(); err != nil {
-		t.Fatalf("context: %v", err)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("wg.Wait(): timeout")
 	}
+
 	if clientErr != nil {
 		t.Fatalf("DumpChangesSequential: %v", clientErr)
 	}
 	if srvErr != nil {
 		t.Fatalf("Handle: %v", srvErr)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context: %v", err)
 	}
 	if !bytes.Equal(dev.buf, snapshotData) {
 		t.Fatalf("device mismatch")
@@ -212,8 +230,12 @@ func TestRsyncDeltaCDCShift(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer c2.Close()
 		close(serverReady)
 		srvErr = srv.Handle(ctx, rsyncwire.NewStream(c2, rsyncMaxFrame))
+		if srvErr != nil {
+			cancel()
+		}
 	}()
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
@@ -223,17 +245,31 @@ func TestRsyncDeltaCDCShift(t *testing.T) {
 		defer c1.Close()
 		<-serverReady
 		clientErr = tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
+		if clientErr != nil {
+			cancel()
+		}
 	}()
 
-	wg.Wait()
-	if err := ctx.Err(); err != nil {
-		t.Fatalf("context: %v", err)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("wg.Wait(): timeout")
 	}
+
 	if clientErr != nil {
 		t.Fatalf("DumpChangesSequential: %v", clientErr)
 	}
 	if srvErr != nil {
 		t.Fatalf("Handle: %v", srvErr)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context: %v", err)
 	}
 	if !bytes.Equal(dev.buf, snapshotData) {
 		t.Fatalf("device mismatch")
@@ -288,8 +324,12 @@ func TestRsyncDeltaCDCMutate(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer c2.Close()
 		close(serverReady)
 		srvErr = srv.Handle(ctx, rsyncwire.NewStream(c2, rsyncMaxFrame))
+		if srvErr != nil {
+			cancel()
+		}
 	}()
 
 	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
@@ -299,17 +339,31 @@ func TestRsyncDeltaCDCMutate(t *testing.T) {
 		defer c1.Close()
 		<-serverReady
 		clientErr = tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
+		if clientErr != nil {
+			cancel()
+		}
 	}()
 
-	wg.Wait()
-	if err := ctx.Err(); err != nil {
-		t.Fatalf("context: %v", err)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("wg.Wait(): timeout")
 	}
+
 	if clientErr != nil {
 		t.Fatalf("DumpChangesSequential: %v", clientErr)
 	}
 	if srvErr != nil {
 		t.Fatalf("Handle: %v", srvErr)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context: %v", err)
 	}
 	if !bytes.Equal(dev.buf, snapshotData) {
 		t.Fatalf("device mismatch")


### PR DESCRIPTION
## Summary
- ensure `net.Pipe` connections are closed and cancel context on goroutine errors
- add timeout guards around `wg.Wait()` to surface blocked goroutines

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: StreamToRemoteRsyncDelta, TestHandleApplyDelta, TestDumpChangesRsyncDelta)*
- `golangci-lint run` *(fails: package comments, unused params, revive/staticcheck warnings)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a66a039e3c83239030a2c7e0542150