### PR TITLE
cmd/verify: propagate contexts through verification

### DIFF
--- a/cmd/verify/config_precedence_test.go
+++ b/cmd/verify/config_precedence_test.go
@@ -1,6 +1,8 @@
+// Package verify contains tests for the verify command.
 package verify
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +23,7 @@ func TestDryRunFlagOverridesEnvAndYAML(t *testing.T) {
 	t.Setenv("LVMSYNC_DRY_RUN", "true")
 	r := newStubRunner()
 	called := false
-	patch := monkey.Patch((*Runner).verifyDevices, func(*Runner, *config.Config, string, string, string, *zap.Logger) error {
+	patch := monkey.Patch((*Runner).verifyDevices, func(*Runner, context.Context, *config.Config, string, string, string, *zap.Logger) error {
 		called = true
 		return nil
 	})
@@ -44,7 +46,7 @@ func TestDryRunEnvOverridesYAML(t *testing.T) {
 	t.Setenv("LVMSYNC_DRY_RUN", "true")
 	r := newStubRunner()
 	called := false
-	patch := monkey.Patch((*Runner).verifyDevices, func(*Runner, *config.Config, string, string, string, *zap.Logger) error {
+	patch := monkey.Patch((*Runner).verifyDevices, func(*Runner, context.Context, *config.Config, string, string, string, *zap.Logger) error {
 		called = true
 		return nil
 	})

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -17,14 +17,15 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 
 	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/device"
 	"lvmsync_go/internal/blockio"
 	"lvmsync_go/internal/config"
 	cpufeatures "lvmsync_go/internal/cpufeatures"
 	digestpkg "lvmsync_go/internal/digest"
+	privilege "lvmsync_go/internal/privilege"
 	manifestpkg "lvmsync_go/manifest"
 )
 
@@ -57,6 +58,7 @@ func (r *Runner) Run(args []string, logger *zap.Logger) error {
 		Short:              "Verify that source and destination contain identical data",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, argv []string) error {
+			ctx := cmd.Context()
 			defaults, err := config.DefaultConfig()
 			if err != nil {
 				return err
@@ -103,7 +105,7 @@ func (r *Runner) Run(args []string, logger *zap.Logger) error {
 				logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
 				return nil
 			}
-			err = r.verifyDevices(cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)
+			err = r.verifyDevices(ctx, cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)
 			if cfg.Output == "json" || cfg.Output == "yaml" {
 				out := struct {
 					Verified bool   `json:"verified" yaml:"verified"`
@@ -137,8 +139,7 @@ func (r *Runner) Run(args []string, logger *zap.Logger) error {
 	return cmd.Execute()
 }
 
-func (r *Runner) verifyDevices(cfg *config.Config, src, dst, manifestPath string, logger *zap.Logger) error {
-	ctx := context.Background()
+func (r *Runner) verifyDevices(ctx context.Context, cfg *config.Config, src, dst, manifestPath string, logger *zap.Logger) error {
 	esc := privilege.New(ctx, logger)
 	runner := device.NewRunner()
 
@@ -183,7 +184,7 @@ func (r *Runner) verifyDevices(cfg *config.Config, src, dst, manifestPath string
 	}
 	if _, err := os.Stat(manifestPath); err != nil {
 		if os.IsNotExist(err) {
-			mctx := context.Background()
+			mctx := ctx
 			if cfg.ManifestTimeout > 0 {
 				var cancel context.CancelFunc
 				mctx, cancel = context.WithTimeout(mctx, cfg.ManifestTimeout)

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -54,7 +54,7 @@ func createTestFile(t testing.TB, size int) string {
 
 // newStubRunner returns a Runner with a no-op rebuild function.
 func newStubRunner() *Runner {
-	return NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	return NewRunnerWithDeps(func(_ context.Context, _ string, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		return nil
 	})
 }
@@ -367,7 +367,7 @@ func TestVerifyDevicesRebuildsManifest(t *testing.T) {
 		t.Fatalf("write dst: %v", err)
 	}
 	called := false
-	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, _ string, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		called = true
 		idx, err := manifestpkg.Create(output, "", uint64(len("foo")), 0, 0, 0, 4096, 0, 0, 0, 0)
 		if err != nil {
@@ -380,7 +380,7 @@ func TestVerifyDevicesRebuildsManifest(t *testing.T) {
 		return idx.Close()
 	})
 	cfg := &config.Config{ChecksumAlgorithm: "blake3"}
-	if err := r.verifyDevices(cfg, src, dst, "", zap.NewNop()); err != nil {
+	if err := r.verifyDevices(context.Background(), cfg, src, dst, "", zap.NewNop()); err != nil {
 		t.Fatalf("verifyDevices: %v", err)
 	}
 	if !called {
@@ -398,14 +398,36 @@ func TestVerifyDevicesTimeout(t *testing.T) {
 	if err := os.WriteFile(dst, []byte("foo"), 0o600); err != nil {
 		t.Fatalf("write dst: %v", err)
 	}
-	r := NewRunnerWithDeps(func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
+	r := NewRunnerWithDeps(func(ctx context.Context, _ string, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		<-ctx.Done()
 		return ctx.Err()
 	})
 	cfg := &config.Config{ManifestTimeout: time.Millisecond, ChecksumAlgorithm: "blake3"}
-	err := r.verifyDevices(cfg, src, dst, "", zap.NewNop())
+	err := r.verifyDevices(context.Background(), cfg, src, dst, "", zap.NewNop())
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestVerifyDevicesContextCancelled(t *testing.T) {
+	r := newStubRunner()
+	ctx, cancel := context.WithCancel(context.Background())
+	called := make(chan struct{})
+	patch := monkey.Patch(device.Detect, func(ctx context.Context, _ string, _ bool, _ string, _ string, _ string, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *device.Runner) (device.Device, error) {
+		close(called)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	defer patch.Unpatch()
+	cfg := &config.Config{ChecksumAlgorithm: "blake3"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.verifyDevices(ctx, cfg, "src", "dst", "", zap.NewNop())
+	}()
+	<-called
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- capture command context in verify Run and plumb to device detection and manifest rebuild
- allow tests to cancel verification through context and add cancellation test

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: many existing issues)*


------
https://chatgpt.com/codex/tasks/task_e_68a7e645512883239cd96f1a0e581780