### PR TITLE
Document Bloom collision handling and reset index on reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,11 @@ The Bloom filter de-duplicates previously seen chunks. Size it with `--bloom-ent
 The defaults (`--bloom-entries=1000000`, `--bloom-fp-rate=0.01`) consume about
 1.14 MiB and yield ~1% false positives, while `--bloom-mbits=27` allocates
 roughly 16 MiB for ~0.8% false positives.
+False positives are rare but possible; if a chunk collides in the Bloom filter
+it is treated as already transferred. A final SHA-256 digest over the transfer
+detects any mismatches so retries can resend the affected data. The mmap-backed
+index (`*.idx`) is truncated to zero on startup so each run begins with a clean
+bitset.
 
 Compression samples 8 KiB from each chunk and skips when the estimated ratio exceeds `--compress-threshold`. `--compress auto` selects LZ4 for chunks under 256 KiB and Zstd for larger chunks when AVX2 or NEON is available, falling back to LZ4 otherwise.
 

--- a/dedup/unit_test.go
+++ b/dedup/unit_test.go
@@ -1,12 +1,17 @@
-package dedup
+package dedup_test
 
 import (
 	"bytes"
 	"encoding/hex"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"lvmsync_go/dedup"
 	"lvmsync_go/hash"
+	"lvmsync_go/internal/config"
+	transfer "lvmsync_go/transfer"
 )
 
 func TestHasher(t *testing.T) {
@@ -39,7 +44,7 @@ func TestHasher(t *testing.T) {
 }
 
 func TestBloom(t *testing.T) {
-	b, err := NewBloom(1000, 0.01)
+	b, err := dedup.NewBloom(1000, 0.01)
 	if err != nil {
 		t.Fatalf("new bloom: %v", err)
 	}
@@ -55,7 +60,7 @@ func TestBloom(t *testing.T) {
 func TestBloomInvalidFpRate(t *testing.T) {
 	cases := []float64{0, 1, -0.5, 1.5}
 	for _, fp := range cases {
-		if _, err := NewBloom(1000, fp); err == nil {
+		if _, err := dedup.NewBloom(1000, fp); err == nil {
 			t.Fatalf("expected error for fpRate %v", fp)
 		}
 	}
@@ -63,7 +68,7 @@ func TestBloomInvalidFpRate(t *testing.T) {
 
 func TestChunkerBounds(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), 1<<20)
-	ch, err := NewChunker(64, 128, 256)
+	ch, err := dedup.NewChunker(64, 128, 256)
 	if err != nil {
 		t.Fatalf("new chunker: %v", err)
 	}
@@ -84,7 +89,7 @@ func TestChunkerBounds(t *testing.T) {
 
 func TestFastCDC(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), 1<<16)
-	chunks, err := FastCDC(bytes.NewReader(data), 64, 128, 256)
+	chunks, err := dedup.FastCDC(bytes.NewReader(data), 64, 128, 256)
 	if err != nil {
 		t.Fatalf("FastCDC failed: %v", err)
 	}
@@ -99,31 +104,31 @@ func TestFastCDC(t *testing.T) {
 }
 
 func TestBloomSizing(t *testing.T) {
-	max, err := MaxChunks(1<<30, 0.01)
+	max, err := dedup.MaxChunks(1<<30, 0.01)
 	if err != nil {
 		t.Fatalf("MaxChunks: %v", err)
 	}
 	if max == 0 {
 		t.Fatalf("expected non-zero max chunks")
 	}
-	avg, chunks, err := AdaptiveAvgChunk(1<<40, 1<<30, 0.01, 64, 1<<20)
+	avg, chunks, err := dedup.AdaptiveAvgChunk(1<<40, 1<<30, 0.01, 64, 1<<20)
 	if err != nil {
 		t.Fatalf("AdaptiveAvgChunk: %v", err)
 	}
 	if avg < 64 || chunks == 0 {
 		t.Fatalf("unexpected sizing avg=%d chunks=%d", avg, chunks)
 	}
-	if _, err := MaxChunks(1<<30, 0); err == nil {
+	if _, err := dedup.MaxChunks(1<<30, 0); err == nil {
 		t.Fatalf("expected error for invalid fpRate in MaxChunks")
 	}
-	if _, _, err := AdaptiveAvgChunk(1<<40, 1<<30, 0, 64, 1<<20); err == nil {
+	if _, _, err := dedup.AdaptiveAvgChunk(1<<40, 1<<30, 0, 64, 1<<20); err == nil {
 		t.Fatalf("expected error for invalid fpRate in AdaptiveAvgChunk")
 	}
 }
 
 func TestChunkerBufferReuse(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), 1<<10)
-	ch, err := NewChunker(64, 128, 256)
+	ch, err := dedup.NewChunker(64, 128, 256)
 	if err != nil {
 		t.Fatalf("new chunker: %v", err)
 	}
@@ -150,5 +155,52 @@ func TestChunkerBufferReuse(t *testing.T) {
 	}
 	if !bytes.Equal(c2.Data, data[c1.Length:c1.Length+c2.Length]) {
 		t.Fatalf("unexpected chunk data")
+	}
+}
+
+func TestBloomStateReuseDiscardsIndex(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		BloomEntries:   1000,
+		BloomFpRate:    0.01,
+		BloomMBits:     10,
+		DedupStateFile: filepath.Join(tmp, "state"),
+		CDCMin:         64,
+		CDCAvg:         128,
+		CDCMax:         256,
+	}
+
+	data := bytes.Repeat([]byte("a"), 1<<10)
+
+	// First run populates the Bloom filter and index.
+	cd1, err := transfer.NewCDCDedup(cfg)
+	if err != nil {
+		t.Fatalf("new cdcdedup: %v", err)
+	}
+	if _, _, err := cd1.ChunkAndHash(data); err != nil {
+		t.Fatalf("chunk and hash: %v", err)
+	}
+	if err := cd1.SaveState(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	idxPath := cfg.DedupStateFile + ".idx"
+	content, err := os.ReadFile(idxPath)
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if bytes.Count(content, []byte{0}) == len(content) {
+		t.Fatalf("expected index to contain data")
+	}
+
+	// Second run reuses Bloom state but should discard the previous index.
+	if _, err := transfer.NewCDCDedup(cfg); err != nil {
+		t.Fatalf("new cdcdedup reuse: %v", err)
+	}
+	content2, err := os.ReadFile(idxPath)
+	if err != nil {
+		t.Fatalf("read index after reuse: %v", err)
+	}
+	if bytes.Count(content2, []byte{0}) != len(content2) {
+		t.Fatalf("stale index not discarded")
 	}
 }

--- a/docs/dedup_benchmarks.md
+++ b/docs/dedup_benchmarks.md
@@ -42,3 +42,11 @@ To reduce false positives, lower the configured rate at the cost of additional
 memory. `MaxChunks` estimates the number of unique chunks supported for a given
 false positive rate and available RAM.
 
+## Collisions and Index Cleanup
+
+During transfers a Bloom filter hit means a chunk is assumed to have been seen
+before. Rare false positives can therefore skip a changed block, but a final
+SHA-256 digest over all chunks exposes any mismatch and the transfer can be
+retried. When a Bloom filter uses the optional mmap-backed bitset, the `*.idx`
+file is truncated on startup so stale bits from earlier runs are removed.
+

--- a/transfer/dedup_cdc.go
+++ b/transfer/dedup_cdc.go
@@ -55,7 +55,10 @@ func NewCDCDedupWithDeps(cfg *config.Config, deps *Deps) (*CDCDedup, error) {
 	}
 	if cfg.BloomMBits > 0 {
 		size := 1 << (cfg.BloomMBits - 3)
-		f, err := os.OpenFile(cfg.DedupStateFile+".idx", os.O_RDWR|os.O_CREATE, 0o600)
+		// Truncate the index file on each run to discard stale bits from previous
+		// transfers. The mmap is recreated against a zero-filled file to avoid
+		// false hits when reusing Bloom state.
+		f, err := os.OpenFile(cfg.DedupStateFile+".idx", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 		if err == nil {
 			if err := f.Truncate(int64(size)); err == nil {
 				data, err := unix.Mmap(int(f.Fd()), 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)


### PR DESCRIPTION
## Summary
- document Bloom filter collision handling and index cleanup
- truncate mmap Bloom index on startup to drop stale bits
- test Bloom state reuse discards existing index

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: revive unused params, many lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cdbbedd883238d42f624d86e07e5