### PR TITLE
dedup: add Bloom filter false positive benchmark

### DIFF
--- a/dedup/bloom_false_positive_benchmark_test.go
+++ b/dedup/bloom_false_positive_benchmark_test.go
@@ -1,0 +1,56 @@
+package dedup
+
+import (
+	"encoding/binary"
+	"fmt"
+	mathrand "math/rand"
+	"testing"
+)
+
+// BenchmarkBloomFalsePositiveRate measures the observed false positive rate of
+// the Bloom filter against its configured rate. It inserts a large number of
+// unique digests and then tests randomly generated digests that were not
+// inserted. The benchmark reports the observed false positive rate as an extra
+// metric and fails if the rate exceeds twice the configured value.
+func BenchmarkBloomFalsePositiveRate(b *testing.B) {
+	const insertCount = 100000
+	digests := make([][]byte, insertCount)
+	for i := 0; i < insertCount; i++ {
+		d := make([]byte, 32)
+		binary.LittleEndian.PutUint64(d, uint64(i))
+		digests[i] = d
+	}
+
+	rates := []float64{0.1, 0.01, 0.001}
+	for _, rate := range rates {
+		b.Run(fmt.Sprintf("fp%g", rate), func(b *testing.B) {
+			bloom, err := NewBloom(uint(insertCount), rate)
+			if err != nil {
+				b.Fatalf("new bloom: %v", err)
+			}
+			for _, d := range digests {
+				// Ignore return value; false positives are expected as the
+				// filter fills up.
+				bloom.TestAndAdd(d)
+			}
+
+			testRng := mathrand.New(mathrand.NewSource(2))
+			b.ResetTimer()
+			falsePos := 0
+			for i := 0; i < b.N; i++ {
+				d := make([]byte, 32)
+				if _, err := testRng.Read(d); err != nil {
+					b.Fatalf("rng read: %v", err)
+				}
+				if bloom.filter.Test(d) {
+					falsePos++
+				}
+			}
+			observed := float64(falsePos) / float64(b.N)
+			b.ReportMetric(observed, "false_positive_rate")
+			if observed > rate*2 {
+				b.Fatalf("observed false positive rate %.4f exceeds threshold for configured %.4f", observed, rate)
+			}
+		})
+	}
+}

--- a/docs/dedup_benchmarks.md
+++ b/docs/dedup_benchmarks.md
@@ -24,3 +24,21 @@ on patterned and random datasets using Go's testing framework.
 | Hybrid patterned | 145286614 | 7.22 | 1403394 | 225 |
 | Hybrid random | 341517485 | 3.07 | 1459349 | 337 |
 
+## Bloom Filter False Positive Rates
+
+The Bloom filter is configured with 100k inserted digests. Random digests are
+tested for membership without insertion to measure the observed false positive
+rate.
+
+- Command: `go test -run '^$' -bench BloomFalsePositiveRate -benchtime=100000x -benchmem ./dedup`
+
+| Configured FP | Observed FP |
+|--------------:|------------:|
+| 0.1 | 0.1027 |
+| 0.01 | 0.01001 |
+| 0.001 | 0.00093 |
+
+To reduce false positives, lower the configured rate at the cost of additional
+memory. `MaxChunks` estimates the number of unique chunks supported for a given
+false positive rate and available RAM.
+


### PR DESCRIPTION
## Summary
- add benchmark test measuring Bloom filter false-positive rate vs configured rate
- document benchmark results and tuning guidance in dedup benchmarks doc

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRecvAckNetTimeoutBeforeDeadline context deadline exceeded)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: 1266 issues)*
- `go test -run '^$' -bench BloomFalsePositiveRate -benchtime=100000x -benchmem ./dedup`


------
https://chatgpt.com/codex/tasks/task_e_68a8b961c8ec8323aa4f14709046c1be