### PR TITLE
Add rsync server delta apply test

### DIFF
--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -130,7 +130,32 @@ func TestNewNilLogger(t *testing.T) {
 }
 
 func TestHandleApplyDelta(t *testing.T) {
-	t.Skip("TODO: fix rsync server hang")
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	data := []byte("hi")
+	dev := &memDevice{buf: make([]byte, len(data))}
+	srv := newServer(t, dev, data)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Handle(ctx, rsyncwire.NewStream(c2, maxFrame)) }()
+
+	cl := rsyncwire.NewClient(rsyncwire.NewStream(c1, maxFrame))
+	sendIdentity(t, ctx, cl, device.DeviceIdentity{SizeBytes: uint64(len(dev.buf))})
+	sendDelta(t, ctx, cl, 0, data)
+	c1.Close()
+	cancel()
+	if err := waitHandle(t, errCh); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if string(dev.buf) != string(data) {
+		t.Fatalf("device %q want %q", dev.buf, data)
+	}
+	if !dev.sync {
+		t.Fatalf("expected sync")
+	}
 }
 
 func TestHandleShortWrite(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a unit test exercising delta application in the rsync server

## Testing
- `go build ./...`
- `go test ./internal/rsyncserver -run TestHandleApplyDelta -count=1` *(hangs)*
- `golangci-lint run` *(fails: unused-parameter, redefines-builtin-id, and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c1d950288323a5722fb7c1e9a83d