### PR TITLE
transport: panic on duplicate registration

### DIFF
--- a/transport/h2/h2.go
+++ b/transport/h2/h2.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 
-	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/internal/logging"
 	"lvmsync_go/transport"
@@ -102,8 +101,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	logger := zap.NewNop()
-	if err := transport.MustRegister("h2", func(cfg transport.Config) (transport.Interface, error) {
+	transport.MustRegister("h2", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(cfg)
 		if err != nil {
 			return nil, err
@@ -112,10 +110,7 @@ func init() {
 			return nil, fmt.Errorf("h2: nil transport")
 		}
 		return tr, nil
-	}); err != nil {
-		logger.Error("register_failed", zap.String("transport", "h2"), zap.Error(err))
-		rootcmd.SyncLogger(logger)
-	}
+	})
 }
 
 func (t *Transport) Name() string { return "h2" }

--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -15,7 +15,6 @@ import (
 
 	quic "github.com/quic-go/quic-go"
 
-	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/internal/logging"
 	"lvmsync_go/transport"
@@ -101,8 +100,7 @@ func init() {
 	if !enabled {
 		return
 	}
-	logger := zap.NewNop()
-	if err := transport.MustRegister("quic", func(cfg transport.Config) (transport.Interface, error) {
+	transport.MustRegister("quic", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(cfg)
 		if err != nil {
 			return nil, err
@@ -111,10 +109,7 @@ func init() {
 			return nil, fmt.Errorf("quic: nil transport")
 		}
 		return tr, nil
-	}); err != nil {
-		logger.Error("register_failed", zap.String("transport", "quic"), zap.Error(err))
-		rootcmd.SyncLogger(logger)
-	}
+	})
 }
 
 func (t *Transport) Name() string { return "quic" }

--- a/transport/registry.go
+++ b/transport/registry.go
@@ -28,11 +28,13 @@ func Register(name string, f Factory) error {
 	return nil
 }
 
-// MustRegister adds a transport factory to the registry.
-//
-// It returns an error if the transport is already registered.
-func MustRegister(name string, f Factory) error {
-	return Register(name, f)
+// MustRegister adds a transport factory to the registry and panics if
+// registration fails. This is intended for use in package init functions where
+// duplicate registrations indicate a programming error.
+func MustRegister(name string, f Factory) {
+	if err := Register(name, f); err != nil {
+		panic(err)
+	}
 }
 
 // Get returns a transport from the registry by name.

--- a/transport/registry_test.go
+++ b/transport/registry_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/common"
 )
@@ -138,22 +136,12 @@ func TestMustRegisterDuplicate(t *testing.T) {
 		regMu.Unlock()
 	}()
 
-	if err := MustRegister("dup", func(Config) (Interface, error) { return nil, nil }); err != nil {
-		t.Fatalf("first register: %v", err)
-	}
+	MustRegister("dup", func(Config) (Interface, error) { return nil, nil })
 
-	syncLogger := func(l *zap.Logger) { _ = l.Sync() }
-	core, obs := observer.New(zapcore.ErrorLevel)
-	logger := zap.New(core)
-
-	if err := MustRegister("dup", func(Config) (Interface, error) { return nil, nil }); err != nil {
-		logger.Error("register_failed", zap.String("transport", "dup"), zap.Error(err))
-		syncLogger(logger)
-	} else {
-		t.Fatalf("expected duplicate registration error")
-	}
-
-	if obs.FilterMessage("register_failed").Len() != 1 {
-		t.Fatalf("expected register_failed log")
-	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on duplicate registration")
+		}
+	}()
+	MustRegister("dup", func(Config) (Interface, error) { return nil, nil })
 }

--- a/transport/rsyncwire/rsyncwire.go
+++ b/transport/rsyncwire/rsyncwire.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gokrazy/rsync"
 	"go.uber.org/zap"
 
-	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
@@ -40,8 +39,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	logger := zap.NewNop()
-	if err := transport.MustRegister("rsync", func(cfg transport.Config) (transport.Interface, error) {
+	transport.MustRegister("rsync", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(cfg)
 		if err != nil {
 			return nil, err
@@ -50,10 +48,7 @@ func init() {
 			return nil, fmt.Errorf("rsync: nil transport")
 		}
 		return tr, nil
-	}); err != nil {
-		logger.Error("register_failed", zap.String("transport", "rsync"), zap.Error(err))
-		rootcmd.SyncLogger(logger)
-	}
+	})
 }
 
 func (t *Transport) Name() string { return "rsync" }

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
 
-	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/transport"
 )
@@ -182,8 +181,7 @@ func agentSigners(ctx context.Context, sock string) ([]ssh.Signer, error) {
 }
 
 func init() {
-	logger := zap.NewNop()
-	if err := transport.MustRegister("ssh", func(cfg transport.Config) (transport.Interface, error) {
+	transport.MustRegister("ssh", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(context.Background(), cfg)
 		if err != nil {
 			return nil, err
@@ -192,10 +190,7 @@ func init() {
 			return nil, fmt.Errorf("ssh: nil transport")
 		}
 		return tr, nil
-	}); err != nil {
-		logger.Error("register_failed", zap.String("transport", "ssh"), zap.Error(err))
-		rootcmd.SyncLogger(logger)
-	}
+	})
 }
 
 func (t *Transport) Name() string { return "ssh" }

--- a/transport/tcp_tls/tcp_tls.go
+++ b/transport/tcp_tls/tcp_tls.go
@@ -10,7 +10,6 @@ import (
 
 	"go.uber.org/zap"
 
-	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
 	"lvmsync_go/internal/logging"
 	"lvmsync_go/transport"
@@ -74,8 +73,7 @@ func New(cfg transport.Config) (transport.Interface, error) {
 }
 
 func init() {
-	logger := zap.NewNop()
-	if err := transport.MustRegister("tcp+tls", func(cfg transport.Config) (transport.Interface, error) {
+	transport.MustRegister("tcp+tls", func(cfg transport.Config) (transport.Interface, error) {
 		tr, err := New(cfg)
 		if err != nil {
 			return nil, err
@@ -84,10 +82,7 @@ func init() {
 			return nil, fmt.Errorf("tcp+tls: nil transport")
 		}
 		return tr, nil
-	}); err != nil {
-		logger.Error("register_failed", zap.String("transport", "tcp+tls"), zap.Error(err))
-		rootcmd.SyncLogger(logger)
-	}
+	})
 }
 
 func (t *Transport) Name() string { return "tcp+tls" }


### PR DESCRIPTION
## Summary
- convert MustRegister to panic on registration errors
- update transport init functions to use MustRegister without error checks
- test duplicate registration panics

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many unused-parameter and exported warnings)*
- `go test ./transport`


------
https://chatgpt.com/codex/tasks/task_e_68a72361f4fc83239dbd15a91a201fa1