### PR TITLE
Add transport fallback integration test and require explicit allow-insecure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,8 +563,7 @@ first):
 
 This precedence applies to duration timeouts, filesystem paths, and security
 flags. Unknown keys in `config.yaml` generate warnings, and settings like
-`allow_insecure` must be explicitly acknowledged via flag or environment
-variable.
+`allow_insecure` must be explicitly acknowledged via the flag.
 
 Environment variables use the flag name in uppercase with underscores, e.g.:
 
@@ -732,7 +731,7 @@ Flags override environment variables, which override `config.yaml` values.
 | `--client-cert` | `LVMSYNC_CLIENT_CERT` | `client_cert` | Client TLS certificate file |
 | `--client-key` | `LVMSYNC_CLIENT_KEY` | `client_key` | Client TLS key file |
 | `--ca-cert` | `LVMSYNC_CA_CERT` | `ca_cert` | CA certificate file |
-| `--allow-insecure` | `LVMSYNC_ALLOW_INSECURE` | `allow_insecure` | Allow insecure (no TLS) |
+| `--allow-insecure` | - | `allow_insecure` | Allow insecure (no TLS) |
 
 If `--ssh-key` is empty, lvmsync contacts the SSH agent referenced by `SSH_AUTH_SOCK`. The agent connection uses `--ssh-timeout` as its deadline.
 SSH transport negotiation also derives read and write deadlines from the caller's context; when the context expires, the handshake fails quickly and deadlines are cleared afterward.
@@ -832,9 +831,9 @@ transports to attempt (for example `ssh,tcp+tls,h2,quic`). The `quic` transport 
 authentication, negotiates the `lvmsync` ALPN, and exposes both bidirectional streams and datagrams. The `h2`
 transport also requires TLS 1.3 with client certificates and negotiates the `h2` ALPN. Provide certificates via
 `--server-cert`, `--server-key`, `--client-cert`, `--client-key`, and `--ca-cert`. TLS transports require a trusted CA certificate and refuse
-connections when no roots are provided unless insecure mode is explicitly acknowledged with the `--allow-insecure`
-flag or the `LVMSYNC_ALLOW_INSECURE` environment variable. This bypasses certificate verification and is intended
-for development only; configuration files alone cannot enable it. Client certificates must be supplied explicitly;
+connections when no roots are provided unless insecure mode is explicitly acknowledged with the `--allow-insecure` flag.
+This bypasses certificate verification and is intended for development only; configuration files alone cannot enable it.
+Client certificates must be supplied explicitly;
 transports no longer generate self-signed certificates automatically. The [transport documentation](docs/transports.md) covers each option in depth. The flags below
 configure transport behavior.
 

--- a/docs/config_env.md
+++ b/docs/config_env.md
@@ -2,7 +2,7 @@
 
 | ENV | Flag | YAML | Description |
 | --- | ---- | ---- | ----------- |
-| LVMSYNC_ALLOW_INSECURE | `--allow-insecure` | `allow-insecure` | allow insecure connections (disable TLS and host key verification) |
+| - | `--allow-insecure` | `allow-insecure` | allow insecure connections (disable TLS and host key verification) |
 | LVMSYNC_ALLOW_OVERWRITE | `--allow-overwrite` | `allow-overwrite` | Allow overwriting existing data; requires --yes-i-know for non-interactive sessions |
 | LVMSYNC_BLOCK_SIZE | `--block-size` | `block-size` | Block size for data transfer; specify 'auto' or 0 for automatic detection |
 | LVMSYNC_BLOOM_ENTRIES | `--bloom-entries` | `bloom-entries` | Bloom filter entries |

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -56,9 +56,8 @@ explicitly restrict `tls.Config.CipherSuites` to
 these ciphers. TLS transports require an explicit set of trusted CA roots.
 Connections are rejected if no roots are provided unless the transport
 configuration sets `AllowInsecure` and the user explicitly acknowledges the risk
-with the `--allow-insecure` flag or `LVMSYNC_ALLOW_INSECURE` environment
-variable. This disables certificate verification, logs a warning, and should be
-used only in development.
+with the `--allow-insecure` flag. This disables certificate verification, logs a
+warning, and should be used only in development.
 
 ## Examples
 

