### PR TITLE
escalate: log sanitized env variables

### DIFF
--- a/escalate/escalate.go
+++ b/escalate/escalate.go
@@ -86,12 +86,12 @@ func IsRoot(opts Options) bool {
 	return geteuid() == 0
 }
 
+const defaultTimeout = 5 * time.Second
+
 // EnsureRootOrReexec ensures the process runs as root.
 // If already root, returns (false, nil).
 // If not root, re-execs the current binary through `sudo -n` and returns (true, err).
 // When (true, nil) is returned, the caller should exit immediately.
-const defaultTimeout = 5 * time.Second
-
 func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
 	argv := opts.Args
 	if argv == nil {
@@ -128,6 +128,7 @@ func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
 	args = append(args, filterAllowed(argv[1:], opts.AllowedPassthrough)...)
 
 	var env []string
+	var removed []string
 	sanitize := false
 	if opts.SanitizeEnv != nil {
 		sanitize = *opts.SanitizeEnv
@@ -136,10 +137,14 @@ func EnsureRootOrReexec(opts Options, logger *zap.Logger) (bool, error) {
 	if opts.Environ != nil {
 		environ = opts.Environ
 	}
+	origEnv := environ()
 	if sanitize {
-		env = sanitizedChildEnv(environ())
+		env, removed = sanitizedChildEnv(origEnv)
+		if len(removed) > 0 {
+			logger.Info("ensure_root_or_reexec", zap.String("action_id", actionID), zap.Strings("argv", argv), zap.String("hostname", host), zap.String("result", "env_sanitized"), zap.Strings("removed_env_keys", removed))
+		}
 	} else {
-		env = environ()
+		env = origEnv
 	}
 
 	stdin := opts.Stdin // nil by default (no TTY password prompts)
@@ -236,15 +241,22 @@ func DropToInvokerIfSudo(opts Options, logger *zap.Logger) error {
 
 // ---- Internal helpers (kept small, pure, and fully tested) ----
 
-func sanitizedChildEnv(environ []string) []string {
+// sanitizedChildEnv filters environment variables for child processes,
+// returning the sanitized environment along with the names of variables that
+// were removed.
+func sanitizedChildEnv(environ []string) ([]string, []string) {
 	whitelist := map[string]bool{
 		"LC_ALL":   true,
 		"LC_CTYPE": true,
 		"TERM":     true,
 	}
 	out := make([]string, 0, len(environ))
+	removed := make([]string, 0, len(environ))
 	for _, kv := range environ {
 		if strings.HasPrefix(kv, "LD_") || strings.HasPrefix(kv, "GCONV_PATH=") {
+			if i := strings.IndexByte(kv, '='); i > 0 {
+				removed = append(removed, kv[:i])
+			}
 			continue
 		}
 		i := strings.IndexByte(kv, '=')
@@ -254,9 +266,11 @@ func sanitizedChildEnv(environ []string) []string {
 		k := kv[:i]
 		if whitelist[k] {
 			out = append(out, kv)
+		} else {
+			removed = append(removed, k)
 		}
 	}
-	return out
+	return out, removed
 }
 
 func filterAllowed(argv []string, allow map[string]bool) []string {

--- a/escalate/escalate_test.go
+++ b/escalate/escalate_test.go
@@ -42,7 +42,7 @@ func TestSanitizedChildEnv(t *testing.T) {
 		"FOO=BAR",
 		"TERM=xterm-256color",
 	}
-	out := sanitizedChildEnv(in)
+	out, removed := sanitizedChildEnv(in)
 	joined := strings.Join(out, "\n")
 	if strings.Contains(joined, "LD_PRELOAD=") || strings.Contains(joined, "GCONV_PATH=") {
 		t.Fatalf("disallowed vars leaked: %v", out)
@@ -52,6 +52,10 @@ func TestSanitizedChildEnv(t *testing.T) {
 	}
 	if len(out) != 1 || out[0] != "TERM=xterm-256color" {
 		t.Fatalf("unexpected sanitized env: %v", out)
+	}
+	wantRemoved := []string{"LD_PRELOAD", "GCONV_PATH", "PATH", "LANG", "FOO"}
+	if !reflect.DeepEqual(removed, wantRemoved) {
+		t.Fatalf("removed = %v, want %v", removed, wantRemoved)
 	}
 }
 
@@ -117,8 +121,8 @@ func (m *mockSys) Setresuid(r, e, s int) error {
 
 func TestDropToInvokerIfSudo_NoEnv(t *testing.T) {
 	m := &mockSys{}
-	os.Unsetenv("SUDO_UID")
-	os.Unsetenv("SUDO_GID")
+	t.Setenv("SUDO_UID", "")
+	t.Setenv("SUDO_GID", "")
 
 	if err := DropToInvokerIfSudo(Options{Sys: m}, zap.NewNop()); err != nil {
 		t.Fatalf("expected no-op nil err, got %v", err)
@@ -421,7 +425,7 @@ func TestEnsureRootOrReexec_SanitizeEnvTrue(t *testing.T) {
 	if err != nil || !reexeced {
 		t.Fatalf("unexpected result: %v %v", reexeced, err)
 	}
-	want := sanitizedChildEnv(env)
+	want, _ := sanitizedChildEnv(env)
 	if !reflect.DeepEqual(got.env, want) {
 		t.Fatalf("env = %v, want %v", got.env, want)
 	}
@@ -499,6 +503,47 @@ func TestEnsureRootOrReexec_SanitizeEnvDropsDisallowed(t *testing.T) {
 	}
 	if !strings.Contains(joined, "TERM=dumb") {
 		t.Fatalf("TERM missing: %v", got.env)
+	}
+}
+
+func TestEnsureRootOrReexec_SanitizeEnvLogsRemovedVars(t *testing.T) {
+	var got execCall
+	env := []string{"LD_PRELOAD=/tmp/x.so", "GCONV_PATH=/bad", "PATH=/usr/local/bin", "LANG=C", "TERM=dumb"}
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	reexeced, err := EnsureRootOrReexec(Options{
+		Geteuid:     func() int { return 1000 },
+		LookPath:    func(string) (string, error) { return "/usr/bin/sudo", nil },
+		SanitizeEnv: boolPtr(true),
+		Environ:     func() []string { return env },
+		ExecRunner:  fakeRunner(&got, nil),
+	}, logger)
+	if err != nil || !reexeced {
+		t.Fatalf("unexpected result: %v %v", reexeced, err)
+	}
+	entries := logs.All()
+	if len(entries) < 3 {
+		t.Fatalf("expected at least 3 log entries, got %d", len(entries))
+	}
+	sanitized := entries[1].ContextMap()
+	if sanitized["result"] != "env_sanitized" {
+		t.Fatalf("result = %v", sanitized["result"])
+	}
+	var removed []string
+	switch v := sanitized["removed_env_keys"].(type) {
+	case []string:
+		removed = v
+	case []interface{}:
+		removed = make([]string, len(v))
+		for i, val := range v {
+			removed[i] = fmt.Sprint(val)
+		}
+	default:
+		t.Fatalf("removed_env_keys type = %T", sanitized["removed_env_keys"])
+	}
+	want := []string{"LD_PRELOAD", "GCONV_PATH", "PATH", "LANG"}
+	if !reflect.DeepEqual(removed, want) {
+		t.Fatalf("removed_env_keys = %v, want %v", removed, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- log names of environment variables removed during escalation when sanitization is enabled
- cover sanitized environment logging in unit tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestVerifyWithManifestParallel expected parallel verification faster)*
- `golangci-lint run ./escalate`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a8c13bf3148323b4b828a38cb3857f