### PR TITLE
test: cover compress config precedence and remove gap

### DIFF
--- a/internal/config/compress_precedence_test.go
+++ b/internal/config/compress_precedence_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestCompressFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("compress: none\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_COMPRESSION_COMPRESS", "lz4")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--compress", "zstd"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.Compress != "zstd" {
+		t.Fatalf("Compress=%q want %q", cfg.Compress, "zstd")
+	}
+}
+
+func TestCompressEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("compress: none\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_COMPRESSION_COMPRESS", "lz4")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.Compress != "lz4" {
+		t.Fatalf("Compress=%q want %q", cfg.Compress, "lz4")
+	}
+}

--- a/reports/gaps.json
+++ b/reports/gaps.json
@@ -1,11 +1,1 @@
-[
-  {
-    "type": "testing",
-    "component": "configuration precedence",
-    "evidence": "AGENTS.md TODO: Expand coverage for configuration precedence across flags, environment variables, and config files",
-    "impact": "Configuration precedence behavior unverified; user options may not apply as expected",
-    "fix": "Add tests covering configuration precedence across flags, environment variables, and config files",
-    "priority": "P2",
-    "status": "open"
-  }
-]
+[]

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -1,5 +1,3 @@
 | Type | Component | Evidence | Impact | Fix | Priority |
 |------|-----------|----------|--------|-----|----------|
 
-| Testing | Configuration Precedence | AGENTS.md TODO: Expand coverage for configuration precedence across flags, environment variables, and config files | Configuration precedence behavior unverified; user options may not apply as expected | Add tests covering configuration precedence across flags, environment variables, and config files | P2 |
-


### PR DESCRIPTION
## Summary
- add tests demonstrating `--compress` flag overrides environment and YAML
- remove resolved configuration precedence gap

## Testing
- `go test ./internal/config ./reports`


------
https://chatgpt.com/codex/tasks/task_e_68a8801b8bd8832387ea2e21378cfe08