### PR TITLE
privilege: add root sudo Ensure tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Go test with race detector
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Root tests
+        run: sudo make test-root
+
       - name: Show coverage
         run: go tool cover -func=coverage.out | tail -n 1
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Go test (race + cover)
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Root tests
+        run: sudo make test-root
+
       - name: Integration tests (PR)
         if: github.event_name == 'pull_request' && startsWith(matrix.os, 'ubuntu-')
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX := >
-.PHONY: deps build test lint verify coverage bench bench-lan bench-wan vet staticcheck test-race integration release docs-check
+.PHONY: deps build test lint verify coverage bench bench-lan bench-wan vet staticcheck test-race integration release docs-check test-root
 
 deps:
 > scripts/check_deps.sh
@@ -10,6 +10,9 @@ build: deps
 
 test:
 > go test -coverprofile=coverage.out ./...
+
+test-root:
+> if [ "$$(id -u)" -eq 0 ]; then go test -tags=root ./escalate ./internal/privilege; else echo "skipping root tests"; fi
 
 coverage:
 > go test -coverprofile=coverage.out ./...

--- a/internal/privilege/ensure_root_test.go
+++ b/internal/privilege/ensure_root_test.go
@@ -1,0 +1,110 @@
+//go:build root
+
+package privilege_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"go.uber.org/zap"
+
+	rootcmd "lvmsync_go/cmd/root"
+	"lvmsync_go/internal/exitcode"
+	"lvmsync_go/internal/privilege"
+)
+
+func TestEnsureSudoTrue(t *testing.T) {
+	requireSudo(t)
+	privilege.HasCaps = func() bool { return false }
+	defer func() { privilege.HasCaps = privilege.RealHasCaps }()
+	esc := privilege.New(context.Background(), zap.NewNop())
+	if err := esc.Ensure(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureSudoErrorsExitCode(t *testing.T) {
+	requireRoot(t)
+	tests := []struct {
+		name   string
+		runner *privilege.Runner
+	}{
+		{
+			name:   "missing_sudo",
+			runner: &privilege.Runner{LookPath: fakeLookPath(errors.New("not found"))},
+		},
+		{
+			name: "denied",
+			runner: &privilege.Runner{
+				Cmd:      cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd { return fakeSudo(1)(name, args...) }),
+				LookPath: fakeLookPath(nil),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			privilege.HasCaps = func() bool { return false }
+			defer func() { privilege.HasCaps = privilege.RealHasCaps }()
+			esc := privilege.NewWithRunner(context.Background(), tt.runner, zap.NewNop())
+			err := esc.Ensure(context.Background())
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if code := rootcmd.ExitCode(fmt.Errorf("privilege check failed: %w", err)); code != exitcode.ErrCapability {
+				t.Fatalf("exit code = %d, want %d", code, exitcode.ErrCapability)
+			}
+		})
+	}
+}
+
+// Helpers for external test package.
+
+type cmdFunc func(context.Context, string, ...string) *exec.Cmd
+
+func (f cmdFunc) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return f(ctx, name, args...)
+}
+
+func fakeLookPath(err error) func(string) (string, error) {
+	return func(string) (string, error) { return "/usr/bin/sudo", err }
+}
+
+func fakeSudo(code int) func(string, ...string) *exec.Cmd {
+	return func(string, ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", strconv.Itoa(code)}
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+		return cmd
+	}
+}
+
+func requireSudo(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("root required")
+	}
+	if _, err := exec.LookPath("sudo"); err != nil {
+		t.Skip("sudo not available")
+	}
+}
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("root required")
+	}
+}
+
+// TestHelperProcess allows exec.Command stubbing.
+func TestHelperProcess(_ *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	code, _ := strconv.Atoi(os.Args[len(os.Args)-1])
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- add root-only tests for privilege Ensure covering sudo success and failure paths
- run root-tag tests via new `test-root` make target
- invoke root tests in CI workflows

## Testing
- `go build ./...`
- `go test ./...` *(fails: TestDumpChangesRsyncDelta: io: read/write on closed pipe)*
- `golangci-lint run` *(fails: many issues)*
- `go test -tags=root ./internal/privilege`
- `go test -tags=root ./escalate`
- `make test-root`

------
https://chatgpt.com/codex/tasks/task_e_68a828ca4998832395017a1eac123325