### PR TITLE
device: handle bind mounts with multiple entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,7 @@ lvmsync manifest rebuild /dev/vg0/lv0
 Progress logs are emitted every 10s by default; adjust with `--manifest-progress-interval`.
 The command times out after 1m unless overridden with `--manifest-timeout` (0 disables).
 Rebuild refuses to run if the device is mounted read-write; pass `--manifest-allow-mounted` to override.
-Mount detection parses `/proc/self/mountinfo` using `github.com/moby/sys/mountinfo` to correctly handle devices with spaces or special characters.
+Mount detection parses `/proc/self/mountinfo` using `github.com/moby/sys/mountinfo`, correctly handling bind mounts, repeated entries, and devices with spaces or special characters.
 Rebuild fails if the device reports a block size of 0.
 
 Manifests embed a persistent device identifier in a fixed 64-byte field. The

--- a/device/info.go
+++ b/device/info.go
@@ -224,7 +224,13 @@ func defaultMountFunc(ctx context.Context, path string) (bool, error) {
 	}
 	ch := make(chan result, 1)
 	go func() {
-		infos, err := mountinfo.GetMounts(nil)
+		filter := func(mi *mountinfo.Info) (bool, bool) {
+			if mi.Source == real || mi.Mountpoint == real || mi.Root == real {
+				return false, false
+			}
+			return true, false
+		}
+		infos, err := mountinfo.GetMounts(filter)
 		ch <- result{infos: infos, err: err}
 	}()
 	var infos []*mountinfo.Info
@@ -238,9 +244,6 @@ func defaultMountFunc(ctx context.Context, path string) (bool, error) {
 		infos = r.infos
 	}
 	for _, mi := range infos {
-		if mi.Source != real && mi.Mountpoint != real && mi.Root != real {
-			continue
-		}
 		for _, opt := range strings.Split(mi.Options, ",") {
 			if opt == "rw" {
 				return true, nil

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -371,7 +371,7 @@ func TestDefaultMountFuncBindMountMountpoint(t *testing.T) {
 	}
 }
 
-func TestDefaultMountFuncDuplicateEntries(t *testing.T) {
+func TestDefaultMountFuncRepeatedDeviceEntries(t *testing.T) {
 	dev, err := os.CreateTemp("", "dev")
 	if err != nil {
 		t.Fatalf("create device: %v", err)
@@ -411,6 +411,46 @@ func TestDefaultMountFuncDuplicateEntries(t *testing.T) {
 	}
 }
 
+func TestDefaultMountFuncRepeatedDeviceEntriesAllRO(t *testing.T) {
+	dev, err := os.CreateTemp("", "dev")
+	if err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+	defer os.Remove(dev.Name())
+	dev.Close()
+
+	dir := t.TempDir()
+	mp := filepath.Join(dir, "mnt")
+	if err := os.Mkdir(mp, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	mounts, err := os.CreateTemp("", "mountinfo")
+	if err != nil {
+		t.Fatalf("create mountinfo: %v", err)
+	}
+	escaped := strings.ReplaceAll(dev.Name(), " ", "\\040")
+	line1 := fmt.Sprintf("42 24 0:0 / %s ro,relatime - ext4 %s rw\n", mp, escaped)
+	line2 := fmt.Sprintf("43 24 0:0 / %s ro,relatime - ext4 %s rw\n", mp, escaped)
+	if _, err := mounts.WriteString(line1 + line2); err != nil {
+		t.Fatalf("write mountinfo: %v", err)
+	}
+	mounts.Close()
+	defer os.Remove(mounts.Name())
+
+	info := NewInfo()
+	prev := info.SetMountFunc(mountFuncFromMountInfoFile(mounts.Name()))
+	defer info.SetMountFunc(prev)
+
+	got, err := info.IsMountedRW(context.Background(), mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatalf("expected not mounted read-write")
+	}
+}
+
 func TestDefaultMountFuncError(t *testing.T) {
 	dev, err := os.CreateTemp("", "dev")
 	if err != nil {
@@ -440,14 +480,17 @@ func mountFuncFromMountInfoFile(p string) func(context.Context, string) (bool, e
 			return false, err
 		}
 		defer f.Close()
-		infos, err := mountinfo.GetMountsFromReader(f, nil)
+		filter := func(mi *mountinfo.Info) (bool, bool) {
+			if mi.Source == real || mi.Mountpoint == real || mi.Root == real {
+				return false, false
+			}
+			return true, false
+		}
+		infos, err := mountinfo.GetMountsFromReader(f, filter)
 		if err != nil {
 			return false, err
 		}
 		for _, mi := range infos {
-			if mi.Source != real && mi.Mountpoint != real && mi.Root != real {
-				continue
-			}
 			for _, opt := range strings.Split(mi.Options, ",") {
 				if opt == "rw" {
 					return true, nil


### PR DESCRIPTION
## Summary
- filter mountinfo records by source, mountpoint, or root to detect bind mounts and duplicates
- add unit tests for bind mounts and repeated device entries
- document improved mount detection

## Testing
- `go test ./device`


------
https://chatgpt.com/codex/tasks/task_e_68a6fc3866788323a72e357b1e65df4b