### PR TITLE
manifest: add check subcommand

### DIFF
--- a/cmd/manifest/check_test.go
+++ b/cmd/manifest/check_test.go
@@ -1,0 +1,67 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/config"
+	manifestpkg "lvmsync_go/manifest"
+)
+
+func TestRunCheckHealthy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "good.man")
+	idx, err := manifestpkg.Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	if err := Run(cfg, []string{"check", path}, zap.NewNop()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestRunCheckCorrupted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.man")
+	idx, err := manifestpkg.Create(path, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := os.Truncate(path, info.Size()-1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	if err := Run(cfg, []string{"check", path}, zap.NewNop()); err == nil {
+		t.Fatalf("expected error for corrupted manifest")
+	}
+}
+
+func TestRunCheckMissingFile(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	if err := Run(cfg, []string{"check", "missing.man"}, zap.NewNop()); err == nil {
+		t.Fatalf("expected error for missing manifest")
+	}
+}

--- a/cmd/manifest/main.go
+++ b/cmd/manifest/main.go
@@ -18,11 +18,12 @@ type Runner struct {
 	Rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error
 	GC      func(path string, opts ...manifestpkg.IndexOption) error
 	Compact func(path string, opts ...manifestpkg.IndexOption) error
+	Open    func(path string, opts ...manifestpkg.IndexOption) (*manifestpkg.Index, error)
 }
 
 // NewRunner returns a Runner with production dependencies.
 func NewRunner() *Runner {
-	return &Runner{Rebuild: manifestpkg.Rebuild, GC: manifestpkg.GC, Compact: manifestpkg.Compact}
+	return &Runner{Rebuild: manifestpkg.Rebuild, GC: manifestpkg.GC, Compact: manifestpkg.Compact, Open: manifestpkg.Open}
 }
 
 // NewRunnerWithDeps creates a Runner with custom rebuild function.
@@ -30,8 +31,9 @@ func NewRunnerWithDeps(
 	rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error,
 	gc func(path string, opts ...manifestpkg.IndexOption) error,
 	compact func(path string, opts ...manifestpkg.IndexOption) error,
+	open func(path string, opts ...manifestpkg.IndexOption) (*manifestpkg.Index, error),
 ) *Runner {
-	return &Runner{Rebuild: rebuild, GC: gc, Compact: compact}
+	return &Runner{Rebuild: rebuild, GC: gc, Compact: compact, Open: open}
 }
 
 func init() {
@@ -45,7 +47,7 @@ func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) erro
 	if len(args) == 0 {
 		fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)
 		fs.Usage()
-		return fmt.Errorf("usage: lvmsync manifest <rebuild|gc|compact>")
+		return fmt.Errorf("usage: lvmsync manifest <rebuild|gc|compact|check>")
 	}
 	switch args[0] {
 	case "rebuild":
@@ -129,10 +131,40 @@ func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) erro
 		}
 		logger.Info("compact complete")
 		return nil
+	case "check":
+		if len(args) != 2 {
+			fs := pflag.NewFlagSet("manifest check", pflag.ContinueOnError)
+			fs.Usage()
+			return fmt.Errorf("usage: lvmsync manifest check <path>")
+		}
+		path := args[1]
+		logger.Info("manifest_check", zap.String("path", path))
+		if cfg.DryRun {
+			logger.Info("dry run - skipping check")
+			return nil
+		}
+		idx, err := r.Open(path)
+		if err != nil {
+			logger.Error("manifest_corrupt", zap.Error(err))
+			return err
+		}
+		for i := uint64(0); i < idx.ChunkCount(); i++ {
+			if _, _, _, _, _, err := idx.Entry(i); err != nil {
+				idx.Close()
+				logger.Error("manifest_corrupt", zap.Error(err))
+				return err
+			}
+		}
+		if err := idx.Close(); err != nil {
+			logger.Error("manifest_check_close_error", zap.Error(err))
+			return err
+		}
+		logger.Info("manifest_ok")
+		return nil
 	default:
 		fs := pflag.NewFlagSet("manifest", pflag.ContinueOnError)
 		fs.Usage()
-		return fmt.Errorf("usage: lvmsync manifest <rebuild|gc|compact>")
+		return fmt.Errorf("usage: lvmsync manifest <rebuild|gc|compact|check>")
 	}
 }
 

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -48,7 +48,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 	r := NewRunnerWithDeps(func(ctx context.Context, dev, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		opts = append(opts, manifestpkg.WithDeviceInfo(info))
 		return manifestpkg.Rebuild(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
-	}, nil, nil)
+	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, []string{"rebuild", devicePath}, logger); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestRunManifestPathFlag(t *testing.T) {
 	r := NewRunnerWithDeps(func(ctx context.Context, dev, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		opts = append(opts, manifestpkg.WithDeviceInfo(info))
 		return manifestpkg.Rebuild(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
-	}, nil, nil)
+	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, args, logger); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -158,6 +158,7 @@ func TestRunMissingArgs(t *testing.T) {
 		{"missing device", []string{"rebuild"}},
 		{"gc missing path", []string{"gc"}},
 		{"compact missing path", []string{"compact"}},
+		{"check missing path", []string{"check"}},
 	}
 
 	for _, tc := range cases {
@@ -200,7 +201,7 @@ func TestRunAppliesManifestTimeout(t *testing.T) {
 	r := NewRunnerWithDeps(func(ctx context.Context, _, _ string, _ *zap.Logger, _ time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
-	}, nil, nil)
+	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -219,7 +220,7 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	r := NewRunnerWithDeps(func(ctx context.Context, _, _ string, _ *zap.Logger, _ time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
-	}, nil, nil)
+	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -244,7 +245,7 @@ func TestRunContextNoDeadline(t *testing.T) {
 	r := NewRunnerWithDeps(func(ctx context.Context, _, _ string, _ *zap.Logger, _ time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		captured = ctx
 		return nil
-	}, nil, nil)
+	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, []string{"rebuild", "/dev/test"}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -296,7 +297,7 @@ func TestRunWritesVersion(t *testing.T) {
 	r := NewRunnerWithDeps(func(ctx context.Context, dev, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		opts = append(opts, manifestpkg.WithDeviceInfo(info))
 		return manifestpkg.Rebuild(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
-	}, nil, nil)
+	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, []string{"rebuild", devicePath}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -20,6 +20,8 @@ copies can be verified.
   regenerates it when digests or metadata are stale.
 - `lvmsync manifest compact <path>` rewrites the manifest using a temporary file
   and `fsync` before atomically swapping it into place.
+- `lvmsync manifest check <path>` validates manifest headers and indexes,
+  reporting corruption.
 - `lvmsync verify <source> <dest>` compares a destination against the manifest
   for the source. Override the manifest path with `--manifest-path` if needed.
 
@@ -147,6 +149,14 @@ lvmsync manifest rebuild /dev/vg0/lv0
 Progress logs are emitted every 10s by default; adjust with
 `--manifest-progress-interval`. The rebuild operation times out after 1m unless
 `--manifest-timeout` is set (0 disables).
+
+### Check
+
+Validate an existing manifest and report corruption:
+
+```sh
+lvmsync manifest check /path/to/device.manifest
+```
 
 ### Verify
 


### PR DESCRIPTION
## Summary
- add `manifest check` command to validate manifest headers and indexes
- exercise healthy, corrupted, and missing-manifest checks
- document `manifest check` usage

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b08dab48323a4d1cd269c852f3f