### PR TITLE
Skip integration tests when prerequisites are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1632,6 +1632,10 @@ go tool cover -func=coverage.out
 
 Some privileged tests are skipped when run without root access.
 
+Integration tests manipulate LVM volumes and loop devices. Running them
+requires root privileges and utilities such as `lvremove`, `pvremove`, and
+`losetup`. These tests are skipped when prerequisites are missing.
+
 The workflow enforces a minimum of 50% total coverage.
 
 ## License

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -19,7 +19,9 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 	"gopkg.in/yaml.v3"
 
+	device "lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	privilege "lvmsync_go/internal/privilege"
 	manifestpkg "lvmsync_go/manifest"
 )
 

--- a/integration/compress_resume_verify_test.go
+++ b/integration/compress_resume_verify_test.go
@@ -3,16 +3,16 @@
 package integration
 
 import (
-    "os/exec"
-    "testing"
+	"os/exec"
+	"testing"
 )
 
 func TestCompressResumeVerify(t *testing.T) {
-    cmd := exec.Command("bash", "./integration/compress_resume_verify.sh")
-    cmd.Dir = ".."
-    out, err := cmd.CombinedOutput()
-    if err != nil {
-        t.Fatalf("compress resume verify failed: %v\n%s", err, out)
-    }
+	requireRootAndCommands(t)
+	cmd := exec.Command("bash", "./integration/compress_resume_verify.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compress resume verify failed: %v\n%s", err, out)
+	}
 }
-

