### PR TITLE
docs: record manifest and RecvAck gaps

### DIFF
--- a/reports/gaps.json
+++ b/reports/gaps.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "type": "bug",
+    "component": "Manifest",
+    "evidence": "go run /tmp/manifest_fail.go -> manifest: file too small",
+    "impact": "Corrupt manifests halt resume operations",
+    "fix": "Add rebuild command to regenerate or replace damaged manifests",
+    "priority": "high"
+  },
+  {
+    "type": "bug",
+    "component": "RecvAck",
+    "evidence": "go test ./remote -run TestRecvAckPipe -> RecvAck blocked beyond deadline",
+    "impact": "Hung transfers and goroutine leaks when helper stdout lacks deadline support",
+    "fix": "Close reader or avoid draining when context is canceled; add tests",
+    "priority": "medium"
+  }
+]

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -1,3 +1,4 @@
 | Type | Component | Evidence | Impact | Fix | Priority |
 |------|-----------|----------|--------|-----|----------|
-
+| Bug | Manifest | `go run /tmp/manifest_fail.go` → `manifest: file too small` | Corrupt manifests halt resume operations | Add rebuild command to regenerate or replace damaged manifests | High |
+| Bug | RecvAck | `go test ./remote -run TestRecvAckPipe` → `RecvAck blocked beyond deadline` | Hung transfers and goroutine leaks when helper stdout lacks deadline support | Close reader or avoid draining when context is canceled; add tests | Medium |


### PR DESCRIPTION
## Summary
- document corrupt manifest halting resumes
- capture RecvAck blocking behaviour when helper lacks deadline support

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: 1270 issues)*
- `go test -v ./reports` *(fails: found 2 unresolved gap(s))*


------
https://chatgpt.com/codex/tasks/task_e_68aa3b47b6d48323b011184a9486d2b2