### PR TITLE
Fix manifest digest verification to always use BLAKE3

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -175,8 +175,8 @@ func (r *Runner) verifyDevices(cfg *config.Config, src, dst, manifestPath string
 		zap.Bool("avx512", cpufeatures.HasAVX512()),
 		zap.Bool("neon", cpufeatures.HasNEON()),
 	)
-       post := strings.ToLower(cfg.VerifyLevel) == "post"
-       match, srcSum, dstSum, err := digestpkg.VerifyFiles(src, dst, alg, post)
+	post := strings.ToLower(cfg.VerifyLevel) == "post"
+	match, srcSum, dstSum, err := digestpkg.VerifyFiles(src, dst, alg, post)
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,7 @@ func verifyWithManifest(cfg *config.Config, devicePath, manifestPath string, log
 
 	mismatches := 0
 	buf := make([]byte, 0)
-	hash := digestFunc(cfg)
+	hash := blake3.Sum256
 	for i := uint64(0); i < idx.ChunkCount(); i++ {
 		off, length, _, _, digest, err := idx.Entry(i)
 		if err != nil {

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -167,9 +167,9 @@ func TestVerifyInlineAllocations(t *testing.T) {
 	dst := createTestFile(t, size)
 	cfg := &config.Config{BlockSize: blockSize}
 	allocs := testing.AllocsPerRun(10, func() {
-               if err := verifyInline(cfg, src, dst, zap.NewNop()); err != nil {
-                       t.Fatalf("verifyInline: %v", err)
-               }
+		if err := verifyInline(cfg, src, dst, zap.NewNop()); err != nil {
+			t.Fatalf("verifyInline: %v", err)
+		}
 	})
 	if allocs >= 15 {
 		t.Fatalf("expected fewer allocations, got %f", allocs)
@@ -182,9 +182,19 @@ func TestVerifyInlineSHA256(t *testing.T) {
 	src := createTestFile(t, size)
 	dst := createTestFile(t, size)
 	cfg := &config.Config{BlockSize: blockSize, ChecksumAlgorithm: "sha256"}
-       if err := verifyInline(cfg, src, dst, zap.NewNop()); err != nil {
-               t.Fatalf("verifyInline: %v", err)
-       }
+	if err := verifyInline(cfg, src, dst, zap.NewNop()); err != nil {
+		t.Fatalf("verifyInline: %v", err)
+	}
+}
+
+func TestVerifyWithManifestSHA256(t *testing.T) {
+	size := 1024
+	src := createTestFile(t, size)
+	createManifest(t, src)
+	cfg := &config.Config{ChecksumAlgorithm: "sha256"}
+	if err := verifyWithManifest(cfg, src, src+".manifest", zap.NewNop()); err != nil {
+		t.Fatalf("verifyWithManifest: %v", err)
+	}
 }
 
 func TestVerifyWithManifestAllocations(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure verifyWithManifest always uses BLAKE3 regardless of configured digest
- add regression test confirming manifest verification succeeds when `--digest sha256` is set

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: numerous lint issues)*
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a7d9cd963083239aae6a8b84dcf465