### PR TITLE
verify: add privilege and device imports

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -17,14 +17,15 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 
 	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/device"
 	"lvmsync_go/internal/blockio"
 	"lvmsync_go/internal/config"
 	cpufeatures "lvmsync_go/internal/cpufeatures"
 	digestpkg "lvmsync_go/internal/digest"
+	"lvmsync_go/internal/privilege"
 	manifestpkg "lvmsync_go/manifest"
 )
 

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -19,9 +19,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 	"gopkg.in/yaml.v3"
 
-	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
-	privilege "lvmsync_go/internal/privilege"
 	manifestpkg "lvmsync_go/manifest"
 )
 


### PR DESCRIPTION
## Summary
- fix verify command imports by removing unused unix entry
- add privilege and device dependencies for device verification
- clean up verify tests

## Testing
- `go build ./cmd/verify`
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: 1228 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e62b7970832397b2a7359ca6def5