### PR TITLE
cmd/verify: add device and privilege imports

### DIFF
--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -19,7 +19,9 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 	"gopkg.in/yaml.v3"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	privilege "lvmsync_go/internal/privilege"
 	manifestpkg "lvmsync_go/manifest"
 )
 


### PR DESCRIPTION
## Summary
- fix verify test imports for device detection and privilege escalation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1226 issues)*
- `go test ./cmd/verify`


------
https://chatgpt.com/codex/tasks/task_e_68a7eaa400448323ba8cc71e039e99c2