### PR TITLE
test: add delta precedence

### DIFF
--- a/docs/config_env.md
+++ b/docs/config_env.md
@@ -95,3 +95,35 @@
 | LVMSYNC_YES_I_KNOW | `--yes-i-know` | `yes-i-know` | Confirm destructive write operations in non-interactive sessions |
 | LVMSYNC_ZEROCOPY | `--zerocopy` | `zerocopy` | Enable zero-copy transfers |
 | LVMSYNC_ZSTD_LEVEL | `--zstd-level` | `zstd-level` | Zstd compression level (1-5) |
+
+## Examples
+
+Configuration values follow flag > environment variable > YAML file precedence. For the `delta` option:
+
+1. Environment variables override YAML:
+
+   `config.yaml`:
+
+   ```yaml
+   delta: none
+   ```
+
+   ```sh
+   LVMSYNC_DELTA=rsync lvmsync --config config.yaml
+   ```
+
+   The effective value is `rsync`.
+
+2. Flags override environment variables and YAML:
+
+   `config.yaml`:
+
+   ```yaml
+   delta: rsync
+   ```
+
+   ```sh
+   LVMSYNC_DELTA=rsync lvmsync --config config.yaml --delta none
+   ```
+
+   The effective value is `none`.

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -55,6 +55,52 @@ func TestFreezeTimeoutEnvOverridesYAML(t *testing.T) {
 	}
 }
 
+func TestDeltaFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("delta: rsync\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_DELTA", "rsync")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--delta", "none"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.Delta != "none" {
+		t.Fatalf("Delta=%q want %q", cfg.Delta, "none")
+	}
+}
+
+func TestDeltaEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("delta: none\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_DELTA", "rsync")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.Delta != "rsync" {
+		t.Fatalf("Delta=%q want %q", cfg.Delta, "rsync")
+	}
+}
+
 func TestLVMSyncPathFlagOverridesEnvAndYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()


### PR DESCRIPTION
## Summary
- cover delta flag/env/YAML precedence
- document delta precedence examples

## Testing
- `go build ./... && echo build-success`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: package-comments, redefines-builtin-id, unused-parameter, exported, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a66a07f8b08323a1a0c2a29561916d