### PR TITLE
Warn on insecure transports

### DIFF
--- a/cmd/root/plan.go
+++ b/cmd/root/plan.go
@@ -57,8 +57,16 @@ func emitPlan(cfg *config.Config, args []string, logger *zap.Logger) error {
 	if len(args) < 1 {
 		return fmt.Errorf("missing source argument")
 	}
-	if cfg.AllowInsecure || strings.Contains(cfg.Transport, "rsync") {
-		fmt.Fprintln(os.Stderr, "allow_insecure enabled; security checks disabled")
+	transports := splitList(cfg.Transport)
+	rsyncRequested := false
+	for _, t := range transports {
+		if t == "rsync" {
+			rsyncRequested = true
+			break
+		}
+	}
+	if cfg.AllowInsecure || rsyncRequested {
+		logger.Warn("allow_insecure enabled; security checks disabled", zap.String("reason", "allow_insecure_enabled"))
 		if !cfg.AllowInsecure {
 			return fmt.Errorf("insecure configuration requires --allow-insecure")
 		}
@@ -69,7 +77,7 @@ func emitPlan(cfg *config.Config, args []string, logger *zap.Logger) error {
 	}
 	po := planOutput{
 		Config:         redactConfig(cfg),
-		TransportOrder: splitList(cfg.Transport),
+		TransportOrder: transports,
 		EstimatedBytes: est,
 		Compression:    buildCompressionPlan(cfg),
 	}

--- a/cmd/root/plan_test.go
+++ b/cmd/root/plan_test.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/internal/config"
 )
@@ -40,19 +40,18 @@ func TestEmitPlanAllowInsecureWarns(t *testing.T) {
 	}
 	cfg := &config.Config{AllowInsecure: true}
 	rOut, wOut, _ := os.Pipe()
-	rErr, wErr, _ := os.Pipe()
-	stdout, stderr := os.Stdout, os.Stderr
-	os.Stdout, os.Stderr = wOut, wErr
-	defer func() { os.Stdout, os.Stderr = stdout, stderr }()
-	if e := emitPlan(cfg, []string{f.Name()}, zap.NewNop()); e != nil {
+	stdout := os.Stdout
+	os.Stdout = wOut
+	obs, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(obs)
+	if e := emitPlan(cfg, []string{f.Name()}, logger); e != nil {
 		t.Fatalf("emitPlan: %v", e)
 	}
 	wOut.Close()
-	wErr.Close()
+	os.Stdout = stdout
 	outBytes, _ := io.ReadAll(rOut)
-	errBytes, _ := io.ReadAll(rErr)
-	if !strings.Contains(string(errBytes), "allow_insecure enabled") {
-		t.Fatalf("missing warning: %q", errBytes)
+	if logs.Len() == 0 {
+		t.Fatalf("missing warning")
 	}
 	if len(outBytes) == 0 {
 		t.Fatalf("expected plan output")
@@ -66,22 +65,72 @@ func TestEmitPlanRsyncRequiresAllowInsecure(t *testing.T) {
 	}
 	cfg := &config.Config{Transport: "rsync"}
 	rOut, wOut, _ := os.Pipe()
-	rErr, wErr, _ := os.Pipe()
-	stdout, stderr := os.Stdout, os.Stderr
-	os.Stdout, os.Stderr = wOut, wErr
-	defer func() { os.Stdout, os.Stderr = stdout, stderr }()
-	if e := emitPlan(cfg, []string{f.Name()}, zap.NewNop()); e == nil {
+	stdout := os.Stdout
+	os.Stdout = wOut
+	obs, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(obs)
+	if e := emitPlan(cfg, []string{f.Name()}, logger); e == nil {
 		t.Fatalf("expected error")
 	}
 	wOut.Close()
-	wErr.Close()
+	os.Stdout = stdout
 	outBytes, _ := io.ReadAll(rOut)
-	errBytes, _ := io.ReadAll(rErr)
-	if !strings.Contains(string(errBytes), "allow_insecure enabled") {
-		t.Fatalf("missing warning: %q", errBytes)
+	if logs.Len() == 0 {
+		t.Fatalf("missing warning")
 	}
 	if len(outBytes) != 0 {
 		t.Fatalf("unexpected plan output: %q", outBytes)
+	}
+}
+
+func TestEmitPlanRsyncExactMatch(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "src")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	cases := []struct {
+		name      string
+		transport string
+		warn      bool
+		wantErr   bool
+	}{
+		{name: "exact", transport: "rsync", warn: true, wantErr: true},
+		{name: "prefix", transport: "rsyncssh", warn: false, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Transport: tc.transport}
+			rOut, wOut, _ := os.Pipe()
+			stdout := os.Stdout
+			os.Stdout = wOut
+			obs, logs := observer.New(zap.WarnLevel)
+			logger := zap.New(obs)
+			err := emitPlan(cfg, []string{f.Name()}, logger)
+			wOut.Close()
+			os.Stdout = stdout
+			outBytes, _ := io.ReadAll(rOut)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.warn && logs.Len() == 0 {
+				t.Fatalf("missing warning")
+			}
+			if !tc.warn && logs.Len() != 0 {
+				t.Fatalf("unexpected warning: %v", logs.All())
+			}
+			if tc.wantErr {
+				if len(outBytes) != 0 {
+					t.Fatalf("unexpected plan output: %q", outBytes)
+				}
+			} else {
+				if len(outBytes) == 0 {
+					t.Fatalf("expected plan output")
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- use structured logging for allow-insecure warnings
- check transports for exact `rsync` entries
- add tests for insecure transport handling

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: 1230 issues)*


------
https://chatgpt.com/codex/tasks/task_e_68a86efe34648323a2fe4a215046b391