### PR TITLE
test: verify deadlines cleared after successful negotiate

### DIFF
--- a/transport/h2/h2_test.go
+++ b/transport/h2/h2_test.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -104,6 +105,19 @@ func generateSelfSignedCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 	pool.AddCert(parsed)
 	return cert, pool
 }
+
+type recordingConn struct {
+	net.Conn
+	deadlines []time.Time
+}
+
+func (r *recordingConn) SetDeadline(t time.Time) error {
+	r.deadlines = append(r.deadlines, t)
+	return nil
+}
+
+func (r *recordingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (r *recordingConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 func TestDialTLS(t *testing.T) {
 	cert, pool := generateSelfSignedCert(t)
@@ -413,6 +427,37 @@ func TestDialClearDeadlineError(t *testing.T) {
 	}
 	if entries[0].Level != zapcore.ErrorLevel {
 		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}
+
+func TestNegotiateClearDeadlineSuccess(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop(), clearDeadline: func(conn net.Conn) error { return conn.SetDeadline(time.Time{}) }}
+	c1, c2 := net.Pipe()
+	client := &recordingConn{Conn: c1}
+	server := &recordingConn{Conn: c2}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var srvErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, srvErr = tr.Negotiate(ctx, server, transport.Server, common.Handshake{})
+	}()
+
+	if _, err := tr.Negotiate(ctx, client, transport.Client, common.Handshake{}); err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	wg.Wait()
+	if srvErr != nil {
+		t.Fatalf("server negotiate: %v", srvErr)
+	}
+	if len(client.deadlines) == 0 {
+		t.Fatalf("expected deadlines to be set")
+	}
+	if !client.deadlines[len(client.deadlines)-1].IsZero() {
+		t.Fatalf("deadline not cleared")
 	}
 }
 

--- a/transport/quic/deadline_test.go
+++ b/transport/quic/deadline_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,13 +30,26 @@ func (f failingConn) SetDeadline(t time.Time) error {
 	}
 	return nil
 }
