### PR TITLE
docs: revise escalate usage comment

### DIFF
--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -16,15 +16,21 @@
 //
 // Typical usage:
 //
-//			reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{}, logger)
-//			if err != nil { log.Fatal(err) }
-//			if reexeced { return } // parent should exit after delegating to sudo
+//	logger := zap.NewExample()
+//	defer rootcmd.SyncLogger(logger)
+//	reexeced, err := escalate.EnsureRootOrReexec(escalate.Options{}, logger)
+//	if err != nil {
+//		return err // or logger.Error("ensure_root_or_reexec", zap.Error(err))
+//	}
+//	if reexeced {
+//		return nil // parent should exit after delegating to sudo
+//	}
 //
-//			// ... privileged work ...
-//	             if err := escalate.DropToInvokerIfSudo(escalate.Options{}, logger); err != nil {
-//	                     log.Fatal(err)
-//	             }
-//	             // ... continue unprivileged work ...
+//	// ... privileged work ...
+//	if err := escalate.DropToInvokerIfSudo(escalate.Options{}, logger); err != nil {
+//		return err
+//	}
+//	// ... continue unprivileged work ...
 package escalate
 
 import (


### PR DESCRIPTION
## Summary
- document typical `escalate` usage with zap logger and error returns

## Testing
- `go vet ./escalate`
- `go build ./...` *(fails: lvmsync_go/cmd/verify: imported and not used)*
- `go test -cover ./...` *(fails: lvmsync_go/cmd/verify build failure and manifest_ctx_test.go: TestReadManifestHeaderCanceled)*
- `golangci-lint run` *(fails: typecheck errors in cmd/verify)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e141004c8323bed9f6dd7e677d17