### PR TITLE
device: error on nil logger

### DIFF
--- a/device/discard_linux.go
+++ b/device/discard_linux.go
@@ -1,5 +1,6 @@
 //go:build linux
 
+// Package device provides Linux device utilities.
 package device
 
 import (
@@ -42,10 +43,10 @@ func SetDiscardFunc(fn func(*os.File, uint64, uint64, bool, bool, *zap.Logger) e
 	return func() { discardImpl = orig }
 }
 
-// DiscardRange issues BLKDISCARD for the specified range on f.
+// DiscardRange issues BLKDISCARD for the specified range on f. logger must be non-nil.
 func DiscardRange(f *os.File, offset, length uint64, sanitize, noNewPrivs bool, logger *zap.Logger) error {
 	if logger == nil {
-		panic("nil logger")
+		return fmt.Errorf("logger is nil")
 	}
 	return discardImpl(f, offset, length, sanitize, noNewPrivs, logger)
 }

--- a/device/discard_linux_test.go
+++ b/device/discard_linux_test.go
@@ -15,7 +15,7 @@ func TestDiscardRangeStubAndRestore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("temp file: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	stubErr := errors.New("stub discard error")
 	calls := 0
@@ -46,16 +46,13 @@ func TestDiscardRangeStubAndRestore(t *testing.T) {
 	}
 }
 
-func TestDiscardRangeNilLoggerPanics(t *testing.T) {
+func TestDiscardRangeNilLogger(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "discard")
 	if err != nil {
 		t.Fatalf("temp file: %v", err)
 	}
-	defer f.Close()
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic")
-		}
-	}()
-	_ = DiscardRange(f, 0, 0, false, false, nil)
+	defer func() { _ = f.Close() }()
+	if err := DiscardRange(f, 0, 0, false, false, nil); err == nil {
+		t.Fatalf("expected error when logger is nil")
+	}
 }


### PR DESCRIPTION
## Summary
- return error when DiscardRange receives a nil logger
- adjust tests to expect error and cover nil/non-nil logger cases

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run device/discard_linux.go device/discard_linux_test.go`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a7236121688323a1e3fea8d780b625