-func (f failingConn) SetReadDeadline(t time.Time) error  { return nil }
-func (f failingConn) SetWriteDeadline(t time.Time) error { return nil }
+func (f failingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (f failingConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 type dummyAddr struct{}
 
 func (dummyAddr) Network() string { return "tcp" }
 func (dummyAddr) String() string  { return "dummy" }
+
+type recordingConn struct {
+	net.Conn
+	deadlines []time.Time
+}
+
+func (r *recordingConn) SetDeadline(t time.Time) error {
+	r.deadlines = append(r.deadlines, t)
+	return nil
+}
+
+func (r *recordingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (r *recordingConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 func TestNegotiateClearDeadlineFailure(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
@@ -50,5 +64,36 @@ func TestNegotiateClearDeadlineFailure(t *testing.T) {
 	}
 	if entries[0].Level != zapcore.ErrorLevel {
 		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}
+
+func TestNegotiateClearDeadlineSuccess(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	c1, c2 := net.Pipe()
+	client := &recordingConn{Conn: c1}
+	server := &recordingConn{Conn: c2}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var srvErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, srvErr = tr.Negotiate(ctx, server, transport.Server, common.Handshake{})
+	}()
+
+	if _, err := tr.Negotiate(ctx, client, transport.Client, common.Handshake{}); err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	wg.Wait()
+	if srvErr != nil {
+		t.Fatalf("server negotiate: %v", srvErr)
+	}
+	if len(client.deadlines) == 0 {
+		t.Fatalf("expected deadlines to be set")
+	}
+	if !client.deadlines[len(client.deadlines)-1].IsZero() {
+		t.Fatalf("deadline not cleared")
 	}
 }

--- a/transport/ssh/deadline_test.go
+++ b/transport/ssh/deadline_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,13 +30,26 @@ func (f failingConn) SetDeadline(t time.Time) error {
 	}
 	return nil
 }
-func (f failingConn) SetReadDeadline(t time.Time) error  { return nil }
-func (f failingConn) SetWriteDeadline(t time.Time) error { return nil }
+func (f failingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (f failingConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 type dummyAddr struct{}
 
 func (dummyAddr) Network() string { return "tcp" }
 func (dummyAddr) String() string  { return "dummy" }
+
+type recordingConn struct {
+	net.Conn
+	deadlines []time.Time
+}
+
+func (r *recordingConn) SetDeadline(t time.Time) error {
+	r.deadlines = append(r.deadlines, t)
+	return nil
+}
+
+func (r *recordingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (r *recordingConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 func TestNegotiateClearDeadlineFailure(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
@@ -50,5 +64,36 @@ func TestNegotiateClearDeadlineFailure(t *testing.T) {
 	}
 	if entries[0].Level != zapcore.ErrorLevel {
 		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}
+
+func TestNegotiateClearDeadlineSuccess(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	c1, c2 := net.Pipe()
+	client := &recordingConn{Conn: c1}
+	server := &recordingConn{Conn: c2}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var srvErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, srvErr = tr.Negotiate(ctx, server, transport.Server, common.Handshake{})
+	}()
+
+	if _, err := tr.Negotiate(ctx, client, transport.Client, common.Handshake{}); err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	wg.Wait()
+	if srvErr != nil {
+		t.Fatalf("server negotiate: %v", srvErr)
+	}
+	if len(client.deadlines) == 0 {
+		t.Fatalf("expected deadlines to be set")
+	}
+	if !client.deadlines[len(client.deadlines)-1].IsZero() {
+		t.Fatalf("deadline not cleared")
 	}
 }

--- a/transport/tcp_tls/deadline_test.go
+++ b/transport/tcp_tls/deadline_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,13 +30,26 @@ func (f failingConn) SetDeadline(t time.Time) error {
 	}
 	return nil
 }
-func (f failingConn) SetReadDeadline(t time.Time) error  { return nil }
-func (f failingConn) SetWriteDeadline(t time.Time) error { return nil }
+func (f failingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (f failingConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 type dummyAddr struct{}
 
 func (dummyAddr) Network() string { return "tcp" }
 func (dummyAddr) String() string  { return "dummy" }
+
+type recordingConn struct {
+	net.Conn
+	deadlines []time.Time
+}
+
+func (r *recordingConn) SetDeadline(t time.Time) error {
+	r.deadlines = append(r.deadlines, t)
+	return nil
+}
+
+func (r *recordingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (r *recordingConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 func TestNegotiateClearDeadlineFailure(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
@@ -50,5 +64,36 @@ func TestNegotiateClearDeadlineFailure(t *testing.T) {
 	}
 	if entries[0].Level != zapcore.ErrorLevel {
 		t.Fatalf("expected error level, got %v", entries[0].Level)
+	}
+}
+
+func TestNegotiateClearDeadlineSuccess(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	c1, c2 := net.Pipe()
+	client := &recordingConn{Conn: c1}
+	server := &recordingConn{Conn: c2}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var srvErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, srvErr = tr.Negotiate(ctx, server, transport.Server, common.Handshake{})
+	}()
+
+	if _, err := tr.Negotiate(ctx, client, transport.Client, common.Handshake{}); err != nil {
+		t.Fatalf("client negotiate: %v", err)
+	}
+	wg.Wait()
+	if srvErr != nil {
+		t.Fatalf("server negotiate: %v", srvErr)
+	}
+	if len(client.deadlines) == 0 {
+		t.Fatalf("expected deadlines to be set")
+	}
+	if !client.deadlines[len(client.deadlines)-1].IsZero() {
+		t.Fatalf("deadline not cleared")
 	}
 }


### PR DESCRIPTION
## Summary
- add success-path deadline clearing tests for tcp+tls, ssh, quic, and h2 transports

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ef6cb350832382634e5caa1ff142