### PR TITLE
test: cover quic handshake failures

### DIFF
--- a/transport/quic/handshake_flow_test.go
+++ b/transport/quic/handshake_flow_test.go
@@ -1,0 +1,53 @@
+package quic
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+)
+
+// TestClientHandshakeFailureWhenServerCloses verifies that the client-side
+// handshake fails if the server reads the handshake and closes without
+// responding.
+func TestClientHandshakeFailureWhenServerCloses(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	cli, srv := net.Pipe()
+	defer cli.Close()
+
+	hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
+
+	done := make(chan struct{})
+	go func() {
+		buf := bufio.NewReader(srv)
+		common.ReadHandshake(buf) // ignore result; simulate server read
+		srv.Close()               // close without sending handshake
+		close(done)
+	}()
+
+	if _, err := tr.Negotiate(context.Background(), cli, transport.Client, hs); err == nil {
+		t.Fatalf("expected client negotiate error")
+	}
+	<-done
+}
+
+// TestServerHandshakeFailureWhenClientCloses verifies that the server-side
+// handshake fails if the client disconnects before sending a handshake.
+func TestServerHandshakeFailureWhenClientCloses(t *testing.T) {
+	tr := &Transport{logger: zap.NewNop()}
+	srv, cli := net.Pipe()
+	defer srv.Close()
+
+	hs := common.Handshake{CDCMin: 64, CDCAvg: 128, CDCMax: 256, CRC32C: true}
+
+	cli.Close() // client disconnects without sending handshake
+
+	if _, err := tr.Negotiate(context.Background(), srv, transport.Server, hs); err == nil {
+		t.Fatalf("expected server negotiate error")
+	}
+}


### PR DESCRIPTION
## Summary
- test client fails when server closes after reading handshake
- test server fails when client closes before sending handshake

## Testing
- `go test ./transport/quic`


------
https://chatgpt.com/codex/tasks/task_e_68a9e39cc8808323944b69b86444ce25