### PR TITLE
test: add redaction and transport order test

### DIFF
--- a/cmd/root/plan_test.go
+++ b/cmd/root/plan_test.go
@@ -1,8 +1,10 @@
 package root
 
 import (
+	"encoding/json"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -80,5 +82,43 @@ func TestEmitPlanRsyncRequiresAllowInsecure(t *testing.T) {
 	}
 	if len(outBytes) != 0 {
 		t.Fatalf("unexpected plan output: %q", outBytes)
+	}
+}
+
+func TestEmitPlanRedactsAndOrdersTransports(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	cfg := &config.Config{
+		SSHPassword:    "pass",
+		SSHKeyPath:     "keypath",
+		SSHHostKey:     "hostkey",
+		SSHHostKeyPath: "hostkeypath",
+		KnownHosts:     "known",
+		ClientCert:     "cert",
+		ClientKey:      "clientkey",
+		CACert:         "ca",
+		Transport:      "ssh,tcp,tls",
+	}
+	rOut, wOut, _ := os.Pipe()
+	stdout := os.Stdout
+	os.Stdout = wOut
+	if e := emitPlan(cfg, []string{f.Name()}, zap.NewNop()); e != nil {
+		t.Fatalf("emitPlan: %v", e)
+	}
+	wOut.Close()
+	os.Stdout = stdout
+	outBytes, _ := io.ReadAll(rOut)
+	var po planOutput
+	if err := json.Unmarshal(outBytes, &po); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+	if po.Config.SSHPassword != "" || po.Config.SSHKeyPath != "" || po.Config.SSHHostKey != "" || po.Config.SSHHostKeyPath != "" || po.Config.KnownHosts != "" || po.Config.ClientCert != "" || po.Config.ClientKey != "" || po.Config.CACert != "" {
+		t.Fatalf("secrets not redacted: %#v", po.Config)
+	}
+	expected := []string{"ssh", "tcp", "tls"}
+	if !reflect.DeepEqual(po.TransportOrder, expected) {
+		t.Fatalf("transport order %v != %v", po.TransportOrder, expected)
 	}
 }


### PR DESCRIPTION
## Summary
- add test validating emitPlan redacts secrets and preserves transport order

## Testing
- `go test ./cmd/root`
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unused-parameter and other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d59f34e883239ddde32b680cd79c