### PR TITLE
Add compression algorithm selection tests and docs

### DIFF
--- a/docs/compression.md
+++ b/docs/compression.md
@@ -20,6 +20,14 @@ LVMSync compresses data on a per‑chunk basis. Each chunk passes through a clas
 
 Compression levels are tuned with `--zstd-level 1..5` or `--lz4-level {fast|hc}`.
 
+### Selection Matrix
+
+| Chunk size      | CPU features      | Algorithm | Level mapping                           |
+|-----------------|-------------------|-----------|-----------------------------------------|
+| `<256` KiB      | Any               | LZ4       | level1 when `--lz4-level` is `0`        |
+| `≥256` KiB      | AVX2 or NEON      | Zstd      | default `1`; values `>3` cap to `3`     |
+| `≥256` KiB      | Neither detected  | LZ4       | level1 when `--lz4-level` is `0`        |
+
 ## Dictionary Training
 
 Early chunks seed a dictionary which is reused for subsequent blocks. The dictionary is trained from sampled data so small or repetitive chunks compress efficiently. Both LZ4 and Zstd dictionaries are supported.

--- a/internal/compressiondetect/compressiondetect_test.go
+++ b/internal/compressiondetect/compressiondetect_test.go
@@ -1,6 +1,12 @@
 package compressiondetect
 
-import "testing"
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/klauspost/cpuid/v2"
+)
 
 func TestBenchmarkCompression(t *testing.T) {
 	algo := BenchmarkCompression()
@@ -69,5 +75,34 @@ func TestDetectOptimalCompressionBenchmarkFallback(t *testing.T) {
 	got := DetectOptimalCompression()
 	if got != "lz4" && got != "zstd" {
 		t.Fatalf("unexpected %s", got)
+	}
+}
+
+func TestDetectOptimalCompressionBenchmarkCache(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+	origAVX2, origNEON := hasAVX2, hasNEON
+	defer func() { hasAVX2, hasNEON = origAVX2, origNEON }()
+	hasAVX2 = func() bool { return false }
+	hasNEON = func() bool { return false }
+
+	cores := cpuid.CPU.PhysicalCores
+	if cores == 0 {
+		cores = runtime.NumCPU()
+	}
+	cacheSize := 0
+	if cpuid.CPU.Cache.L3 > 0 {
+		cacheSize += cpuid.CPU.Cache.L3
+	}
+	if cpuid.CPU.Cache.L2 > 0 {
+		cacheSize += cpuid.CPU.Cache.L2
+	}
+	key := fmt.Sprintf("%d-%d", cores, cacheSize)
+	benchMu.Lock()
+	benchCache[key] = "lz4"
+	benchMu.Unlock()
+
+	if got := DetectOptimalCompression(); got != "lz4" {
+		t.Fatalf("expected lz4 from cache, got %s", got)
 	}
 }

--- a/transfer/compression_selection_test.go
+++ b/transfer/compression_selection_test.go
@@ -129,6 +129,31 @@ func TestSelectAlgorithmExplicitOverride(t *testing.T) {
 	}
 }
 
+func TestCompressChunkSelectsAlgorithmBySize(t *testing.T) {
+	origAVX2, origNEON := hasAVX2, hasNEON
+	defer func() { hasAVX2, hasNEON = origAVX2, origNEON }()
+	hasAVX2 = func() bool { return true }
+	hasNEON = func() bool { return false }
+
+	small := bytes.Repeat([]byte{0}, 128*1024)
+	_, algo, err := CompressChunk(small, StrategyAuto, 0, 0, 1, 0.8, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if algo != compressionLZ4 {
+		t.Fatalf("expected lz4 for <256KiB, got %s", algo)
+	}
+
+	large := bytes.Repeat([]byte{0}, 512*1024)
+	_, algo, err = CompressChunk(large, StrategyAuto, 0, 0, 1, 0.8, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if algo != compressionZSTD {
+		t.Fatalf("expected zstd for >=256KiB with SIMD, got %s", algo)
+	}
+}
+
 func TestCompressionSkipsWhenRatioAtThreshold(t *testing.T) {
 	origAVX2, origNEON := hasAVX2, hasNEON
 	hasAVX2 = func() bool { return false }


### PR DESCRIPTION
## Summary
- test transfer compression selection for <256KiB and >=256KiB chunks
- mock CPU feature detection to verify benchmark cache fallback
- document compression selection matrix and level mapping

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unused parameters, package comments, and staticcheck issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68a9da63aed083238cf89e9c2d66e27b