### PR TITLE
priv_helper: NACK oversized payloads

### DIFF
--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -186,6 +186,9 @@ func privilegedPwriteServer(rw io.ReadWriter, fd int, pwrite pwriteFunc) error {
 		offset := binary.BigEndian.Uint64(header[0:8])
 		length := binary.BigEndian.Uint32(header[8:12])
 		if length > maxPayloadLength {
+			if _, err := rw.Write([]byte{'N'}); err != nil {
+				return err
+			}
 			if _, err := io.CopyN(io.Discard, rw, int64(maxPayloadLength)); err != nil {
 				return err
 			}

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -125,7 +125,7 @@ func TestPrivilegedHelperOversizedLength(t *testing.T) {
 	}
 	ack, err := privClient.RecvAck(ctx)
 	if err != nil {
-		t.Fatalf("RecvAck: %v", err)
+		t.Fatalf("expected NACK without error, got %v", err)
 	}
 	if ack {
 		t.Fatalf("expected NACK for oversized payload")
@@ -207,6 +207,31 @@ func TestPrivilegedPwriteServerLargeDeclaredLength(t *testing.T) {
 	}
 	if cr.n > maxPayloadLength {
 		t.Fatalf("read %d bytes, expected at most %d", cr.n, maxPayloadLength)
+	}
+}
+
+func TestPrivilegedPwriteServerOversizedLengthNACK(t *testing.T) {
+	payloadLen := maxPayloadLength + 1
+	header := make([]byte, 8+4+32)
+	binary.BigEndian.PutUint64(header[0:8], 0)
+	binary.BigEndian.PutUint32(header[8:12], uint32(payloadLen))
+	payload := make([]byte, payloadLen)
+	reader := io.MultiReader(bytes.NewReader(header), bytes.NewReader(payload))
+	var out bytes.Buffer
+	rw := struct {
+		io.Reader
+		io.Writer
+	}{Reader: reader, Writer: &out}
+	pw := func(fd int, p []byte, off int64) (int, error) {
+		t.Fatalf("pwrite should not be called")
+		return len(p), nil
+	}
+	err := privilegedPwriteServer(rw, 0, pw)
+	if err == nil {
+		t.Fatalf("expected error for oversized payload")
+	}
+	if out.String() != "N" {
+		t.Fatalf("expected NACK, got %q", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- NACK oversized payloads before draining and returning an error
- Expect NACK for oversized writes
- Regression test for NACK on oversized payloads

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: 1232 issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a8163fa7fc832396bfcba4de462372