### PR TITLE
config: test check-partition precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,11 @@ specifies `LVMSYNC_DEDUP_STRATEGY=checksum`, running
 `lvmsync --dedup-strategy auto` resolves to `auto`. Likewise,
 `--transport quic` overrides `LVMSYNC_TRANSPORT_TRANSPORT=ssh` and the
 `transport` key in `config.yaml`.
+For boolean options, the same precedence applies. If `config.yaml`
+specifies `check_partition: true` but `LVMSYNC_CHECK_PARTITION=false` is
+set, `lvmsync --check-partition` enables the check. Omitting the flag
+leaves partition checks disabled because the environment value overrides
+the YAML configuration.
 
 With a `config.yaml` containing:
 

--- a/internal/config/check_partition_precedence_test.go
+++ b/internal/config/check_partition_precedence_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestCheckPartitionFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	flagSets := NewFlagSets(defaults)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	registerFlags(flagSets, fs)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("check_partition: true\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_CHECK_PARTITION", "false")
+	if err := fs.Parse([]string{"--config", cfgFile, "--check-partition"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, _, _, _, err := buildViper(flagSets)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	vb := &builder{v: v, defaults: defaults}
+	cfg, err := vb.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !cfg.CheckPartition {
+		t.Fatalf("CheckPartition=%v want %v", cfg.CheckPartition, true)
+	}
+}
+
+func TestCheckPartitionEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	flagSets := NewFlagSets(defaults)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	registerFlags(flagSets, fs)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("check_partition: true\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_CHECK_PARTITION", "false")
+	if err := fs.Parse([]string{"--config", cfgFile}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, _, _, _, err := buildViper(flagSets)
+	if err != nil {
+		t.Fatalf("buildViper: %v", err)
+	}
+	vb := &builder{v: v, defaults: defaults}
+	cfg, err := vb.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.CheckPartition {
+		t.Fatalf("CheckPartition=%v want %v", cfg.CheckPartition, false)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests verifying flag/env/YAML precedence for --check-partition
- document precedence example for --check-partition in README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run --new-from-rev=HEAD~1`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a82d11f87883238dfce005b5edb277