### PR TITLE
refactor: inject dump dependencies via Runner

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -69,21 +69,6 @@ type Runner struct {
 }
 
 var (
-	openFile       = os.OpenFile
-	sumFile        = digestpkg.SumFile
-	newSSHClient   = remote.NewSSHClient
-	detectDevice   = device.Detect
-	streamToRemote = func(ctx context.Context, cfg *config.Config, remoteStdin io.WriteCloser, snapshotDevice, originDevice, alg string, logger *zap.Logger) error {
-		r := &Runner{
-			dumpSeq:        dumpChangesSequential,
-			dumpPar:        dumpChangesParallel,
-			dumpDedup:      dumpChangesWithDeduplication,
-			sumFile:        sumFile,
-			openFile:       openFile,
-			verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
-		}
-		return r.StreamToRemote(ctx, cfg, remoteStdin, snapshotDevice, originDevice, alg, logger)
-	}
 	dumpChangesSequential = func(ctx context.Context, t *transfer.Transfer, cfg *config.Config, snap, origin string, out io.Writer) error {
 		return t.DumpChangesSequential(ctx, cfg, snap, origin, out)
 	}
@@ -96,27 +81,27 @@ var (
 	probeDestination = func(ctx context.Context, cfg *config.Config, dest string, logger *zap.Logger) (device.DeviceIdentity, error) {
 		return realProbeDestination(ctx, cfg, dest, logger)
 	}
-	verifyIdentity = device.VerifyIdentity
 )
 
 // NewRunner constructs a Runner with production dependencies.
 func NewRunner() *Runner {
-	return &Runner{
+	r := &Runner{
 		dumpSeq:        dumpChangesSequential,
 		dumpPar:        dumpChangesParallel,
 		dumpDedup:      dumpChangesWithDeduplication,
-		newSSHClient:   newSSHClient,
-		openFile:       openFile,
-		detectDevice:   detectDevice,
-		sumFile:        sumFile,
-		streamToRemote: streamToRemote,
+		newSSHClient:   remote.NewSSHClient,
+		openFile:       os.OpenFile,
+		detectDevice:   device.Detect,
+		sumFile:        digestpkg.SumFile,
 		probeDest:      probeDestination,
 		createLV:       lvm.CreateLogicalVolume,
 		parseLVPath:    lvm.ParseLVPath,
 		getVolumeSize:  lvm.GetVolumeSize,
 		newFDC:         lvm.NewDeviceFDCache,
-		verifyIdentity: verifyIdentity,
+		verifyIdentity: device.VerifyIdentity,
 	}
+	r.streamToRemote = r.StreamToRemote
+	return r
 }
 
 // ExecuteDump is a convenience wrapper using a default Runner.

--- a/cmd/dump/client_test.go
+++ b/cmd/dump/client_test.go
@@ -103,14 +103,12 @@ func TestRunSyncsLogger(t *testing.T) {
 	cfg := &config.Config{StdoutMode: true, Parallel: 1, BlockSize: 4096, DedupStrategy: "none"}
 	core := &countingSyncCore{Core: zapcore.NewNopCore()}
 	logger := zap.New(core)
-	origSeq := dumpChangesSequential
-	dumpChangesSequential = func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error { return nil }
-	defer func() { dumpChangesSequential = origSeq }()
+	r := NewRunnerWithDeps(&Runner{dumpSeq: func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error { return nil }})
 	snap := filepath.Join(t.TempDir(), "snap")
 	if err := os.WriteFile(snap, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write snap: %v", err)
 	}
-	if _, err := Run(context.Background(), cfg, snap, "", logger); err != nil {
+	if _, err := r.Run(context.Background(), cfg, snap, "", logger); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if core.count != 1 {

--- a/cmd/dump/local_dump_test.go
+++ b/cmd/dump/local_dump_test.go
@@ -23,30 +23,26 @@ func TestRunLocalDumpSuccess(t *testing.T) {
 	cfg.Parallel = 1
 	cfg.SpeedLimit = 0
 
-	originalOpen := openFile
 	var openCalled bool
-	openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
-		openCalled = true
-		if name != "/fake/dest" {
-			t.Fatalf("expected dest /fake/dest, got %s", name)
-		}
-		return os.OpenFile(os.DevNull, os.O_RDWR, 0)
-	}
-	defer func() { openFile = originalOpen }()
-
-	originalDump := dumpChangesSequential
 	var dumpCalled bool
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
-		dumpCalled = true
-		if snap != "snap" || origin != "orig" {
-			t.Fatalf("unexpected devices: %s %s", snap, origin)
-		}
-		return nil
-	}
-	defer func() { dumpChangesSequential = originalDump }()
-
+	r := NewRunnerWithDeps(&Runner{
+		openFile: func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			openCalled = true
+			if name != "/fake/dest" {
+				t.Fatalf("expected dest /fake/dest, got %s", name)
+			}
+			return os.OpenFile(os.DevNull, os.O_RDWR, 0)
+		},
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+			dumpCalled = true
+			if snap != "snap" || origin != "orig" {
+				t.Fatalf("unexpected devices: %s %s", snap, origin)
+			}
+			return nil
+		},
+		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
+	})
 	originalDestType := cfg.DestType
-	r := NewRunnerWithDeps(&Runner{verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil }})
 	destType, err := r.RunLocalDump(context.Background(), cfg, "snap", "orig", "/fake/dest", zap.NewNop())
 	if err != nil {
 		t.Fatalf("runLocalDump returned error: %v", err)
@@ -71,21 +67,19 @@ func TestRunLocalDumpOpenError(t *testing.T) {
 		t.Fatalf("DefaultConfig returned error: %v", err)
 	}
 
-	originalOpen := openFile
-	openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
-		return nil, errors.New("open error")
-	}
-	defer func() { openFile = originalOpen }()
-
-	originalDump := dumpChangesSequential
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
-		t.Fatalf("dumpChangesSequential should not be called on open error")
-		return nil
-	}
-	defer func() { dumpChangesSequential = originalDump }()
-
+	var openCalled bool
+	r := NewRunnerWithDeps(&Runner{
+		openFile: func(string, int, os.FileMode) (*os.File, error) {
+			openCalled = true
+			return nil, errors.New("open error")
+		},
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+			t.Fatalf("dumpChangesSequential should not be called on open error")
+			return nil
+		},
+		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
+	})
 	originalDestType := cfg.DestType
