### PR TITLE
feat: add partition hash to device identity

### DIFF
--- a/device/identity.go
+++ b/device/identity.go
@@ -1,15 +1,21 @@
 package device
 
-import wal "lvmsync_go/internal/wal"
+import (
+	"bytes"
+
+	wal "lvmsync_go/internal/wal"
+)
 
 // DeviceIdentity describes metadata uniquely identifying a block device.
-// The identity tuple is (size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch).
+// The identity tuple is (size_bytes, kernel_uuid, gpt_uuid, mbr_signature,
+// fs_uuid, partition_hash, major, minor, manifest_epoch).
 type DeviceIdentity struct {
 	SizeBytes     uint64
 	KernelUUID    string
 	GPTUUID       string
 	MBRSignature  string
 	FSUUID        string
+	PartitionHash [32]byte
 	Major         uint32
 	Minor         uint32
 	ManifestEpoch uint64
@@ -26,6 +32,7 @@ func SameIdentity(a, b DeviceIdentity) bool {
 		a.GPTUUID == b.GPTUUID &&
 		a.MBRSignature == b.MBRSignature &&
 		a.FSUUID == b.FSUUID &&
+		bytes.Equal(a.PartitionHash[:], b.PartitionHash[:]) &&
 		a.ManifestEpoch == b.ManifestEpoch
 }
 
@@ -37,6 +44,7 @@ func SameIdentityStrict(a, b DeviceIdentity) bool {
 		a.GPTUUID == b.GPTUUID &&
 		a.MBRSignature == b.MBRSignature &&
 		a.FSUUID == b.FSUUID &&
+		bytes.Equal(a.PartitionHash[:], b.PartitionHash[:]) &&
 		a.Major == b.Major &&
 		a.Minor == b.Minor &&
 		a.ManifestEpoch == b.ManifestEpoch

--- a/device/identity_preflight.go
+++ b/device/identity_preflight.go
@@ -1,6 +1,7 @@
 package device
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -67,6 +68,9 @@ func VerifyIdentity(ctx context.Context, info *Info, src, dest string) (err erro
 	}
 	if idA.MBRSignature != idB.MBRSignature && !allow {
 		return fmt.Errorf("mbr signature mismatch: %w", exitcode.ErrPrecondition)
+	}
+	if !bytes.Equal(idA.PartitionHash[:], idB.PartitionHash[:]) && !allow {
+		return fmt.Errorf("partition hash mismatch: %w", exitcode.ErrPrecondition)
 	}
 	if idA.ManifestEpoch != idB.ManifestEpoch && !allow {
 		return fmt.Errorf("manifest epoch mismatch: %w", exitcode.ErrPrecondition)

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -3,6 +3,7 @@ package device
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"lvmsync_go/hash"
 	"lvmsync_go/internal/privilege"
 )
 
@@ -20,6 +22,7 @@ type identityStub struct {
 	epoch uint64
 	gpt   string
 	mbr   string
+	phash [32]byte
 }
 
 func (s *identityStub) Path() string                                     { return "" }
@@ -29,7 +32,7 @@ func (s *identityStub) Snapshot(context.Context, string) (Device, error) { retur
 func (s *identityStub) Cleanup(context.Context) error                    { return nil }
 func (s *identityStub) Close() error                                     { return nil }
 func (s *identityStub) Identity(context.Context) (DeviceIdentity, error) {
-	return DeviceIdentity{SizeBytes: s.size, GPTUUID: s.gpt, MBRSignature: s.mbr, ManifestEpoch: s.epoch}, nil
+	return DeviceIdentity{SizeBytes: s.size, GPTUUID: s.gpt, MBRSignature: s.mbr, ManifestEpoch: s.epoch, PartitionHash: s.phash}, nil
 }
 func (s *identityStub) AppendWAL(r Range) error               { return nil }
 func (s *identityStub) RecoverWAL(fn func(Range) error) error { return nil }
@@ -107,6 +110,20 @@ func TestIdentityMBRSignatureMismatch(t *testing.T) {
 	}
 }
 
+func TestIdentityPartitionHashMismatch(t *testing.T) {
+	info := NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
+	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
+		if strings.Contains(path, "src") {
+			return &identityStub{size: 1, epoch: 1, phash: hash.SumBLAKE3([]byte("a"))}, nil
+		}
+		return &identityStub{size: 1, epoch: 1, phash: hash.SumBLAKE3([]byte("b"))}, nil
+	})
+	defer info.SetDetectFunc(prev)
+	if err := VerifyIdentity(context.Background(), info, "/dev/src", "/dev/dest"); err == nil || !strings.Contains(err.Error(), "partition hash mismatch") {
+		t.Fatalf("expected partition hash mismatch error, got %v", err)
+	}
+}
+
 func TestVerifyIdentityManifestEpochMismatch(t *testing.T) {
 	info := NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
 	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
@@ -128,16 +145,23 @@ func TestDeviceIdentityFormatParseOrder(t *testing.T) {
 		GPTUUID:       "g",
 		MBRSignature:  "m",
 		FSUUID:        "f",
+		PartitionHash: hash.SumBLAKE3([]byte("p")),
 		Major:         2,
 		Minor:         3,
 		ManifestEpoch: 4,
 	}
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%d %s %s %s %s %d %d %d", id.SizeBytes, id.KernelUUID, id.GPTUUID, id.MBRSignature, id.FSUUID, id.Major, id.Minor, id.ManifestEpoch)
+	fmt.Fprintf(&buf, "%d %s %s %s %s %x %d %d %d", id.SizeBytes, id.KernelUUID, id.GPTUUID, id.MBRSignature, id.FSUUID, id.PartitionHash, id.Major, id.Minor, id.ManifestEpoch)
 	var parsed DeviceIdentity
-	if _, err := fmt.Fscan(&buf, &parsed.SizeBytes, &parsed.KernelUUID, &parsed.GPTUUID, &parsed.MBRSignature, &parsed.FSUUID, &parsed.Major, &parsed.Minor, &parsed.ManifestEpoch); err != nil {
+	var ph string
+	if _, err := fmt.Fscan(&buf, &parsed.SizeBytes, &parsed.KernelUUID, &parsed.GPTUUID, &parsed.MBRSignature, &parsed.FSUUID, &ph, &parsed.Major, &parsed.Minor, &parsed.ManifestEpoch); err != nil {
 		t.Fatalf("Fscan: %v", err)
 	}
+	b, err := hex.DecodeString(ph)
+	if err != nil || len(b) != 32 {
+		t.Fatalf("decode partition hash: %v", err)
+	}
+	copy(parsed.PartitionHash[:], b)
 	if parsed != id {
 		t.Fatalf("round-trip mismatch: got %+v want %+v", parsed, id)
 	}

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -3,6 +3,7 @@
 package device
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 
+	"lvmsync_go/hash"
 	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/internal/lock"
 	"lvmsync_go/lvm"
@@ -166,6 +168,13 @@ func (d *LVMDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
 	if gpt, mbr, err := readPartitionSignatures(d.Path()); err == nil {
 		id.GPTUUID = gpt
 		id.MBRSignature = mbr
+	}
+	if layout, err := readPartitionLayout(ctx, d.Path(), d.runner); err == nil {
+		var buf bytes.Buffer
+		for _, p := range layout {
+			fmt.Fprintf(&buf, "%d:%d:%s;", p.Start, p.End, p.Type)
+		}
+		id.PartitionHash = hash.SumBLAKE3(buf.Bytes())
 	}
 	return id, nil
 }

--- a/device/raw.go
+++ b/device/raw.go
@@ -3,6 +3,7 @@
 package device
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 
+	"lvmsync_go/hash"
 	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/internal/privilege"
 	"lvmsync_go/remote"
@@ -225,6 +227,13 @@ func (d *RawDevice) Identity(ctx context.Context) (DeviceIdentity, error) {
 	if gpt, mbr, err := readPartitionSignatures(d.Path()); err == nil {
 		id.GPTUUID = gpt
 		id.MBRSignature = mbr
+	}
+	if layout, err := readPartitionLayout(ctx, d.Path(), d.runner); err == nil {
+		var buf bytes.Buffer
+		for _, p := range layout {
+			fmt.Fprintf(&buf, "%d:%d:%s;", p.Start, p.End, p.Type)
+		}
+		id.PartitionHash = hash.SumBLAKE3(buf.Bytes())
 	}
 	return id, nil
 }

--- a/device/wal.go
+++ b/device/wal.go
@@ -1,7 +1,9 @@
 package device
 
 import (
+	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -16,15 +18,30 @@ import (
 )
 
 const (
-	walVersion      = 4
+	walVersion      = 5
 	walHeaderV0Size = 8 + 64 + 64 + 64 + 32
 	walHeaderV1Size = 8 + 8 + 64 + 64 + 64 + 32
 	walHeaderV2Size = 8 + 8 + 4 + 4 + 64 + 64 + 64 + 32
 	walHeaderV3Size = 8 + 8 + 8 + 4 + 4 + 64 + 64 + 64 + 32
-	walHeaderSize   = 8 + 8 + 8 + 4 + 4 + 64 + 64 + 4 + 64 + 32
+	walHeaderV4Size = 8 + 8 + 8 + 4 + 4 + 64 + 64 + 4 + 64 + 32
+	walHeaderSize   = walHeaderV4Size + 32
 )
 
 type walHeader struct {
+	Version uint64
+	Size    uint64
+	Epoch   uint64
+	Major   uint32
+	Minor   uint32
+	Kernel  [64]byte
+	GPT     [64]byte
+	MBR     [4]byte
+	FS      [64]byte
+	Part    [32]byte
+	MAC     [32]byte
+}
+
+type walHeaderV4 struct {
 	Version uint64
 	Size    uint64
 	Epoch   uint64
@@ -92,6 +109,21 @@ type WALDeps = walpkg.Deps
 func NewWALDeps() *WALDeps { return walpkg.NewDeps() }
 
 func walHeaderMAC(h *walHeader) [32]byte {
+	var buf [8 + 8 + 8 + 4 + 4 + 64 + 64 + 4 + 64 + 32]byte
+	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
+	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
+	binary.LittleEndian.PutUint64(buf[16:24], h.Epoch)
+	binary.LittleEndian.PutUint32(buf[24:28], h.Major)
+	binary.LittleEndian.PutUint32(buf[28:32], h.Minor)
+	copy(buf[32:96], h.Kernel[:])
+	copy(buf[96:160], h.GPT[:])
+	copy(buf[160:164], h.MBR[:])
+	copy(buf[164:228], h.FS[:])
+	copy(buf[228:260], h.Part[:])
+	return blake3.Sum256(buf[:])
+}
+
+func walHeaderMACV4(h *walHeaderV4) [32]byte {
 	var buf [8 + 8 + 8 + 4 + 4 + 64 + 64 + 4 + 64]byte
 	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
 	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
@@ -189,6 +221,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 			binary.LittleEndian.PutUint32(hdr.MBR[:], uint32(v))
 		}
 		copy(hdr.FS[:], []byte(id.FSUUID))
+		hdr.Part = id.PartitionHash
 		hdr.MAC = walHeaderMAC(&hdr)
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
@@ -200,7 +233,8 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		copy(buf[96:160], hdr.GPT[:])
 		copy(buf[160:164], hdr.MBR[:])
 		copy(buf[164:228], hdr.FS[:])
-		copy(buf[228:260], hdr.MAC[:])
+		copy(buf[228:260], hdr.Part[:])
+		copy(buf[260:292], hdr.MAC[:])
 		if n, err := f.Write(buf[:]); err != nil {
 			f.Close()
 			return nil, err
@@ -242,7 +276,8 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		copy(hdr.GPT[:], buf[96:160])
 		copy(hdr.MBR[:], buf[160:164])
 		copy(hdr.FS[:], buf[164:228])
-		copy(hdr.MAC[:], buf[228:260])
+		copy(hdr.Part[:], buf[228:260])
+		copy(hdr.MAC[:], buf[260:292])
 		if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
 			f.Close()
 			return nil, fmt.Errorf("wal: header mac mismatch")
@@ -252,7 +287,8 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 			string(hdr.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
 			string(hdr.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
 			binary.LittleEndian.Uint32(hdr.MBR[:]) != uint32(idMBR) ||
-			string(hdr.FS[:len(id.FSUUID)]) != id.FSUUID {
+			string(hdr.FS[:len(id.FSUUID)]) != id.FSUUID ||
+			!bytes.Equal(hdr.Part[:], id.PartitionHash[:]) {
 			f.Close()
 			hdrID := DeviceIdentity{
 				SizeBytes:     hdr.Size,
@@ -260,6 +296,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 				GPTUUID:       strings.TrimRight(string(hdr.GPT[:]), "\x00"),
 				MBRSignature:  fmt.Sprintf("%08x", binary.LittleEndian.Uint32(hdr.MBR[:])),
 				FSUUID:        strings.TrimRight(string(hdr.FS[:]), "\x00"),
+				PartitionHash: hdr.Part,
 				Major:         hdr.Major,
 				Minor:         hdr.Minor,
 				ManifestEpoch: hdr.Epoch,
@@ -274,6 +311,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 				zap.String("header_gpt_uuid", hdrID.GPTUUID),
 				zap.String("header_mbr_signature", hdrID.MBRSignature),
 				zap.String("header_fs_uuid", hdrID.FSUUID),
+				zap.String("header_partition_hash", hex.EncodeToString(hdrID.PartitionHash[:])),
 				zap.Uint64("identity_size_bytes", id.SizeBytes),
 				zap.Uint64("identity_manifest_epoch", id.ManifestEpoch),
 				zap.Uint32("identity_major", id.Major),
@@ -282,6 +320,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 				zap.String("identity_gpt_uuid", id.GPTUUID),
 				zap.String("identity_mbr_signature", id.MBRSignature),
 				zap.String("identity_fs_uuid", id.FSUUID),
+				zap.String("identity_partition_hash", hex.EncodeToString(id.PartitionHash[:])),
 				zap.Error(err),
 			)
 			return nil, err
@@ -306,7 +345,98 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		return w, nil
 	}
 
-	if ver == walVersion-1 && st.Size() >= walHeaderV3Size {
+	if ver == walVersion-1 && st.Size() >= walHeaderV4Size {
+		var buf4 [walHeaderV4Size]byte
+		if _, err := f.ReadAt(buf4[:], 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		var hdr4 walHeaderV4
+		hdr4.Version = binary.LittleEndian.Uint64(buf4[0:8])
+		hdr4.Size = binary.LittleEndian.Uint64(buf4[8:16])
+		hdr4.Epoch = binary.LittleEndian.Uint64(buf4[16:24])
+		hdr4.Major = binary.LittleEndian.Uint32(buf4[24:28])
+		hdr4.Minor = binary.LittleEndian.Uint32(buf4[28:32])
+		copy(hdr4.Kernel[:], buf4[32:96])
+		copy(hdr4.GPT[:], buf4[96:160])
+		copy(hdr4.MBR[:], buf4[160:164])
+		copy(hdr4.FS[:], buf4[164:228])
+		copy(hdr4.MAC[:], buf4[228:260])
+		if mac := walHeaderMACV4(&hdr4); mac != hdr4.MAC {
+			f.Close()
+			return nil, fmt.Errorf("wal: header mac mismatch")
+		}
+		idMBR, _ := strconv.ParseUint(id.MBRSignature, 16, 32)
+		if hdr4.Size != id.SizeBytes || hdr4.Epoch != id.ManifestEpoch || hdr4.Major != id.Major || hdr4.Minor != id.Minor ||
+			string(hdr4.Kernel[:len(id.KernelUUID)]) != id.KernelUUID ||
+			string(hdr4.GPT[:len(id.GPTUUID)]) != id.GPTUUID ||
+			binary.LittleEndian.Uint32(hdr4.MBR[:]) != uint32(idMBR) ||
+			string(hdr4.FS[:len(id.FSUUID)]) != id.FSUUID {
+			f.Close()
+			return nil, fmt.Errorf("wal: metadata mismatch")
+		}
+		data := make([]byte, st.Size()-walHeaderV4Size)
+		if _, err := f.ReadAt(data, walHeaderV4Size); err != nil && err != io.EOF {
+			f.Close()
+			return nil, err
+		}
+		var hdr walHeader
+		hdr.Version = walVersion
+		hdr.Size = hdr4.Size
+		hdr.Epoch = hdr4.Epoch
+		hdr.Major = hdr4.Major
+		hdr.Minor = hdr4.Minor
+		hdr.Kernel = hdr4.Kernel
+		hdr.GPT = hdr4.GPT
+		hdr.MBR = hdr4.MBR
+		hdr.FS = hdr4.FS
+		hdr.Part = id.PartitionHash
+		hdr.MAC = walHeaderMAC(&hdr)
+		var buf [walHeaderSize]byte
+		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
+		binary.LittleEndian.PutUint64(buf[16:24], hdr.Epoch)
+		binary.LittleEndian.PutUint32(buf[24:28], hdr.Major)
+		binary.LittleEndian.PutUint32(buf[28:32], hdr.Minor)
+		copy(buf[32:96], hdr.Kernel[:])
+		copy(buf[96:160], hdr.GPT[:])
+		copy(buf[160:164], hdr.MBR[:])
+		copy(buf[164:228], hdr.FS[:])
+		copy(buf[228:260], hdr.Part[:])
+		copy(buf[260:292], hdr.MAC[:])
+		if n, err := f.WriteAt(buf[:], 0); err != nil {
+			f.Close()
+			return nil, err
+		} else if n != len(buf) {
+			f.Close()
+			return nil, fmt.Errorf("wal: short write: wrote %d of %d bytes", n, len(buf))
+		}
+		if len(data) > 0 {
+			if n, err := f.WriteAt(data, walHeaderSize); err != nil {
+				f.Close()
+				return nil, err
+			} else if n != len(data) {
+				f.Close()
+				return nil, fmt.Errorf("wal: short write: wrote %d of %d bytes", n, len(data))
+			}
+		}
+		if err := f.Truncate(int64(walHeaderSize + len(data))); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, err
+		}
+		w.header = hdr
+		if _, err := f.Seek(int64(walHeaderSize+len(data)), 0); err != nil {
+			f.Close()
+			return nil, err
+		}
+		return w, nil
+	}
+
+	if ver == walVersion-2 && st.Size() >= walHeaderV3Size {
 		var buf3 [walHeaderV3Size]byte
 		if _, err := f.ReadAt(buf3[:], 0); err != nil {
 			f.Close()
@@ -350,6 +480,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 			binary.LittleEndian.PutUint32(hdr.MBR[:], uint32(v))
 		}
 		hdr.FS = hdr3.FS
+		hdr.Part = id.PartitionHash
 		hdr.MAC = walHeaderMAC(&hdr)
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
@@ -361,7 +492,8 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		copy(buf[96:160], hdr.GPT[:])
 		copy(buf[160:164], hdr.MBR[:])
 		copy(buf[164:228], hdr.FS[:])
-		copy(buf[228:260], hdr.MAC[:])
+		copy(buf[228:260], hdr.Part[:])
+		copy(buf[260:292], hdr.MAC[:])
 		if n, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, err
@@ -400,7 +532,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		return w, nil
 	}
 
-	if ver == walVersion-2 && st.Size() >= walHeaderV2Size {
+	if ver == walVersion-3 && st.Size() >= walHeaderV2Size {
 		var buf2 [walHeaderV2Size]byte
 		if _, err := f.ReadAt(buf2[:], 0); err != nil {
 			f.Close()
@@ -443,6 +575,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 			binary.LittleEndian.PutUint32(hdr.MBR[:], uint32(v))
 		}
 		hdr.FS = hdr2.FS
+		hdr.Part = id.PartitionHash
 		hdr.MAC = walHeaderMAC(&hdr)
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
@@ -454,7 +587,8 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		copy(buf[96:160], hdr.GPT[:])
 		copy(buf[160:164], hdr.MBR[:])
 		copy(buf[164:228], hdr.FS[:])
-		copy(buf[228:260], hdr.MAC[:])
+		copy(buf[228:260], hdr.Part[:])
+		copy(buf[260:292], hdr.MAC[:])
 		if n, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, err
@@ -493,7 +627,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		return w, nil
 	}
 
-	if ver == walVersion-3 && st.Size() >= walHeaderV1Size {
+	if ver == walVersion-4 && st.Size() >= walHeaderV1Size {
 		var buf1 [walHeaderV1Size]byte
 		if _, err := f.ReadAt(buf1[:], 0); err != nil {
 			f.Close()
@@ -534,6 +668,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 			binary.LittleEndian.PutUint32(hdr.MBR[:], uint32(v))
 		}
 		hdr.FS = hdr1.FS
+		hdr.Part = id.PartitionHash
 		hdr.MAC = walHeaderMAC(&hdr)
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
@@ -545,7 +680,8 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		copy(buf[96:160], hdr.GPT[:])
 		copy(buf[160:164], hdr.MBR[:])
 		copy(buf[164:228], hdr.FS[:])
-		copy(buf[228:260], hdr.MAC[:])
+		copy(buf[228:260], hdr.Part[:])
+		copy(buf[260:292], hdr.MAC[:])
 		if n, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, err
@@ -630,6 +766,7 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 			binary.LittleEndian.PutUint32(hdr.MBR[:], uint32(v))
 		}
 		hdr.FS = hdr0.FS
+		hdr.Part = id.PartitionHash
 		hdr.MAC = walHeaderMAC(&hdr)
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
@@ -641,7 +778,8 @@ func OpenWAL(path string, id DeviceIdentity, logger *zap.Logger, deps *WALDeps) 
 		copy(buf[96:160], hdr.GPT[:])
 		copy(buf[160:164], hdr.MBR[:])
 		copy(buf[164:228], hdr.FS[:])
-		copy(buf[228:260], hdr.MAC[:])
+		copy(buf[228:260], hdr.Part[:])
+		copy(buf[260:292], hdr.MAC[:])
 		if n, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, err

--- a/device/wal_test.go
+++ b/device/wal_test.go
@@ -130,26 +130,27 @@ func TestWALVersionMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open file: %v", err)
 	}
-	var buf [walHeaderSize]byte
-	if _, err := f.ReadAt(buf[:], 0); err != nil {
-		t.Fatalf("read header: %v", err)
-	}
-	var hdr walHeader
-	hdr.Version = walVersion + 1
-	hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
-	hdr.Epoch = binary.LittleEndian.Uint64(buf[16:24])
-	hdr.Major = binary.LittleEndian.Uint32(buf[24:28])
-	hdr.Minor = binary.LittleEndian.Uint32(buf[28:32])
-	copy(hdr.Kernel[:], buf[32:96])
-	copy(hdr.GPT[:], buf[96:160])
-	copy(hdr.MBR[:], buf[160:164])
-	copy(hdr.FS[:], buf[164:228])
-	hdr.MAC = walHeaderMAC(&hdr)
-	binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
-	copy(buf[228:260], hdr.MAC[:])
-	if _, err := f.WriteAt(buf[:], 0); err != nil {
-		t.Fatalf("write header: %v", err)
-	}
+        var buf [walHeaderSize]byte
+        if _, err := f.ReadAt(buf[:], 0); err != nil {
+                t.Fatalf("read header: %v", err)
+        }
+        var hdr walHeader
+        hdr.Version = walVersion + 1
+        hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
+        hdr.Epoch = binary.LittleEndian.Uint64(buf[16:24])
+        hdr.Major = binary.LittleEndian.Uint32(buf[24:28])
+        hdr.Minor = binary.LittleEndian.Uint32(buf[28:32])
+        copy(hdr.Kernel[:], buf[32:96])
+        copy(hdr.GPT[:], buf[96:160])
+        copy(hdr.MBR[:], buf[160:164])
+        copy(hdr.FS[:], buf[164:228])
+        copy(hdr.Part[:], buf[228:260])
+        hdr.MAC = walHeaderMAC(&hdr)
+        binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+        copy(buf[260:292], hdr.MAC[:])
+        if _, err := f.WriteAt(buf[:], 0); err != nil {
+                t.Fatalf("write header: %v", err)
+        }
 	f.Close()
 	if _, err := OpenWAL(path, id, zap.NewNop(), nil); err == nil {
 		t.Fatalf("expected version mismatch error")

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -56,7 +56,7 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	digest := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{ResumeState: stateFile, Compress: "none", ChecksumAlgorithm: "blake3", DedupMode: "fixed"}
 	chk := resumeChunk{Chunk: digest, Offset: 1024, Length: 2048}
-	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: chk}, 0, "", 0)
+	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: chk}, 0, "", 0, [32]byte{})
 
 	val := readResumeState(cfg, logger, device.DeviceIdentity{FSUUID: cfg.DeviceUUID}, [32]byte{}).Fixed
 	if val.Chunk != digest {

--- a/transfer/loopback_integration_test.go
+++ b/transfer/loopback_integration_test.go
@@ -101,7 +101,7 @@ func TestLoopbackLVMToRawOverSSH(t *testing.T) {
 		CheckpointBytes:   1,
 	}
 	digest0 := blake3.Sum256(srcData0)
-	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 
 	ctx := context.Background()
 	tr, err := transport.Get("ssh", transport.Config{Logger: zap.NewNop(), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true})
@@ -214,7 +214,7 @@ func TestLoopbackFileToFileOverTCPTLS(t *testing.T) {
 		CheckpointBytes:   1,
 	}
 	digest0 := blake3.Sum256(srcData0)
-	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 
 	ctx := context.Background()
 	tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
@@ -355,7 +355,7 @@ func TestLoopbackLVMToRawOverTCPTLS(t *testing.T) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 
 			ctx := context.Background()
 			tr, err := transport.Get("tcp+tls", transport.Config{Logger: zap.NewNop(), AllowInsecure: true})
@@ -476,7 +476,7 @@ func runRawToRawLoopback(t *testing.T, transportName string) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 
 			ctx := context.Background()
 			tcfg := transport.Config{Logger: zap.NewNop()}
@@ -654,7 +654,7 @@ func TestLoopbackSparseFileToFileOverSSH(t *testing.T) {
 				CheckpointBytes:   1,
 			}
 			digest0 := blake3.Sum256(srcData0)
-			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
+			writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest0, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 
 			ctx := context.Background()
 			tr, err := transport.Get("ssh", transport.Config{Logger: zap.NewNop(), SSHUser: "test", SSHPassword: "pass", AllowInsecure: true})

--- a/transfer/resume.go
+++ b/transfer/resume.go
@@ -27,9 +27,10 @@ type resumeTracker struct {
 	bytes int64
 	last  time.Time
 	resumeChunks
-	sizeBytes uint64
-	deviceID  string
-	epoch     uint64
+	sizeBytes     uint64
+	deviceID      string
+	epoch         uint64
+	partitionHash [32]byte
 }
 
 func (rt *resumeTracker) chunk(mode string) *resumeChunk {

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -23,7 +23,7 @@ func TestResumeCDCOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0)
+	writeResumeState(cfg, logger, state, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0, [32]byte{})
 
 	chk := readResumeState(cfg, logger, device.DeviceIdentity{FSUUID: cfg.DeviceUUID}, [32]byte{})
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -45,7 +45,7 @@ func TestResumeCDCSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
@@ -70,7 +70,7 @@ func TestResumeCDCIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_fixed_test.go
+++ b/transfer/resume_fixed_test.go
@@ -23,7 +23,7 @@ func TestResumeFixedIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -23,7 +23,7 @@ func TestResumeHybridOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0)
+	writeResumeState(cfg, logger, state, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0, [32]byte{})
 
 	chk := readResumeState(cfg, logger, device.DeviceIdentity{FSUUID: cfg.DeviceUUID}, [32]byte{})
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -45,7 +45,7 @@ func TestResumeHybridSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
@@ -70,7 +70,7 @@ func TestResumeHybridIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0)
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -36,13 +36,14 @@ type resumeState struct {
 	SizeBytes         uint64           `json:"size_bytes"`
 	DeviceID          string           `json:"device_id"`
 	Epoch             uint64           `json:"epoch"`
+	PartitionHash     string           `json:"partition_hash"`
 	FirstBlockDigest  string           `json:"first_block_digest"`
 }
 
 // writeResumeState persists resume state using a WAL file. The state is written
 // to a temporary file, fsynced, and atomically renamed to `<path>.wal` to avoid
 // corruption on crashes. The logger must be non-nil.
-func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunks resumeChunks, size uint64, deviceID string, epoch uint64) {
+func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunks resumeChunks, size uint64, deviceID string, epoch uint64, partHash [32]byte) {
 	toState := func(ch resumeChunk) resumeChunkState {
 		return resumeChunkState{
 			Offset: ch.Offset,
@@ -62,6 +63,7 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunk
 		SizeBytes:         size,
 		DeviceID:          deviceID,
 		Epoch:             epoch,
+		PartitionHash:     hex.EncodeToString(partHash[:]),
 		FirstBlockDigest:  cfg.FirstBlockDigest,
 	}
 	data, err := json.Marshal(rs)
@@ -118,7 +120,7 @@ func saveResumeState(cfg *config.Config, rt *resumeTracker, offset uint64, chunk
 	*rc = resumeChunk{Chunk: chunk, Offset: offset, Length: uint32(size)}
 	if (cfg.CheckpointBytes > 0 && rt.bytes >= int64(cfg.CheckpointBytes)) ||
 		(cfg.CheckpointInterval > 0 && time.Since(rt.last) >= cfg.CheckpointInterval) {
-		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunks{Fixed: rt.Fixed, CDC: rt.CDC, Hybrid: rt.Hybrid}, rt.sizeBytes, rt.deviceID, rt.epoch)
+		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunks{Fixed: rt.Fixed, CDC: rt.CDC, Hybrid: rt.Hybrid}, rt.sizeBytes, rt.deviceID, rt.epoch, rt.partitionHash)
 		rt.bytes = 0
 		rt.last = time.Now()
 	}
@@ -143,6 +145,7 @@ func finalizeResumeState(cfg *config.Config, rt *resumeTracker, logger *zap.Logg
 	rt.sizeBytes = 0
 	rt.deviceID = ""
 	rt.epoch = 0
+	rt.partitionHash = [32]byte{}
 }
 
 func readResumeState(cfg *config.Config, logger *zap.Logger, id device.DeviceIdentity, digest [32]byte) resumeCheckpoint {
@@ -184,7 +187,11 @@ func loadResumeState(path string, cfg *config.Config, id device.DeviceIdentity, 
 	if cfg.ResumeToken == "" {
 		cfg.ResumeToken = rs.ResumeToken
 	}
-	storedID := device.DeviceIdentity{SizeBytes: rs.SizeBytes, FSUUID: rs.DeviceID, ManifestEpoch: rs.Epoch}
+	var part [32]byte
+	if b, err := hex.DecodeString(rs.PartitionHash); err == nil && len(b) == 32 {
+		copy(part[:], b)
+	}
+	storedID := device.DeviceIdentity{SizeBytes: rs.SizeBytes, FSUUID: rs.DeviceID, ManifestEpoch: rs.Epoch, PartitionHash: part}
 	actualID := id
 	if storedID.SizeBytes == 0 || actualID.SizeBytes == 0 {
 		storedID.SizeBytes = 0
@@ -197,6 +204,10 @@ func loadResumeState(path string, cfg *config.Config, id device.DeviceIdentity, 
 	if storedID.ManifestEpoch == 0 || actualID.ManifestEpoch == 0 {
 		storedID.ManifestEpoch = 0
 		actualID.ManifestEpoch = 0
+	}
+	if storedID.PartitionHash == ([32]byte{}) || actualID.PartitionHash == ([32]byte{}) {
+		storedID.PartitionHash = [32]byte{}
+		actualID.PartitionHash = [32]byte{}
 	}
 	if !device.SameIdentityStrict(storedID, actualID) {
 		return out, false

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -40,7 +40,7 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int, algo string)
 		digest = blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
 	}
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: algo, DedupMode: "fixed"}
-	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0)
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
 	return srcPath, snapshot, resumePath
 }
 
@@ -151,7 +151,7 @@ func TestResumeModeTransitions(t *testing.T) {
 			default:
 				chunks.Fixed = rc
 			}
-			writeResumeState(cfgStart, zap.NewNop(), resume, chunks, 0, "", 0)
+			writeResumeState(cfgStart, zap.NewNop(), resume, chunks, 0, "", 0, [32]byte{})
 
 			cfgResume := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.to}
 

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pierrec/lz4/v4"
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/common"
@@ -24,6 +23,7 @@ import (
 	hashutil "lvmsync_go/hash"
 	"lvmsync_go/internal/config"
 	"lvmsync_go/internal/exitcode"
+	"lvmsync_go/internal/privilege"
 	"lvmsync_go/lvm"
 	manifestpkg "lvmsync_go/manifest"
 )
@@ -289,41 +289,45 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 	if cfg.ResumeState != "" && strings.ToLower(cfg.VerifyLevel) != "none" {
 		cfg.ResumeVerify = true
 	}
-	var size uint64
-	var id string
-	var epoch uint64
+	dev, err := device.Detect(ctx, destPath, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
+	if err != nil {
+		return 0, "", 0, err
+	}
+	defer dev.Close()
+	ident, err := dev.Identity(ctx)
+	if err != nil {
+		return 0, "", 0, err
+	}
+	size := ident.SizeBytes
+	id := ident.FSUUID
+	if id == "" && (cfg.ManifestPath != "" || cfg.ResumeState != "" || cfg.DeviceUUID != "") {
+		if v, err := t.Info.GetDeviceID(ctx, destPath); err == nil {
+			id = v
+		} else {
+			return 0, "", 0, fmt.Errorf("read destination id: %w", err)
+		}
+	}
+	epoch := ident.ManifestEpoch
+	t.Tracker.partitionHash = ident.PartitionHash
+
 	if cfg.ManifestPath != "" {
 		hdr, err := readManifestHeader(ctx, cfg.ManifestPath, 0)
 		if err != nil {
 			return 0, "", 0, err
-		}
-		id, err = t.Info.GetDeviceID(ctx, destPath)
-		if err != nil {
-			return 0, "", 0, fmt.Errorf("read destination id: %w", err)
 		}
 		manID := strings.TrimRight(string(hdr.DeviceID[:]), "\x00")
 		if id != manID {
 			t.Logger.Error("device_id_mismatch", zap.String("expected_resource_id", manID), zap.String("resource_id", id))
 			return 0, "", 0, fmt.Errorf("precondition: destination device id %s does not match manifest %s: %w", id, manID, exitcode.ErrPrecondition)
 		}
-		size, err = t.Info.SizeBytes(ctx, destPath)
-		if err != nil {
-			return 0, "", 0, fmt.Errorf("read destination size: %w", err)
-		}
 		if size != hdr.SizeBytes {
 			t.Logger.Error("device_size_mismatch", zap.Uint64("expected_size_bytes", hdr.SizeBytes), zap.Uint64("size_bytes", size))
 			return 0, "", 0, fmt.Errorf("precondition: destination device size %d does not match manifest %d: %w", size, hdr.SizeBytes, exitcode.ErrPrecondition)
 		}
-		var st unix.Stat_t
-		if err := unix.Stat(destPath, &st); err != nil {
-			return 0, "", 0, fmt.Errorf("stat destination: %w", err)
-		}
-		major := uint32(unix.Major(uint64(st.Rdev)))
-		minor := uint32(unix.Minor(uint64(st.Rdev)))
 		expectedID := device.DeviceIdentity{SizeBytes: hdr.SizeBytes, Major: hdr.Major, Minor: hdr.Minor}
-		actualID := device.DeviceIdentity{SizeBytes: size, Major: major, Minor: minor}
+		actualID := device.DeviceIdentity{SizeBytes: size, Major: ident.Major, Minor: ident.Minor}
 		if !device.SameIdentityStrict(expectedID, actualID) {
-			t.Logger.Error("device_number_mismatch", zap.Uint32("expected_major", hdr.Major), zap.Uint32("expected_minor", hdr.Minor), zap.Uint32("major", major), zap.Uint32("minor", minor))
+			t.Logger.Error("device_number_mismatch", zap.Uint32("expected_major", hdr.Major), zap.Uint32("expected_minor", hdr.Minor), zap.Uint32("major", ident.Major), zap.Uint32("minor", ident.Minor))
 			return 0, "", 0, fmt.Errorf("precondition: destination device number mismatch: %w", exitcode.ErrPrecondition)
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
@@ -340,7 +344,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 		if cfg.ResumeState != "" {
 			if _, err := os.Stat(cfg.ResumeState); err == nil {
-				chk := readResumeState(cfg, t.Logger, device.DeviceIdentity{SizeBytes: hdr.SizeBytes, FSUUID: manID, ManifestEpoch: hdr.Epoch}, hdr.FirstBlockDigest)
+				chk := readResumeState(cfg, t.Logger, ident, hdr.FirstBlockDigest)
 				if chk == (resumeCheckpoint{}) {
 					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata: %w", exitcode.ErrPrecondition)
 				}
@@ -350,17 +354,8 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		t.Logger.Info("destination_validated", zap.String("resource_id", id), zap.Uint64("size_bytes", size))
 	} else {
 		if cfg.ResumeState != "" || cfg.DeviceUUID != "" {
-			var err error
-			id, err = t.Info.GetDeviceID(ctx, destPath)
-			if err != nil {
-				return 0, "", 0, fmt.Errorf("read destination id: %w", err)
-			}
 			if cfg.ResumeState != "" {
-				size, err = t.Info.SizeBytes(ctx, destPath)
-				if err != nil {
-					return 0, "", 0, fmt.Errorf("read destination size: %w", err)
-				}
-				chk := readResumeState(cfg, t.Logger, device.DeviceIdentity{SizeBytes: size, FSUUID: id}, [32]byte{})
+				chk := readResumeState(cfg, t.Logger, ident, [32]byte{})
 				if chk == (resumeCheckpoint{}) {
 					return 0, "", 0, fmt.Errorf("precondition: resume state does not match destination metadata: %w", exitcode.ErrPrecondition)
 				}


### PR DESCRIPTION
## Summary
- track partition table state with a new PartitionHash in DeviceIdentity
- log and verify partition hashes across WAL, resume state, and verification helpers
- test partition hash mismatches to catch silent partition table changes

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: unused parameter, lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3c0bb9fc832380918e268437bbad