### PR TITLE
Add stable device identity comparison helper

### DIFF
--- a/device/identity.go
+++ b/device/identity.go
@@ -13,6 +13,20 @@ type DeviceIdentity struct {
 	ManifestEpoch uint64
 }
 
+// SameIdentity reports whether two DeviceIdentity values describe the same
+// device based on stable fields.
+//
+// Kernel-assigned Major and Minor numbers can change across reboots or when
+// devices are reattached, so they are intentionally ignored.
+func SameIdentity(a, b DeviceIdentity) bool {
+	return a.SizeBytes == b.SizeBytes &&
+		a.KernelUUID == b.KernelUUID &&
+		a.GPTUUID == b.GPTUUID &&
+		a.MBRSignature == b.MBRSignature &&
+		a.FSUUID == b.FSUUID &&
+		a.ManifestEpoch == b.ManifestEpoch
+}
+
 // Range represents a byte range on a device.
 type Range struct {
 	Start uint64

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -108,6 +108,25 @@ func TestDeviceIdentityFormatParseOrder(t *testing.T) {
 	}
 }
 
+func TestSameIdentityIgnoresMajorMinor(t *testing.T) {
+	a := DeviceIdentity{
+		SizeBytes:     1,
+		KernelUUID:    "k",
+		GPTUUID:       "g",
+		MBRSignature:  "m",
+		FSUUID:        "f",
+		Major:         2,
+		Minor:         3,
+		ManifestEpoch: 4,
+	}
+	b := a
+	b.Major++
+	b.Minor++
+	if !SameIdentity(a, b) {
+		t.Fatalf("expected identities to match: %+v vs %+v", a, b)
+	}
+}
+
 func createEchoScript(t *testing.T, name, output string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -94,7 +94,7 @@ func (s *Server) Handle(ctx context.Context, stream *rsyncwire.Stream) error {
 			if err != nil {
 				return err
 			}
-			if local != id {
+			if !device.SameIdentity(local, id) {
 				return fmt.Errorf("precondition: device identity mismatch")
 			}
 			idOK = true

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -532,3 +532,44 @@ func TestHandleIdentityMismatch(t *testing.T) {
 		t.Fatalf("expected precondition error, got %v", err)
 	}
 }
+
+func TestHandleIdentityIgnoresMajorMinor(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	id := device.DeviceIdentity{
+		SizeBytes:     1,
+		KernelUUID:    "k",
+		GPTUUID:       "g",
+		MBRSignature:  "m",
+		FSUUID:        "f",
+		Major:         1,
+		Minor:         1,
+		ManifestEpoch: 2,
+	}
+	dev := &memDevice{buf: make([]byte, int(id.SizeBytes)), id: id}
+	srv := New(dev, zap.NewNop(), nil, "", "")
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
+
+	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	remote := id
+	remote.Major++
+	remote.Minor++
+	if err := cl.SendIdentity(context.Background(), remote); err != nil {
+		t.Fatalf("SendIdentity: %v", err)
+	}
+	exp, err := digest.SumReader(bytes.NewReader(dev.buf), digest.SHA256)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if err := cl.SendDigest(context.Background(), digest.SHA256, exp); err != nil {
+		t.Fatalf("SendDigest: %v", err)
+	}
+	c1.Close()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `device.SameIdentity` to compare device identities using stable fields only
- use `SameIdentity` in rsync server instead of struct comparison
- test that differing major/minor numbers do not trigger identity mismatch

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: context canceled and timeout)*
- `golangci-lint run` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d83821d4832388f7517a10d2f8b1