### PR TITLE
docs: include mbr signature in probe-only tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ For snapshot cleanup, resuming transfers, and verify-only rollback procedures, s
 - **Remote Execution via SSH**: Replicates data over SSH with support for pre/post-scripts.
 - **Resume Support**: Ability to resume interrupted transfers with verification enabled by default (use `--verify=none` to skip).
 - **Crash-Safe WAL**: Records committed ranges in a write-ahead log so interrupted runs can recover. See [WAL documentation](docs/wal.md) for layout and replay details.
-- **Probe and Verification Modes**: `--probe-only` validates devices and privileges without writing and prints `size_bytes kernel_uuid gpt_uuid fs_uuid major minor manifest_epoch` to stdout, while `--verify-only` scans both sides and reports mismatches.
+ - **Probe and Verification Modes**: `--probe-only` validates devices and privileges without writing and prints `size_bytes kernel_uuid gpt_uuid mbr_signature fs_uuid major minor manifest_epoch` to stdout, while `--verify-only` scans both sides and reports mismatches.
  - **Dry-run Estimates**: `--dry-run` samples the manifest to project bytes and ETA without transferring data.
  - **Planning**: `--plan` prints resolved configuration with secrets redacted, transport order, estimated bytes, and compression decisions as JSON without transferring data.
- - **Device Identity Tuple**: Each run records `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` to prevent writing to the wrong destination.
+ - **Device Identity Tuple**: Each run records `(size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` to prevent writing to the wrong destination.
 
 - **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
 - **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it. Use `--sparse=never` to always write zeros instead.
@@ -710,7 +710,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--enable-quic` | `LVMSYNC_ENABLE_QUIC` | `enable_quic` | Enable QUIC transport registration |
 | `--plan` | `LVMSYNC_PLAN` | `plan` | Print configuration plan as JSON and exit |
 | `--verify-only` | `LVMSYNC_VERIFY_ONLY` | `verify_only` | Read source and destination and report mismatches without writing data |
-| `--probe-only` | `LVMSYNC_PROBE_ONLY` | `probe_only` | Validate devices and privileges and print `size_bytes kernel_uuid gpt_uuid fs_uuid major minor manifest_epoch` without transferring data |
+| `--probe-only` | `LVMSYNC_PROBE_ONLY` | `probe_only` | Validate devices and privileges and print `size_bytes kernel_uuid gpt_uuid mbr_signature fs_uuid major minor manifest_epoch` without transferring data |
 | `--sparse` | `LVMSYNC_SPARSE` | `sparse` | Sparse file handling: `auto` punches holes, `never` writes zero blocks |
 | `--transport` | `LVMSYNC_TRANSPORT_TRANSPORT` | `transport` | Ordered transports to try (e.g., `ssh,tcp+tls,h2,quic`) |
 | `--tcp-port` | `LVMSYNC_TRANSPORT_TCP_PORT` | `tcp_port` | TCP+TLS port |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ The controller orchestrates replication, validates parameters, and interacts wit
 ## Probe and verify modes
 
 Read-only operations can run without elevated privileges.
-`--probe-only` checks device metadata, validates privileges, and emits dry-run estimates. It prints `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` for confirmation.
+`--probe-only` checks device metadata, validates privileges, and emits dry-run estimates. It prints `(size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` for confirmation.
 `--verify-only` reads source and destination devices and reports mismatches.
 
 Both commands exit `0` on success, return `60` for verification failures, and `10` when required capabilities are missing. See [exit code meanings](OPERATIONS.md#exit-codes-and-recovery) for all codes.
@@ -31,7 +31,7 @@ lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target || \
 
 ## Device identity enforcement
 
-Each transfer records `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` and compares it with the destination and any resume state before writing. LVMSync refuses to resume when this tuple differs, preventing accidental or malicious overwrites.
+Each transfer records `(size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` and compares it with the destination and any resume state before writing. LVMSync refuses to resume when this tuple differs, preventing accidental or malicious overwrites.
 
 ## Required sudoers entries
 
@@ -94,7 +94,7 @@ A misconfigured `sudoers` rule or path could destroy unrelated data or allow
 full-disk compromise. LVMSync mitigates this risk by:
 
 * Requiring explicit device paths; globbing and symlinks are rejected.
-* Verifying the device identity tuple `(size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, manifest_epoch)` before writing.
+* Verifying the device identity tuple `(size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` before writing.
 * Dropping privileges immediately after completing the privileged section.
 
 Review `sudoers` entries carefully and test on non-production systems before granting wide access.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -52,7 +52,7 @@ lvmsync run --resume=statefile /dev/vg0/snap0 /dev/vg0/target
 2. If the process is interrupted (for example, by `SIGKILL`), invoke the same
    command with `--resume statefile` to continue copying remaining blocks.
 3. LVMSync validates the device identity tuple `(size_bytes, kernel_uuid,
-   gpt_uuid, fs_uuid, major, minor, manifest_epoch)` against the resume file.
+   gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` against the resume file.
    Mismatches abort with a precondition failure to prevent accidental
    overwrites.
 4. After a successful resume the state file is removed; optionally run

--- a/docs/config_env.md
+++ b/docs/config_env.md
@@ -54,7 +54,7 @@
 | LVMSYNC_OUTPUT | `--output` | `output` | Output format: text, json, or yaml |
 | LVMSYNC_PARALLEL | `--parallel` | `parallel` | Number of concurrent workers |
 | LVMSYNC_PLAN | `--plan` | `plan` | Print configuration plan as JSON and exit |
-| LVMSYNC_PROBE_ONLY | `--probe-only` | `probe-only` | Output size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, and manifest_epoch without writing |
+| LVMSYNC_PROBE_ONLY | `--probe-only` | `probe-only` | Output size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, and manifest_epoch without writing |
 | LVMSYNC_PROGRESS | `--progress` | `progress` | Show progress during transfer |
 | LVMSYNC_REMOTE_POST_SCRIPT | `--remote-post-script` | `remote-post-script` | Remote script to run after transfer |
 | LVMSYNC_REMOTE_PRE_SCRIPT | `--remote-pre-script` | `remote-pre-script` | Remote script to run before transfer |

--- a/internal/config/flagsets.go
+++ b/internal/config/flagsets.go
@@ -57,7 +57,7 @@ func initGeneralFlags(cfg *Config) *pflag.FlagSet {
 	fs.Bool("strict-config", cfg.StrictConfig, "Treat configuration warnings as errors")
 	fs.Bool("yes-i-know", cfg.YesIKnow, "Confirm destructive write operations in non-interactive sessions")
 	fs.Bool("dry-run", cfg.DryRun, "Print actions without executing")
-	fs.Bool("probe-only", cfg.ProbeOnly, "Output size_bytes, kernel_uuid, gpt_uuid, fs_uuid, major, minor, and manifest_epoch without writing")
+       fs.Bool("probe-only", cfg.ProbeOnly, "Output size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, and manifest_epoch without writing")
 	fs.Bool("plan", cfg.Plan, "Print configuration plan as JSON and exit")
 	fs.Bool("force", cfg.Force, "Override safety checks for offline raw access or filesystem freeze")
 	fs.Bool("force-offline", cfg.ForceOffline, "Allow direct device writes; prompts for double-confirm")


### PR DESCRIPTION
## Summary
- document mbr_signature in probe-only output and device identity tuple
- update config flag descriptions and generated env docs
- ensure security and operations docs mention full tuple

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestHandleApplyDelta timeout)*
- `go test readme_examples_test.go -run TestReadme -v`
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: multiple revive/staticcheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c53814408323b10de0892d9c1747