-	r := NewRunnerWithDeps(&Runner{verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil }})
 	if destType, err := r.RunLocalDump(context.Background(), cfg, "snap", "orig", "/fake/dest", zap.NewNop()); err == nil {
 		t.Fatalf("expected error, got nil")
 	} else if destType != originalDestType {
@@ -93,5 +87,8 @@ func TestRunLocalDumpOpenError(t *testing.T) {
 	}
 	if cfg.DestType != originalDestType {
 		t.Fatalf("cfg.DestType was modified: expected %q, got %q", originalDestType, cfg.DestType)
+	}
+	if !openCalled {
+		t.Fatalf("openFile was not called")
 	}
 }

--- a/cmd/dump/remote_dump_test.go
+++ b/cmd/dump/remote_dump_test.go
@@ -55,38 +55,35 @@ func TestRunRemoteDump(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 	cfg.Parallel = 1
 
-	origDump := dumpChangesSequential
-	origSum := sumFile
 	origAVX2, origAVX512, origNEON, origAESNI := digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI
-	origStream := streamToRemote
 	digestpkg.HasAVX2 = func() bool { return false }
 	digestpkg.HasAVX512 = func() bool { return false }
 	digestpkg.HasNEON = func() bool { return false }
 	digestpkg.HasAESNI = func() bool { return false }
-	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
-		if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
-			t.Fatalf("unexpected params: %s %s %s", snap, origin, alg)
-		}
-		return nil
-	}
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
-		if snap != "snap" || origin != "origin" {
-			t.Fatalf("unexpected devices: %s %s", snap, origin)
-		}
-		return nil
-	}
 	defer func() {
-		dumpChangesSequential = origDump
-		sumFile = origSum
 		digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI = origAVX2, origAVX512, origNEON, origAESNI
-		streamToRemote = origStream
 	}()
