### PR TITLE
transfer: replace time.After with resettable timer

### DIFF
--- a/transfer/block_common.go
+++ b/transfer/block_common.go
@@ -90,6 +90,12 @@ func readWithZeroCopy(ctx context.Context, cfg *config.Config, src *os.File, off
 		}
 	}()
 
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		err = ZeroCopyTransfer(src, w, offset, int64(blockSize), pipeFds)
 		if err == nil {
@@ -103,9 +109,13 @@ func readWithZeroCopy(ctx context.Context, cfg *config.Config, src *os.File, off
 			zap.Error(err))
 
 		delay := baseDelay * time.Duration(1<<attempt)
+		timer.Reset(delay)
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
 			if errClose := w.Close(); errClose != nil {
 				logger.Warn("pipe write close", zap.Error(errClose))
 			}
@@ -151,6 +161,13 @@ func retryRead(ctx context.Context, cfg *config.Config, src *os.File, offset int
 	} else {
 		buf = getBlockBuffer(blockSize)
 	}
+
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		n, err := src.ReadAt(buf, offset)
 		if err == nil && n == blockSize {
@@ -164,9 +181,13 @@ func retryRead(ctx context.Context, cfg *config.Config, src *os.File, offset int
 			zap.Error(err))
 
 		delay := baseDelay * time.Duration(1<<attempt)
+		timer.Reset(delay)
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
 			if cfg.ODirect {
 				putAlignedBlockBuffer(buf)
 			} else {

--- a/transfer/block_test.go
+++ b/transfer/block_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"runtime"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -120,5 +121,28 @@ func TestReadBlockWithRetriesContextCancel(t *testing.T) {
 	}
 	if time.Since(start) >= 100*time.Millisecond {
 		t.Fatalf("expected cancellation before backoff elapsed")
+	}
+}
+
+func TestRetryReadNoTimerLeak(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := &config.Config{BlockSize: 4, MaxRetries: 3}
+
+	tmp := newTempFile(t, "block")
+	defer tmp.Close()
+
+	before := runtime.NumGoroutine()
+	for i := 0; i < 10; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+		_, _ = retryRead(ctx, cfg, tmp, 0, logger)
+	}
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+	if after-before > 2 {
+		t.Fatalf("goroutines leaked: before %d after %d", before, after)
 	}
 }


### PR DESCRIPTION
## Summary
- use `time.NewTimer` with reset/stop in block reads to prevent timer leaks
- add test ensuring repeated cancellations don't leak goroutines

## Testing
- `go build ./...`
- `go test -cover ./...`
- `go test -race ./transfer`
- `golangci-lint run` *(fails: existing issues)*


------
https://chatgpt.com/codex/tasks/task_e_68a7f478abd88323b8fe30aaec117fb7