### PR TITLE
log: ensure snake_case units for verify dry run

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -102,7 +102,11 @@ func (r *Runner) Run(args []string, logger *zap.Logger) error {
 				if cfg.SpeedLimit > 0 {
 					eta = time.Duration(size/int64(cfg.SpeedLimit)) * time.Second
 				}
-				logger.Info("dry run", zap.Int64("size_bytes", size), zap.Duration("eta", eta))
+				logger.Info(
+					"dry run",
+					zap.Int64("size_bytes", size),
+					zap.Int64("eta_ms", eta.Milliseconds()),
+				)
 				return nil
 			}
 			err = r.verifyDevices(ctx, cfg, remaining[0], remaining[1], cfg.ManifestPath, logger)


### PR DESCRIPTION
## Summary
- log verify dry run ETA using snake_case field with millisecond units
- confirm verify command flushes logs via `rootcmd.SyncLogger`

## Testing
- `go build ./...`
- `go test ./...`
- `golangci-lint run` *(fails: unused parameters, package comments, and other revive/staticcheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a87d4654308323aada2b0964492a0b