### PR TITLE
remote: handle short writes

### DIFF
--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -75,8 +75,15 @@ func (c *PrivHelperClient) send(offset uint64, payload []byte, hash [32]byte) er
 	}
 	buf.Write(hash[:])
 	buf.Write(payload)
-	_, err := c.stdin.Write(buf.Bytes())
-	return err
+	data := buf.Bytes()
+	n, err := c.stdin.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
 }
 
 // Send queues a write operation at the given offset with the provided payload.

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -66,5 +67,24 @@ func TestStartPrivHelperInvalidCommand(t *testing.T) {
 	defer cancel()
 	if _, err := StartPrivHelper(ctx, client, "bad;cmd", zap.NewNop()); err == nil || !strings.Contains(err.Error(), "invalid characters") {
 		t.Fatalf("expected invalid characters error, got %v", err)
+	}
+}
+
+type shortWriteCloser struct{}
+
+func (shortWriteCloser) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
+}
+
+func (shortWriteCloser) Close() error { return nil }
+
+func TestPrivHelperSendShortWrite(t *testing.T) {
+	c := &PrivHelperClient{stdin: shortWriteCloser{}, logger: zap.NewNop()}
+	err := c.Send(0, []byte("data"))
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("expected io.ErrShortWrite, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- handle short writes from privileged helper channel writes
- cover partial write behavior in privileged helper tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./remote`
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: 1227 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f477609c8323bc5480927785d0f2