### PR TITLE
manifest: support v1 header upgrade

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -74,20 +74,24 @@ placeholder table previously used.
 
 ## Layout and Versioning
 
-The file begins with a 136 byte little‑endian header:
+The file begins with a 184 byte little‑endian header:
 
-| Field          | Size | Description |
-|----------------|-----:|-------------|
-| `version`      | 4    | Manifest format version (`2` today) |
-| `block_size`   | 4    | Device block size in bytes |
-| `size_bytes`   | 8    | Total device size |
-| `chunk_count`  | 8    | Number of chunks tracked |
-| `cdc_min`      | 4    | Minimum CDC chunk size |
-| `cdc_avg`      | 4    | Average CDC chunk size |
-| `cdc_max`      | 4    | Maximum CDC chunk size |
-| `hybrid_fixed` | 4    | Fixed chunk size when hybrid dedup is used (0 otherwise) |
-| `device_id`    | 64   | Persistent device identifier |
-| `mac`          | 32   | BLAKE3 digest of the preceding header fields |
+| Field               | Size | Description |
+|---------------------|-----:|-------------|
+| `version`           | 4    | Manifest format version (`2` today) |
+| `block_size`        | 4    | Device block size in bytes |
+| `size_bytes`        | 8    | Total device size |
+| `chunk_count`       | 8    | Number of chunks tracked |
+| `cdc_min`           | 4    | Minimum CDC chunk size |
+| `cdc_avg`           | 4    | Average CDC chunk size |
+| `cdc_max`           | 4    | Maximum CDC chunk size |
+| `hybrid_fixed`      | 4    | Fixed chunk size when hybrid dedup is used (0 otherwise) |
+| `epoch`             | 8    | Manifest creation time in nanoseconds |
+| `major`             | 4    | Device major number |
+| `minor`             | 4    | Device minor number |
+| `device_id`         | 64   | Persistent device identifier |
+| `first_block_digest`| 32   | BLAKE3 digest of the first 1 MiB of the device |
+| `mac`               | 32   | BLAKE3 digest of the preceding header fields |
 
 Each subsequent entry describes one chunk and also uses little‑endian encoding:
 
@@ -99,10 +103,17 @@ Each subsequent entry describes one chunk and also uses little‑endian encoding
 | `xxh3`    | 8    | Fast non‑cryptographic hash |
 | `blake3`  | 32   | BLAKE3 digest of the chunk |
 
-The `version` field records the manifest format revision. LVMSync upgrades
-older headers in place when possible and recalculates the header MAC.
-Manifests written with unknown versions should be regenerated with
-`lvmsync manifest rebuild` to migrate to the current layout.
+The `version` field records the manifest format revision.
+Manifests written with versions `0` or `1` are upgraded in place to version `2`
+when opened, recalculating the header MAC. Manifests with unknown versions
+should be regenerated with `lvmsync manifest rebuild` to migrate to the current
+layout.
+
+### Version History
+
+- **Version 1:** Initial manifest format.
+- **Version 2:** Adds `epoch`, device major/minor numbers, and
+  `first_block_digest` fields.
 
 ## Two-Level Index
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -339,7 +339,7 @@ func Upgrade(path string, opts ...IndexOption) (*Index, error) {
 			return nil, err
 		}
 		switch idx.hdr.Version {
-		case 0:
+		case 0, 1:
 			idx.hdr.Version = Version
 			idx.hdr.MAC = headerMAC(&idx.hdr)
 			idx.writeHeader()

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -207,40 +208,63 @@ func TestCreateSyncsHeader(t *testing.T) {
 }
 
 func TestUpgrade(t *testing.T) {
+	versions := []uint32{0, 1}
+	for _, ver := range versions {
+		t.Run(fmt.Sprintf("v%d", ver), func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "old.man")
+			idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			idx.hdr.Version = ver
+			idx.hdr.MAC = headerMAC(&idx.hdr)
+			idx.writeHeader()
+			if err := idx.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+			if _, err := Open(path); !errors.Is(err, ErrVersionMismatch) {
+				t.Fatalf("expected version mismatch, got %v", err)
+			}
+			up, err := Upgrade(path)
+			if err != nil {
+				t.Fatalf("Upgrade: %v", err)
+			}
+			if up.hdr.Version != Version {
+				t.Fatalf("version not upgraded: %d", up.hdr.Version)
+			}
+			if err := up.Close(); err != nil {
+				t.Fatalf("close upgraded: %v", err)
+			}
+			idx2, err := Open(path)
+			if err != nil {
+				t.Fatalf("Open after upgrade: %v", err)
+			}
+			if idx2.hdr.Version != Version {
+				t.Fatalf("version mismatch after upgrade: %d", idx2.hdr.Version)
+			}
+			if err := idx2.Close(); err != nil {
+				t.Fatalf("close2: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpgradeUnknownVersion(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "old.man")
+	path := filepath.Join(dir, "bad.man")
 	idx, err := Create(path, "dev", 4096, 0, 0, 0, 4096, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	idx.hdr.Version = 0
+	idx.hdr.Version = 99
 	idx.hdr.MAC = headerMAC(&idx.hdr)
 	idx.writeHeader()
 	if err := idx.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if _, err := Open(path); !errors.Is(err, ErrVersionMismatch) {
-		t.Fatalf("expected version mismatch, got %v", err)
-	}
-	up, err := Upgrade(path)
-	if err != nil {
-		t.Fatalf("Upgrade: %v", err)
-	}
-	if up.hdr.Version != Version {
-		t.Fatalf("version not upgraded: %d", up.hdr.Version)
-	}
-	if err := up.Close(); err != nil {
-		t.Fatalf("close upgraded: %v", err)
-	}
-	idx2, err := Open(path)
-	if err != nil {
-		t.Fatalf("Open after upgrade: %v", err)
-	}
-	if idx2.hdr.Version != Version {
-		t.Fatalf("version mismatch after upgrade: %d", idx2.hdr.Version)
-	}
-	if err := idx2.Close(); err != nil {
-		t.Fatalf("close2: %v", err)
+	if _, err := Upgrade(path); err == nil || !strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("expected unsupported version error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow manifest.Upgrade to migrate v0 and v1 headers to v2
- add tests for upgrading supported versions and rejecting unknown ones
- document manifest version history and automatic upgrade behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: manifest rebuild requires non-mounted devices; other tests fail)*
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run` *(fails: many lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0c8209208323a8a4015fa62de2cd