+
+	r := NewRunnerWithDeps(&Runner{
+		sumFile: func(string, string) ([32]byte, error) { return [32]byte{}, nil },
+		streamToRemote: func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+			if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
+				t.Fatalf("unexpected params: %s %s %s", snap, origin, alg)
+			}
+			return nil
+		},
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+			if snap != "snap" || origin != "origin" {
+				t.Fatalf("unexpected devices: %s %s", snap, origin)
+			}
+			return nil
+		},
+	})
 
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop()); err != nil {
+	if err := r.RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop()); err != nil {
 		t.Fatalf("runRemoteDump returned error: %v", err)
 	}
 
@@ -133,35 +130,32 @@ func TestRunRemoteDumpError(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 	cfg.Parallel = 1
 
-	origDump := dumpChangesSequential
-	origSum := sumFile
 	origAVX2, origAVX512, origNEON, origAESNI := digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI
-	origStream := streamToRemote
 	digestpkg.HasAVX2 = func() bool { return false }
 	digestpkg.HasAVX512 = func() bool { return false }
 	digestpkg.HasNEON = func() bool { return false }
 	digestpkg.HasAESNI = func() bool { return false }
-	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
-		if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
-			t.Fatalf("unexpected params: %s %s %s", snap, origin, alg)
-		}
-		return nil
-	}
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
-		return nil
-	}
 	defer func() {
-		dumpChangesSequential = origDump
-		sumFile = origSum
 		digestpkg.HasAVX2, digestpkg.HasAVX512, digestpkg.HasNEON, digestpkg.HasAESNI = origAVX2, origAVX512, origNEON, origAESNI
-		streamToRemote = origStream
 	}()
+
+	r := NewRunnerWithDeps(&Runner{
+		sumFile: func(string, string) ([32]byte, error) { return [32]byte{}, nil },
+		streamToRemote: func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+			if snap != "snap" || origin != "origin" || alg != digestpkg.SHA256 {
+				t.Fatalf("unexpected params: %s %s %s", snap, origin, alg)
+			}
+			return nil
+		},
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+			return nil
+		},
+	})
 
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
+	err = r.RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !errors.Is(err, ErrRemoteCommand) {
 		t.Fatalf("expected remote command error, got %v", err)
 	}
