### PR TITLE
Add strict device identity comparison with major/minor

### DIFF
--- a/device/identity.go
+++ b/device/identity.go
@@ -27,6 +27,19 @@ func SameIdentity(a, b DeviceIdentity) bool {
 		a.ManifestEpoch == b.ManifestEpoch
 }
 
+// SameIdentityStrict reports whether two DeviceIdentity values describe the
+// same device including kernel-assigned Major and Minor numbers.
+func SameIdentityStrict(a, b DeviceIdentity) bool {
+	return a.SizeBytes == b.SizeBytes &&
+		a.KernelUUID == b.KernelUUID &&
+		a.GPTUUID == b.GPTUUID &&
+		a.MBRSignature == b.MBRSignature &&
+		a.FSUUID == b.FSUUID &&
+		a.Major == b.Major &&
+		a.Minor == b.Minor &&
+		a.ManifestEpoch == b.ManifestEpoch
+}
+
 // Range represents a byte range on a device.
 type Range struct {
 	Start uint64

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -113,8 +113,8 @@ func TestDeviceIdentityFormatParseOrder(t *testing.T) {
 	}
 }
 
-func TestSameIdentityIgnoresMajorMinor(t *testing.T) {
-	a := DeviceIdentity{
+func TestSameIdentityStrictDetectsMajorMinorMismatch(t *testing.T) {
+	base := DeviceIdentity{
 		SizeBytes:     1,
 		KernelUUID:    "k",
 		GPTUUID:       "g",
@@ -124,11 +124,17 @@ func TestSameIdentityIgnoresMajorMinor(t *testing.T) {
 		Minor:         3,
 		ManifestEpoch: 4,
 	}
-	b := a
+
+	b := base
 	b.Major++
+	if SameIdentityStrict(base, b) {
+		t.Fatalf("expected major mismatch: %+v vs %+v", base, b)
+	}
+
+	b = base
 	b.Minor++
-	if !SameIdentity(a, b) {
-		t.Fatalf("expected identities to match: %+v vs %+v", a, b)
+	if SameIdentityStrict(base, b) {
+		t.Fatalf("expected minor mismatch: %+v vs %+v", base, b)
 	}
 }
 

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -319,7 +319,9 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		major := uint32(unix.Major(uint64(st.Rdev)))
 		minor := uint32(unix.Minor(uint64(st.Rdev)))
-		if major != hdr.Major || minor != hdr.Minor {
+		expectedID := device.DeviceIdentity{SizeBytes: hdr.SizeBytes, Major: hdr.Major, Minor: hdr.Minor}
+		actualID := device.DeviceIdentity{SizeBytes: size, Major: major, Minor: minor}
+		if !device.SameIdentityStrict(expectedID, actualID) {
 			t.Logger.Error("device_number_mismatch", zap.Uint32("expected_major", hdr.Major), zap.Uint32("expected_minor", hdr.Minor), zap.Uint32("major", major), zap.Uint32("minor", minor))
 			return 0, "", 0, fmt.Errorf("precondition: destination device number mismatch")
 		}


### PR DESCRIPTION
## Summary
- add `SameIdentityStrict` to include major/minor comparison
- use strict identity comparison when validating manifest preconditions
- test mismatched major/minor handling

## Testing
- `go build ./...`
- `go test -run TestSameIdentityStrictDetectsMajorMinorMismatch -count=1 -v ./device`
- `go test -run TestVerifyDestinationDeviceNumberMismatch -count=1 -v ./transfer`
- `golangci-lint run ./device/... ./transfer/...` *(fails: Error return value of `f.Close` is not checked, exported method comments missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a81d3ce10083238acbb1604f75eb42