### PR TITLE
cmd/verify: test verify-only exit code

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -49,7 +49,8 @@ continuing.
 lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
 ```
 
-Reads both devices and reports mismatches without writing data.
+Reads both devices and reports mismatches without writing data. Exits with
+code `60` when blocks differ.
 
 ## Skipping Snapshot Creation
 

--- a/cmd/verify/verify_only_command_integration_test.go
+++ b/cmd/verify/verify_only_command_integration_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package verify
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"lvmsync_go/internal/exitcode"
+)
+
+func TestRunVerifyOnlyMismatchExitCode(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src.img")
+	dstFile := filepath.Join(dir, "dst.img")
+
+	block := bytes.Repeat([]byte{1}, 4096)
+	if err := os.WriteFile(srcFile, block, 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dstData := append([]byte{}, block...)
+	dstData[0] = 2
+	if err := os.WriteFile(dstFile, dstData, 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	srcLoop := setupLoop(t, srcFile)
+	dstLoop := setupLoop(t, dstFile)
+
+	bin := filepath.Join(dir, "lvmsync")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = filepath.Join("..", "..")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build lvmsync: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin, "run", "--verify-only", srcLoop, dstLoop)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected verify-only to fail")
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("verify-only: %v", err)
+	}
+	if exitErr.ExitCode() != exitcode.Verify {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Verify, exitErr.ExitCode())
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test covering `--verify-only` mismatch exit code
- document verify-only exit code in operations guide

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go test -tags integration ./cmd/verify -run TestRunVerifyOnlyMismatchExitCode -count=1`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unused-parameter, package-comments, and other revive/staticcheck warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b93f51a88323ac92718794e284f9