### PR TITLE
docs: document QUIC vs HTTP/2 trade-offs

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -88,10 +88,18 @@ Listeners enforce these defaults:
 - Enabled by default; disable registration with `--enable-quic=false` or `LVMSYNC_ENABLE_QUIC=false`
 - Flags: `--server-cert`, `--server-key`, `--client-cert`, `--client-key`, `--ca-cert`, `--allow-insecure`
 
-Example:
+QUIC's UDP-based design avoids TCP head-of-line blocking and its BBR congestion
+control quickly ramps up on long fat networks. It performs well on lossy or
+high-latency links but consumes more CPU and may be blocked by middleboxes that
+drop UDP. Prefer QUIC when you need fast recovery and rapid BDP ramp-up;
+fallback to HTTP/2 when UDP is restricted or when kernel TCP offload is
+required.
+
+High BDP example:
 
 ```sh
-lvmsyncd --listen quic://:12000 --server-cert cert.pem --server-key key.pem --client-cert cert.pem --client-key key.pem --ca-cert ca.pem
+lvmsync run --transport quic --concurrency 64 \
+  --client-cert cert.pem --client-key key.pem --ca-cert ca.pem /dev/vg0/snap0 /mnt/backup
 ```
 
 ## HTTP/2 (h2)
@@ -100,6 +108,19 @@ lvmsyncd --listen quic://:12000 --server-cert cert.pem --server-key key.pem --cl
 - Provides stream-level back-pressure
 - Enforces context deadlines during connection and HTTP/2 handshakes
 - Flags: `--server-cert`, `--server-key`, `--client-cert`, `--client-key`, `--ca-cert`, `--allow-insecure`, `--tcp-port`
+
+HTTP/2 rides on a single TCP connection, benefiting from ubiquitous firewall
+support and kernel networking optimizations. On very long or fast links it can
+lag behind QUIC due to TCP slow start and head-of-line blocking, but it is a
+good choice when UDP is unavailable or when existing TLS load balancers must
+terminate the connection.
+
+High BDP example:
+
+```sh
+lvmsync run --transport h2 --concurrency 64 --tcp-parallel 4 --tcp-lowat 1048576 \
+  --client-cert cert.pem --client-key key.pem --ca-cert ca.pem /dev/vg0/snap0 /mnt/backup
+```
 
 ## TCP+TLS
 


### PR DESCRIPTION
## Summary
- explain QUIC vs HTTP/2 behavior on high-latency links
- add high BDP flag examples for QUIC and HTTP/2 transports

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: numerous lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d59dd34c832384731e13c807d63c