### PR TITLE
rsyncserver: require non-nil logger

### DIFF
--- a/cmd/dump/rsync_delta_integration_test.go
+++ b/cmd/dump/rsync_delta_integration_test.go
@@ -60,7 +60,10 @@ func TestStreamToRemoteRsyncDelta(t *testing.T) {
 
 	dev := &rsyncserverMemDevice{buf: make([]byte, len(originData))}
 	copy(dev.buf, originData)
-	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	srv, err := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)

--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -52,8 +52,11 @@ type Server struct {
 
 // New constructs a Server using the provided Device and logger.
 // The digest algorithm and expected sum are supplied via a later digest frame.
-func New(dev Device, logger *zap.Logger, cache *signaturecache.Cache, vg, lv string) *Server {
-	return &Server{dev: dev, logger: logger, cache: cache, vg: vg, lv: lv}
+func New(dev Device, logger *zap.Logger, cache *signaturecache.Cache, vg, lv string) (*Server, error) {
+	if logger == nil {
+		return nil, errors.New("logger is nil")
+	}
+	return &Server{dev: dev, logger: logger, cache: cache, vg: vg, lv: lv}, nil
 }
 
 // Handle consumes frames from the Stream until EOF, applying any delta frames to

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -71,7 +71,10 @@ func (m *memDevice) Identity(context.Context) (device.DeviceIdentity, error) {
 
 func newServer(t *testing.T, dev *memDevice, data []byte) *Server {
 	t.Helper()
-	srv := New(dev, zap.NewNop(), nil, "", "")
+	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	exp, err := digest.SumReader(bytes.NewReader(data), digest.SHA256)
 	if err != nil {
 		t.Fatalf("digest: %v", err)
@@ -120,8 +123,14 @@ func waitHandle(t *testing.T, errCh <-chan error) error {
 	}
 }
 
+func TestNewNilLogger(t *testing.T) {
+	if _, err := New(nil, nil, nil, "", ""); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
+}
+
 func TestHandleApplyDelta(t *testing.T) {
-       t.Skip("TODO: fix rsync server hang")
+	t.Skip("TODO: fix rsync server hang")
 }
 
 func TestHandleShortWrite(t *testing.T) {
@@ -152,7 +161,10 @@ func TestHandleRejectsOversizedSignatures(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{buf: make([]byte, 1)}
-	srv := New(dev, zap.NewNop(), nil, "", "")
+	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -188,7 +200,10 @@ func TestHandleCacheHit(t *testing.T) {
 	if err := cache.Put("vg", "lv", int64(len(data)), dgst[:]); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	srv := New(dev, zap.NewNop(), cache, "vg", "lv")
+	srv, err := New(dev, zap.NewNop(), cache, "vg", "lv")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	c1, c2 := net.Pipe()
 	defer c1.Close()
 	defer c2.Close()
@@ -218,7 +233,10 @@ func TestHandleCacheMissUpdates(t *testing.T) {
 	cache := signaturecache.New(dir, time.Hour, 10)
 	data := []byte("hi")
 	dev := &memDevice{buf: make([]byte, len(data))}
-	srv := New(dev, zap.NewNop(), cache, "vg", "lv")
+	srv, err := New(dev, zap.NewNop(), cache, "vg", "lv")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	dgst, err := digest.SumReader(bytes.NewReader(data), digest.SHA256)
 	if err != nil {
 		t.Fatalf("digest: %v", err)
@@ -270,7 +288,10 @@ func TestHandleCacheTTLExpiry(t *testing.T) {
 	}
 	time.Sleep(20 * time.Millisecond)
 	dev := &memDevice{buf: append([]byte{}, data...)}
-	srv := New(dev, zap.NewNop(), cache, "vg", "lv")
+	srv, err := New(dev, zap.NewNop(), cache, "vg", "lv")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	c1, c2 := net.Pipe()
 	defer c1.Close()
 	defer c2.Close()
@@ -304,7 +325,10 @@ func TestHandleCacheLRUEviction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("digest: %v", err)
 		}
-		srv := New(dev, zap.NewNop(), cache, vg, lv)
+		srv, err := New(dev, zap.NewNop(), cache, vg, lv)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
 		c1, c2 := net.Pipe()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -340,7 +364,10 @@ func TestHandleDeltaOffsetOverflow(t *testing.T) {
 
 	dev := &memDevice{buf: make([]byte, 1)}
 	core, logs := observer.New(zap.ErrorLevel)
-	srv := New(dev, zap.New(core), nil, "", "")
+	srv, err := New(dev, zap.New(core), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -380,7 +407,10 @@ func TestHandleDeltaOutOfBounds(t *testing.T) {
 
 	dev := &memDevice{buf: make([]byte, 10)}
 	core, logs := observer.New(zap.ErrorLevel)
-	srv := New(dev, zap.New(core), nil, "", "")
+	srv, err := New(dev, zap.New(core), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -419,7 +449,10 @@ func TestHandleUnknownFrameType(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{buf: make([]byte, 1)}
-	srv := New(dev, zap.NewNop(), nil, "", "")
+	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -440,7 +473,10 @@ func TestHandleDigestMismatch(t *testing.T) {
 
 	dev := &memDevice{buf: make([]byte, 2)}
 	core, logs := observer.New(zap.ErrorLevel)
-	srv := New(dev, zap.New(core), nil, "", "")
+	srv, err := New(dev, zap.New(core), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -486,7 +522,10 @@ func TestHandleMissingIdentity(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{buf: make([]byte, 1)}
-	srv := New(dev, zap.NewNop(), nil, "", "")
+	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -507,7 +546,10 @@ func TestHandleIdentityMismatch(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{buf: make([]byte, 1)}
-	srv := New(dev, zap.NewNop(), nil, "", "")
+	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -539,7 +581,10 @@ func TestHandleIdentityIgnoresMajorMinor(t *testing.T) {
 		ManifestEpoch: 2,
 	}
 	dev := &memDevice{buf: make([]byte, int(id.SizeBytes)), id: id}
-	srv := New(dev, zap.NewNop(), nil, "", "")
+	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -578,7 +623,10 @@ func TestHandleIdentityMismatchFields(t *testing.T) {
 		ManifestEpoch: 2,
 	}
 	dev := &memDevice{buf: make([]byte, int(id.SizeBytes)), id: id}
-	srv := New(dev, zap.NewNop(), nil, "", "")
+	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -137,7 +137,10 @@ func TestDumpChangesRsyncDelta(t *testing.T) {
 
 	dev := &rsyncserverMemDevice{buf: make([]byte, len(originData))}
 	copy(dev.buf, originData)
-	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	srv, err := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
@@ -239,7 +242,10 @@ func TestRsyncDeltaCDCShift(t *testing.T) {
 
 	dev := &rsyncserverMemDevice{buf: make([]byte, len(originData))}
 	copy(dev.buf, originData)
-	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	srv, err := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
@@ -342,7 +348,10 @@ func TestRsyncDeltaCDCMutate(t *testing.T) {
 
 	dev := &rsyncserverMemDevice{buf: make([]byte, len(originData))}
 	copy(dev.buf, originData)
-	srv := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	srv, err := rsyncserver.New(dev, zap.NewNop(), nil, "", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)


### PR DESCRIPTION
## Summary
- return error when rsyncserver.New is called with a nil logger
- update call sites to pass zap.NewNop() when logging is disabled
- add test for nil logger

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestHandleShortWrite timeout; TestReadManifestHeaderCanceled expectation)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: multiple issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7115039988323b10b6c063e67139d