### PR TITLE
Refactor exit code handling with sentinel errors

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -123,27 +123,27 @@ committed ranges.
 | Constant | Code | Meaning | Recovery Step |
 |----------|------|---------|---------------|
 | [`exitcode.OK`](internal/exitcode/exitcode.go) | `0`  | Success | None |
-| [`exitcode.ErrCapability`](internal/exitcode/exitcode.go) | `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
-| [`exitcode.ErrDevice`](internal/exitcode/exitcode.go) | `20` | Device error | Verify device paths and snapshot health. |
-| [`exitcode.ErrSnapshotExhausted`](internal/exitcode/exitcode.go) | `25` | Snapshot space exhausted | Grow or recreate the snapshot before resuming. |
-| [`exitcode.ErrPlatform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform | Run on a supported Linux platform. |
-| [`exitcode.ErrConfig`](internal/exitcode/exitcode.go) | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
-| [`exitcode.ErrRuntime`](internal/exitcode/exitcode.go) | `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
-| [`exitcode.ErrVerify`](internal/exitcode/exitcode.go) | `60` | Verification mismatch | Investigate mismatched data before retrying. |
-| [`exitcode.ErrPartial`](internal/exitcode/exitcode.go) | `70` | Partial transfer | Address the error and resume with `--resume`. |
-| [`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) | `80` | Precondition failed | Fix prerequisites and retry. |
-| [`exitcode.ErrResumable`](internal/exitcode/exitcode.go) | `90` | Resumable exit | Resume with `--resume` after resolving the issue. |
+| [`exitcode.Capability`](internal/exitcode/exitcode.go) | `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
+| [`exitcode.Device`](internal/exitcode/exitcode.go) | `20` | Device error | Verify device paths and snapshot health. |
+| [`exitcode.SnapshotExhausted`](internal/exitcode/exitcode.go) | `25` | Snapshot space exhausted | Grow or recreate the snapshot before resuming. |
+| [`exitcode.Platform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform | Run on a supported Linux platform. |
+| [`exitcode.Config`](internal/exitcode/exitcode.go) | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
+| [`exitcode.Runtime`](internal/exitcode/exitcode.go) | `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
+| [`exitcode.Verify`](internal/exitcode/exitcode.go) | `60` | Verification mismatch | Investigate mismatched data before retrying. |
+| [`exitcode.Partial`](internal/exitcode/exitcode.go) | `70` | Partial transfer | Address the error and resume with `--resume`. |
+| [`exitcode.Precondition`](internal/exitcode/exitcode.go) | `80` | Precondition failed | Fix prerequisites and retry. |
+| [`exitcode.Resumable`](internal/exitcode/exitcode.go) | `90` | Resumable exit | Resume with `--resume` after resolving the issue. |
 
 Definitions live in [internal/exitcode](internal/exitcode/exitcode.go).
 
-Verification mismatches exit with [`exitcode.ErrVerify`](internal/exitcode/exitcode.go):
+Verification mismatches exit with [`exitcode.Verify`](internal/exitcode/exitcode.go):
 
 ```sh
 lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/bad_target || echo "verify failed with exit $?"
 # verify failed with exit 60
 ```
 
-Precondition failures exit with [`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go):
+Precondition failures exit with [`exitcode.Precondition`](internal/exitcode/exitcode.go):
 
 ```sh
 lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with exit $?"
@@ -154,7 +154,7 @@ Partition-table changes between runs also trigger this error when GPT or MBR sig
 
 When using the `rsync` transport, the client sends the destination device identity
 before writing. If the server's identity differs, the transfer aborts with
-[`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) (`80`).
+[`exitcode.Precondition`](internal/exitcode/exitcode.go) (`80`).
 
 ## Troubleshooting
 
@@ -166,7 +166,7 @@ before writing. If the server's identity differs, the transfer aborts with
 ### Snapshot Overflow
 
 Snapshot volumes fill when copy-on-write blocks exceed the allocated snapshot size.
-LVMSync exits with [`exitcode.ErrDevice`](internal/exitcode/exitcode.go) (`20`).
+LVMSync exits with [`exitcode.Device`](internal/exitcode/exitcode.go) (`20`).
 Grow the snapshot or create a larger one, then rerun with the same `--resume` state:
 
 ```sh
@@ -177,7 +177,7 @@ lvmsync run /dev/vg0/snap_full /dev/vg0/dst || echo "snapshot overflow exit $?"
 ### Verify Failure
 
 Verification mismatches stop the transfer with
-[`exitcode.ErrVerify`](internal/exitcode/exitcode.go) (`60`). Inspect the logs to
+[`exitcode.Verify`](internal/exitcode/exitcode.go) (`60`). Inspect the logs to
 identify mismatched blocks before retrying:
 
 ```sh
