### PR TITLE
feat: verify partition signatures

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -377,7 +377,7 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 // RunLocalDump dumps changes to a local destination device and returns the detected destination type.
 func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotDevice, originDevice, dest string, logger *zap.Logger) (string, error) {
 	destType := cfg.DestType
-	devCtx := device.WithForce(context.Background(), cfg.Force)
+	devCtx := device.WithForce(ctx, cfg.Force)
 	devCtx = device.WithAllowOverwrite(devCtx, cfg.AllowOverwrite)
 	devCtx = device.WithYesIKnow(devCtx, cfg.YesIKnow)
 	devRunner := device.NewRunner()
@@ -385,7 +385,27 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 		return destType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, io.Discard, logger)
 	}
 	if destType == "auto" {
-		if dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx, logger), logger, devRunner); err == nil {
+		dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx, logger), logger, devRunner)
+		if err != nil {
+			if cfg.CheckPartition && strings.Contains(err.Error(), "partition table mismatch") {
+				if !cfg.Force {
+					return destType, fmt.Errorf("precondition: partition table mismatch")
+				}
+				if !cfg.VerifyOnly && strings.ToLower(cfg.VerifyLevel) != "none" {
+					return destType, fmt.Errorf("partition table mismatch: run --verify-only first or set --verify none with --force")
+				}
+				tmpCtx := device.WithForce(context.Background(), cfg.Force)
+				tmpCtx = device.WithAllowOverwrite(tmpCtx, cfg.AllowOverwrite)
+				tmpCtx = device.WithYesIKnow(tmpCtx, cfg.YesIKnow)
+				dev, err = device.Detect(tmpCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(tmpCtx, logger), logger, devRunner)
+				if err != nil {
+					dev = nil
+				}
+			} else {
+				dev = nil
+			}
+		}
+		if dev != nil {
 			switch dev.(type) {
 			case *device.RawDevice:
 				if !cfg.SkipSnapshotCreation {
@@ -442,7 +462,16 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 	}
 	info := device.NewInfo()
 	if err := r.verifyIdentity(devCtx, info, snapshotDevice, dest); err != nil {
-		return destType, err
+		if cfg.CheckPartition && strings.Contains(err.Error(), "partition table mismatch") {
+			if !cfg.Force {
+				return destType, fmt.Errorf("precondition: partition table mismatch")
+			}
+			if !cfg.VerifyOnly && strings.ToLower(cfg.VerifyLevel) != "none" {
+				return destType, fmt.Errorf("partition table mismatch: run --verify-only first or set --verify none with --force")
+			}
+		} else {
+			return destType, err
+		}
 	}
 	destFile, err := r.openFile(dest, os.O_RDWR, 0)
 	if err != nil {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/term"
 
 	"lvmsync_go/app"
+	"lvmsync_go/device"
 	clientpkg "lvmsync_go/internal/client"
 	"lvmsync_go/internal/config"
 	"lvmsync_go/internal/exitcode"
@@ -238,6 +239,9 @@ func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Lo
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	if cfg.CheckPartition {
+		ctx = device.WithPartitionSignatures(ctx, "", "")
+	}
 
 	var snapshotPath string
 	signals, sigErrCh := r.setupSignalHandleFn(ctx, cfg, &snapshotPath, logger)

--- a/integration/partition_signatures.sh
+++ b/integration/partition_signatures.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+SRC_LOOP=""
+DST_LOOP=""
+cleanup() {
+  set +e
+  if [ -n "$SRC_LOOP" ]; then
+    losetup -d "$SRC_LOOP" >/dev/null 2>&1
+  fi
+  if [ -n "$DST_LOOP" ]; then
+    losetup -d "$DST_LOOP" >/dev/null 2>&1
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+BIN="$TMPDIR/lvmsync"
+go build -o "$BIN" .
+
+SRC_IMG="$TMPDIR/src.img"
+DST_IMG="$TMPDIR/dst.img"
+dd if=/dev/zero of="$SRC_IMG" bs=1M count=8
+dd if=/dev/zero of="$DST_IMG" bs=1M count=8
+SRC_LOOP=$(losetup --find --show "$SRC_IMG")
+DST_LOOP=$(losetup --find --show "$DST_IMG")
+
+printf ',8M,L\n' | sfdisk "$SRC_LOOP"
+printf ',8M,L\n' | sfdisk "$DST_LOOP"
+printf '\xDE\xAD\xBE\xEF' | dd of="$SRC_LOOP" bs=1 seek=440 conv=notrunc
+printf '\xDE\xAD\xBE\xEF' | dd of="$DST_LOOP" bs=1 seek=440 conv=notrunc
+
+"$BIN" run --offline --skip-snapshot-creation --check-partition "$SRC_LOOP" "$DST_LOOP"
+
+printf ',4M,L\n' | sfdisk "$DST_LOOP"
+printf '\xDE\xAD\xBE\xEF' | dd of="$DST_LOOP" bs=1 seek=440 conv=notrunc
+
+"$BIN" run --offline --skip-snapshot-creation --force --verify none --check-partition "$SRC_LOOP" "$DST_LOOP"
+
+printf ',4M,L\n' | sfdisk "$DST_LOOP"
+printf '\xDE\xAD\xBE\xEF' | dd of="$DST_LOOP" bs=1 seek=440 conv=notrunc
+
+set +e
+"$BIN" run --offline --skip-snapshot-creation --force --verify inline --check-partition "$SRC_LOOP" "$DST_LOOP"
+status=$?
+set -e
+if [ "$status" -ne 80 ]; then
+  echo "expected exit code 80, got $status"
+  exit 1
+fi
+
+exit 0

--- a/integration/partition_signatures_test.go
+++ b/integration/partition_signatures_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestPartitionSignatures(t *testing.T) {
+	requireRootAndCommands(t, "sfdisk")
+	cmd := exec.Command("bash", "./integration/partition_signatures.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("partition-signatures integration failed: %v\n%s", err, out)
+	}
+}


### PR DESCRIPTION
## Summary
- capture source partition signatures when `--check-partition` is enabled
- enforce partition signature comparison on destinations with optional forced bypass
- add integration test covering success, forced, and refusal flows

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: context deadline exceeded in remote tests)*
- `golangci-lint run` *(fails: multiple lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a81f16efb483238abd36b5558948db