### PR TITLE
Verify generated config docs in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,3 +114,20 @@ jobs:
 
       - name: Validate sudoers file
         run: visudo -cf docs/sudoers.d/lvmsync
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24' }}"
+          cache: true
+
+      - name: Docs check
+        run: make docs-check

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -157,13 +157,7 @@ jobs:
           jq -e 'map(select(.type | contains("(resolved)") | not)) | length == 0' reports/machine/gaps.json
 
       - name: Docs check
-        if: hashFiles('Makefile') != ''
-        run: |
-          if grep -q '^docs-check:' Makefile; then
-            make docs-check
-          else
-            echo "No docs-check target; skipping."
-          fi
+        run: make docs-check
 
       - name: Verify sudoers commands
         if: hashFiles('scripts/verify_sudoers.sh') != ''

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ verify: deps
 > golangci-lint run
 
 docs-check:
+> go run ./cmd/configdoc
+> git diff --exit-code docs/config_env.md
 > go test ./docs
 
 test-race:


### PR DESCRIPTION
## Summary
- ensure `make docs-check` regenerates config env docs and fails if stale
- run docs check in CI workflows

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: manifest tests report devices mounted read-write, remote and transfer tests fail)*
- `golangci-lint run` *(fails: many lint issues)*
- `make docs-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ec28c188323818acacbfedace83