### PR TITLE
Add optional partition signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--force` | `LVMSYNC_FORCE` | `force` | Override safety checks and proceed on mounted destination |
 | `--force-offline` | `LVMSYNC_FORCE_OFFLINE` | `force_offline` | Allow direct device writes; prompts for `double-confirm` when interactive (requires `--yes-i-know` otherwise) |
 | `--allow-overwrite` | `LVMSYNC_ALLOW_OVERWRITE` | `allow_overwrite` | Allow overwriting existing data; requires `--yes-i-know` for non-interactive sessions |
+| `--check-partition` | `LVMSYNC_CHECK_PARTITION` | `check_partition` | Verify partition signatures for source and destination |
 | `--discard` | `LVMSYNC_DISCARD` | `discard` | Issue BLKDISCARD before writing blocks and verify discarded regions |
 | `--dry-run` | `LVMSYNC_DRY_RUN` | `dry_run` | Log estimated transfer bytes without sending data; uses manifest sampling when available |
 | `--plan` | `LVMSYNC_PLAN` | `plan` | Print configuration plan as JSON and exit |

--- a/device/context.go
+++ b/device/context.go
@@ -48,15 +48,21 @@ func yesIKnowFromContext(ctx context.Context) bool {
 	return false
 }
 
-// WithPartitionSignatures returns a context carrying expected partition table
-// signatures. Empty strings skip the comparison.
-func WithPartitionSignatures(ctx context.Context, gpt, mbr string) context.Context {
-	return context.WithValue(ctx, ptSigKey, [2]string{gpt, mbr})
+type partitionSignatures struct {
+	gpt string
+	mbr string
 }
 
-func partitionSignaturesFromContext(ctx context.Context) (string, string) {
-	if v, ok := ctx.Value(ptSigKey).([2]string); ok {
-		return v[0], v[1]
+// WithPartitionSignatures returns a context carrying partition table
+// signatures. Empty strings enable comparison while deferring the actual
+// values to the first device detection.
+func WithPartitionSignatures(ctx context.Context, gpt, mbr string) context.Context {
+	return context.WithValue(ctx, ptSigKey, &partitionSignatures{gpt: gpt, mbr: mbr})
+}
+
+func partitionSignaturesFromContext(ctx context.Context) *partitionSignatures {
+	if v, ok := ctx.Value(ptSigKey).(*partitionSignatures); ok {
+		return v
 	}
-	return "", ""
+	return nil
 }

--- a/device/detect.go
+++ b/device/detect.go
@@ -16,18 +16,18 @@ import (
 )
 
 func verifyPartition(ctx context.Context, dev Device) error {
-	gpt, mbr := partitionSignaturesFromContext(ctx)
-	if gpt == "" && mbr == "" {
+	sig := partitionSignaturesFromContext(ctx)
+	if sig == nil || (sig.gpt == "" && sig.mbr == "") {
 		return nil
 	}
 	id, err := dev.Identity(ctx)
 	if err != nil {
 		return err
 	}
-	if gpt != "" && id.GPTUUID != gpt {
+	if sig.gpt != "" && id.GPTUUID != sig.gpt {
 		return fmt.Errorf("precondition: partition table mismatch")
 	}
-	if mbr != "" && id.MBRSignature != mbr {
+	if sig.mbr != "" && id.MBRSignature != sig.mbr {
 		return fmt.Errorf("precondition: partition table mismatch")
 	}
 	return nil
@@ -153,6 +153,30 @@ func Detect(
 	if err != nil {
 		logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "stat"), zap.Error(err))
 		return nil, err
+	}
+	if sig := partitionSignaturesFromContext(ctx); sig != nil {
+		gpt, mbr, err := readPartitionSignatures(resolved)
+		if err != nil {
+			logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
+			return nil, err
+		}
+		if sig.gpt == "" && sig.mbr == "" {
+			if gpt == "" && mbr == "" {
+				err := fmt.Errorf("precondition: partition signatures missing")
+				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
+				return nil, err
+			}
+			sig.gpt = gpt
+			sig.mbr = mbr
+		} else {
+			if gpt == "" && mbr == "" ||
+				(sig.gpt != "" && gpt != sig.gpt) ||
+				(sig.mbr != "" && mbr != sig.mbr) {
+				err := fmt.Errorf("precondition: partition table mismatch")
+				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
+				return nil, err
+			}
+		}
 	}
 	if explicitType != "" && explicitType != TypeAuto {
 		switch explicitType {

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"encoding/binary"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -358,3 +359,67 @@ func TestDetectRawPartitionMatch(t *testing.T) {
 	}
 	dev.Close()
 }
+
+func TestDetectPartitionComparison(t *testing.T) {
+	cases := []struct {
+		name    string
+		sig1    uint32
+		sig2    *uint32
+		wantErr bool
+	}{
+		{name: "match", sig1: 0x12345678, sig2: ptr(uint32(0x12345678)), wantErr: false},
+		{name: "mismatch", sig1: 0x12345678, sig2: ptr(uint32(0x87654321)), wantErr: true},
+		{name: "missing", sig1: 0x12345678, sig2: nil, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f1 := createMBRFile(t, &tc.sig1)
+			var f2 string
+			if tc.sig2 != nil {
+				f2 = createMBRFile(t, tc.sig2)
+			} else {
+				f2 = createMBRFile(t, nil)
+			}
+			ctx := WithPartitionSignatures(context.Background(), "", "")
+			ctx = WithForce(ctx, true)
+			ctx = WithAllowOverwrite(ctx, true)
+			ctx = WithYesIKnow(ctx, true)
+			dev, err := Detect(ctx, f1, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+			if err != nil {
+				t.Fatalf("detect src: %v", err)
+			}
+			dev.Close()
+			_, err = Detect(ctx, f2, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "precondition") {
+					t.Fatalf("expected precondition error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("detect dst: %v", err)
+			}
+		})
+	}
+}
+
+func createMBRFile(t *testing.T, sig *uint32) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "mbr")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	var buf [512]byte
+	if sig != nil {
+		binary.LittleEndian.PutUint32(buf[440:444], *sig)
+		buf[510] = 0x55
+		buf[511] = 0xaa
+	}
+	if _, err := f.Write(buf[:]); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/docs/config_env.md
+++ b/docs/config_env.md
@@ -11,6 +11,7 @@
 | LVMSYNC_CDC_AVG | `--cdc-avg` | `cdc-avg` | Average chunk size for CDC |
 | LVMSYNC_CDC_MAX | `--cdc-max` | `cdc-max` | Maximum chunk size for CDC |
 | LVMSYNC_CDC_MIN | `--cdc-min` | `cdc-min` | Minimum chunk size for CDC |
+| LVMSYNC_CHECK_PARTITION | `--check-partition` | `check-partition` | Verify partition signatures for source and destination |
 | LVMSYNC_CHECKPOINT_BYTES | `--checkpoint-bytes` | `checkpoint-bytes` | Bytes between resume checkpoints |
 | LVMSYNC_CHECKPOINT_INTERVAL | `--checkpoint-interval` | `checkpoint-interval` | Duration between checkpoints |
 | LVMSYNC_CHUNK_SEED | `--chunk-seed` | `chunk-seed` | Seed for chunking |

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -37,6 +37,7 @@ type Config struct {
 	Force                    bool          `mapstructure:"force"`
 	ForceOffline             bool          `mapstructure:"force_offline"`
 	AllowOverwrite           bool          `mapstructure:"allow_overwrite"`
+	CheckPartition           bool          `mapstructure:"check_partition"`
 	StrictConfig             bool          `mapstructure:"strict_config"`
 	Discard                  bool          `mapstructure:"discard"`
 	Offline                  bool          `mapstructure:"offline"`
@@ -186,6 +187,7 @@ func DefaultConfig() (*Config, error) {
 		Force:                    false,
 		ForceOffline:             false,
 		AllowOverwrite:           false,
+		CheckPartition:           false,
 		StrictConfig:             false,
 		Offline:                  false,
 		Sparse:                   Auto,

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -62,6 +62,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("force", cfg.Force, "Override safety checks for offline raw access or filesystem freeze")
 	fs.Bool("force-offline", cfg.ForceOffline, "Allow direct device writes; prompts for double-confirm")
 	fs.Bool("allow-overwrite", cfg.AllowOverwrite, "Allow overwriting existing data; requires --yes-i-know for non-interactive sessions")
+	fs.Bool("check-partition", cfg.CheckPartition, "Verify partition signatures for source and destination")
 	fs.Bool("discard", cfg.Discard, "Issue BLKDISCARD before writing blocks and verify discarded regions")
 	fs.Bool("offline", cfg.Offline, "Assume source raw device is offline")
 	fs.Bool("sanitize-env", cfg.SanitizeEnv, "Drop PATH, LANG, and unsafe variables before privilege escalation (enable with --sanitize-env)")

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -29,6 +29,9 @@
     "cdc_min": {
       "type": "integer"
     },
+    "check_partition": {
+      "type": "boolean"
+    },
     "checkpoint_bytes": {
       "type": "string"
     },


### PR DESCRIPTION
## Summary
- add `--check-partition` flag and config field
- compare source and destination partition signatures during device detection
- test signature match, mismatch, and absence cases

## Testing
- `go build ./...`
- `go test -cover ./device ./internal/config`
- `golangci-lint run` *(fails: many revive/staticcheck issues)*
- `go test -cover ./...` *(timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a66a04a6608323817d4cf5fce5441d