### PR TITLE
test: expect context deadline on net timeout

### DIFF
--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -124,8 +124,8 @@ func TestRecvAckNetTimeoutBeforeDeadline(t *testing.T) {
 	if _, err := c.RecvAck(ctx); err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		t.Fatalf("context finished unexpectedly: %v", ctxErr)
+	if ctxErr := ctx.Err(); !errors.Is(ctxErr, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", ctxErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- update TestRecvAckNetTimeoutBeforeDeadline to expect context deadline

## Testing
- `go test ./remote` *(fails: priv_helper_test.go:128: expected context deadline exceeded, got <nil>)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e094bca4832393f155c86a1e3f14