### PR TITLE
Document dedup auto strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1498,6 +1498,17 @@ dedup_strategy: bloom
 dedup_state_file: ~/.lvmsync_state
 ```
 
+When `--dedup-strategy auto` is used, lvmsync chooses a strategy based on available RAM, volume size, and CPU capabilities.
+
+| Condition | Selected strategy |
+|-----------|------------------|
+| Bloom filter fits in RAM | `bloom` |
+| Doesn't fit, checksum acceleration available | `checksum` |
+| Doesn't fit, no acceleration | `rolling_hash` |
+
+See [docs/dedup_strategies.md](docs/dedup_strategies.md) for more details.
+
+
 LVMSync automatically reloads this state file on startup. Delete it to reset deduplication: `rm ~/.lvmsync_dedup`.
 When saving Bloom filter state, LVMSync logs `dedup_bloom_stats` with `entries`, `configured_fp_rate`, and `observed_fp_rate`.
 

--- a/dedup/config_test.go
+++ b/dedup/config_test.go
@@ -67,3 +67,25 @@ func TestLoadConfigFailures(t *testing.T) {
 		}
 	})
 }
+
+func TestAutoStrategy(t *testing.T) {
+	cases := []struct {
+		name       string
+		volumeSize uint64
+		ramBytes   uint64
+		accel      bool
+		want       string
+	}{
+		{"bloom", 1 << 30, 1 << 27, false, "bloom"},
+		{"checksum", 1 << 40, 1 << 30, true, "checksum"},
+		{"rolling", 1 << 40, 1 << 30, false, "rolling_hash"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AutoStrategy(tc.volumeSize, tc.ramBytes, tc.accel)
+			if got != tc.want {
+				t.Fatalf("AutoStrategy(%d,%d,%v)=%q want %q", tc.volumeSize, tc.ramBytes, tc.accel, got, tc.want)
+			}
+		})
+	}
+}

--- a/dedup/strategy.go
+++ b/dedup/strategy.go
@@ -1,0 +1,38 @@
+package dedup
+
+// defaultFpRate is the Bloom filter false positive rate used when evaluating
+// automatic strategy selection.
+const defaultFpRate = 0.001
+
+const minChunk = 4 * 1024
+
+// AutoStrategy selects a deduplication strategy based on volume size, RAM budget,
+// and whether the CPU has checksum acceleration. When a Bloom filter sized for
+// the volume fits within the RAM budget, it returns "bloom". Otherwise it falls
+// back to "checksum" if acceleration is available or "rolling_hash".
+func AutoStrategy(volumeSize, ramBytes uint64, hasAccel bool) string {
+	maxChunks, err := MaxChunks(ramBytes, defaultFpRate)
+	if err == nil {
+		volumeChunks := volumeSize / uint64(minChunk)
+		if volumeChunks == 0 {
+			volumeChunks = 1
+		}
+		if maxChunks >= volumeChunks {
+			return "bloom"
+		}
+	}
+	if hasAccel {
+		return "checksum"
+	}
+	return "rolling_hash"
+}
+
+// AutoStrategyTable returns the decision table used by AutoStrategy in
+// Markdown format so documentation can be kept in sync.
+func AutoStrategyTable() string {
+	return "| Condition | Selected strategy |\n" +
+		"|-----------|------------------|\n" +
+		"| Bloom filter fits in RAM | `bloom` |\n" +
+		"| Doesn't fit, checksum acceleration available | `checksum` |\n" +
+		"| Doesn't fit, no acceleration | `rolling_hash` |\n"
+}

--- a/docs/dedup_strategies.md
+++ b/docs/dedup_strategies.md
@@ -1,0 +1,10 @@
+# Deduplication Strategies
+
+When `--dedup-strategy auto` is selected, lvmsync chooses a strategy based on
+available resources and CPU capabilities.
+
+| Condition | Selected strategy |
+|-----------|------------------|
+| Bloom filter fits in RAM | `bloom` |
+| Doesn't fit, checksum acceleration available | `checksum` |
+| Doesn't fit, no acceleration | `rolling_hash` |

--- a/readme_examples_test.go
+++ b/readme_examples_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/tools/imports"
 	lvmsynccmd "lvmsync_go/cmd/lvmsync"
+	"lvmsync_go/dedup"
 	"lvmsync_go/internal/config"
 )
 
@@ -239,5 +240,16 @@ func TestFlagDocumentation(t *testing.T) {
 	}
 	if len(missing) > 0 {
 		t.Fatalf("flags missing from README: %v", missing)
+	}
+}
+
+func TestDedupStrategyDocs(t *testing.T) {
+	want := dedup.AutoStrategyTable()
+	data, err := os.ReadFile("docs/dedup_strategies.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("dedup strategy table out of sync")
 	}
 }


### PR DESCRIPTION
## Summary
- document how `--dedup-strategy auto` resolves to bloom, checksum, or rolling_hash
- add auto strategy helper and tests
- keep docs synchronized with a golden test

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestStreamToRemoteRsyncDelta)*
- `golangci-lint run` *(fails: many issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a9c9cb70808323b4225c6a8f6d5ed3