### PR TITLE
test: cover freeze/thaw command precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,31 @@ specifies `LVMSYNC_DEDUP_STRATEGY=checksum`, running
 `lvmsync --dedup-strategy auto` resolves to `auto`. Likewise,
 `--transport quic` overrides `LVMSYNC_TRANSPORT_TRANSPORT=ssh` and the
 `transport` key in `config.yaml`.
+
+`--sanitize-env` and filesystem freeze/thaw commands follow the same precedence. With a `config.yaml` containing:
+
+```yaml
+fs-freeze-command: "/usr/sbin/fsfreeze -f '/mnt/yaml dir'"
+fs-thaw-command: "/usr/sbin/fsfreeze -u '/mnt/yaml dir'"
+sanitize_env: false
+```
+
+```sh
+export LVMSYNC_FS_FREEZE_COMMAND="/usr/sbin/fsfreeze -f '/mnt/env dir'"
+export LVMSYNC_FS_THAW_COMMAND="/usr/sbin/fsfreeze -u '/mnt/env dir'"
+export LVMSYNC_SANITIZE_ENV=0
+```
+
+Running:
+
+```sh
+lvmsync --fs-freeze-command "/usr/sbin/fsfreeze -f '/mnt/flag dir'" \
+        --fs-thaw-command "/usr/sbin/fsfreeze -u '/mnt/flag dir'" \
+        --sanitize-env run /dev/sdb /tmp/dump
+```
+
+uses the flag-supplied command paths and enables sanitization.
+
 For boolean options, the same precedence applies. If `config.yaml`
 specifies `check_partition: true` but `LVMSYNC_CHECK_PARTITION=false` is
 set, `lvmsync --check-partition` enables the check. Omitting the flag

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -793,3 +793,60 @@ func TestTransportEnvOverridesYAML(t *testing.T) {
 		t.Fatalf("Transport=%q want %q", cfg.Transport, "ssh")
 	}
 }
+
+func TestFSFreezeCommandFlagOverridesEnvAndYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	yaml := "fs-freeze-command: \"/bin/echo yaml freeze\"\nfs-thaw-command: \"/bin/echo yaml thaw\"\n"
+	if err := os.WriteFile(cfgFile, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_FS_FREEZE_COMMAND", "/bin/echo 'env freeze'")
+	t.Setenv("LVMSYNC_FS_THAW_COMMAND", "/bin/echo 'env thaw'")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	args := []string{"--config", cfgFile, "--fs-freeze-command", "/bin/echo 'flag freeze'", "--fs-thaw-command", "/bin/echo 'flag thaw'"}
+	cfg, _, _, err := b.Build(fs, args)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.FSFreezeCommand != "/bin/echo 'flag freeze'" {
+		t.Fatalf("FSFreezeCommand=%q want %q", cfg.FSFreezeCommand, "/bin/echo 'flag freeze'")
+	}
+	if cfg.FSThawCommand != "/bin/echo 'flag thaw'" {
+		t.Fatalf("FSThawCommand=%q want %q", cfg.FSThawCommand, "/bin/echo 'flag thaw'")
+	}
+}
+
+func TestFSFreezeCommandEnvOverridesYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defaults, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	b := NewBuilder(defaults)
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "cfg.yaml")
+	yaml := "fs-freeze-command: \"/bin/echo yaml freeze\"\nfs-thaw-command: \"/bin/echo yaml thaw\"\n"
+	if err := os.WriteFile(cfgFile, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("LVMSYNC_FS_FREEZE_COMMAND", "/bin/echo 'env freeze'")
+	t.Setenv("LVMSYNC_FS_THAW_COMMAND", "/bin/echo 'env thaw'")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg, _, _, err := b.Build(fs, []string{"--config", cfgFile})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if cfg.FSFreezeCommand != "/bin/echo 'env freeze'" {
+		t.Fatalf("FSFreezeCommand=%q want %q", cfg.FSFreezeCommand, "/bin/echo 'env freeze'")
+	}
+	if cfg.FSThawCommand != "/bin/echo 'env thaw'" {
+		t.Fatalf("FSThawCommand=%q want %q", cfg.FSThawCommand, "/bin/echo 'env thaw'")
+	}
+}


### PR DESCRIPTION
## Summary
- add precedence tests for fs freeze/thaw commands
- document sanitize-env and fs freeze/thaw command precedence in README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameters, missing comments, 1268 issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a8c15168a88323808f8ce028c4fb49