--- a/integration/compression_skip_test.go
+++ b/integration/compression_skip_test.go
@@ -43,6 +43,7 @@ func throughput(data []byte, t *testing.T) (string, float64) {
 }
 
 func TestCompressionSkip(t *testing.T) {
+	requireRootAndCommands(t)
 	pre := generateGzip(t, 64*1024)
 	zeros := bytes.Repeat([]byte{0}, 64*1024)
 

--- a/integration/daemon_mtls_test.go
+++ b/integration/daemon_mtls_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestDaemonMTLS(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/daemon_mtls.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/framed_resume_test.go
+++ b/integration/framed_resume_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestFramedResumeWithCompression(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/framed_resume.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/hole_punch_st_blocks_test.go
+++ b/integration/hole_punch_st_blocks_test.go
@@ -24,14 +24,7 @@ func runCmd(t *testing.T, cmd *exec.Cmd) string {
 }
 
 func TestHolePunchStBlocks(t *testing.T) {
-	for _, tool := range []string{"losetup", "mkfs.ext4", "mount", "umount"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not available", tool)
-		}
-	}
-	if os.Geteuid() != 0 {
-		t.Skip("root required")
-	}
+	requireRootAndCommands(t, "mkfs.ext4", "mount", "umount")
 
 	tmpDir := t.TempDir()
 	tmpfsDir := filepath.Join(tmpDir, "tmpfs")

--- a/integration/loopback_test.go
+++ b/integration/loopback_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestLoopbackTransfer(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/loopback.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/offline_enforcement_test.go
+++ b/integration/offline_enforcement_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestOfflineEnforcement(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/offline_enforcement.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/prereq_test.go
+++ b/integration/prereq_test.go
@@ -1,0 +1,26 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// requireRootAndCommands skips the test when run without root privileges or
+// when required external commands are missing. The default checks cover common
+// LVM utilities and loop device helpers; additional tools can be passed via
+// cmds.
+func requireRootAndCommands(t *testing.T, cmds ...string) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("root required")
+	}
+	tools := append([]string{"lvremove", "pvremove", "losetup"}, cmds...)
+	for _, tool := range tools {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available", tool)
+		}
+	}
+}

--- a/integration/resume_dedup_mismatch_test.go
+++ b/integration/resume_dedup_mismatch_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestResumeDedupMismatch(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/resume_dedup_mismatch.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/resume_identity_mismatch_test.go
+++ b/integration/resume_identity_mismatch_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestResumeIdentityMismatch(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/resume_identity_mismatch.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/resume_test.go
+++ b/integration/resume_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestResumeMidTransfer(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/resume.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/rsync_refusal_test.go
+++ b/integration/rsync_refusal_test.go
@@ -13,6 +13,8 @@ import (
 
 // TestRsyncRefusal exercises rsync transport refusal and related warnings.
 func TestRsyncRefusal(t *testing.T) {
+	requireRootAndCommands(t, "lvs")
+
 	tmp := t.TempDir()
 
 	// Build lvmsync binary into the temp directory.
@@ -21,10 +23,6 @@ func TestRsyncRefusal(t *testing.T) {
 	build.Dir = ".."
 	if out, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("build lvmsync: %v\n%s", err, out)
-	}
-
-	if _, err := exec.LookPath("lvs"); err != nil {
-		t.Skip("lvs not available")
 	}
 
 	// Prepare a 1MiB source image and matching destinations.

--- a/integration/safe_overwrite_test.go
+++ b/integration/safe_overwrite_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestSafeOverwrite(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/safe_overwrite.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()

--- a/integration/snapshot_failure_test.go
+++ b/integration/snapshot_failure_test.go
@@ -22,14 +22,7 @@ func run(t *testing.T, cmd *exec.Cmd) string {
 }
 
 func TestSnapshotCleanupOnFailure(t *testing.T) {
-	for _, tool := range []string{"losetup", "pvcreate", "vgcreate", "lvcreate", "dd"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not available", tool)
-		}
-	}
-	if os.Geteuid() != 0 {
-		t.Skip("root required")
-	}
+	requireRootAndCommands(t, "pvcreate", "vgcreate", "lvcreate", "dd", "lvs")
 
 	tmpDir := t.TempDir()
 	bin := filepath.Join(tmpDir, "lvmsync")

--- a/integration/snapshot_pressure_test.go
+++ b/integration/snapshot_pressure_test.go
@@ -26,15 +26,7 @@ func run(t *testing.T, cmd *exec.Cmd) string {
 }
 
 func TestSnapshotPressure(t *testing.T) {
-	// Require necessary LVM tools
-	for _, tool := range []string{"losetup", "pvcreate", "vgcreate", "lvcreate", "dd"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not available", tool)
-		}
-	}
-	if os.Geteuid() != 0 {
-		t.Skip("root required")
-	}
+	requireRootAndCommands(t, "pvcreate", "vgcreate", "lvcreate", "dd")
 
 	tmpDir := t.TempDir()
 	bin := filepath.Join(tmpDir, "lvmsync")

--- a/integration/snapshot_signal_test.go
+++ b/integration/snapshot_signal_test.go
@@ -24,14 +24,7 @@ func run(t *testing.T, cmd *exec.Cmd) string {
 }
 
 func TestSnapshotCleanupOnSignal(t *testing.T) {
-	for _, tool := range []string{"losetup", "pvcreate", "vgcreate", "lvcreate", "dd"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not available", tool)
-		}
-	}
-	if os.Geteuid() != 0 {
-		t.Skip("root required")
-	}
+	requireRootAndCommands(t, "pvcreate", "vgcreate", "lvcreate", "dd", "lvs")
 
 	tmpDir := t.TempDir()
 	bin := filepath.Join(tmpDir, "lvmsync")

--- a/integration/snapshot_usage_guard_test.go
+++ b/integration/snapshot_usage_guard_test.go
@@ -40,14 +40,7 @@ func waitForSnapshot(t *testing.T, vg string) {
 }
 
 func TestSnapshotUsageGuard(t *testing.T) {
-	for _, tool := range []string{"losetup", "pvcreate", "vgcreate", "lvcreate", "dd"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not available", tool)
-		}
-	}
-	if os.Geteuid() != 0 {
-		t.Skip("root required")
-	}
+	requireRootAndCommands(t, "pvcreate", "vgcreate", "lvcreate", "dd", "lvs")
 
 	tmpDir := t.TempDir()
 	bin := filepath.Join(tmpDir, "lvmsync")

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestVerifyOnly(t *testing.T) {
+	requireRootAndCommands(t)
 	cmd := exec.Command("bash", "./integration/verify.sh")
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary
- add shared helper to skip integration tests when not root or missing LVM tools
- wire helper into integration tests and document requirements in README
- fix verify tests by importing device and privilege packages

## Testing
- `go build ./...`
- `go test -cover ./...`
- `go test -tags=integration ./integration` *(fails: run redeclared)*
- `golangci-lint run` *(fails: 1226 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eaa850b48323b0ac6926471b2a76