### PR TITLE
rsyncwire: replace goroutine deadlines with per-op deadlines

### DIFF
--- a/internal/rsyncwire/stream_test.go
+++ b/internal/rsyncwire/stream_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"hash/crc32"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -146,4 +147,59 @@ func TestStreamSendTimeout(t *testing.T) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 	_ = c2.Close()
+}
+
+// TestStreamNoGoroutineLeak ensures Send and Recv do not spawn lingering goroutines
+// when contexts are not cancelled.
+func TestStreamNoGoroutineLeak(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	sender := NewStream(c1, 1<<20)
+	receiver := NewStream(c2, 1<<20)
+
+	payload := []byte("data")
+	start := runtime.NumGoroutine()
+	for i := 0; i < 100; i++ {
+		sendCtx, _ := context.WithCancel(context.Background())
+		recvCtx, _ := context.WithCancel(context.Background())
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- sender.Send(sendCtx, payload) }()
+		if _, err := receiver.Recv(recvCtx); err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		if err := <-errCh; err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+	}
+	// Allow any goroutines to exit and force GC.
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+	after := runtime.NumGoroutine()
+	if diff := after - start; diff > 5 {
+		t.Fatalf("goroutines leaked: before=%d after=%d", start, after)
+	}
+}
+
+func BenchmarkStreamSend(b *testing.B) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	sender := NewStream(c1, 1<<20)
+	go func() {
+		buf := make([]byte, 1<<20)
+		for {
+			if _, err := c2.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	payload := []byte("benchmark")
+	for i := 0; i < b.N; i++ {
+		if err := sender.Send(context.Background(), payload); err != nil {
+			b.Fatalf("Send: %v", err)
+		}
+	}
 }

--- a/internal/rsyncwire/wire.go
+++ b/internal/rsyncwire/wire.go
@@ -49,9 +49,11 @@ func (s *Stream) Send(ctx context.Context, p []byte) error {
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(p)))
 	binary.BigEndian.PutUint32(hdr[4:8], crc32.Checksum(p, crcTable))
 
-	if err := withDeadline(ctx, s.rw); err != nil {
+	reset, err := withWriteDeadline(ctx, s.rw)
+	if err != nil {
 		return err
 	}
+	defer reset()
 	if err := writeFull(ctx, s.rw, hdr[:]); err != nil {
 		return err
 	}
@@ -98,9 +100,11 @@ func (s *Stream) Recv(ctx context.Context) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if err := withDeadline(ctx, s.rw); err != nil {
+	reset, err := withReadDeadline(ctx, s.rw)
+	if err != nil {
 		return nil, err
 	}
+	defer reset()
 	var hdr [8]byte
 	if err := readFull(ctx, s.rw, hdr[:]); err != nil {
 		return nil, err
@@ -151,33 +155,42 @@ func readFull(ctx context.Context, r io.Reader, buf []byte) error {
 	return nil
 }
 
-// withDeadline applies the context deadline to conn if it supports deadlines
-// and ensures it is cleared when the context completes. For contexts without a
-// deadline it sets a deadline when the context is cancelled.
-func withDeadline(ctx context.Context, rw io.ReadWriter) error {
-	conn, ok := rw.(net.Conn)
+// withReadDeadline applies the context deadline to conn if it supports read deadlines.
+// It returns a function that clears the deadline after the operation completes.
+func withReadDeadline(ctx context.Context, r io.Reader) (func(), error) {
+	conn, ok := r.(interface{ SetReadDeadline(time.Time) error })
 	if !ok {
-		return nil
+		return func() {}, nil
 	}
-	if dl, ok := ctx.Deadline(); ok {
-		if err := conn.SetDeadline(dl); err != nil {
-			return err
-		}
-		if done := ctx.Done(); done != nil {
-			go func() {
-				<-done
-				_ = conn.SetDeadline(time.Time{})
-			}()
-		}
-		return nil
+	dl, ok := ctx.Deadline()
+	if !ok {
+		return func() {}, nil
 	}
-	if done := ctx.Done(); done != nil {
-		go func() {
-			<-done
-			_ = conn.SetDeadline(time.Now())
-		}()
+	if err := conn.SetReadDeadline(dl); err != nil {
+		return nil, err
 	}
-	return nil
+	return func() {
+		_ = conn.SetReadDeadline(time.Time{})
+	}, nil
+}
+
+// withWriteDeadline applies the context deadline to conn if it supports write deadlines.
+// It returns a function that clears the deadline after the operation completes.
+func withWriteDeadline(ctx context.Context, w io.Writer) (func(), error) {
+	conn, ok := w.(interface{ SetWriteDeadline(time.Time) error })
+	if !ok {
+		return func() {}, nil
+	}
+	dl, ok := ctx.Deadline()
+	if !ok {
+		return func() {}, nil
+	}
+	if err := conn.SetWriteDeadline(dl); err != nil {
+		return nil, err
+	}
+	return func() {
+		_ = conn.SetWriteDeadline(time.Time{})
+	}, nil
 }
 
 // Client transmits rsync signatures and deltas over a Stream.


### PR DESCRIPTION
## Summary
- avoid spawning goroutines to reset deadlines in rsyncwire
- add helper functions for read and write deadlines
- test to ensure Send/Recv don't leak goroutines and add a Send benchmark

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: signal interrupt in internal/rsyncserver)*
- `golangci-lint run` *(fails: revive and other lint issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a711554ec483238d876dfb1377b38e