### PR TITLE
device: surface missing dependency errors

### DIFF
--- a/device/identity_cmds.go
+++ b/device/identity_cmds.go
@@ -1,20 +1,35 @@
 package device
 
 import (
+	"errors"
+	"fmt"
 	"os/exec"
 	"time"
 )
 
 var (
 	blkidPath string
+	blkidErr  error
 	lvsPath   string
+	lvsErr    error
 	lsblkPath string
+	lsblkErr  error
 )
 
 const identityTimeout = 5 * time.Second
 
+// ErrDependencyMissing indicates that a required external command is unavailable.
+var ErrDependencyMissing = errors.New("dependency missing")
+
 func init() {
-	blkidPath, _ = exec.LookPath("blkid")
-	lvsPath, _ = exec.LookPath("lvs")
-	lsblkPath, _ = exec.LookPath("lsblk")
+	var err error
+	if blkidPath, err = exec.LookPath("blkid"); err != nil {
+		blkidErr = fmt.Errorf("blkid: %w", ErrDependencyMissing)
+	}
+	if lvsPath, err = exec.LookPath("lvs"); err != nil {
+		lvsErr = fmt.Errorf("lvs: %w", ErrDependencyMissing)
+	}
+	if lsblkPath, err = exec.LookPath("lsblk"); err != nil {
+		lsblkErr = fmt.Errorf("lsblk: %w", ErrDependencyMissing)
+	}
 }

--- a/device/identity_command_test.go
+++ b/device/identity_command_test.go
@@ -3,6 +3,7 @@ package device
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,11 +44,17 @@ func TestRawIdentityTimeout(t *testing.T) {
 	script := createSleepScript(t, "blkid")
 	origBLKID := blkidPath
 	origLSBLK := lsblkPath
+	origBLKIDErr := blkidErr
+	origLSBLKErr := lsblkErr
 	blkidPath = script
 	lsblkPath = script
+	blkidErr = nil
+	lsblkErr = nil
 	defer func() {
 		blkidPath = origBLKID
 		lsblkPath = origLSBLK
+		blkidErr = origBLKIDErr
+		lsblkErr = origLSBLKErr
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -86,8 +93,10 @@ func TestLVMIdentityTimeout(t *testing.T) {
 	d := &LVMDevice{path: f.Name(), logger: zap.NewNop()}
 	script := createSleepScript(t, "lvs")
 	orig := lvsPath
+	origErr := lvsErr
 	lvsPath = script
-	defer func() { lvsPath = orig }()
+	lvsErr = nil
+	defer func() { lvsPath = orig; lvsErr = origErr }()
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	if _, err := d.Identity(ctx); err == nil || !(errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "signal: killed")) {
@@ -113,5 +122,44 @@ func TestLVMIdentityIgnoresPATH(t *testing.T) {
 	_, _ = d.Identity(context.Background())
 	if _, err := os.Stat(marker); err == nil {
 		t.Fatalf("malicious lvs executed")
+	}
+}
+
+func TestRawIdentityMissingDependency(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	defer f.Close()
+	d := &RawDevice{f: f, logger: zap.NewNop()}
+	origPath := blkidPath
+	origErr := blkidErr
+	blkidPath = ""
+	blkidErr = fmt.Errorf("blkid: %w", ErrDependencyMissing)
+	defer func() {
+		blkidPath = origPath
+		blkidErr = origErr
+	}()
+	if _, err := d.Identity(context.Background()); err == nil || !errors.Is(err, ErrDependencyMissing) || !strings.Contains(err.Error(), "blkid") {
+		t.Fatalf("expected blkid missing error, got %v", err)
+	}
+}
+
+func TestLVMIdentityMissingDependency(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	d := &LVMDevice{path: f.Name(), logger: zap.NewNop()}
+	origPath := lvsPath
+	origErr := lvsErr
+	lvsPath = ""
+	lvsErr = fmt.Errorf("lvs: %w", ErrDependencyMissing)
+	defer func() {
+		lvsPath = origPath
+		lvsErr = origErr
+	}()
+	if _, err := d.Identity(context.Background()); err == nil || !errors.Is(err, ErrDependencyMissing) || !strings.Contains(err.Error(), "lvs") {
+		t.Fatalf("expected lvs missing error, got %v", err)
 	}
 }

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -114,11 +114,11 @@ func (d *LVMDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
 		ctx, cancel = context.WithTimeout(ctx, identityTimeout)
 		defer cancel()
 	}
-	if lvsPath == "" {
-		return DeviceIdentity{}, fmt.Errorf("lvs not found")
+	if lvsErr != nil {
+		return DeviceIdentity{}, lvsErr
 	}
-	if blkidPath == "" {
-		return DeviceIdentity{}, fmt.Errorf("blkid not found")
+	if blkidErr != nil {
+		return DeviceIdentity{}, blkidErr
 	}
 	var st unix.Stat_t
 	if err := unix.Stat(d.Path(), &st); err != nil {

--- a/device/raw.go
+++ b/device/raw.go
@@ -190,11 +190,11 @@ func (d *RawDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
 		ctx, cancel = context.WithTimeout(ctx, identityTimeout)
 		defer cancel()
 	}
-	if blkidPath == "" {
-		return DeviceIdentity{}, fmt.Errorf("blkid not found")
+	if blkidErr != nil {
+		return DeviceIdentity{}, blkidErr
 	}
-	if lsblkPath == "" {
-		return DeviceIdentity{}, fmt.Errorf("lsblk not found")
+	if lsblkErr != nil {
+		return DeviceIdentity{}, lsblkErr
 	}
 	var st unix.Stat_t
 	if err := unix.Stat(d.Path(), &st); err != nil {


### PR DESCRIPTION
## Summary
- report explicit dependency errors when identity tools are missing
- cover missing blkid and lvs commands in identity tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a8874482b083238ac4a9d675b7e176