### PR TITLE
fail plan without explicit allow-insecure

### DIFF
--- a/cmd/root/plan.go
+++ b/cmd/root/plan.go
@@ -57,6 +57,12 @@ func emitPlan(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if len(args) < 1 {
 		return fmt.Errorf("missing source argument")
 	}
+	if cfg.AllowInsecure || strings.Contains(cfg.Transport, "rsync") {
+		fmt.Fprintln(os.Stderr, "allow_insecure enabled; security checks disabled")
+		if !cfg.AllowInsecure {
+			return fmt.Errorf("insecure configuration requires --allow-insecure")
+		}
+	}
 	_, est, err := estimateBytes(args[0], cfg)
 	if err != nil {
 		return err

--- a/cmd/root/plan_test.go
+++ b/cmd/root/plan_test.go
@@ -1,7 +1,12 @@
 package root
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
+
+	"go.uber.org/zap"
 
 	"lvmsync_go/internal/config"
 )
@@ -23,5 +28,57 @@ func TestRedactConfig(t *testing.T) {
 	}
 	if cfg.SSHPassword == "" || cfg.ClientKey == "" {
 		t.Fatalf("original config modified: %#v", cfg)
+	}
+}
+
+func TestEmitPlanAllowInsecureWarns(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	cfg := &config.Config{AllowInsecure: true}
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	stdout, stderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = wOut, wErr
+	defer func() { os.Stdout, os.Stderr = stdout, stderr }()
+	if e := emitPlan(cfg, []string{f.Name()}, zap.NewNop()); e != nil {
+		t.Fatalf("emitPlan: %v", e)
+	}
+	wOut.Close()
+	wErr.Close()
+	outBytes, _ := io.ReadAll(rOut)
+	errBytes, _ := io.ReadAll(rErr)
+	if !strings.Contains(string(errBytes), "allow_insecure enabled") {
+		t.Fatalf("missing warning: %q", errBytes)
+	}
+	if len(outBytes) == 0 {
+		t.Fatalf("expected plan output")
+	}
+}
+
+func TestEmitPlanRsyncRequiresAllowInsecure(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	cfg := &config.Config{Transport: "rsync"}
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	stdout, stderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = wOut, wErr
+	defer func() { os.Stdout, os.Stderr = stdout, stderr }()
+	if e := emitPlan(cfg, []string{f.Name()}, zap.NewNop()); e == nil {
+		t.Fatalf("expected error")
+	}
+	wOut.Close()
+	wErr.Close()
+	outBytes, _ := io.ReadAll(rOut)
+	errBytes, _ := io.ReadAll(rErr)
+	if !strings.Contains(string(errBytes), "allow_insecure enabled") {
+		t.Fatalf("missing warning: %q", errBytes)
+	}
+	if len(outBytes) != 0 {
+		t.Fatalf("unexpected plan output: %q", outBytes)
 	}
 }


### PR DESCRIPTION
## Summary
- fail plan when insecure transports require confirmation
- add tests for warning and error in plan

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: context deadline / unable to complete internal/rsyncserver)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: 1211 issues)*
- `go test ./cmd/root -run .`


------
https://chatgpt.com/codex/tasks/task_e_68a7115300c88323927053fac974b495