### PR TITLE
Send full device identity in rsync delta

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -536,14 +536,34 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 	}
 	defer common.CloseWithErr(orig, &err, "close origin")
 
+	logger.Warn("plaintext_connection", zap.String("transport", "rsync"), zap.String("docs", "docs/transports.md"))
+
 	rw := writeOnlyReadWriter{remoteStdin}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, maxFrame))
-	info, err := orig.Stat()
+	dev, err := r.detectDevice(ctx, originDevice, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 	if err != nil {
 		remoteStdin.Close()
-		return fmt.Errorf("stat origin: %w", err)
+		return fmt.Errorf("detect origin: %w", err)
 	}
-	if err := cl.SendIdentity(ctx, device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
+	id, err := dev.Identity(ctx)
+	dev.Close()
+	if err != nil {
+		remoteStdin.Close()
+		return fmt.Errorf("destination identity: %w", err)
+	}
+	if id.KernelUUID == "" {
+		id.KernelUUID = "0"
+	}
+	if id.GPTUUID == "" {
+		id.GPTUUID = "0"
+	}
+	if id.MBRSignature == "" {
+		id.MBRSignature = "0"
+	}
+	if id.FSUUID == "" {
+		id.FSUUID = "0"
+	}
+	if err := cl.SendIdentity(ctx, id); err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("send identity: %w", err)
 	}

--- a/cmd/dump/fake_device_test.go
+++ b/cmd/dump/fake_device_test.go
@@ -6,16 +6,25 @@ import (
 	"lvmsync_go/device"
 )
 
-type fakeDevice struct{ path string }
+type fakeDevice struct {
+	path string
+	size uint64
+}
 
 func (f *fakeDevice) Path() string                                            { return f.path }
-func (f *fakeDevice) SizeBytes() uint64                                       { return 0 }
+func (f *fakeDevice) SizeBytes() uint64                                       { return f.size }
 func (f *fakeDevice) BlockSize() uint64                                       { return 0 }
 func (f *fakeDevice) Snapshot(context.Context, string) (device.Device, error) { return f, nil }
 func (f *fakeDevice) Cleanup(context.Context) error                           { return nil }
 func (f *fakeDevice) Close() error                                            { return nil }
 func (f *fakeDevice) Identity(context.Context) (device.DeviceIdentity, error) {
-	return device.DeviceIdentity{}, nil
+	return device.DeviceIdentity{
+		SizeBytes:    f.size,
+		KernelUUID:   "0",
+		GPTUUID:      "0",
+		MBRSignature: "0",
+		FSUUID:       "0",
+	}, nil
 }
 func (f *fakeDevice) AppendWAL(r device.Range) error               { return nil }
 func (f *fakeDevice) RecoverWAL(fn func(device.Range) error) error { return nil }

--- a/cmd/dump/rsync_delta_integration_test.go
+++ b/cmd/dump/rsync_delta_integration_test.go
@@ -157,5 +157,11 @@ func (m *rsyncserverMemDevice) Size() int64 { return int64(len(m.buf)) }
 func (m *rsyncserverMemDevice) Sync() error { return nil }
 
 func (m *rsyncserverMemDevice) Identity(context.Context) (device.DeviceIdentity, error) {
-	return device.DeviceIdentity{SizeBytes: uint64(len(m.buf))}, nil
+	return device.DeviceIdentity{
+		SizeBytes:    uint64(len(m.buf)),
+		KernelUUID:   "0",
+		GPTUUID:      "0",
+		MBRSignature: "0",
+		FSUUID:       "0",
+	}, nil
 }

--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -8,12 +8,14 @@ import (
 	"os"
 
 	"github.com/zeebo/blake3"
+	"go.uber.org/zap"
 
 	"lvmsync_go/common"
 	"lvmsync_go/dedup"
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 	digestpkg "lvmsync_go/internal/digest"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/internal/rsyncwire"
 	manifestpkg "lvmsync_go/manifest"
 )
@@ -40,14 +42,33 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 	}
 	defer common.CloseWithErr(orig, &err, "close origin")
 
+	t.Logger.Warn("plaintext_connection", zap.String("transport", "rsync"), zap.String("docs", "docs/transports.md"))
+
 	rw := writeOnlyReadWriter{out}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, rsyncMaxFrame))
-	// Send destination identity based on the origin size.
-	info, err := orig.Stat()
+	// Send destination identity to allow early mismatch detection.
+	dev, err := device.Detect(ctx, origin, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
 	if err != nil {
-		return fmt.Errorf("stat origin: %w", err)
+		return fmt.Errorf("detect origin: %w", err)
 	}
-	if err := cl.SendIdentity(ctx, device.DeviceIdentity{SizeBytes: uint64(info.Size())}); err != nil {
+	defer dev.Close()
+	id, err := dev.Identity(ctx)
+	if err != nil {
+		return fmt.Errorf("destination identity: %w", err)
+	}
+	if id.KernelUUID == "" {
+		id.KernelUUID = "0"
+	}
+	if id.GPTUUID == "" {
+		id.GPTUUID = "0"
+	}
+	if id.MBRSignature == "" {
+		id.MBRSignature = "0"
+	}
+	if id.FSUUID == "" {
+		id.FSUUID = "0"
+	}
+	if err := cl.SendIdentity(ctx, id); err != nil {
 		return fmt.Errorf("send identity: %w", err)
 	}
 	if _, err := cl.SendSignatures(ctx, orig); err != nil {

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -64,7 +64,13 @@ func (m *rsyncserverMemDevice) Size() int64 { return int64(len(m.buf)) }
 func (m *rsyncserverMemDevice) Sync() error { return nil }
 
 func (m *rsyncserverMemDevice) Identity(context.Context) (device.DeviceIdentity, error) {
-	return device.DeviceIdentity{SizeBytes: uint64(len(m.buf))}, nil
+	return device.DeviceIdentity{
+		SizeBytes:    uint64(len(m.buf)),
+		KernelUUID:   "0",
+		GPTUUID:      "0",
+		MBRSignature: "0",
+		FSUUID:       "0",
+	}, nil
 }
 
 type rdMockDevice struct {
@@ -82,7 +88,13 @@ func (m *rdMockDevice) Snapshot(ctx context.Context, snapshotSize string) (devic
 func (m *rdMockDevice) Cleanup(ctx context.Context) error { return nil }
 func (m *rdMockDevice) Close() error                      { return nil }
 func (m *rdMockDevice) Identity(context.Context) (device.DeviceIdentity, error) {
-	return device.DeviceIdentity{}, nil
+	return device.DeviceIdentity{
+		SizeBytes:    m.size,
+		KernelUUID:   "0",
+		GPTUUID:      "0",
+		MBRSignature: "0",
+		FSUUID:       "0",
+	}, nil
 }
 func (m *rdMockDevice) AppendWAL(device.Range) error              { return nil }
 func (m *rdMockDevice) RecoverWAL(func(device.Range) error) error { return nil }


### PR DESCRIPTION
## Summary
- Retrieve full destination device identity in rsync delta and log plaintext connection
- Normalize device identity fields and send them in rsync delta client
- Update tests and fakes to use matching identities

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: many lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d836fe0083239b5b994c8cfe70d5