### PR TITLE
Add pre-build checks for LVM2 dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .RECIPEPREFIX := >
-.PHONY: build test lint verify bench bench-lan bench-wan vet staticcheck test-race integration release docs-check
+.PHONY: deps build test lint verify bench bench-lan bench-wan vet staticcheck test-race integration release docs-check
 
-build:
+deps:
+> scripts/check_deps.sh
+build: deps
 > @mkdir -p bin
 > go build -o bin/lvmsync .
 > go build -o bin/lvmsyncd ./cmd/lvmsyncd
@@ -18,7 +20,7 @@ vet:
 staticcheck:
 > staticcheck ./...
 
-verify:
+verify: deps
 > go build ./...
 > go test -coverprofile=coverage.out ./...
 > golangci-lint run

--- a/README.md
+++ b/README.md
@@ -1000,6 +1000,7 @@ A final object with `{"event": "complete", "progress_percent": 100}` marks compl
 
 - Go 1.22+
 - Linux only (tested on `amd64` and `arm64` architectures)
+- `pkg-config`
 - LVM2 with development headers providing `liblvm2cmd` (`liblvm2-dev`)
   - A recent LVM2 release providing the modern `liblvm2cmd` API (e.g., 2.03.21+) is required.
 - SSH client & server (for remote transfers)
@@ -1022,7 +1023,15 @@ find them.
 
 ### Build
 
-Clone the repository and build the binary using Go modules with CGO enabled:
+Clone the repository and build the binary using Go modules with CGO enabled. A helper target checks for the
+required native libraries and `pkg-config`:
+
+```sh
+make deps  # verify pkg-config, device-mapper, and LVM2 headers
+```
+The `make build` target runs this check automatically.
+
+Then build the binaries:
 
 ```sh
 git clone https://github.com/oferchen/lvmsync_go.git

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v pkg-config >/dev/null 2>&1; then
+  echo "pkg-config is required but not installed" >&2
+  exit 1
+fi
+
+if ! pkg-config --exists devmapper; then
+  echo "device-mapper development files are missing" >&2
+  exit 1
+fi
+
+if pkg-config --exists lvm2; then
+  exit 0
+fi
+
+if [ ! -f /usr/include/lvm2cmd.h ]; then
+  echo "liblvm2 development headers (liblvm2-dev) are required" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- document `pkg-config` and LVM2 development headers as build requirements
- add `deps` target to Makefile and run it from `build` and `verify`
- introduce `scripts/check_deps.sh` to verify required native libraries

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: undefined: device/privilege in cmd/verify)*
- `golangci-lint run` *(fails: typecheck in cmd/verify)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eaa74374832381568468ee9c37d6