### PR TITLE
test: cover sudo escalation

### DIFF
--- a/internal/privilege/sudo_integration_test.go
+++ b/internal/privilege/sudo_integration_test.go
@@ -3,6 +3,7 @@ package privilege
 import (
 	"context"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -37,6 +38,29 @@ func TestSudoCommandRealFailure(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 	if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 1 {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSudoCommandNonInteractive(t *testing.T) {
+	requireSudo(t)
+	HasCaps = func() bool { return false }
+	esc := New(context.Background(), zap.NewNop())
+	cmd := esc.Command(context.Background(), "true")
+	if len(cmd.Args) < 2 || cmd.Args[1] != "-n" {
+		t.Fatalf("expected -n flag, got args %v", cmd.Args)
+	}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureMissingSudo(t *testing.T) {
+	requireSudo(t)
+	t.Setenv("PATH", "/nonexistent")
+	HasCaps = func() bool { return false }
+	esc := New(context.Background(), zap.NewNop())
+	if err := esc.Ensure(context.Background()); err == nil || !strings.Contains(err.Error(), "sudo not found") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/reports/gaps.json
+++ b/reports/gaps.json
@@ -1,15 +1,6 @@
 [
   {
     "type": "testing",
-    "component": "privilege escalation",
-    "evidence": "AGENTS.md TODO: Add privilege escalation tests covering success and error paths",
-    "impact": "Privilege escalation logic untested; potential regressions or security issues",
-    "fix": "Implement privilege escalation tests for success and error paths; skip when non-root",
-    "priority": "P1",
-    "status": "open"
-  },
-  {
-    "type": "testing",
     "component": "configuration precedence",
     "evidence": "AGENTS.md TODO: Expand coverage for configuration precedence across flags, environment variables, and config files",
     "impact": "Configuration precedence behavior unverified; user options may not apply as expected",

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -1,6 +1,5 @@
 | Type | Component | Evidence | Impact | Fix | Priority |
 |------|-----------|----------|--------|-----|----------|
 
-| Testing | Privilege Escalation | AGENTS.md TODO: Add privilege escalation tests covering success and error paths | Privilege escalation logic untested; potential regressions or security issues | Implement privilege escalation tests for success and error paths; skip when non-root | P1 |
 | Testing | Configuration Precedence | AGENTS.md TODO: Expand coverage for configuration precedence across flags, environment variables, and config files | Configuration precedence behavior unverified; user options may not apply as expected | Add tests covering configuration precedence across flags, environment variables, and config files | P2 |
 


### PR DESCRIPTION
## Summary
- test sudo escalation via non-interactive `sudo -n`
- ensure `Ensure` fails cleanly when `sudo` is missing
- drop resolved privilege escalation gap report

## Testing
- `go test ./internal/privilege ./reports`

------
https://chatgpt.com/codex/tasks/task_e_68a87ade7cac8323a2f02d2eb1c37973