### PR TITLE
Reuse buffer in estimateBytes to reduce allocations

### DIFF
--- a/cmd/root/plan.go
+++ b/cmd/root/plan.go
@@ -106,6 +106,21 @@ func estimateBytes(src string, cfg *config.Config) (int64, int64, error) {
 	if samples > 0 && chunks > samples {
 		step = chunks / samples
 	}
+	var maxLen uint32
+	for i := uint64(0); i < samples; i++ {
+		idxPos := i * step
+		if idxPos >= chunks {
+			idxPos = chunks - 1
+		}
+		_, length, _, _, _, err := idx.Entry(idxPos)
+		if err != nil {
+			return 0, 0, fmt.Errorf("manifest entry: %w", err)
+		}
+		if length > maxLen {
+			maxLen = length
+		}
+	}
+	buf := make([]byte, maxLen)
 	changed := 0
 	for i := uint64(0); i < samples; i++ {
 		idxPos := i * step
@@ -116,8 +131,7 @@ func estimateBytes(src string, cfg *config.Config) (int64, int64, error) {
 		if err != nil {
 			return 0, 0, fmt.Errorf("manifest entry: %w", err)
 		}
-		buf := make([]byte, length)
-		n, err := f.ReadAt(buf, int64(off))
+		n, err := f.ReadAt(buf[:length], int64(off))
 		if err != nil && err != io.EOF {
 			return 0, 0, fmt.Errorf("read source: %w", err)
 		}

--- a/cmd/root/plan_benchmark_test.go
+++ b/cmd/root/plan_benchmark_test.go
@@ -1,0 +1,54 @@
+package root
+
+import (
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
+
+	"lvmsync_go/internal/config"
+	"lvmsync_go/manifest"
+)
+
+func BenchmarkEstimateBytes(b *testing.B) {
+	dir := b.TempDir()
+	file, err := os.CreateTemp(dir, "src-*.bin")
+	if err != nil {
+		b.Fatalf("tempfile: %v", err)
+	}
+	data1 := make([]byte, 4096)
+	data2 := make([]byte, 4096)
+	r := rand.New(rand.NewSource(1))
+	r.Read(data1)
+	r.Read(data2)
+	if _, err := file.Write(append(data1, data2...)); err != nil {
+		b.Fatalf("write: %v", err)
+	}
+	file.Close()
+
+	manPath := filepath.Join(dir, "src.man")
+	idx, err := manifest.Create(manPath, "dev", 8192, 0, 0, 0, 4096, 0, 0, 0, 0)
+	if err != nil {
+		b.Fatalf("manifest create: %v", err)
+	}
+	if err := idx.Set(0, 4096, 0, xxh3.Hash(data1), blake3.Sum256(data1)); err != nil {
+		b.Fatalf("manifest set1: %v", err)
+	}
+	if err := idx.Set(4096, 4096, 0, xxh3.Hash(data2), blake3.Sum256(data2)); err != nil {
+		b.Fatalf("manifest set2: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		b.Fatalf("manifest close: %v", err)
+	}
+
+	cfg := &config.Config{ManifestPath: manPath}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := estimateBytes(file.Name(), cfg); err != nil {
+			b.Fatalf("estimateBytes: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- reuse a single buffer in `estimateBytes` based on the max chunk length
- add a benchmark for `estimateBytes` to track allocations

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: 1233 issues)*
- `go test -bench=EstimateBytes -benchmem ./cmd/root`

------
https://chatgpt.com/codex/tasks/task_e_68a86f08b12483239c7f70a1a5eb2c00