### PR TITLE
remote: enforce logger requirement for StartPrivHelper

### DIFF
--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -28,8 +28,12 @@ type PrivHelperClient struct {
 // The helper reads (index, payload, hash) messages and performs pwrite operations.
 // The provided context controls the lifetime of the startup; if it is canceled
 // before the remote command begins executing, an error is returned. logger must
-// be non-nil; use zap.NewNop() to disable logging.
+// be non-nil; use zap.NewNop() to disable logging. StartPrivHelper returns an
+// error if logger is nil.
 func StartPrivHelper(ctx context.Context, client *ssh.Client, command string, logger *zap.Logger) (*PrivHelperClient, error) {
+	if logger == nil {
+		return nil, errors.New("logger is nil")
+	}
 	command = strings.TrimSpace(command)
 	if !ValidRemoteCommand(command) {
 		return nil, fmt.Errorf("remote command %s contains invalid characters", command)

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -71,6 +71,15 @@ func TestStartPrivHelperInvalidCommand(t *testing.T) {
 	}
 }
 
+func TestStartPrivHelperNilLogger(t *testing.T) {
+	_, client := newSSHServerClientWithChannel(t, func(_ string, _ ssh.Channel) int { return 0 })
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := StartPrivHelper(ctx, client, "privhelper", nil); err == nil || !strings.Contains(err.Error(), "logger is nil") {
+		t.Fatalf("expected nil logger error, got %v", err)
+	}
+}
+
 func TestRecvAckTimeout(t *testing.T) {
 	r, w := net.Pipe()
 	defer r.Close() //nolint:errcheck
@@ -78,8 +87,14 @@ func TestRecvAckTimeout(t *testing.T) {
 	c := &PrivHelperClient{stdout: r}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	if _, err := c.RecvAck(ctx); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected deadline exceeded, got %v", err)
+	if _, err := c.RecvAck(ctx); err == nil {
+		t.Fatalf("expected timeout")
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		if ne, ok := err.(interface{ Timeout() bool }); !ok || !ne.Timeout() {
+			t.Fatalf("expected deadline exceeded, got %v", err)
+		}
+	}
+}
 
 func TestPrivilegedHelperOversizedLength(t *testing.T) {
 	handler := func(cmd string, ch ssh.Channel) int {
@@ -106,7 +121,7 @@ func TestPrivilegedHelperOversizedLength(t *testing.T) {
 	if err := privClient.Send(0, payload); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	ack, err := privClient.RecvAck()
+	ack, err := privClient.RecvAck(context.Background())
 	if err != nil {
 		t.Fatalf("RecvAck: %v", err)
 	}
@@ -137,12 +152,14 @@ func TestPrivilegedHelperShortWrite(t *testing.T) {
 	if err := privClient.Send(0, []byte("hello")); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	ack, err := privClient.RecvAck()
+	ack, err := privClient.RecvAck(context.Background())
 	if err != nil {
 		t.Fatalf("RecvAck: %v", err)
 	}
 	if ack {
 		t.Fatalf("expected NACK for short write")
+	}
+}
 
 type shortWriteCloser struct{}
 


### PR DESCRIPTION
## Summary
- return an error if `StartPrivHelper` receives a nil logger and document this requirement
- cover nil logger path with unit test
- fix and update remote privilege helper tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: revive, errcheck, gocritic, govet, staticcheck issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a7fc01e2a88323b0281e4a752a64dd