### PR TITLE
device: use sentinel error for partition mismatches

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -387,12 +387,12 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 	if destType == "auto" {
 		dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx, logger), logger, devRunner)
 		if err != nil {
-			if cfg.CheckPartition && strings.Contains(err.Error(), "partition table mismatch") {
+			if cfg.CheckPartition && errors.Is(err, device.ErrPartitionMismatch) {
 				if !cfg.Force {
-					return destType, fmt.Errorf("precondition: partition table mismatch")
+					return destType, fmt.Errorf("precondition: %w", device.ErrPartitionMismatch)
 				}
 				if !cfg.VerifyOnly && strings.ToLower(cfg.VerifyLevel) != "none" {
-					return destType, fmt.Errorf("partition table mismatch: run --verify-only first or set --verify none with --force")
+					return destType, fmt.Errorf("partition table mismatch: run --verify-only first or set --verify none with --force: %w", device.ErrPartitionMismatch)
 				}
 				tmpCtx := device.WithForce(context.Background(), cfg.Force)
 				tmpCtx = device.WithAllowOverwrite(tmpCtx, cfg.AllowOverwrite)
@@ -462,12 +462,12 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 	}
 	info := device.NewInfo()
 	if err := r.verifyIdentity(devCtx, info, snapshotDevice, dest); err != nil {
-		if cfg.CheckPartition && strings.Contains(err.Error(), "partition table mismatch") {
+		if cfg.CheckPartition && errors.Is(err, device.ErrPartitionMismatch) {
 			if !cfg.Force {
-				return destType, fmt.Errorf("precondition: partition table mismatch")
+				return destType, fmt.Errorf("precondition: %w", device.ErrPartitionMismatch)
 			}
 			if !cfg.VerifyOnly && strings.ToLower(cfg.VerifyLevel) != "none" {
-				return destType, fmt.Errorf("partition table mismatch: run --verify-only first or set --verify none with --force")
+				return destType, fmt.Errorf("partition table mismatch: run --verify-only first or set --verify none with --force: %w", device.ErrPartitionMismatch)
 			}
 		} else {
 			return destType, err

--- a/cmd/dump/local_dump_test.go
+++ b/cmd/dump/local_dump_test.go
@@ -95,3 +95,22 @@ func TestRunLocalDumpOpenError(t *testing.T) {
 		t.Fatalf("cfg.DestType was modified: expected %q, got %q", originalDestType, cfg.DestType)
 	}
 }
+
+func TestRunLocalDumpPartitionMismatch(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig returned error: %v", err)
+	}
+	cfg.DedupStrategy = "none"
+	cfg.Parallel = 1
+	cfg.CheckPartition = true
+	cfg.DestType = "file"
+
+	r := NewRunnerWithDeps(&Runner{verifyIdentity: func(context.Context, *device.Info, string, string) error {
+		return device.ErrPartitionMismatch
+	}})
+
+	if _, err := r.RunLocalDump(context.Background(), cfg, "snap", "orig", "/fake/dest", zap.NewNop()); err == nil || !errors.Is(err, device.ErrPartitionMismatch) {
+		t.Fatalf("expected partition mismatch error, got %v", err)
+	}
+}

--- a/device/detect.go
+++ b/device/detect.go
@@ -29,14 +29,14 @@ func verifyPartition(ctx context.Context, dev Device, runner *Runner, logger *za
 		return err
 	}
 	if sig.gpt != "" && id.GPTUUID != sig.gpt {
-		return fmt.Errorf("precondition: partition table mismatch")
+		return fmt.Errorf("precondition: %w", ErrPartitionMismatch)
 	}
 	if sig.mbr != "" && id.MBRSignature != sig.mbr {
-		return fmt.Errorf("precondition: partition table mismatch")
+		return fmt.Errorf("precondition: %w", ErrPartitionMismatch)
 	}
 	if diffs := diffPartitionLayouts(sig.layout, layout); len(diffs) > 0 {
 		logger.Error("partition_layout_mismatch", zap.Any("diff", diffs))
-		return fmt.Errorf("precondition: partition table mismatch")
+		return fmt.Errorf("precondition: %w", ErrPartitionMismatch)
 	}
 	return nil
 }
@@ -189,12 +189,12 @@ func Detect(
 			if gpt == "" && mbr == "" ||
 				(sig.gpt != "" && gpt != sig.gpt) ||
 				(sig.mbr != "" && mbr != sig.mbr) {
-				err := fmt.Errorf("precondition: partition table mismatch")
+				err := fmt.Errorf("precondition: %w", ErrPartitionMismatch)
 				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Error(err))
 				return nil, err
 			}
 			if diffs := diffPartitionLayouts(sig.layout, layout); len(diffs) > 0 {
-				err := fmt.Errorf("precondition: partition table mismatch")
+				err := fmt.Errorf("precondition: %w", ErrPartitionMismatch)
 				logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "partition"), zap.Any("diff", diffs), zap.Error(err))
 				return nil, err
 			}

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -3,6 +3,7 @@ package device
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -323,8 +324,8 @@ func TestDetectRawPartitionMismatch(t *testing.T) {
 	ctx = WithForce(ctx, true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := detectRawDevice(ctx, loop, true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "precondition") {
-		t.Fatalf("expected precondition error, got %v", err)
+	if _, err := detectRawDevice(ctx, loop, true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, ErrPartitionMismatch) {
+		t.Fatalf("expected partition mismatch error, got %v", err)
 	}
 }
 
@@ -391,8 +392,8 @@ func TestDetectPartitionComparison(t *testing.T) {
 			dev.Close()
 			_, err = Detect(ctx, f2, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 			if tc.wantErr {
-				if err == nil || !strings.Contains(err.Error(), "precondition") {
-					t.Fatalf("expected precondition error, got %v", err)
+				if err == nil || !errors.Is(err, ErrPartitionMismatch) {
+					t.Fatalf("expected partition mismatch error, got %v", err)
 				}
 				return
 			}

--- a/device/errors.go
+++ b/device/errors.go
@@ -1,0 +1,6 @@
+package device
+
+import "errors"
+
+// ErrPartitionMismatch indicates the partition table does not match the expected signature or layout.
+var ErrPartitionMismatch = errors.New("partition table mismatch")


### PR DESCRIPTION
## Summary
- add ErrPartitionMismatch for partition table mismatches
- detect partition mismatches with errors.Is in dump client
- expect ErrPartitionMismatch in device and dump tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRecvAckNetTimeoutBeforeDeadline)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8914608ac8323b2995ad16d18f1eb