### PR TITLE
Return precondition error for invalid freeze/thaw helpers

### DIFF
--- a/device/raw.go
+++ b/device/raw.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/internal/privilege"
 	"lvmsync_go/remote"
 )
@@ -56,13 +57,13 @@ func prepareFreeze(
 		return false, nil
 	}
 	if fsFreezeCmdPath == "" || fsThawCmdPath == "" {
-		return false, fmt.Errorf("raw sources require --offline or --fs-freeze-command/--fs-thaw-command")
+		return false, fmt.Errorf("raw sources require --offline or --fs-freeze-command/--fs-thaw-command: %w", fmt.Errorf("precondition: %w", exitcode.ErrPrecondition))
 	}
 	if err := ValidateCmd(fsFreezeCmdPath, fsFreezeCmdArgs); err != nil {
-		return false, fmt.Errorf("invalid freeze command: %w", err)
+		return false, fmt.Errorf("invalid freeze command: %w", fmt.Errorf("precondition: %w", exitcode.ErrPrecondition))
 	}
 	if err := ValidateCmd(fsThawCmdPath, fsThawCmdArgs); err != nil {
-		return false, fmt.Errorf("invalid thaw command: %w", err)
+		return false, fmt.Errorf("invalid thaw command: %w", fmt.Errorf("precondition: %w", exitcode.ErrPrecondition))
 	}
 	logger.Info("fs_freeze_start", zap.String("command", fsFreezeCmdPath), zap.Strings("args", fsFreezeCmdArgs))
 	freezeCtx := ctx
@@ -271,7 +272,7 @@ func (d *RawDevice) Cleanup(ctx context.Context) error {
 	if d.freezeIssued {
 		if err := ValidateCmd(d.thawCmdPath, d.thawCmdArgs); err != nil {
 			d.logger.Error("fs_thaw_failed", zap.Error(err))
-			return fmt.Errorf("invalid thaw command: %w", err)
+			return fmt.Errorf("invalid thaw command: %w", fmt.Errorf("precondition: %w", exitcode.ErrPrecondition))
 		}
 		d.logger.Info("fs_thaw_start", zap.String("command", d.thawCmdPath), zap.Strings("args", d.thawCmdArgs))
 		thawCtx := ctx

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -14,6 +14,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/internal/exitcode"
 )
 
 type ttyReader struct{ io.Reader }
@@ -118,8 +120,8 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
-		t.Fatalf("expected offline or freeze command error")
+	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
 	}
 }
 

--- a/device/raw_validate_cmd_test.go
+++ b/device/raw_validate_cmd_test.go
@@ -1,9 +1,16 @@
 package device
 
 import (
+	"context"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/exitcode"
 )
 
 func TestValidateCmd(t *testing.T) {
@@ -70,5 +77,28 @@ func TestValidateCmd(t *testing.T) {
 				t.Fatalf("got %q, want %q", err.Error(), tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestPrepareFreezeInvalidCommands(t *testing.T) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("missing true binary: %v", err)
+	}
+	ctx := WithForce(context.Background(), true)
+	ctx = WithAllowOverwrite(ctx, true)
+	ctx = WithYesIKnow(ctx, true)
+	if _, err := prepareFreeze(ctx, false, "/does-not-exist", nil, truePath, nil, time.Second, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error for freeze command, got %v", err)
+	}
+	if _, err := prepareFreeze(ctx, false, truePath, nil, "/does-not-exist", nil, time.Second, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error for thaw command, got %v", err)
+	}
+}
+
+func TestCleanupInvalidThawCommand(t *testing.T) {
+	d := &RawDevice{freezeIssued: true, logger: zap.NewNop(), thawCmdPath: "/does-not-exist", runner: NewRunner()}
+	if err := d.Cleanup(context.Background()); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
 	}
 }

--- a/integration/freeze_helper_validation_test.go
+++ b/integration/freeze_helper_validation_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestFreezeHelperValidation(t *testing.T) {
+	requireRootAndCommands(t)
+
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "lvmsync")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = ".."
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build lvmsync: %v\n%s", err, out)
+	}
+
+	dest := filepath.Join(tmp, "dest")
+	cmd := exec.Command(bin,
+		"--dry-run",
+		"--transport=rsync",
+		"--force",
+		"--allow-overwrite",
+		"--yes-i-know",
+		"--fs-freeze-command", "/does-not-exist",
+		"--fs-thaw-command", "/bin/true",
+		"/dev/null", dest,
+	)
+	cmd.Dir = tmp
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure with invalid freeze helper\n%s", out)
+	}
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("unexpected error type: %T\n%s", err, out)
+	}
+	if ee.ExitCode() != 80 {
+		t.Fatalf("expected exit code 80, got %d\n%s", ee.ExitCode(), out)
+	}
+}


### PR DESCRIPTION
## Summary
- wrap missing or invalid freeze/thaw helpers with exitcode.ErrPrecondition
- test freeze/thaw helper validation and exit code mapping

## Testing
- `go build ./...`
- `go test -cover ./...`
- `go test -tags=integration -v ./integration/freeze_helper_validation_test.go ./integration/prereq_test.go` *(fails: lvremove not available)*
- `golangci-lint run` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a978a81818832389309e2ce09747bb