@@ -207,26 +201,20 @@ func TestRunRemoteDumpTimeout(t *testing.T) {
 	cfg.Parallel = 1
 	cfg.SSHTimeout = 20 * time.Millisecond
 
-	origDump := dumpChangesSequential
-	origSum := sumFile
-	origStream := streamToRemote
-	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
-		return nil
-	}
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
-		return nil
-	}
-	defer func() {
-		dumpChangesSequential = origDump
-		sumFile = origSum
-		streamToRemote = origStream
-	}()
+	r := NewRunnerWithDeps(&Runner{
+		sumFile: func(string, string) ([32]byte, error) { return [32]byte{}, nil },
+		streamToRemote: func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+			return nil
+		},
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+			return nil
+		},
+	})
 
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
+	err = r.RunRemoteDump(ctx, cfg, "snap", "origin", dest, zap.NewNop())
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
@@ -293,21 +281,15 @@ func TestRunRemoteDumpLogsDigestSelection(t *testing.T) {
 	cfg.Parallel = 1
 	cfg.ChecksumAlgorithm = digestpkg.SHA256
 
-	origDump := dumpChangesSequential
-	origSum := sumFile
-	origStream := streamToRemote
-	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	streamToRemote = func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
-		return nil
-	}
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
-		return nil
-	}
-	defer func() {
-		dumpChangesSequential = origDump
-		sumFile = origSum
-		streamToRemote = origStream
-	}()
+	r := NewRunnerWithDeps(&Runner{
+		sumFile: func(string, string) ([32]byte, error) { return [32]byte{}, nil },
+		streamToRemote: func(_ context.Context, _ *config.Config, _ io.WriteCloser, snap, origin, alg string, _ *zap.Logger) error {
+			return nil
+		},
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snap, origin string, out io.Writer) error {
+			return nil
+		},
+	})
 
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -316,7 +298,7 @@ func TestRunRemoteDumpLogsDigestSelection(t *testing.T) {
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 
-	if err := RunRemoteDump(ctx, cfg, "snap", "origin", dest, logger); err != nil {
+	if err := r.RunRemoteDump(ctx, cfg, "snap", "origin", dest, logger); err != nil {
 		t.Fatalf("RunRemoteDump returned error: %v", err)
 	}
 

--- a/cmd/dump/remote_helpers_test.go
+++ b/cmd/dump/remote_helpers_test.go
@@ -26,17 +26,16 @@ func TestSetupSSHClient(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		dummy := &remote.SSHClient{Logger: zap.NewNop()}
 		called := false
-		newSSHClient = func(ctx context.Context, host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
+		r := NewRunnerWithDeps(&Runner{newSSHClient: func(ctx context.Context, host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
 			called = true
 			if host != "dest" {
 				t.Fatalf("unexpected host %s", host)
 			}
 			return dummy, nil
-		}
-		defer func() { newSSHClient = remote.NewSSHClient }()
+		}})
 
 		ctx, outerCancel := context.WithTimeout(context.Background(), time.Second)
-		client, cancel, err := SetupSSHClient(ctx, cfg, "dest", zap.NewNop())
+		client, cancel, err := r.SetupSSHClient(ctx, cfg, "dest", zap.NewNop())
 		if err != nil {
 			t.Fatalf("SetupSSHClient returned error: %v", err)
 		}
@@ -51,14 +50,13 @@ func TestSetupSSHClient(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		newSSHClient = func(ctx context.Context, host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
+		r := NewRunnerWithDeps(&Runner{newSSHClient: func(ctx context.Context, host, user, keyPath string, port int, knownHostsPath string, verify bool, timeout, keepAliveInterval time.Duration, retries int, logger *zap.Logger) (*remote.SSHClient, error) {
 			return nil, errors.New("fail")
-		}
-		defer func() { newSSHClient = remote.NewSSHClient }()
+		}})
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		_, _, err := SetupSSHClient(ctx, cfg, "dest", zap.NewNop())
+		_, _, err := r.SetupSSHClient(ctx, cfg, "dest", zap.NewNop())
 		if err == nil || !strings.Contains(err.Error(), "failed to create SSH client") {
 			t.Fatalf("expected wrapped error, got %v", err)
 		}
@@ -151,9 +149,6 @@ func TestStreamToRemote(t *testing.T) {
 	}
 	cfg.Parallel = 1
 
-	orig := dumpChangesSequential
-	t.Cleanup(func() { dumpChangesSequential = orig })
-
 	tests := []struct {
 		name     string
 		dumpErr  error
@@ -171,11 +166,11 @@ func TestStreamToRemote(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, origin string, out io.Writer) error {
+			r := NewRunnerWithDeps(&Runner{dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, origin string, out io.Writer) error {
 				return tc.dumpErr
-			}
+			}})
 			remoteStdin := &mockWriteCloser{Writer: io.Discard, closeErr: tc.closeErr}
-			err := StreamToRemote(context.Background(), cfg, remoteStdin, snapFile, "origin", digestpkg.SHA256, zap.NewNop())
+			err := r.StreamToRemote(context.Background(), cfg, remoteStdin, snapFile, "origin", digestpkg.SHA256, zap.NewNop())
 			if tc.dumpErr == nil && tc.closeErr == nil {
 				if err != nil {
 					t.Fatalf("expected nil error, got %v", err)

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -46,23 +46,21 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 	cfg.StrictHostKeyCheck = true
 	cfg.LVMSyncPath = "lvmsync"
 
-	original := dumpChangesSequential
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
-		return io.ErrUnexpectedEOF
-	}
-	origSum := sumFile
-	sumFile = func(string, string) ([32]byte, error) { return [32]byte{}, nil }
-	defer func() { dumpChangesSequential = original; sumFile = origSum }()
+	r := NewRunnerWithDeps(&Runner{
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
+			return io.ErrUnexpectedEOF
+		},
+		sumFile: func(string, string) ([32]byte, error) { return [32]byte{}, nil },
+		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+			return &fakeDevice{path: "/dev/snap"}, nil
+		},
+		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
+	})
 
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
-		return &fakeDevice{path: "/dev/snap"}, nil
-	}
-	defer func() { detectDevice = origDetect }()
-	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
+	_, err = r.Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "dumpChanges") {
 		t.Fatalf("expected dumpChanges error, got %v", err)
 	}
@@ -108,15 +106,16 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	cfg.StrictHostKeyCheck = true
 	cfg.LVMSyncPath = "lvmsync"
 
+	r := NewRunnerWithDeps(&Runner{
+		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+			return &fakeDevice{path: "/dev/snap"}, nil
+		},
+		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
+	})
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
-		return &fakeDevice{path: "/dev/snap"}, nil
-	}
-	defer func() { detectDevice = origDetect }()
-	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
+	_, err = r.Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	if err == nil {
 		t.Fatalf("expected error from pre-script")
 	}
