### PR TITLE
test: allow rebuild on mounted tmpfs

### DIFF
--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -42,6 +42,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
+	cfg.ManifestAllowMounted = true
 
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
@@ -85,6 +86,7 @@ func TestRunManifestPathFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
+	cfg.ManifestAllowMounted = true
 
 	outputPath := filepath.Join(dir, "custom.manifest")
 	args := []string{"rebuild", "--manifest-path", outputPath, devicePath}
@@ -130,6 +132,7 @@ func TestRunLogsConfigWarnings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
+	cfg.ManifestAllowMounted = true
 	cfg.DryRun = true
 
 	cfgPath := filepath.Join(dir, "config.yaml")
@@ -215,6 +218,7 @@ func TestRunZeroManifestTimeoutUsesBackground(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
+	cfg.ManifestAllowMounted = true
 	cfg.ManifestTimeout = 0
 	var captured context.Context
 	r := NewRunnerWithDeps(func(ctx context.Context, _, _ string, _ *zap.Logger, _ time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
@@ -267,6 +271,7 @@ func TestRunSyncsLoggerDryRun(t *testing.T) {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
 
+	cfg.ManifestAllowMounted = true
 	cfg.DryRun = true
 
 	var syncs int
@@ -294,6 +299,7 @@ func TestRunWritesVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}
+	cfg.ManifestAllowMounted = true
 	r := NewRunnerWithDeps(func(ctx context.Context, dev, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		opts = append(opts, manifestpkg.WithDeviceInfo(info))
 		return manifestpkg.Rebuild(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -499,7 +499,7 @@ func TestRebuild(t *testing.T) {
 	manPath := filepath.Join(dir, "rebuild.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -552,7 +552,7 @@ func TestRebuildCloseHook(t *testing.T) {
 	hook := func() error { count++; return nil }
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, WithCloseHook(hook), WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, WithCloseHook(hook), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if count != 1 {
@@ -580,7 +580,7 @@ func TestRebuildCloseError(t *testing.T) {
 	hook := func() error { return hookErr }
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, WithCloseHook(hook), WithDeviceInfo(info)); err == nil || !strings.Contains(err.Error(), "close fail") {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, WithCloseHook(hook), WithDeviceInfo(info)); err == nil || !strings.Contains(err.Error(), "close fail") {
 		t.Fatalf("expected close error, got %v", err)
 	}
 }
@@ -613,7 +613,7 @@ func TestRebuildOptionApplication(t *testing.T) {
 	manPath := filepath.Join(dir, "options.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithCloseHook(hook), WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithCloseHook(hook), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	if !calledDetect {
@@ -650,7 +650,7 @@ func TestRebuildNonDefaultBlockSize(t *testing.T) {
 	manPath := filepath.Join(dir, "rebuildbs.man")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	idx, err := Open(manPath)
@@ -699,7 +699,7 @@ func TestRebuildLogsProgress(t *testing.T) {
 	logger := zap.New(core)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, logger, 0, false, 0, 0, 0, 0, WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, logger, 0, true, 0, 0, 0, 0, WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	entries := logs.FilterMessage("rebuild progress").All()
@@ -734,7 +734,7 @@ func TestRebuildLogsCompletion(t *testing.T) {
 	logger := zap.New(core)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := Rebuild(ctx, file.Name(), manPath, logger, 0, false, 0, 0, 0, 0, WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(ctx, file.Name(), manPath, logger, 0, true, 0, 0, 0, 0, WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	entries := logs.FilterMessage("rebuild_complete").All()
@@ -770,7 +770,7 @@ func TestRebuildCanceledContext(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		cancel()
 	}()
-	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); !errors.Is(err, context.Canceled) {
+	if err := Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }

--- a/manifest/rebuild_test.go
+++ b/manifest/rebuild_test.go
@@ -25,7 +25,7 @@ func TestRegenerateMissing(t *testing.T) {
 		return &mockDevice{path: dev, size: uint64(len(data)), blockSize: 4}, nil
 	}
 	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
-	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("regenerate: %v", err)
 	}
 	idx, err := Open(man)
@@ -57,7 +57,7 @@ func TestRegenerateStale(t *testing.T) {
 		return &mockDevice{path: dev, size: uint64(len(orig)), blockSize: 4}, nil
 	}
 	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
-	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	// modify device so manifest becomes stale
@@ -65,7 +65,7 @@ func TestRegenerateStale(t *testing.T) {
 	if err := os.WriteFile(dev, updated, 0o600); err != nil {
 		t.Fatalf("update device: %v", err)
 	}
-	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("regenerate: %v", err)
 	}
 	idx, err := Open(man)
@@ -94,14 +94,14 @@ func TestRegenerateExisting(t *testing.T) {
 		return &mockDevice{path: dev, size: uint64(len(data)), blockSize: 4}, nil
 	}
 	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
-	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	before, err := os.Stat(man)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("regenerate: %v", err)
 	}
 	after, err := os.Stat(man)
@@ -126,7 +126,7 @@ func TestRegenerateSizeMismatch(t *testing.T) {
 		return &mockDevice{path: dev, size: size, blockSize: 4}, nil
 	}
 	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
-	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 	before, err := os.Stat(man)
@@ -138,7 +138,7 @@ func TestRegenerateSizeMismatch(t *testing.T) {
 		t.Fatalf("enlarge device: %v", err)
 	}
 	size = uint64(len(enlarged))
-	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, false, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+	if err := Regenerate(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
 		t.Fatalf("regenerate: %v", err)
 	}
 	after, err := os.Stat(man)

--- a/transfer/dedup_persistence_test.go
+++ b/transfer/dedup_persistence_test.go
@@ -124,7 +124,7 @@ func TestManifestIndexLifecycle(t *testing.T) {
 	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := manifestpkg.Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, manifestpkg.WithDeviceInfo(info)); err != nil {
+	if err := manifestpkg.Rebuild(ctx, file.Name(), manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, manifestpkg.WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 

--- a/transfer/dumpchanges_test.go
+++ b/transfer/dumpchanges_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"lvmsync_go/common"
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 
 	"go.uber.org/zap"
@@ -51,7 +52,7 @@ func parseOffsetsNoHandshake(t *testing.T, r io.Reader) []int64 {
 }
 
 func TestDumpChangesSequential(t *testing.T) {
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, device.NewInfoWithDeps(nil, nil, func(context.Context, string) (bool, error) { return false, nil }, nil, nil))
 	blockSize := int64(1024)
 	changed := []int{0, 2}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)
@@ -130,7 +131,7 @@ func TestDumpChangesParallelProgress(t *testing.T) {
 }
 
 func TestProcessDumpDataAutoDecompression(t *testing.T) {
-	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, nil)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, device.NewInfoWithDeps(nil, nil, func(context.Context, string) (bool, error) { return false, nil }, nil, nil))
 	blockSize := int64(1024)
 	changed := []int{0}
 	src, snapshot := createDumpTestFiles(t, blockSize, changed)

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -105,7 +105,7 @@ func rdBuildManifest(t *testing.T, devPath, manPath string, size uint64, cdcMin,
 		return &rdMockDevice{path: devPath, size: size, blockSize: 4}, nil
 	}
 	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
-	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, cdcMin, cdcAvg, cdcMax, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
+	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, true, cdcMin, cdcAvg, cdcMax, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 }

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -37,7 +37,7 @@ func buildManifest(t *testing.T, devPath, manPath, uuid string, size uint64) {
 		return &mockDevice{path: devPath, size: size, blockSize: 4}, nil
 	}
 	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return uuid, nil }, nil, nil, nil, nil)
-	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, false, 0, 0, 0, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
+	if err := manifestpkg.Rebuild(context.Background(), devPath, manPath, zap.NewNop(), 0, true, 0, 0, 0, 0, manifestpkg.WithDetectDevice(detect), manifestpkg.WithDeviceInfo(info)); err != nil {
 		t.Fatalf("rebuild: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- allow manifest rebuild tests to run against temporary files on mounted filesystems
- enable ManifestAllowMounted in CLI rebuild tests
- stub mount checks in transfer tests using manifest rebuilds or dump data

## Testing
- `go build ./...`
- `go test ./manifest ./transfer ./cmd/manifest`


------
https://chatgpt.com/codex/tasks/task_e_68aa12b0aa288323b14018435461ed9b