### PR TITLE
docs: document env sanitization in sudoers guide

### DIFF
--- a/docs/sudoers.md
+++ b/docs/sudoers.md
@@ -44,6 +44,12 @@ shell escapes, while `!setenv` blocks attackers from altering the execution
 environment. These restrictions help contain compromised helpers and reduce
 privilege-escalation risks.
 
+LVMSync forwards the invoking environment to escalated commands by default.
+The `sudoers` examples above already block environment injection with
+`!setenv`, but inherited variables remain untouched. Operators who need to
+drop potentially unsafe variables must pass `--sanitize-env` or set
+`LVMSYNC_SANITIZE_ENV=1` to enable explicit sanitization.
+
 Test each entry carefully to ensure no additional privileges are granted.
 
 ## Auditing


### PR DESCRIPTION
## Summary
- clarify that LVMSync forwards the invoking environment by default
- note that `--sanitize-env`/`LVMSYNC_SANITIZE_ENV=1` is required to drop variables even with `!setenv`

## Testing
- `make docs-check`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5357d90832382f8d852176f4260