### PR TITLE
feat(device): enforce snapshot requirement for LVM volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: document snapshot cleanup, resume, and verify-only rollback procedures in docs/danger_rollback.md
 - device: split Detect into detectFileDevice, detectLVMDevice, and detectRawDevice helpers with dedicated tests
 - device: detect LVM, raw, or file devices using blkid metadata
+- device: enforce snapshot requirement for LVM volumes unless --offline is set
 - cmd: manage LVM snapshot lifecycle within dump and apply commands
 - tests: add coverage for adaptive chunk sizing, index option application, TLS version helper, capability checks, and data size overflow; include loop device setup integration test.
 - Log dial and listen lifecycle events with duration_ms and error fields across transports, with tests covering handshake and teardown logs.

--- a/device/detect.go
+++ b/device/detect.go
@@ -53,7 +53,7 @@ func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
 }
 
 // detectLVMDevice opens an LVM logical volume.
-func detectLVMDevice(ctx context.Context, path, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
+func detectLVMDevice(ctx context.Context, path string, offline bool, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
 	if err := lvm.VerifyEscalationCommand(lvmEscalation); err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
@@ -63,7 +63,7 @@ func detectLVMDevice(ctx context.Context, path, lvmEscalation string, runner *Ru
 		return nil, err
 	}
 	defer cache.Close()
-	dev, err := runner.OpenLVM(ctx, path, cache, lvmEscalation, logger)
+	dev, err := runner.OpenLVM(ctx, path, cache, offline, lvmEscalation, logger)
 	if err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
@@ -211,7 +211,7 @@ func Detect(
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type lvm: %s", resolved)
 			}
-			return detectLVMDevice(ctx, resolved, lvmEscalation, runner, logger)
+			return detectLVMDevice(ctx, resolved, offline, lvmEscalation, runner, logger)
 		case TypeRaw:
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
@@ -228,7 +228,7 @@ func Detect(
 		out, err := runner.command.CommandContext(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
 		fsType := strings.TrimSpace(string(out))
 		if err == nil && fsType == "LVM2_member" {
-			return detectLVMDevice(ctx, resolved, lvmEscalation, runner, logger)
+			return detectLVMDevice(ctx, resolved, offline, lvmEscalation, runner, logger)
 		}
 		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, esc, logger, runner)
 	}

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -56,10 +56,10 @@ func TestDetectLVMDeviceSuccess(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 	runner := NewRunner()
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
-	dev, err := detectLVMDevice(context.Background(), "/dev/test", "", runner, logger)
+	dev, err := detectLVMDevice(context.Background(), "/dev/test", false, "", runner, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -83,10 +83,10 @@ func TestDetectLVMDeviceError(t *testing.T) {
 	restore := lvm.SetEscalationChecker(func(string) error { return nil })
 	defer restore()
 	runner := NewRunner()
-	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error) {
 		return nil, errors.New("fail")
 	}
-	if _, err := detectLVMDevice(context.Background(), "/dev/test", "", runner, zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice(context.Background(), "/dev/test", false, "", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -96,11 +96,11 @@ func TestDetectLVMDeviceEscalationError(t *testing.T) {
 	defer restore()
 	runner := NewRunner()
 	called := false
-	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error) {
 		called = true
 		return &LVMDevice{path: "/dev/test", logger: zap.NewNop(), runner: runner}, nil
 	}
-	if _, err := detectLVMDevice(context.Background(), "/dev/test", "sudo -n", runner, zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice(context.Background(), "/dev/test", false, "sudo -n", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 	if called {

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -242,7 +242,7 @@ func TestDetectLVM(t *testing.T) {
 		return exec.CommandContext(ctx, name, args...)
 	})
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
 	ctx := WithForce(context.Background(), true)

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
 )
@@ -34,10 +35,11 @@ type LVMDevice struct {
 }
 
 // OpenLVM opens an LVM logical volume and queries its size and block size.
-// Size information is obtained through the lvm package helpers.
-func (r *Runner) OpenLVM(ctx context.Context, path string, cache *lvm.FDCache, escalation string, logger *zap.Logger) (*LVMDevice, error) {
+// It fails unless the device is a snapshot or offline is true. Size
+// information is obtained through the lvm package helpers.
+func (r *Runner) OpenLVM(ctx context.Context, path string, cache *lvm.FDCache, offline bool, escalation string, logger *zap.Logger) (*LVMDevice, error) {
 	if r.openLVMOverride != nil {
-		return r.openLVMOverride(ctx, path, cache, escalation, logger)
+		return r.openLVMOverride(ctx, path, cache, offline, escalation, logger)
 	}
 	exists, err := r.volumeExists(ctx, path)
 	if err != nil {
@@ -66,6 +68,23 @@ func (r *Runner) OpenLVM(ctx context.Context, path string, cache *lvm.FDCache, e
 	}
 	if mounted {
 		return nil, fmt.Errorf("device %s mounted", path)
+	}
+	if !offline {
+		if lvsErr != nil {
+			return nil, lvsErr
+		}
+		out, err := exec.CommandContext(ctx, lvsPath, "--noheadings", "-o", "lv_attr,lv_role", path).Output()
+		if err != nil {
+			return nil, err
+		}
+		fields := strings.Fields(string(out))
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("unexpected lvs output for %s", path)
+		}
+		attr, typ := fields[0], fields[1]
+		if typ != "snapshot" && !strings.HasPrefix(attr, "s") {
+			return nil, fmt.Errorf("precondition: volume %s is not a snapshot: %w", path, exitcode.ErrPrecondition)
+		}
 	}
 	vg, lv, err := lvm.ParseLVPath(path)
 	if err != nil {
@@ -267,7 +286,7 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 		return nil, err
 	}
 	defer cache.Close()
-	snapDev, err := d.runner.OpenLVM(ctx, snapPath, cache, d.escalation, d.logger)
+	snapDev, err := d.runner.OpenLVM(ctx, snapPath, cache, false, d.escalation, d.logger)
 	if err != nil {
 		_ = d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -27,7 +27,7 @@ func NewRunnerWithDeps(func(context.Context, string) (bool, error), func(context
 type LVMDevice struct{}
 
 // OpenLVM returns an error on non-Linux systems.
-func (r *Runner) OpenLVM(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error) {
+func (r *Runner) OpenLVM(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error) {
 	return nil, fmt.Errorf("LVM devices are only supported on Linux")
 }
 

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -4,6 +4,7 @@ package device
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -77,7 +78,7 @@ func TestOpenLVM(t *testing.T) {
 	}
 	defer cache.Close()
 	runner := NewRunner()
-	dev, err := runner.OpenLVM(context.Background(), loop, cache, "", zap.NewNop())
+	dev, err := runner.OpenLVM(context.Background(), loop, cache, false, "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -102,7 +103,7 @@ func TestOpenLVMNonBlockDevice(t *testing.T) {
 	}
 	defer cache.Close()
 	runner := NewRunner()
-	if _, err := runner.OpenLVM(context.Background(), f.Name(), cache, "", zap.NewNop()); err == nil {
+	if _, err := runner.OpenLVM(context.Background(), f.Name(), cache, false, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error for non-block device")
 	}
 }
@@ -114,9 +115,82 @@ func TestOpenLVMChecks(t *testing.T) {
 	}
 	defer cache.Close()
 	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, defaultIsMountedRW, lock.Acquire, nil)
-	if _, err := runner.OpenLVM(context.Background(), "/dev/missing", cache, "", zap.NewNop()); err == nil {
+	if _, err := runner.OpenLVM(context.Background(), "/dev/missing", cache, false, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error when volume missing")
 	}
+}
+
+func TestOpenLVMRequiresSnapshot(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "lvs")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho '-wi-a----- linear'\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	origPath, origErr := lvsPath, lvsErr
+	lvsPath, lvsErr = script, nil
+	t.Cleanup(func() { lvsPath, lvsErr = origPath, origErr })
+
+	cache, err := lvm.NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
+	defer cache.Close()
+	runner := NewRunnerWithDeps(
+		func(context.Context, string) (bool, error) { return true, nil },
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(context.Context, string) (bool, error) { return true, nil },
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(string, string) (*lock.Lock, error) { return &lock.Lock{}, nil },
+		nil,
+	)
+	if _, err := runner.OpenLVM(context.Background(), loop, cache, false, "", zap.NewNop()); !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
+	}
+	if _, err := runner.OpenLVM(context.Background(), loop, cache, true, "", zap.NewNop()); err != nil {
+		t.Fatalf("offline open: %v", err)
+	}
+}
+
+func TestOpenLVMSnapshotAllowed(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	loop, cleanup := setupLoop(t, 1<<20)
+	defer cleanup()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "lvs")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 'swi-a-s--- snapshot'\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	origPath, origErr := lvsPath, lvsErr
+	lvsPath, lvsErr = script, nil
+	t.Cleanup(func() { lvsPath, lvsErr = origPath, origErr })
+
+	cache, err := lvm.NewDeviceFDCache(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDeviceFDCache: %v", err)
+	}
+	defer cache.Close()
+	runner := NewRunnerWithDeps(
+		func(context.Context, string) (bool, error) { return true, nil },
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(context.Context, string) (bool, error) { return true, nil },
+		func(context.Context, string) (bool, error) { return false, nil },
+		func(string, string) (*lock.Lock, error) { return &lock.Lock{}, nil },
+		nil,
+	)
+	dev, err := runner.OpenLVM(context.Background(), loop, cache, false, "", zap.NewNop())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	dev.Close()
 }
 
 func TestRunLVMPrivilegeEscalation(t *testing.T) {
@@ -349,7 +423,7 @@ func TestSnapshotReadOnly(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop(), runner: runner}, nil
 	}
 

--- a/device/runner.go
+++ b/device/runner.go
@@ -31,7 +31,7 @@ type Runner struct {
 	discardEnabled    func(context.Context, string) (bool, error)
 	isMountedRW       func(context.Context, string) (bool, error)
 	lockAcquire       func(string, string) (*lock.Lock, error)
-	openLVMOverride   func(context.Context, string, *lvm.FDCache, string, *zap.Logger) (*LVMDevice, error)
+	openLVMOverride   func(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error)
 	openRawOverride   func(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger) (*RawDevice, error)
 }
 

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -67,7 +67,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop(), runner: runner}, nil
 	}
 


### PR DESCRIPTION
## Summary
- ensure OpenLVM only operates on snapshot LVs unless --offline is provided
- return a precondition error for non-snapshot volumes
- add unit tests covering snapshot and non-snapshot cases

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a89b4abf508323bb40e043e570afde