@@ -188,7 +188,7 @@ lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target || echo "verify exit $?
 ### Resume After Interruption
 
 Unexpected interruptions (signals, network loss) exit with
-[`exitcode.ErrResumable`](internal/exitcode/exitcode.go) (`90`). Fix the underlying
+[`exitcode.Resumable`](internal/exitcode/exitcode.go) (`90`). Fix the underlying
 issue and resume the transfer:
 
 ```sh
@@ -198,7 +198,7 @@ lvmsync run --resume state /dev/vg0/snap0 /dev/vg0/target
 ### Identity Tuple Mismatch
 
 If the source or destination no longer matches the resume state, LVMSync exits with
-[`exitcode.ErrPrecondition`](internal/exitcode/exitcode.go) (`80`) and refuses to resume. Recreate the
+[`exitcode.Precondition`](internal/exitcode/exitcode.go) (`80`) and refuses to resume. Recreate the
 destination or regenerate the resume state before restarting.
 
 ## Failure Drills
@@ -238,7 +238,7 @@ scenarios.
    ```sh
    lvmsync run --remote https://badhost /dev/vg0/snap0 user@host:/dev/vg0/dst
    ```
-2. The TLS handshake fails with `exitcode.ErrRuntime`. Verify certificates and
+2. The TLS handshake fails with `exitcode.Runtime`. Verify certificates and
    trust stores, then retry the transfer.
 
 ## Symptom Reference

--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -158,22 +159,26 @@ func TestStartMissingCerts(t *testing.T) {
 
 func TestExitCodeMapping(t *testing.T) {
 	tests := []struct {
-		name string
-		err  error
-		code int
+		name    string
+		err     error
+		code    int
+		wantErr error
 	}{
-		{"success", nil, exitcode.OK},
-		{"config", errors.New("parse listen"), exitcode.ErrConfig},
-		{"runtime", errors.New("listen failed"), exitcode.ErrRuntime},
-		{"verify", errors.New("digest mismatch"), exitcode.ErrVerify},
-		{"partial", errors.New("received signal: interrupt"), exitcode.ErrPartial},
-		{"precondition", errors.New("precondition not met"), exitcode.ErrPrecondition},
-		{"resumable", errors.New("resumable: retry later"), exitcode.ErrResumable},
+		{"success", nil, exitcode.OK, nil},
+		{"config", fmt.Errorf("parse listen: %w", exitcode.ErrConfig), exitcode.Config, exitcode.ErrConfig},
+		{"runtime", fmt.Errorf("listen failed: %w", exitcode.ErrRuntime), exitcode.Runtime, exitcode.ErrRuntime},
+		{"verify", fmt.Errorf("digest mismatch: %w", exitcode.ErrVerify), exitcode.Verify, exitcode.ErrVerify},
+		{"partial", fmt.Errorf("received signal: %w", exitcode.ErrPartial), exitcode.Partial, exitcode.ErrPartial},
+		{"precondition", fmt.Errorf("precondition not met: %w", exitcode.ErrPrecondition), exitcode.Precondition, exitcode.ErrPrecondition},
+		{"resumable", fmt.Errorf("resumable: %w", exitcode.ErrResumable), exitcode.Resumable, exitcode.ErrResumable},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if c := rootcmd.ExitCode(tt.err); c != tt.code {
 				t.Fatalf("expected %d, got %d", tt.code, c)
+			}
+			if tt.wantErr != nil && !errors.Is(tt.err, tt.wantErr) {
+				t.Fatalf("expected error %v", tt.wantErr)
 			}
 		})
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -353,25 +353,24 @@ func ExitCode(err error) int {
 	if err == nil {
 		return exitcode.OK
 	}
-	msg := err.Error()
 	switch {
-	case strings.Contains(msg, "privilege check"):
-		return exitcode.ErrCapability
-	case strings.Contains(msg, "parse") || strings.Contains(msg, "missing") || strings.Contains(msg, "required") || strings.Contains(msg, "invalid") || strings.Contains(msg, "config"):
-		return exitcode.ErrConfig
-	case strings.Contains(msg, "precondition"):
-		return exitcode.ErrPrecondition
-	case strings.Contains(msg, "resumable") || strings.Contains(msg, "resume"):
-		return exitcode.ErrResumable
-	case strings.Contains(msg, "snapshot exhausted"):
-		return exitcode.ErrSnapshotExhausted
-	case strings.Contains(msg, "device"):
-		return exitcode.ErrDevice
-	case strings.Contains(msg, "mismatch") || strings.Contains(msg, "blocks differ"):
-		return exitcode.ErrVerify
-	case strings.Contains(msg, "signal") || errors.Is(err, context.Canceled):
-		return exitcode.ErrPartial
+	case errors.Is(err, exitcode.ErrCapability):
+		return exitcode.Capability
+	case errors.Is(err, exitcode.ErrConfig):
+		return exitcode.Config
+	case errors.Is(err, exitcode.ErrPrecondition):
+		return exitcode.Precondition
+	case errors.Is(err, exitcode.ErrResumable):
+		return exitcode.Resumable
+	case errors.Is(err, exitcode.ErrSnapshotExhausted):
+		return exitcode.SnapshotExhausted
+	case errors.Is(err, exitcode.ErrDevice):
+		return exitcode.Device
+	case errors.Is(err, exitcode.ErrVerify):
+		return exitcode.Verify
+	case errors.Is(err, exitcode.ErrPartial) || errors.Is(err, context.Canceled):
+		return exitcode.Partial
 	default:
-		return exitcode.ErrRuntime
+		return exitcode.Runtime
 	}
 }

--- a/cmd/verify/verify_command_integration_test.go
+++ b/cmd/verify/verify_command_integration_test.go
@@ -63,7 +63,7 @@ func TestVerifyCommandMismatchExitCode(t *testing.T) {
 	if !ok {
 		t.Fatalf("verify: %v", err)
 	}
-	if exitErr.ExitCode() != exitcode.ErrVerify {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrVerify, exitErr.ExitCode())
+	if exitErr.ExitCode() != exitcode.Verify {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Verify, exitErr.ExitCode())
 	}
 }

--- a/device/identity_preflight.go
+++ b/device/identity_preflight.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/internal/privilege"
 )
 
@@ -26,14 +27,14 @@ func VerifyIdentity(ctx context.Context, info *Info, src, dest string) (err erro
 		return err
 	}
 	if sizeA != sizeB && !allow {
-		return fmt.Errorf("size mismatch")
+		return fmt.Errorf("size mismatch: %w", exitcode.ErrPrecondition)
 	}
 	match, err := info.IDsMatch(ctx, src, dest)
 	if err != nil {
 		return err
 	}
 	if !match && !allow {
-		return fmt.Errorf("uuid mismatch")
+		return fmt.Errorf("uuid mismatch: %w", exitcode.ErrPrecondition)
 	}
 	devA, err := info.detectFunc(ctx, src, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
 	if err != nil {
@@ -62,13 +63,13 @@ func VerifyIdentity(ctx context.Context, info *Info, src, dest string) (err erro
 		return err
 	}
 	if idA.GPTUUID != idB.GPTUUID && !allow {
-		return fmt.Errorf("gpt uuid mismatch")
+		return fmt.Errorf("gpt uuid mismatch: %w", exitcode.ErrPrecondition)
 	}
 	if idA.MBRSignature != idB.MBRSignature && !allow {
-		return fmt.Errorf("mbr signature mismatch")
+		return fmt.Errorf("mbr signature mismatch: %w", exitcode.ErrPrecondition)
 	}
 	if idA.ManifestEpoch != idB.ManifestEpoch && !allow {
-		return fmt.Errorf("manifest epoch mismatch")
+		return fmt.Errorf("manifest epoch mismatch: %w", exitcode.ErrPrecondition)
 	}
 	return nil
 }

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -321,12 +321,12 @@ func TestSelectVolumeGroupNoMatchErrDevice(t *testing.T) {
 	if _, err := r.SelectVolumeGroupForSize(context.Background(), []string{"vg1"}, 50); err == nil {
 		t.Fatalf("expected error")
 	} else {
-		code := exitcode.ErrRuntime
+		code := exitcode.Runtime
 		if strings.Contains(err.Error(), "device") {
-			code = exitcode.ErrDevice
+			code = exitcode.Device
 		}
-		if code != exitcode.ErrDevice {
-			t.Fatalf("exit code = %d, want %d", code, exitcode.ErrDevice)
+		if code != exitcode.Device {
+			t.Fatalf("exit code = %d, want %d", code, exitcode.Device)
 		}
 	}
 }

--- a/integration/snapshot_pressure_test.go
+++ b/integration/snapshot_pressure_test.go
@@ -66,7 +66,7 @@ func TestSnapshotPressure(t *testing.T) {
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("expected exit error, got %v", err)
 	}
-	if exitErr.ExitCode() != exitcode.ErrDevice {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrDevice, exitErr.ExitCode())
+	if exitErr.ExitCode() != exitcode.Device {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Device, exitErr.ExitCode())
 	}
 }

--- a/integration/snapshot_usage_guard_test.go
+++ b/integration/snapshot_usage_guard_test.go
@@ -85,8 +85,8 @@ func TestSnapshotUsageGuard(t *testing.T) {
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("expected exit error, got %v", err)
 	}
-	if exitErr.ExitCode() != exitcode.ErrSnapshotExhausted {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrSnapshotExhausted, exitErr.ExitCode())
+	if exitErr.ExitCode() != exitcode.SnapshotExhausted {
+		t.Fatalf("expected exit code %d, got %d", exitcode.SnapshotExhausted, exitErr.ExitCode())
 	}
 
 	out := run(t, exec.Command("lvs", "--noheadings", "-o", "lv_name", "vgtest"))

--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -1,26 +1,42 @@
 package exitcode
 
+import "errors"
+
 // Exit codes for lvmsync binaries.
 const (
 	OK = 0
-	// ErrCapability indicates missing privileges or capabilities.
-	ErrCapability = 10
-	// ErrDevice indicates a device-related failure.
-	ErrDevice = 20
-	// ErrSnapshotExhausted indicates snapshot space was exhausted during transfer.
-	ErrSnapshotExhausted = 25
-	// ErrPlatform is returned when the operating system is unsupported.
-	ErrPlatform = 30
-	// ErrConfig represents configuration or validation failures.
-	ErrConfig = 40
-	// ErrRuntime represents errors during command execution.
-	ErrRuntime = 50
-	// ErrVerify indicates checksum or digest verification failures.
-	ErrVerify = 60
-	// ErrPartial indicates a resumable transfer was aborted before completion.
-	ErrPartial = 70
-	// ErrPrecondition indicates a precondition failure before execution.
-	ErrPrecondition = 80
-	// ErrResumable indicates the process exited early but can be resumed.
-	ErrResumable = 90
+	// Capability indicates missing privileges or capabilities.
+	Capability = 10
+	// Device indicates a device-related failure.
+	Device = 20
+	// SnapshotExhausted indicates snapshot space was exhausted during transfer.
+	SnapshotExhausted = 25
+	// Platform is returned when the operating system is unsupported.
+	Platform = 30
+	// Config represents configuration or validation failures.
+	Config = 40
+	// Runtime represents errors during command execution.
+	Runtime = 50
+	// Verify indicates checksum or digest verification failures.
+	Verify = 60
+	// Partial indicates a resumable transfer was aborted before completion.
+	Partial = 70
+	// Precondition indicates a precondition failure before execution.
+	Precondition = 80
+	// Resumable indicates the process exited early but can be resumed.
+	Resumable = 90
+)
+
+// Sentinel errors corresponding to exit codes.
+var (
+	ErrCapability        = errors.New("capability failure")
+	ErrDevice            = errors.New("device failure")
+	ErrSnapshotExhausted = errors.New("snapshot exhausted")
+	ErrPlatform          = errors.New("unsupported platform")
+	ErrConfig            = errors.New("configuration error")
+	ErrRuntime           = errors.New("runtime error")
+	ErrVerify            = errors.New("verification failure")
+	ErrPartial           = errors.New("partial transfer")
+	ErrPrecondition      = errors.New("precondition failure")
+	ErrResumable         = errors.New("resumable error")
 )

--- a/internal/exitcode/exitcode_test.go
+++ b/internal/exitcode/exitcode_test.go
@@ -9,16 +9,16 @@ func TestExitCodeValues(t *testing.T) {
 		want int
 	}{
 		{"OK", OK, 0},
-		{"ErrCapability", ErrCapability, 10},
-		{"ErrDevice", ErrDevice, 20},
-		{"ErrSnapshotExhausted", ErrSnapshotExhausted, 25},
-		{"ErrPlatform", ErrPlatform, 30},
-		{"ErrConfig", ErrConfig, 40},
-		{"ErrRuntime", ErrRuntime, 50},
-		{"ErrVerify", ErrVerify, 60},
-		{"ErrPartial", ErrPartial, 70},
-		{"ErrPrecondition", ErrPrecondition, 80},
-		{"ErrResumable", ErrResumable, 90},
+		{"Capability", Capability, 10},
+		{"Device", Device, 20},
+		{"SnapshotExhausted", SnapshotExhausted, 25},
+		{"Platform", Platform, 30},
+		{"Config", Config, 40},
+		{"Runtime", Runtime, 50},
+		{"Verify", Verify, 60},
+		{"Partial", Partial, 70},
+		{"Precondition", Precondition, 80},
+		{"Resumable", Resumable, 90},
 	}
 	for _, c := range cases {
 		if c.code != c.want {

--- a/internal/privilege/ensure_root_test.go
+++ b/internal/privilege/ensure_root_test.go
@@ -55,8 +55,8 @@ func TestEnsureSudoErrorsExitCode(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error")
 			}
-			if code := rootcmd.ExitCode(fmt.Errorf("privilege check failed: %w", err)); code != exitcode.ErrCapability {
-				t.Fatalf("exit code = %d, want %d", code, exitcode.ErrCapability)
+			if code := rootcmd.ExitCode(fmt.Errorf("privilege check failed: %w", err)); code != exitcode.Capability {
+				t.Fatalf("exit code = %d, want %d", code, exitcode.Capability)
 			}
 		})
 	}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/internal/sizeparse"
 )
 
@@ -164,7 +165,7 @@ func (r *Runner) MonitorSnapshot(ctx context.Context, snapshotPath string, thres
 					zap.String("snapshot", snapshotPath),
 					zap.Float64("usage_percent", usage),
 					zap.Float64("threshold_percent", threshold))
-				return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%", usage, threshold)
+				return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%: %w", usage, threshold, exitcode.ErrSnapshotExhausted)
 			}
 		case <-ctx.Done():
 			logger.Info("snapshot monitoring stopped", zap.String("snapshot", snapshotPath))

--- a/lvm/snapshot_pressure_test.go
+++ b/lvm/snapshot_pressure_test.go
@@ -68,8 +68,8 @@ func TestSnapshotPressureAbortCleanup(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "snapshot exhausted") {
 		t.Fatalf("expected snapshot exhausted error, got %v", err)
 	}
-	if code := rootcmd.ExitCode(err); code != exitcode.ErrSnapshotExhausted {
-		t.Fatalf("exit code = %d; want %d", code, exitcode.ErrSnapshotExhausted)
+	if code := rootcmd.ExitCode(err); code != exitcode.SnapshotExhausted {
+		t.Fatalf("exit code = %d; want %d", code, exitcode.SnapshotExhausted)
 	}
 
 	cleanup()

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func (r *Runner) Run() {
 		tmpLogger := r.ExampleLogger()
 		tmpLogger.Error("unsupported platform", zap.String("goos", r.GOOS))
 		rootcmd.SyncLogger(tmpLogger)
-		r.Exit(exitcode.ErrPlatform)
+		r.Exit(exitcode.Platform)
 		return
 	}
 

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"go.uber.org/zap"
@@ -36,7 +37,9 @@ func TestMainLogsStructuredError(t *testing.T) {
 	var code int
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
-		func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("boom") },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error {
+			return fmt.Errorf("boom: %w", exitcode.ErrRuntime)
+		},
 		rootcmd.SyncLogger,
 		func(c int) { code = c },
 		func() *zap.Logger { return zap.NewNop() },
@@ -44,8 +47,8 @@ func TestMainLogsStructuredError(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != exitcode.ErrRuntime {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrRuntime, code)
+	if code != exitcode.Runtime {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Runtime, code)
 	}
 
 	entries := logs.FilterMessage("run failed").All()
@@ -76,7 +79,7 @@ func TestMainLogsConfigError(t *testing.T) {
 	var code int
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) {
-			return nil, nil, nil, errors.New("config invalid")
+			return nil, nil, nil, fmt.Errorf("config invalid: %w", exitcode.ErrConfig)
 		},
 		rootcmd.Run,
 		rootcmd.SyncLogger,
@@ -86,8 +89,8 @@ func TestMainLogsConfigError(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != exitcode.ErrConfig {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrConfig, code)
+	if code != exitcode.Config {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Config, code)
 	}
 
 	entries := logs.FilterMessage("configuration failed").All()
@@ -126,8 +129,8 @@ func TestMainErrorsOnNonLinux(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != exitcode.ErrPlatform {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrPlatform, code)
+	if code != exitcode.Platform {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Platform, code)
 	}
 
 	entries := logs.FilterMessage("unsupported platform").All()
@@ -153,7 +156,7 @@ func TestMainCapabilityErrorExitCode(t *testing.T) {
 	var code int
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) {
-			return nil, nil, nil, errors.New("privilege check failed: caps")
+			return nil, nil, nil, fmt.Errorf("privilege check failed: %w", exitcode.ErrCapability)
 		},
 		rootcmd.Run,
 		rootcmd.SyncLogger,
@@ -162,8 +165,8 @@ func TestMainCapabilityErrorExitCode(t *testing.T) {
 		"linux",
 	)
 	runner.Run()
-	if code != exitcode.ErrCapability {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrCapability, code)
+	if code != exitcode.Capability {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Capability, code)
 	}
 }
 
@@ -172,15 +175,17 @@ func TestMainDeviceErrorExitCode(t *testing.T) {
 	logger := zap.NewNop()
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
-		func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("device lost") },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error {
+			return fmt.Errorf("device lost: %w", exitcode.ErrDevice)
+		},
 		rootcmd.SyncLogger,
 		func(c int) { code = c },
 		func() *zap.Logger { return zap.NewNop() },
 		"linux",
 	)
 	runner.Run()
-	if code != exitcode.ErrDevice {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrDevice, code)
+	if code != exitcode.Device {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Device, code)
 	}
 }
 
@@ -189,15 +194,17 @@ func TestMainVerifyExitCode(t *testing.T) {
 	logger := zap.NewNop()
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
-		func(_ *config.Config, _ []string, _ *zap.Logger) error { return errors.New("digest mismatch") },
+		func(_ *config.Config, _ []string, _ *zap.Logger) error {
+			return fmt.Errorf("digest mismatch: %w", exitcode.ErrVerify)
+		},
 		rootcmd.SyncLogger,
 		func(c int) { code = c },
 		func() *zap.Logger { return zap.NewNop() },
 		"linux",
 	)
 	runner.Run()
-	if code != exitcode.ErrVerify {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrVerify, code)
+	if code != exitcode.Verify {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Verify, code)
 	}
 }
 
@@ -207,7 +214,7 @@ func TestMainPartialExitCode(t *testing.T) {
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
 		func(_ *config.Config, _ []string, _ *zap.Logger) error {
-			return errors.New("received signal: interrupt")
+			return fmt.Errorf("received signal: %w", exitcode.ErrPartial)
 		},
 		rootcmd.SyncLogger,
 		func(c int) { code = c },
@@ -215,7 +222,7 @@ func TestMainPartialExitCode(t *testing.T) {
 		"linux",
 	)
 	runner.Run()
-	if code != exitcode.ErrPartial {
-		t.Fatalf("expected exit code %d, got %d", exitcode.ErrPartial, code)
+	if code != exitcode.Partial {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Partial, code)
 	}
 }

--- a/main_exitcode_test.go
+++ b/main_exitcode_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 
 	"go.uber.org/zap"
@@ -20,15 +20,15 @@ func TestRunnerExitCodes(t *testing.T) {
 		want   int
 	}{
 		{"success", "linux", nil, nil, exitcode.OK},
-		{"platform", "darwin", nil, nil, exitcode.ErrPlatform},
-		{"capability", "linux", errors.New("privilege check failed: missing"), nil, exitcode.ErrCapability},
-		{"config", "linux", errors.New("config invalid"), nil, exitcode.ErrConfig},
-		{"device", "linux", nil, errors.New("device gone"), exitcode.ErrDevice},
-		{"runtime", "linux", nil, errors.New("boom"), exitcode.ErrRuntime},
-		{"verify", "linux", nil, errors.New("digest mismatch"), exitcode.ErrVerify},
-		{"partial", "linux", nil, errors.New("received signal: interrupt"), exitcode.ErrPartial},
-		{"precondition", "linux", nil, errors.New("precondition not met"), exitcode.ErrPrecondition},
-		{"resumable", "linux", nil, errors.New("resumable: retry"), exitcode.ErrResumable},
+		{"platform", "darwin", nil, nil, exitcode.Platform},
+		{"capability", "linux", fmt.Errorf("privilege: %w", exitcode.ErrCapability), nil, exitcode.Capability},
+		{"config", "linux", fmt.Errorf("config invalid: %w", exitcode.ErrConfig), nil, exitcode.Config},
+		{"device", "linux", nil, fmt.Errorf("device gone: %w", exitcode.ErrDevice), exitcode.Device},
+		{"runtime", "linux", nil, fmt.Errorf("boom: %w", exitcode.ErrRuntime), exitcode.Runtime},
+		{"verify", "linux", nil, fmt.Errorf("digest mismatch: %w", exitcode.ErrVerify), exitcode.Verify},
+		{"partial", "linux", nil, fmt.Errorf("interrupt: %w", exitcode.ErrPartial), exitcode.Partial},
+		{"precondition", "linux", nil, fmt.Errorf("precondition: %w", exitcode.ErrPrecondition), exitcode.Precondition},
+		{"resumable", "linux", nil, fmt.Errorf("resumable: %w", exitcode.ErrResumable), exitcode.Resumable},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -61,15 +61,15 @@ func TestExitCodeValues(t *testing.T) {
 		want int
 	}{
 		{"OK", exitcode.OK, 0},
-		{"ErrCapability", exitcode.ErrCapability, 10},
-		{"ErrDevice", exitcode.ErrDevice, 20},
-		{"ErrPlatform", exitcode.ErrPlatform, 30},
-		{"ErrConfig", exitcode.ErrConfig, 40},
-		{"ErrRuntime", exitcode.ErrRuntime, 50},
-		{"ErrVerify", exitcode.ErrVerify, 60},
-		{"ErrPartial", exitcode.ErrPartial, 70},
-		{"ErrPrecondition", exitcode.ErrPrecondition, 80},
-		{"ErrResumable", exitcode.ErrResumable, 90},
+		{"Capability", exitcode.Capability, 10},
+		{"Device", exitcode.Device, 20},
+		{"Platform", exitcode.Platform, 30},
+		{"Config", exitcode.Config, 40},
+		{"Runtime", exitcode.Runtime, 50},
+		{"Verify", exitcode.Verify, 60},
+		{"Partial", exitcode.Partial, 70},
+		{"Precondition", exitcode.Precondition, 80},
+		{"Resumable", exitcode.Resumable, 90},
 	}
 	for _, tt := range cases {
 		if tt.code != tt.want {

--- a/transfer/apply_device_test.go
+++ b/transfer/apply_device_test.go
@@ -15,6 +15,7 @@ import (
 	"lvmsync_go/common"
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/exitcode"
 	manifestpkg "lvmsync_go/manifest"
 
 	"go.uber.org/zap"
@@ -62,8 +63,8 @@ func TestProcessDumpDataUUIDMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for uuid mismatch")
 	}
-	if !strings.Contains(err.Error(), "does not match expected") {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
 	}
 	after, err := os.Stat(dest)
 	if err != nil {
@@ -114,8 +115,8 @@ func TestProcessDumpDataMountedDevice(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for mounted device")
 	}
-	if !strings.Contains(err.Error(), "mounted read-write") {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
 	}
 	after, err := os.Stat(dest)
 	if err != nil {

--- a/transfer/destination_precondition_test.go
+++ b/transfer/destination_precondition_test.go
@@ -47,7 +47,10 @@ func TestProcessDumpDataDeviceIDMismatchPrecondition(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error for device mismatch")
 			}
-			if rootcmd.ExitCode(err) != exitcode.ErrPrecondition {
+			if !errors.Is(err, exitcode.ErrPrecondition) {
+				t.Fatalf("expected precondition error, got %v", err)
+			}
+			if rootcmd.ExitCode(err) != exitcode.Precondition {
 				t.Fatalf("expected precondition exit code, got %d: %v", rootcmd.ExitCode(err), err)
 			}
 			if logs.FilterMessage("device_id_mismatch").Len() == 0 {
@@ -99,7 +102,10 @@ func TestProcessDumpDataSizeMismatchPrecondition(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected size mismatch error")
 	}
-	if rootcmd.ExitCode(err) != exitcode.ErrPrecondition {
+	if !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
+	}
+	if rootcmd.ExitCode(err) != exitcode.Precondition {
 		t.Fatalf("expected precondition exit code, got %d: %v", rootcmd.ExitCode(err), err)
 	}
 	if logs.FilterMessage("device_size_mismatch").Len() == 0 {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -23,6 +23,7 @@ import (
 	"lvmsync_go/device"
 	hashutil "lvmsync_go/hash"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/lvm"
 	manifestpkg "lvmsync_go/manifest"
 )
@@ -139,10 +140,10 @@ func (t *Transfer) dumpChangesCore(ctx context.Context, cfg *config.Config, snap
 		if err != nil {
 			return err
 		}
-		if usage >= cfg.SnapshotMaxUsage {
-			return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%", usage, cfg.SnapshotMaxUsage)
-		}
-	}
+               if usage >= cfg.SnapshotMaxUsage {
+                       return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%: %w", usage, cfg.SnapshotMaxUsage, exitcode.ErrSnapshotExhausted)
+               }
+       }
 
 	ranges, err := prepareRanges(ctx, cfg, snapshot, source, t.Logger)
 	if err != nil {
@@ -303,7 +304,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		manID := strings.TrimRight(string(hdr.DeviceID[:]), "\x00")
 		if id != manID {
 			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", manID), zap.String("resource_id", id))
-			return 0, "", 0, fmt.Errorf("precondition: destination device id %s does not match manifest %s", id, manID)
+			return 0, "", 0, fmt.Errorf("precondition: destination device id %s does not match manifest %s: %w", id, manID, exitcode.ErrPrecondition)
 		}
 		size, err = t.Info.SizeBytes(ctx, destPath)
 		if err != nil {
@@ -311,7 +312,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		if size != hdr.SizeBytes {
 			t.Logger.Error("device_size_mismatch", zap.Uint64("expected_size_bytes", hdr.SizeBytes), zap.Uint64("size_bytes", size))
-			return 0, "", 0, fmt.Errorf("precondition: destination device size %d does not match manifest %d", size, hdr.SizeBytes)
+			return 0, "", 0, fmt.Errorf("precondition: destination device size %d does not match manifest %d: %w", size, hdr.SizeBytes, exitcode.ErrPrecondition)
 		}
 		var st unix.Stat_t
 		if err := unix.Stat(destPath, &st); err != nil {
@@ -323,7 +324,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		actualID := device.DeviceIdentity{SizeBytes: size, Major: major, Minor: minor}
 		if !device.SameIdentityStrict(expectedID, actualID) {
 			t.Logger.Error("device_number_mismatch", zap.Uint32("expected_major", hdr.Major), zap.Uint32("expected_minor", hdr.Minor), zap.Uint32("major", major), zap.Uint32("minor", minor))
-			return 0, "", 0, fmt.Errorf("precondition: destination device number mismatch")
+			return 0, "", 0, fmt.Errorf("precondition: destination device number mismatch: %w", exitcode.ErrPrecondition)
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 		if err != nil {
@@ -335,13 +336,13 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 				zap.String("expected_digest", hex.EncodeToString(hdr.FirstBlockDigest[:])),
 				zap.String("first_block_digest", hex.EncodeToString(dig[:])),
 			)
-			return 0, "", 0, fmt.Errorf("destination device digest mismatch")
+			return 0, "", 0, fmt.Errorf("destination device digest mismatch: %w", exitcode.ErrVerify)
 		}
 		if cfg.ResumeState != "" {
 			if _, err := os.Stat(cfg.ResumeState); err == nil {
 				chk := readResumeState(cfg, t.Logger, hdr.SizeBytes, manID, hdr.Epoch, hdr.FirstBlockDigest)
 				if chk == (resumeCheckpoint{}) {
-					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata")
+					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata: %w", exitcode.ErrPrecondition)
 				}
 			}
 		}
@@ -361,12 +362,12 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 				}
 				chk := readResumeState(cfg, t.Logger, size, id, 0, [32]byte{})
 				if chk == (resumeCheckpoint{}) {
-					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata")
+					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata: %w", exitcode.ErrPrecondition)
 				}
 			}
 			if cfg.DeviceUUID != "" && id != cfg.DeviceUUID {
 				t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", cfg.DeviceUUID), zap.String("resource_id", id))
-				return 0, "", 0, fmt.Errorf("precondition: destination device uuid %s does not match expected %s", id, cfg.DeviceUUID)
+				return 0, "", 0, fmt.Errorf("precondition: destination device uuid %s does not match expected %s: %w", id, cfg.DeviceUUID, exitcode.ErrPrecondition)
 			}
 			t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
 		}
@@ -377,7 +378,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 			}
 			if hex.EncodeToString(dig[:]) != cfg.FirstBlockDigest {
 				t.Logger.Error("first_block_digest_mismatch", zap.String("expected_digest", cfg.FirstBlockDigest), zap.String("first_block_digest", hex.EncodeToString(dig[:])))
-				return 0, "", 0, fmt.Errorf("destination device digest mismatch")
+				return 0, "", 0, fmt.Errorf("destination device digest mismatch: %w", exitcode.ErrVerify)
 			}
 		}
 		t.Logger.Info("destination_validated", zap.String("resource_id", id))
@@ -388,7 +389,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 	}
 	if mounted && !cfg.Force {
 		t.Logger.Error("destination_mounted_rw", zap.String("path", destPath))
-		return 0, "", 0, fmt.Errorf("destination device %s is mounted read-write", destPath)
+		return 0, "", 0, fmt.Errorf("destination device %s is mounted read-write: %w", destPath, exitcode.ErrPrecondition)
 	}
 	return size, id, epoch, nil
 }

--- a/transfer/verify_destination_validation_test.go
+++ b/transfer/verify_destination_validation_test.go
@@ -15,6 +15,7 @@ import (
 
 	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
+	"lvmsync_go/internal/exitcode"
 	manifestpkg "lvmsync_go/manifest"
 )
 
@@ -77,8 +78,8 @@ func TestVerifyDestinationFirstBlockDigestMismatch(t *testing.T) {
 		t.Fatalf("write dest: %v", err)
 	}
 	cfg := &config.Config{FirstBlockDigest: strings.Repeat("00", 32)}
-	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
-		t.Fatalf("expected digest mismatch, got %v", err)
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !errors.Is(err, exitcode.ErrVerify) {
+		t.Fatalf("expected verify error, got %v", err)
 	}
 }
 
@@ -114,7 +115,7 @@ func TestVerifyDestinationDeviceNumberMismatch(t *testing.T) {
 	}
 	f.Close()
 	cfg := &config.Config{ManifestPath: man}
-	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !strings.Contains(err.Error(), "number mismatch") {
-		t.Fatalf("expected device number mismatch, got %v", err)
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- introduce typed sentinel errors in exitcode package and rename constants
- switch root ExitCode mapping to errors.Is with sentinel errors
- wrap device and transfer path errors with new sentinels

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: revive/unused-parameter, staticcheck, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a89143b6048323824252524adfc779