### PR TITLE
Fix rsync delta integration test flakiness

### DIFF
--- a/cmd/dump/rsync_delta_integration_test.go
+++ b/cmd/dump/rsync_delta_integration_test.go
@@ -32,7 +32,6 @@ func (c *countingConn) Write(p []byte) (int, error) {
 }
 
 func TestStreamToRemoteRsyncDelta(t *testing.T) {
-	t.Skip("flaky in sandbox environment")
 	cfg, err := config.DefaultConfig()
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
@@ -105,8 +104,8 @@ func TestStreamToRemoteRsyncDelta(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("wg.Wait(): timeout")
+	case <-ctx.Done():
+		t.Fatalf("wg.Wait(): %v", ctx.Err())
 	}
 
 	if cliErr != nil {


### PR DESCRIPTION
## Summary
- remove skip from rsync delta integration test
- use context deadline instead of fixed sleep to wait for goroutines

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: unused parameters, missing comments, and other lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b05adcc8323b8d51711a1779209