### PR TITLE
transfer: add reconnect-aware resume path

### DIFF
--- a/transfer/reconnect_integration_test.go
+++ b/transfer/reconnect_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/config"
+	"lvmsync_go/transport"
+)
+
+// compareFiles verifies two paths have identical contents.
+func compareFiles(t *testing.T, a, b string) {
+	t.Helper()
+	da, err := os.ReadFile(a)
+	if err != nil {
+		t.Fatalf("read %s: %v", a, err)
+	}
+	db, err := os.ReadFile(b)
+	if err != nil {
+		t.Fatalf("read %s: %v", b, err)
+	}
+	if !bytes.Equal(da, db) {
+		t.Fatalf("file mismatch")
+	}
+}
+
+// TestReconnectMidTransfer drops the connection and verifies the transfer resumes.
+func TestReconnectMidTransfer(t *testing.T) {
+	blockSize := 4096
+	snapshot := "vg-lv"
+	_, src := createVolumeFiles(t, snapshot, int64(blockSize), []int{0, 1, 2, 3, 4, 5, 6, 7})
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, make([]byte, blockSize*8), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	senderState := filepath.Join(t.TempDir(), "sender.state")
+	applyState := filepath.Join(t.TempDir(), "apply.state")
+
+	applyCfg := &config.Config{BlockSize: blockSize, Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: applyState}
+	tr := NewTransfer(zap.NewNop(), nil, nil)
+
+	trNet, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("get transport: %v", err)
+	}
+	ctx := context.Background()
+	ln, err := trNet.Listen(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		first := true
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				serverDone <- err
+				return
+			}
+			if first {
+				first = false
+				go func(c net.Conn) {
+					time.Sleep(200 * time.Millisecond)
+					c.Close()
+				}(conn)
+			}
+			tt := NewTransfer(zap.NewNop(), nil, nil)
+			err = tt.ProcessDumpData(context.Background(), applyCfg, conn, dest)
+			conn.Close()
+			if err == nil {
+				serverDone <- nil
+				return
+			}
+		}
+	}()
+
+	cfg := &config.Config{
+		BlockSize:         blockSize,
+		Compress:          "none",
+		ChecksumAlgorithm: "blake3",
+		ResumeState:       senderState,
+		ResumeToken:       "tok",
+		CheckpointBytes:   1,
+		SpeedLimit:        1024,
+		MaxRetries:        3,
+		RetryDelay:        200 * time.Millisecond,
+	}
+	if err := tr.DumpChangesWithReconnect(ctx, cfg, trNet, ln.Addr().String(), snapshot, src); err != nil {
+		t.Fatalf("DumpChangesWithReconnect: %v", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+	compareFiles(t, src, dest)
+}

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -28,6 +28,7 @@ type resumeState struct {
 	Compress          string           `json:"compress"`
 	ChecksumAlgorithm string           `json:"checksum_algorithm"`
 	DedupMode         string           `json:"dedup_mode"`
+	ResumeToken       string           `json:"resume_token"`
 	Fixed             resumeChunkState `json:"fixed"`
 	CDC               resumeChunkState `json:"cdc"`
 	Hybrid            resumeChunkState `json:"hybrid"`
@@ -53,6 +54,7 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunk
 		Compress:          cfg.Compress,
 		ChecksumAlgorithm: cfg.ChecksumAlgorithm,
 		DedupMode:         cfg.DedupMode,
+		ResumeToken:       cfg.ResumeToken,
 		Fixed:             toState(chunks.Fixed),
 		CDC:               toState(chunks.CDC),
 		Hybrid:            toState(chunks.Hybrid),
@@ -175,6 +177,12 @@ func loadResumeState(path string, cfg *config.Config, size uint64, deviceID stri
 		return out, false
 	}
 	out.DedupMode = rs.DedupMode
+	if rs.ResumeToken != "" && cfg.ResumeToken != "" && rs.ResumeToken != cfg.ResumeToken {
+		return out, false
+	}
+	if cfg.ResumeToken == "" {
+		cfg.ResumeToken = rs.ResumeToken
+	}
 	if (rs.DeviceID != "" && deviceID != "" && rs.DeviceID != deviceID) ||
 		(rs.SizeBytes != 0 && size != 0 && rs.SizeBytes != size) ||
 		(rs.Epoch != 0 && epoch != 0 && rs.Epoch != epoch) {

--- a/transfer/resume_state_test.go
+++ b/transfer/resume_state_test.go
@@ -23,6 +23,7 @@ func TestSaveAndReadResumeState(t *testing.T) {
 		ResumeState:       path,
 		DedupMode:         "fixed",
 		CheckpointBytes:   4,
+		ResumeToken:       "tok",
 	}
 	rt := &resumeTracker{sizeBytes: 100, deviceID: "fsuuid", epoch: 1}
 	digest := blake3.Sum256([]byte("data"))
@@ -33,6 +34,9 @@ func TestSaveAndReadResumeState(t *testing.T) {
 		t.Fatalf("expected resume wal file: %v", err)
 	}
 	cp := readResumeState(cfg, zap.NewNop(), 100, "fsuuid", 1, digest)
+	if cfg.ResumeToken != "tok" {
+		t.Fatalf("resume token not persisted: %s", cfg.ResumeToken)
+	}
 	rc := cp.chunk("fixed")
 	if rc.Offset != 0 || rc.Length != 4 || hex.EncodeToString(rc.Chunk[:]) != hex.EncodeToString(digest[:]) {
 		t.Fatalf("unexpected checkpoint: %+v", rc)

--- a/transfer/worker.go
+++ b/transfer/worker.go
@@ -3,8 +3,10 @@ package transfer
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"syscall"
 	"time"
@@ -15,6 +17,7 @@ import (
 	"lvmsync_go/common"
 	"lvmsync_go/internal/blocksize"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/transport"
 )
 
 // detectBlockSize sets cfg.BlockSize by probing source; logger must be non-nil.
@@ -202,4 +205,63 @@ func (t *Transfer) DumpChangesParallel(ctx context.Context, cfg *config.Config, 
 		t.Logger.Info("final checksum", zap.String("final_digest", fmt.Sprintf("%x", finalDigest)))
 	}
 	return nil
+}
+
+// DumpChangesWithReconnect streams changes with automatic reconnection on transient dial failures.
+// logger must be non-nil and cfg.MaxRetries governs retry attempts.
+func (t *Transfer) DumpChangesWithReconnect(ctx context.Context, cfg *config.Config, tr transport.Interface, address, snapshot, source string) error {
+	retries := cfg.MaxRetries
+	if retries < 1 {
+		retries = 1
+	}
+	var lastErr error
+	for attempt := 0; ctx.Err() == nil && attempt < retries; attempt++ {
+		conn, err := tr.Dial(ctx, address)
+		if err != nil {
+			lastErr = err
+			if !isTransient(err) || attempt+1 == retries {
+				break
+			}
+			select {
+			case <-time.After(cfg.RetryDelay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			continue
+		}
+		lastErr = t.DumpChangesParallel(ctx, cfg, snapshot, source, conn)
+		conn.Close()
+		if lastErr == nil {
+			return nil
+		}
+		if !isTransient(lastErr) {
+			break
+		}
+		if attempt+1 < retries {
+			select {
+			case <-time.After(cfg.RetryDelay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("retries exhausted")
+	}
+	return lastErr
+}
+
+// isTransient reports whether err is a retryable network error.
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return ne.Timeout() || ne.Temporary()
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- retry transport dial with backoff on transient errors
- persist resume tokens to WAL for reconnects
- integration test for mid-transfer reconnect

## Testing
- `go build ./...`
- `go test ./transfer -run TestSaveAndReadResumeState`
- `golangci-lint run` *(fails: redefinition of built-in ids, unused params, package comments, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a66a06740083239ef3f06b1734cea4