### PR TITLE
Handle mixed-case overwrite confirmations

### DIFF
--- a/device/overwrite.go
+++ b/device/overwrite.go
@@ -29,7 +29,7 @@ func confirmOverwrite(ctx context.Context, stdin io.Reader, stderr io.Writer, is
 		if err != nil {
 			return fmt.Errorf("confirmation failed: %w", err)
 		}
-		if strings.TrimSpace(resp) != "yes" {
+		if !strings.EqualFold(strings.TrimSpace(resp), "yes") {
 			return fmt.Errorf("operation cancelled")
 		}
 		return nil

--- a/device/overwrite_test.go
+++ b/device/overwrite_test.go
@@ -1,0 +1,21 @@
+package device
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+// overwriteTTYReader wraps an io.Reader and implements Fd() to simulate a TTY.
+type overwriteTTYReader struct{ io.Reader }
+
+func (overwriteTTYReader) Fd() uintptr { return 0 }
+
+func TestConfirmOverwriteMixedCase(t *testing.T) {
+	ctx := WithForce(context.Background(), true)
+	r := overwriteTTYReader{strings.NewReader("YeS\n")}
+	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err != nil {
+		t.Fatalf("confirmOverwrite: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- make overwrite confirmation case-insensitive
- add tests for mixed-case overwrite responses

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 5`
- `golangci-lint run` *(fails: issues across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f0207a88323b4e3fe343e59e6da