--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -111,17 +111,16 @@ func (b *ConfigBuilder) Build(fs *pflag.FlagSet, args []string) (*Config, []stri
 		}
 	}
 	if cfg.AllowInsecure {
-		_, envSet := os.LookupEnv("LVMSYNC_ALLOW_INSECURE")
 		flagSet := false
 		if f := fs.Lookup("allow-insecure"); f != nil && f.Changed {
 			flagSet = true
 		}
-		if !envSet && !flagSet {
-			return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow-insecure flag or LVMSYNC_ALLOW_INSECURE environment variable")
+		if !flagSet {
+			return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow-insecure flag")
 		}
 		warns = append(warns, "allow_insecure enabled; security checks disabled")
 	} else if allowInsecureYAML {
-		return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow-insecure flag or LVMSYNC_ALLOW_INSECURE environment variable")
+		return nil, nil, warns, fmt.Errorf("allow_insecure requires --allow-insecure flag")
 	}
 	sort.Strings(warns)
 	if strict && len(warns) > 0 {

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -20,6 +20,9 @@ func EnvDoc(fs *FlagSets) string {
 	for _, set := range fs.All() {
 		set.VisitAll(func(f *pflag.Flag) {
 			env := "LVMSYNC_" + strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+			if f.Name == "allow-insecure" {
+				env = "-"
+			}
 			rows = append(rows, row{env, "--" + f.Name, f.Name, f.Usage})
 		})
 	}

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -564,7 +564,7 @@ func TestCompressThresholdEnvOverridesYAML(t *testing.T) {
 		t.Fatalf("CompressThreshold=%v want %v", cfg.CompressThreshold, 0.6)
 	}
 }
-func TestAllowInsecureFlagOverridesEnvAndYAML(t *testing.T) {
+func TestAllowInsecureFlagOverridesYAML(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()
 	if err != nil {
@@ -576,32 +576,8 @@ func TestAllowInsecureFlagOverridesEnvAndYAML(t *testing.T) {
 	if err := os.WriteFile(cfgFile, []byte("allow_insecure: false\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	t.Setenv("LVMSYNC_ALLOW_INSECURE", "true")
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--allow-insecure=false"})
-	if err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	if cfg.AllowInsecure {
-		t.Fatalf("AllowInsecure=%v want %v", cfg.AllowInsecure, false)
-	}
-}
-
-func TestAllowInsecureEnvOverridesYAML(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	defaults, err := DefaultConfig()
-	if err != nil {
-		t.Fatalf("default: %v", err)
-	}
-	b := NewBuilder(defaults)
-	dir := t.TempDir()
-	cfgFile := filepath.Join(dir, "cfg.yaml")
-	if err := os.WriteFile(cfgFile, []byte("allow_insecure: false\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	t.Setenv("LVMSYNC_ALLOW_INSECURE", "true")
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile, "--allow-insecure"})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -27,7 +27,7 @@ func TestUnknownKeysProduceError(t *testing.T) {
 	}
 }
 
-func TestAllowInsecureRequiresFlagOrEnv(t *testing.T) {
+func TestAllowInsecureRequiresFlag(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	defaults, err := DefaultConfig()
 	if err != nil {

--- a/transport/testutil/fallback_integration_test.go
+++ b/transport/testutil/fallback_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+	_ "lvmsync_go/transport/h2"
+	_ "lvmsync_go/transport/quic"
+	_ "lvmsync_go/transport/ssh"
+	_ "lvmsync_go/transport/tcp_tls"
+)
+
+func TestNegotiationClearsDeadline(t *testing.T) {
+	names := []string{"ssh", "tcp+tls", "h2", "quic"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			tr := NewTransport(t, name)
+			hs := common.Handshake{ALPN: "lvmsync", TLSVersion: "1.3", BlockSize: 4096}
+			if name == "h2" {
+				hs.ALPN = "h2"
+			}
+			ctx := context.Background()
+			ln, err := tr.Listen(ctx, "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			defer ln.Close()
+			addr := ln.Addr().String()
+			srvCh := make(chan error)
+			go func() {
+				conn, err := ln.Accept()
+				if err != nil {
+					srvCh <- err
+					return
+				}
+				defer conn.Close()
+				sctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+				defer cancel()
+				if _, err := tr.Negotiate(sctx, conn, transport.Server, hs); err != nil {
+					srvCh <- err
+					return
+				}
+				buf := make([]byte, 1)
+				_, err = io.ReadFull(conn, buf)
+				srvCh <- err
+			}()
+			cctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+			defer cancel()
+			conn, err := tr.Dial(cctx, addr)
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			if _, err := tr.Negotiate(cctx, conn, transport.Client, hs); err != nil {
+				t.Fatalf("negotiate: %v", err)
+			}
+			time.Sleep(100 * time.Millisecond)
+			if _, err := conn.Write([]byte{1}); err != nil {
+				t.Fatalf("write after deadline: %v", err)
+			}
+			if err := conn.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+			if err := <-srvCh; err != nil {
+				t.Fatalf("server: %v", err)
+			}
+		})
+	}
+}
+
+func TestDialWithFallbackOrderIntegration(t *testing.T) {
+	cert, pool := GenerateSelfSignedCert(t)
+	core, obs := observer.New(zap.InfoLevel)
+	cfg := transport.Config{
+		Logger:        zap.New(core),
+		ClientCert:    cert,
+		ServerCert:    cert,
+		Roots:         pool,
+		SSHUser:       "user",
+		SSHPassword:   "pass",
+		AllowInsecure: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	names := []string{"quic", "h2", "tcp+tls", "ssh"}
+	if _, _, err := transport.DialWithFallback(ctx, "127.0.0.1:9", names, cfg); err == nil {
+		t.Fatalf("expected error")
+	}
+	var seq []string
+	for _, entry := range obs.All() {
+		if entry.Message == "dial_attempt" {
+			if n, ok := entry.ContextMap()["transport"].(string); ok {
+				seq = append(seq, n)
+			}
+		}
+	}
+	if !reflect.DeepEqual(seq, names) {
+		t.Fatalf("attempt sequence %v, want %v", seq, names)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test ensuring multiple transports clear deadlines and respect fallback order
- require --allow-insecure flag to activate insecure modes
- document that insecure mode is flag-only

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: numerous pre-existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c14c7b98832393d026e9696b2a78