@@ -168,15 +167,16 @@ func TestRemotePostScriptContextError(t *testing.T) {
 	cfg.StrictHostKeyCheck = true
 	cfg.LVMSyncPath = "lvmsync"
 
+	r := NewRunnerWithDeps(&Runner{
+		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+			return &fakeDevice{path: "/dev/snap"}, nil
+		},
+		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
+	})
 	dest := host + ":/dev/null"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
-		return &fakeDevice{path: "/dev/snap"}, nil
-	}
-	defer func() { detectDevice = origDetect }()
-	_, err = Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
+	_, err = r.Run(ctx, cfg, "/dev/snap", dest, zap.NewNop())
 	close(slow)
 	if err == nil || !strings.Contains(err.Error(), "remote post-script context error") {
 		t.Fatalf("expected remote post-script context error, got %v", err)

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -27,23 +27,22 @@ func TestRunLogsSaveStateError(t *testing.T) {
 	cfg.BlockSize = 1024
 	cfg.MaxRetries = 1
 
-	original := dumpChangesWithDeduplication
-	dumpChangesWithDeduplication = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
-		return nil
-	}
-	defer func() { dumpChangesWithDeduplication = original }()
-
 	core, observed := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
 
+	r := NewRunnerWithDeps(&Runner{
+		dumpDedup: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
+			return nil
+		},
+		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+			return &fakeDevice{path: "/dev/snap"}, nil
+		},
+		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
+	})
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
-		return &fakeDevice{path: "/dev/snap"}, nil
-	}
-	defer func() { detectDevice = origDetect }()
-	if _, err := Run(ctx, cfg, "/dev/snap", "", logger); err != nil {
+	if _, err := r.Run(ctx, cfg, "/dev/snap", "", logger); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -26,35 +26,33 @@ func TestRunStdout(t *testing.T) {
 	cfg.SpeedLimit = 0
 
 	expected := "test output"
+	r := NewRunnerWithDeps(&Runner{
+		dumpSeq: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
+			_, writeErr := out.Write([]byte(expected))
+			return writeErr
+		},
+		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+			return &fakeDevice{path: "/dev/snap"}, nil
+		},
+		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
+	})
 
-	originalFunc := dumpChangesSequential
-	dumpChangesSequential = func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer) error {
-		_, writeErr := out.Write([]byte(expected))
-		return writeErr
-	}
-	defer func() { dumpChangesSequential = originalFunc }()
-
-	r, w, err := os.Pipe()
+	rPipe, wPipe, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe: %v", err)
 	}
 	oldStdout := os.Stdout
-	os.Stdout = w
+	os.Stdout = wPipe
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	origDetect := detectDevice
-	detectDevice = func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
-		return &fakeDevice{path: "/dev/snap"}, nil
-	}
-	defer func() { detectDevice = origDetect }()
-	if _, err = Run(ctx, cfg, "/dev/snap", "", zap.NewNop()); err != nil {
+	if _, err = r.Run(ctx, cfg, "/dev/snap", "", zap.NewNop()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
-	w.Close()
+	wPipe.Close()
 	os.Stdout = oldStdout
-	output, err := io.ReadAll(r)
+	output, err := io.ReadAll(rPipe)
 	if err != nil {
 		t.Fatalf("failed to read stdout: %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove dump package globals and inject dependencies via Runner
- update dump tests to override Runner fields instead of package variables

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRecvAckNetTimeoutBeforeDeadline)*
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unused parameters, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8913f5dc883239d7b7ff196946fcf