### PR TITLE
remote: cap privileged helper payload length

### DIFF
--- a/docs/privilege_escalation.md
+++ b/docs/privilege_escalation.md
@@ -36,6 +36,10 @@ rights.
 
 For additional hardening, pass `--no-new-privs` or set `LVMSYNC_NO_NEW_PRIVS=1` to call `prctl(PR_SET_NO_NEW_PRIVS)` before `sudo` execution. This prevents escalated commands from gaining further privileges.
 
+## Helper request limits
+
+The privileged helper rejects write requests that declare a payload larger than 1 MiB. It discards at most 1 MiB of data before aborting the session to avoid streaming gigabytes of unsolicited input.
+
 
 
 Roles are read from the certificate's `OrganizationalUnit` field and must

--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -182,13 +182,10 @@ func privilegedPwriteServer(rw io.ReadWriter, fd int, pwrite pwriteFunc) error {
 		offset := binary.BigEndian.Uint64(header[0:8])
 		length := binary.BigEndian.Uint32(header[8:12])
 		if length > maxPayloadLength {
-			if _, err := io.CopyN(io.Discard, rw, int64(length)); err != nil {
+			if _, err := io.CopyN(io.Discard, rw, int64(maxPayloadLength)); err != nil {
 				return err
 			}
-			if _, err := rw.Write([]byte{'N'}); err != nil {
-				return err
-			}
-			continue
+			return fmt.Errorf("payload length %d exceeds maximum %d", length, maxPayloadLength)
 		}
 		var expHash [32]byte
 		copy(expHash[:], header[12:44])

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -1,8 +1,10 @@
 package remote
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"io"
 	"net"
@@ -80,6 +82,8 @@ func TestRecvAckTimeout(t *testing.T) {
 	defer cancel()
 	if _, err := c.RecvAck(ctx); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
 
 func TestPrivilegedHelperOversizedLength(t *testing.T) {
 	handler := func(cmd string, ch ssh.Channel) int {
@@ -106,12 +110,8 @@ func TestPrivilegedHelperOversizedLength(t *testing.T) {
 	if err := privClient.Send(0, payload); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	ack, err := privClient.RecvAck()
-	if err != nil {
-		t.Fatalf("RecvAck: %v", err)
-	}
-	if ack {
-		t.Fatalf("expected NACK for oversized payload")
+	if _, err := privClient.RecvAck(ctx); err == nil {
+		t.Fatalf("expected error for oversized payload")
 	}
 }
 
@@ -137,12 +137,14 @@ func TestPrivilegedHelperShortWrite(t *testing.T) {
 	if err := privClient.Send(0, []byte("hello")); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	ack, err := privClient.RecvAck()
+	ack, err := privClient.RecvAck(ctx)
 	if err != nil {
 		t.Fatalf("RecvAck: %v", err)
 	}
 	if ack {
 		t.Fatalf("expected NACK for short write")
+	}
+}
 
 type shortWriteCloser struct{}
 
@@ -161,4 +163,51 @@ func TestPrivHelperSendShortWrite(t *testing.T) {
 	if !errors.Is(err, io.ErrShortWrite) {
 		t.Fatalf("expected io.ErrShortWrite, got %v", err)
 	}
+}
+
+func TestPrivilegedPwriteServerLargeDeclaredLength(t *testing.T) {
+	const large = 2 * 1024 * 1024 * 1024 // 2 GiB
+	header := make([]byte, 8+4+32)
+	binary.BigEndian.PutUint64(header[0:8], 0)
+	binary.BigEndian.PutUint32(header[8:12], uint32(large))
+	cr := &countingReader{limit: maxPayloadLength * 2}
+	reader := io.MultiReader(bytes.NewReader(header), cr)
+	rw := struct {
+		io.Reader
+		io.Writer
+	}{Reader: reader, Writer: io.Discard}
+	var called bool
+	pw := func(fd int, p []byte, off int64) (int, error) {
+		called = true
+		return len(p), nil
+	}
+	err := privilegedPwriteServer(rw, 0, pw)
+	if err == nil {
+		t.Fatalf("expected error for large declared length")
+	}
+	if called {
+		t.Fatalf("pwrite should not be called")
+	}
+	if cr.n > maxPayloadLength {
+		t.Fatalf("read %d bytes, expected at most %d", cr.n, maxPayloadLength)
+	}
+}
+
+type countingReader struct {
+	n     int
+	limit int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	if c.n >= c.limit {
+		return 0, io.EOF
+	}
+	if len(p) > c.limit-c.n {
+		p = p[:c.limit-c.n]
+	}
+	for i := range p {
+		p[i] = 0
+	}
+	c.n += len(p)
+	return len(p), nil
 }


### PR DESCRIPTION
## Summary
- abort privileged helper when declared payload exceeds 1MiB
- cover oversized length handling with a multi‑gigabyte test
- document helper request limit

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: numerous existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fc02c6148323b664f9bdd0be5a44