### PR TITLE
refactor: extract shared WAL package

### DIFF
--- a/device/identity.go
+++ b/device/identity.go
@@ -1,5 +1,7 @@
 package device
 
+import wal "lvmsync_go/internal/wal"
+
 // DeviceIdentity describes metadata uniquely identifying a block device.
 // The identity tuple is (size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch).
 type DeviceIdentity struct {
@@ -41,7 +43,4 @@ func SameIdentityStrict(a, b DeviceIdentity) bool {
 }
 
 // Range represents a byte range on a device.
-type Range struct {
-	Start uint64
-	End   uint64
-}
+type Range = wal.Range

--- a/device/wal.go
+++ b/device/wal.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
+	walpkg "lvmsync_go/internal/wal"
 )
 
 const (
@@ -77,38 +77,19 @@ type walHeaderV0 struct {
 	MAC    [32]byte
 }
 
-type walFile interface {
-	io.ReaderAt
-	io.Writer
-	io.WriterAt
-	io.Seeker
-	Sync() error
-	Truncate(int64) error
-	Close() error
-	Stat() (fs.FileInfo, error)
-	Name() string
-}
-
 // ErrWALMetadataMismatch indicates the WAL header identity does not match the
 // provided device identity.
 var ErrWALMetadataMismatch = errors.New("wal metadata mismatch")
 
 type WAL struct {
-	f      walFile
+	*walpkg.WAL
 	header walHeader
 	ranges []Range
-	deps   *WALDeps
 }
 
-// WALDeps bundles filesystem interactions for WAL operations.
-type WALDeps struct {
-	syncDir func(string) error
-}
+type WALDeps = walpkg.Deps
 
-// NewWALDeps returns production dependencies.
-func NewWALDeps() *WALDeps {
-	return &WALDeps{syncDir: syncDir}
-}
+func NewWALDeps() *WALDeps { return walpkg.NewDeps() }
 
 func walHeaderMAC(h *walHeader) [32]byte {
 	var buf [8 + 8 + 8 + 4 + 4 + 64 + 64 + 4 + 64]byte
@@ -184,7 +165,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		f.Close()
 		return nil, err
 	}
-	w := &WAL{f: f, deps: deps}
+	w := &WAL{WAL: walpkg.New(f, deps)}
 	if st.Size() < walHeaderV0Size {
 		if st.Size() > 0 {
 			if err := f.Truncate(0); err != nil {
@@ -231,7 +212,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 			f.Close()
 			return nil, err
 		}
-		if err := deps.syncDir(filepath.Dir(path)); err != nil {
+		if err := deps.SyncDir(filepath.Dir(path)); err != nil {
 			f.Close()
 			return nil, err
 		}
@@ -702,66 +683,11 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 // written to `<path>.tmp`, fsynced, atomically renamed to the WAL path, and the
 // directory is fsynced before returning.
 func (w *WAL) Append(r Range) error {
-	name := w.f.Name()
-	tmpPath := name + ".tmp"
-	tf, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
+	if err := w.WAL.Append(r); err != nil {
 		return err
 	}
-	if _, err := w.f.Seek(0, 0); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	st, err := w.f.Stat()
-	if err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if _, err := io.Copy(tf, io.NewSectionReader(w.f, 0, st.Size())); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	var buf [16]byte
-	binary.LittleEndian.PutUint64(buf[0:8], r.Start)
-	binary.LittleEndian.PutUint64(buf[8:16], r.End)
-	if n, err := tf.Write(buf[:]); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	} else if n != len(buf) {
-		tf.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("wal: short write: wrote %d of %d bytes", n, len(buf))
-	}
-	if err := tf.Sync(); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := tf.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := w.f.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, name); err != nil {
-		return err
-	}
-	nf, err := os.OpenFile(name, os.O_RDWR, 0)
-	if err != nil {
-		return err
-	}
-	if _, err := nf.Seek(0, io.SeekEnd); err != nil {
-		nf.Close()
-		return err
-	}
-	w.f = nf
 	w.ranges = append(w.ranges, r)
-	return w.deps.syncDir(filepath.Dir(name))
+	return nil
 }
 
 // Ranges returns the ranges recorded in the WAL.
@@ -778,26 +704,5 @@ func (w *WAL) Has(start, end uint64) bool {
 }
 
 func (w *WAL) Close() error {
-	if w.f == nil {
-		return nil
-	}
-	if err := w.f.Sync(); err != nil {
-		w.f.Close()
-		return err
-	}
-	name := w.f.Name()
-	if err := w.f.Close(); err != nil {
-		return err
-	}
-	w.f = nil
-	return w.deps.syncDir(filepath.Dir(name))
-}
-
-func syncDir(path string) error {
-	d, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	return d.Sync()
+	return w.WAL.Close()
 }

--- a/device/wal_crash_test.go
+++ b/device/wal_crash_test.go
@@ -86,10 +86,10 @@ func TestWALCrashRecovery(t *testing.T) {
 		var entry [16]byte
 		binary.LittleEndian.PutUint64(entry[0:8], 64)
 		binary.LittleEndian.PutUint64(entry[8:16], 128)
-		if _, err := w.f.Write(entry[:]); err != nil {
+		if _, err := w.File().Write(entry[:]); err != nil {
 			t.Fatalf("write entry: %v", err)
 		}
-		if err := w.f.Close(); err != nil {
+		if err := w.File().Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
 		if err := os.Truncate(path, walHeaderSize+16); err != nil {
@@ -119,10 +119,10 @@ func TestWALCrashRecovery(t *testing.T) {
 		var entry [16]byte
 		binary.LittleEndian.PutUint64(entry[0:8], 64)
 		binary.LittleEndian.PutUint64(entry[8:16], 128)
-		if _, err := w.f.Write(entry[:]); err != nil {
+		if _, err := w.File().Write(entry[:]); err != nil {
 			t.Fatalf("write entry: %v", err)
 		}
-		if err := w.f.Close(); err != nil {
+		if err := w.File().Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
 		if err := os.Truncate(path, walHeaderSize+16+8); err != nil {

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"strings"
+	walpkg "lvmsync_go/internal/wal"
 )
 
 func TestWALIdentityMismatch(t *testing.T) {
@@ -215,10 +216,10 @@ func TestWALSyncDirCreate(t *testing.T) {
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
 	stubErr := errors.New("syncdir fail")
 	var calls int
-	deps := &WALDeps{syncDir: func(string) error {
+	deps := walpkg.NewDepsWithSync(func(string) error {
 		calls++
 		return stubErr
-	}}
+	})
 	if _, err := OpenWAL(path, id, zap.NewNop(), deps); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}
@@ -231,21 +232,24 @@ func TestWALSyncDirClose(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
-	w, err := OpenWAL(path, id, zap.NewNop(), nil)
+	stubErr := errors.New("syncdir fail")
+	var calls int
+	deps := walpkg.NewDepsWithSync(func(string) error {
+		calls++
+		if calls > 1 {
+			return stubErr
+		}
+		return nil
+	})
+	w, err := OpenWAL(path, id, zap.NewNop(), deps)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
-	stubErr := errors.New("syncdir fail")
-	var calls int
-	w.deps = &WALDeps{syncDir: func(string) error {
-		calls++
-		return stubErr
-	}}
 	if err := w.Close(); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}
-	if calls != 1 {
-		t.Fatalf("expected syncDir called once, got %d", calls)
+	if calls != 2 {
+		t.Fatalf("expected syncDir called twice, got %d", calls)
 	}
 }
 
@@ -253,21 +257,24 @@ func TestWALSyncDirAppend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
 	id := DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2}
-	w, err := OpenWAL(path, id, zap.NewNop(), nil)
+	stubErr := errors.New("syncdir fail")
+	var calls int
+	deps := walpkg.NewDepsWithSync(func(string) error {
+		calls++
+		if calls > 1 {
+			return stubErr
+		}
+		return nil
+	})
+	w, err := OpenWAL(path, id, zap.NewNop(), deps)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
-	stubErr := errors.New("syncdir fail")
-	var calls int
-	w.deps = &WALDeps{syncDir: func(string) error {
-		calls++
-		return stubErr
-	}}
 	if err := w.Append(Range{Start: 0, End: 1}); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}
-	if calls != 1 {
-		t.Fatalf("expected syncDir called once, got %d", calls)
+	if calls != 2 {
+		t.Fatalf("expected syncDir called twice, got %d", calls)
 	}
 	w.Close()
 }

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -1,0 +1,160 @@
+package wal
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Range represents a byte range.
+type Range struct {
+	Start uint64
+	End   uint64
+}
+
+// File captures the subset of *os.File methods used by WAL operations.
+type File interface {
+	io.ReaderAt
+	io.Writer
+	io.WriterAt
+	io.Seeker
+	Sync() error
+	Truncate(int64) error
+	Close() error
+	Stat() (fs.FileInfo, error)
+	Name() string
+}
+
+// Deps bundles filesystem helpers for WAL operations.
+type Deps struct {
+	syncDir func(string) error
+}
+
+// NewDeps returns production dependencies.
+func NewDeps() *Deps {
+	return &Deps{syncDir: syncDir}
+}
+
+// SyncDir fsyncs the provided directory path.
+func (d *Deps) SyncDir(path string) error { return d.syncDir(path) }
+
+// NewDepsWithSync returns dependencies using the provided syncDir implementation.
+func NewDepsWithSync(fn func(string) error) *Deps { return &Deps{syncDir: fn} }
+
+// WAL manages a write-ahead log backed by a file.
+type WAL struct {
+	f    File
+	deps *Deps
+}
+
+// New returns a WAL using the provided file and dependencies. If deps is nil
+// production defaults are used.
+func New(f File, deps *Deps) *WAL {
+	if deps == nil {
+		deps = NewDeps()
+	}
+	return &WAL{f: f, deps: deps}
+}
+
+// Append records r using a temporary file and atomic rename for crash safety.
+func (w *WAL) Append(r Range) error {
+	name := w.f.Name()
+	tmpPath := name + ".tmp"
+	tf, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := w.f.Seek(0, 0); err != nil {
+		tf.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	st, err := w.f.Stat()
+	if err != nil {
+		tf.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if _, err := io.Copy(tf, io.NewSectionReader(w.f, 0, st.Size())); err != nil {
+		tf.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[0:8], r.Start)
+	binary.LittleEndian.PutUint64(buf[8:16], r.End)
+	if n, err := tf.Write(buf[:]); err != nil {
+		tf.Close()
+		os.Remove(tmpPath)
+		return err
+	} else if n != len(buf) {
+		tf.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("wal: short write: wrote %d of %d bytes", n, len(buf))
+	}
+	if err := tf.Sync(); err != nil {
+		tf.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tf.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, name); err != nil {
+		return err
+	}
+	nf, err := os.OpenFile(name, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	if _, err := nf.Seek(0, io.SeekEnd); err != nil {
+		nf.Close()
+		return err
+	}
+	w.f = nf
+	return w.deps.syncDir(filepath.Dir(name))
+}
+
+// Sync flushes the WAL to stable storage.
+func (w *WAL) Sync() error {
+	if w.f != nil {
+		return w.f.Sync()
+	}
+	return nil
+}
+
+// Close flushes the WAL and fsyncs its parent directory.
+func (w *WAL) Close() error {
+	if w.f == nil {
+		return nil
+	}
+	if err := w.f.Sync(); err != nil {
+		w.f.Close()
+		return err
+	}
+	name := w.f.Name()
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	w.f = nil
+	return w.deps.syncDir(filepath.Dir(name))
+}
+
+// File exposes the underlying file. Primarily intended for tests.
+func (w *WAL) File() File { return w.f }
+
+func syncDir(path string) error {
+	d, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -1,0 +1,38 @@
+package wal
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppendAndClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// seed with dummy header bytes
+	if _, err := f.Write(make([]byte, 16)); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := f.Seek(16, io.SeekStart); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	w := New(f, nil)
+	if err := w.Append(Range{Start: 1, End: 2}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(data) != 32 { // header + one entry
+		t.Fatalf("unexpected size %d", len(data))
+	}
+}

--- a/transfer/types.go
+++ b/transfer/types.go
@@ -1,10 +1,9 @@
 // transfer/types.go
 package transfer
 
-type Range struct {
-	Start uint64
-	End   uint64
-}
+import wal "lvmsync_go/internal/wal"
+
+type Range = wal.Range
 
 type BlockTask struct {
 	Index int

--- a/transfer/wal.go
+++ b/transfer/wal.go
@@ -4,11 +4,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 
 	"github.com/zeebo/blake3"
+	walpkg "lvmsync_go/internal/wal"
 )
 
 const (
@@ -41,33 +41,14 @@ type walHeaderV0 struct {
 // OpenWAL scans for the last complete entry and truncates any partially written
 // tail. Close fsyncs the file and its parent directory to guarantee that the
 // final state of the WAL is persistent.
-type walFile interface {
-	io.ReaderAt
-	io.Writer
-	io.WriterAt
-	io.Seeker
-	Sync() error
-	Truncate(int64) error
-	Close() error
-	Stat() (fs.FileInfo, error)
-	Name() string
-}
-
 type WAL struct {
-	f      walFile
+	*walpkg.WAL
 	header walHeader
-	deps   *WALDeps
 }
 
-// WALDeps bundles filesystem helpers for the WAL.
-type WALDeps struct {
-	syncDir func(string) error
-}
+type WALDeps = walpkg.Deps
 
-// NewWALDeps returns production dependencies.
-func NewWALDeps() *WALDeps {
-	return &WALDeps{syncDir: syncDir}
-}
+func NewWALDeps() *WALDeps { return walpkg.NewDeps() }
 
 func walHeaderMAC(h *walHeader) [32]byte {
 	var buf [8 + 8 + 8 + 64]byte
@@ -103,7 +84,7 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 		f.Close()
 		return nil, nil, err
 	}
-	w := &WAL{f: f, deps: deps}
+	w := &WAL{WAL: walpkg.New(f, deps)}
 	if st.Size() == 0 {
 		w.header.Version = walVersion
 		w.header.Size = size
@@ -131,7 +112,7 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 			f.Close()
 			return nil, nil, err
 		}
-		if err := deps.syncDir(filepath.Dir(path)); err != nil {
+		if err := deps.SyncDir(filepath.Dir(path)); err != nil {
 			f.Close()
 			return nil, nil, err
 		}
@@ -267,102 +248,11 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 	return nil, nil, fmt.Errorf("wal: file too small")
 }
 
-// Append records the range using a temporary file for crash safety. The range is
-// written to `<path>.tmp`, fsynced, atomically renamed to the WAL path, and the
-// directory is fsynced before returning.
-func (w *WAL) Append(r Range) error {
-	name := w.f.Name()
-	tmpPath := name + ".tmp"
-	tf, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return err
-	}
-	if _, err := w.f.Seek(0, 0); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	st, err := w.f.Stat()
-	if err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if _, err := io.Copy(tf, io.NewSectionReader(w.f, 0, st.Size())); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	var buf [16]byte
-	binary.LittleEndian.PutUint64(buf[0:8], r.Start)
-	binary.LittleEndian.PutUint64(buf[8:16], r.End)
-	if n, err := tf.Write(buf[:]); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	} else if n != len(buf) {
-		tf.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("wal: short write: wrote %d of %d bytes", n, len(buf))
-	}
-	if err := tf.Sync(); err != nil {
-		tf.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := tf.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := w.f.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, name); err != nil {
-		return err
-	}
-	nf, err := os.OpenFile(name, os.O_RDWR, 0)
-	if err != nil {
-		return err
-	}
-	if _, err := nf.Seek(0, io.SeekEnd); err != nil {
-		nf.Close()
-		return err
-	}
-	w.f = nf
-	return w.deps.syncDir(filepath.Dir(name))
-}
+// Append records r in the WAL.
+func (w *WAL) Append(r Range) error { return w.WAL.Append(r) }
 
 // Sync flushes the WAL to stable storage.
-func (w *WAL) Sync() error {
-	if w.f != nil {
-		return w.f.Sync()
-	}
-	return nil
-}
+func (w *WAL) Sync() error { return w.WAL.Sync() }
 
 // Close flushes the WAL and fsyncs its parent directory.
-func (w *WAL) Close() error {
-	if w.f == nil {
-		return nil
-	}
-	// Flush file contents first.
-	if err := w.f.Sync(); err != nil {
-		w.f.Close()
-		return err
-	}
-	name := w.f.Name()
-	if err := w.f.Close(); err != nil {
-		return err
-	}
-	w.f = nil
-	return w.deps.syncDir(filepath.Dir(name))
-}
-
-func syncDir(path string) error {
-	d, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	return d.Sync()
-}
+func (w *WAL) Close() error { return w.WAL.Close() }

--- a/transfer/wal_crash_test.go
+++ b/transfer/wal_crash_test.go
@@ -57,10 +57,10 @@ func TestWALCrashRecovery(t *testing.T) {
 		var entry [16]byte
 		binary.LittleEndian.PutUint64(entry[0:8], 64)
 		binary.LittleEndian.PutUint64(entry[8:16], 128)
-		if _, err := w.f.Write(entry[:]); err != nil {
+		if _, err := w.File().Write(entry[:]); err != nil {
 			t.Fatalf("write entry: %v", err)
 		}
-		if err := w.f.Close(); err != nil {
+		if err := w.File().Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
 		if err := os.Truncate(path, walHeaderSize+16); err != nil {

--- a/transfer/wal_resume_test.go
+++ b/transfer/wal_resume_test.go
@@ -25,7 +25,7 @@ func TestWALCommitFsync(t *testing.T) {
 		t.Fatalf("append: %v", err)
 	}
 	// Simulate crash by closing the underlying file without calling Close.
-	if err := w.f.Close(); err != nil {
+	if err := w.File().Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
 	w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
@@ -155,10 +155,10 @@ func TestWALDetectsUnsyncedEntry(t *testing.T) {
 	// Write a partial entry without syncing to simulate a crash before fsync.
 	var buf [8]byte
 	binary.LittleEndian.PutUint64(buf[:], 64)
-	if _, err := w.f.Write(buf[:]); err != nil {
+	if _, err := w.File().Write(buf[:]); err != nil {
 		t.Fatalf("partial write: %v", err)
 	}
-	if err := w.f.Close(); err != nil {
+	if err := w.File().Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
 	w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)

--- a/transfer/wal_test.go
+++ b/transfer/wal_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	walpkg "lvmsync_go/internal/wal"
 )
 
 func TestWALMismatch(t *testing.T) {
@@ -116,21 +118,24 @@ func TestWALPartialWrite(t *testing.T) {
 func TestWALSyncDirAppend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
+	stubErr := errors.New("syncdir fail")
+	var calls int
+	deps := walpkg.NewDepsWithSync(func(string) error {
+		calls++
+		if calls > 1 {
+			return stubErr
+		}
+		return nil
+	})
+	w, _, err := OpenWAL(path, 100, "dev", 1, deps)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
-	stubErr := errors.New("syncdir fail")
-	var calls int
-	w.deps = &WALDeps{syncDir: func(string) error {
-		calls++
-		return stubErr
-	}}
 	if err := w.Append(Range{Start: 0, End: 1}); !errors.Is(err, stubErr) {
 		t.Fatalf("expected %v got %v", stubErr, err)
 	}
-	if calls != 1 {
-		t.Fatalf("expected syncDir called once, got %d", calls)
+	if calls != 2 {
+		t.Fatalf("expected syncDir called twice, got %d", calls)
 	}
 	w.Close()
 }


### PR DESCRIPTION
## Summary
- add internal/wal package with shared WAL logic
- update device and transfer packages to reuse internal/wal
- add tests for shared WAL behaviour

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: manifest tools require mounted devices; remote timeout)*
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run` *(fails: numerous lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e613be8c8323bd93ad4b8e44a580