### PR TITLE
feat(device): log partition layout diff

### DIFF
--- a/device/context.go
+++ b/device/context.go
@@ -48,9 +48,16 @@ func yesIKnowFromContext(ctx context.Context) bool {
 	return false
 }
 
+type partition struct {
+	Start uint64
+	End   uint64
+	Type  string
+}
+
 type partitionSignatures struct {
-	gpt string
-	mbr string
+	gpt    string
+	mbr    string
+	layout []partition
 }
 
 // WithPartitionSignatures returns a context carrying partition table

--- a/device/detect.go
+++ b/device/detect.go
@@ -15,12 +15,16 @@ import (
 	"lvmsync_go/lvm"
 )
 
-func verifyPartition(ctx context.Context, dev Device) error {
+func verifyPartition(ctx context.Context, dev Device, runner *Runner, logger *zap.Logger) error {
 	sig := partitionSignaturesFromContext(ctx)
-	if sig == nil || (sig.gpt == "" && sig.mbr == "") {
+	if sig == nil || (sig.gpt == "" && sig.mbr == "" && sig.layout == nil) {
 		return nil
 	}
 	id, err := dev.Identity(ctx)
+	if err != nil {
+		return err
+	}
+	layout, err := readPartitionLayout(ctx, dev.Path(), runner)
 	if err != nil {
 		return err
 	}
@@ -28,6 +32,10 @@ func verifyPartition(ctx context.Context, dev Device) error {
 		return fmt.Errorf("precondition: partition table mismatch")
 	}
 	if sig.mbr != "" && id.MBRSignature != sig.mbr {
+		return fmt.Errorf("precondition: partition table mismatch")
+	}
+	if diffs := diffPartitionLayouts(sig.layout, layout); len(diffs) > 0 {
+		logger.Error("partition_layout_mismatch", zap.Any("diff", diffs))
 		return fmt.Errorf("precondition: partition table mismatch")
 	}
 	return nil
@@ -60,7 +68,7 @@ func detectLVMDevice(ctx context.Context, path, lvmEscalation string, runner *Ru
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
 	}
-	if err := verifyPartition(ctx, dev); err != nil {
+	if err := verifyPartition(ctx, dev, runner, logger); err != nil {
 		dev.Close()
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
@@ -111,7 +119,7 @@ func detectRawDevice(
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err
 	}
-	if err := verifyPartition(ctx, dev); err != nil {
+	if err := verifyPartition(ctx, dev, runner, logger); err != nil {
 		dev.Close()
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err
@@ -160,7 +168,15 @@ func Detect(
 			logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
 			return nil, err
 		}
-		if sig.gpt == "" && sig.mbr == "" {
+		var layout []partition
+		if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
+			layout, err = readPartitionLayout(ctx, resolved, runner)
+			if err != nil {
+				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
+				return nil, err
+			}
+		}
+		if sig.gpt == "" && sig.mbr == "" && sig.layout == nil {
 			if gpt == "" && mbr == "" {
 				err := fmt.Errorf("precondition: partition signatures missing")
 				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
@@ -168,12 +184,18 @@ func Detect(
 			}
 			sig.gpt = gpt
 			sig.mbr = mbr
+			sig.layout = layout
 		} else {
 			if gpt == "" && mbr == "" ||
 				(sig.gpt != "" && gpt != sig.gpt) ||
 				(sig.mbr != "" && mbr != sig.mbr) {
 				err := fmt.Errorf("precondition: partition table mismatch")
 				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
+				return nil, err
+			}
+			if diffs := diffPartitionLayouts(sig.layout, layout); len(diffs) > 0 {
+				err := fmt.Errorf("precondition: partition table mismatch")
+				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Any("diff", diffs), zap.Error(err))
 				return nil, err
 			}
 		}

--- a/device/partition_layout.go
+++ b/device/partition_layout.go
@@ -1,0 +1,85 @@
+package device
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var sfdiskPath string
+
+func init() {
+	sfdiskPath, _ = exec.LookPath("sfdisk")
+}
+
+func readPartitionLayout(ctx context.Context, path string, runner *Runner) ([]partition, error) {
+	if sfdiskPath == "" {
+		return nil, fmt.Errorf("sfdisk not found")
+	}
+	if runner == nil {
+		runner = NewRunner()
+	}
+	out, err := runner.command.CommandContext(ctx, sfdiskPath, "-d", path).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseSfdiskDump(string(out))
+}
+
+var sfdiskLine = regexp.MustCompile(`^/[^ ]+ : start=\s*(\d+), size=\s*(\d+), type=(\S+)`)
+
+func parseSfdiskDump(out string) ([]partition, error) {
+	var parts []partition
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		m := sfdiskLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		start, err := strconv.ParseUint(m[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		size, err := strconv.ParseUint(m[2], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		end := start + size - 1
+		parts = append(parts, partition{Start: start, End: end, Type: m[3]})
+	}
+	return parts, nil
+}
+
+type partitionDiff struct {
+	Index int        `json:"index"`
+	A     *partition `json:"a,omitempty"`
+	B     *partition `json:"b,omitempty"`
+}
+
+func diffPartitionLayouts(a, b []partition) []partitionDiff {
+	max := len(a)
+	if len(b) > max {
+		max = len(b)
+	}
+	var diffs []partitionDiff
+	for i := 0; i < max; i++ {
+		var pa, pb *partition
+		if i < len(a) {
+			pa = &a[i]
+		}
+		if i < len(b) {
+			pb = &b[i]
+		}
+		if pa == nil || pb == nil || pa.Start != pb.Start || pa.End != pb.End || pa.Type != pb.Type {
+			diffs = append(diffs, partitionDiff{Index: i, A: pa, B: pb})
+		}
+	}
+	return diffs
+}

--- a/device/partition_layout_test.go
+++ b/device/partition_layout_test.go
@@ -1,0 +1,52 @@
+package device
+
+import "testing"
+
+const sampleSfdisk1 = `# partition table of /dev/sda
+unit: sectors
+
+/dev/sda1 : start=        2048, size=     1024, type=83
+/dev/sda2 : start=        4096, size=     2048, type=8e
+`
+
+const sampleSfdisk2 = `# partition table of /dev/sda
+unit: sectors
+
+/dev/sda1 : start=        2048, size=     1024, type=83
+/dev/sda2 : start=        4096, size=     1024, type=83
+`
+
+func TestParseSfdiskDump(t *testing.T) {
+	parts, err := parseSfdiskDump(sampleSfdisk1)
+	if err != nil {
+		t.Fatalf("parseSfdiskDump: %v", err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 partitions, got %d", len(parts))
+	}
+	if parts[0].Start != 2048 || parts[0].End != 3071 || parts[0].Type != "83" {
+		t.Fatalf("unexpected first partition: %+v", parts[0])
+	}
+	if parts[1].Start != 4096 || parts[1].End != 6143 || parts[1].Type != "8e" {
+		t.Fatalf("unexpected second partition: %+v", parts[1])
+	}
+}
+
+func TestDiffPartitionLayouts(t *testing.T) {
+	a, err := parseSfdiskDump(sampleSfdisk1)
+	if err != nil {
+		t.Fatalf("parseSfdiskDump a: %v", err)
+	}
+	b, err := parseSfdiskDump(sampleSfdisk2)
+	if err != nil {
+		t.Fatalf("parseSfdiskDump b: %v", err)
+	}
+	diffs := diffPartitionLayouts(a, b)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.Index != 1 || d.A.Type != "8e" || d.B.Type != "83" {
+		t.Fatalf("unexpected diff: %+v", d)
+	}
+}


### PR DESCRIPTION
## Summary
- capture partition layouts via `sfdisk -d`
- diff partition layouts and log mismatches
- test partition diff generation with sample tables

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a71154bab083239b8fbe42f599fc75