### PR TITLE
device: support read-only file access

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ Override detection with `--source-type` and `--dest-type` when necessary.
 Internally, `device.Detect` delegates to dedicated helpers:
 
 ```go
-dev, err := device.Detect(ctx, "/dev/sdb", true, "auto", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+dev, err := device.Detect(ctx, "/dev/sdb", true, true, "auto", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 // detectFileDevice, detectLVMDevice, or detectRawDevice is selected based on the path.
 ```
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -57,7 +57,7 @@ type Runner struct {
 	dumpDedup      func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer, transfer.DeduplicationStrategy) error
 	newSSHClient   func(context.Context, string, string, string, int, string, bool, time.Duration, time.Duration, int, *zap.Logger) (*remote.SSHClient, error)
 	openFile       func(string, int, os.FileMode) (*os.File, error)
-	detectDevice   func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error)
+	detectDevice   func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error)
 	sumFile        func(string, string) ([32]byte, error)
 	streamToRemote func(context.Context, *config.Config, io.WriteCloser, string, string, string, *zap.Logger) error
 	probeDest      func(context.Context, *config.Config, string, *zap.Logger) (device.DeviceIdentity, error)
@@ -291,6 +291,7 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 	dev, err := r.detectDevice(
 		ctx,
 		source,
+		true,
 		cfg.Offline,
 		cfg.SourceType,
 		cfg.FSFreezeCommand,
@@ -370,7 +371,7 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 		return destType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, io.Discard, logger)
 	}
 	if destType == "auto" {
-		dev, err := device.Detect(devCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx, logger), logger, devRunner)
+		dev, err := device.Detect(devCtx, dest, false, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx, logger), logger, devRunner)
 		if err != nil {
 			if cfg.CheckPartition && errors.Is(err, device.ErrPartitionMismatch) {
 				if !cfg.Force {
@@ -382,7 +383,7 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 				tmpCtx := device.WithForce(context.Background(), cfg.Force)
 				tmpCtx = device.WithAllowOverwrite(tmpCtx, cfg.AllowOverwrite)
 				tmpCtx = device.WithYesIKnow(tmpCtx, cfg.YesIKnow)
-				dev, err = device.Detect(tmpCtx, dest, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(tmpCtx, logger), logger, devRunner)
+				dev, err = device.Detect(tmpCtx, dest, false, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(tmpCtx, logger), logger, devRunner)
 				if err != nil {
 					dev = nil
 				}
@@ -566,7 +567,7 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 
 	rw := writeOnlyReadWriter{remoteStdin}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, maxFrame))
-	dev, err := r.detectDevice(ctx, originDevice, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+	dev, err := r.detectDevice(ctx, originDevice, true, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 	if err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("detect origin: %w", err)

--- a/cmd/dump/probe.go
+++ b/cmd/dump/probe.go
@@ -22,7 +22,7 @@ const firstBlockDigestSize = 1 << 20
 
 func realProbeDestination(ctx context.Context, cfg *config.Config, dest string, logger *zap.Logger) (device.DeviceIdentity, error) {
 	info := device.NewInfo()
-	dev, err := device.Detect(ctx, dest, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+	dev, err := device.Detect(ctx, dest, true, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 	if err != nil {
 		return device.DeviceIdentity{}, err
 	}

--- a/cmd/dump/probe_only_test.go
+++ b/cmd/dump/probe_only_test.go
@@ -30,7 +30,7 @@ func TestProbeOnlyNoSideEffects(t *testing.T) {
 	cfg.ProbeOnly = true
 
 	r := NewRunnerWithDeps(&Runner{
-		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		detectDevice: func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 			t.Fatalf("detectDevice called")
 			return nil, nil
 		},
@@ -79,7 +79,7 @@ func TestDryRunLogsCompression(t *testing.T) {
 	logger := zap.New(core)
 
 	r := NewRunnerWithDeps(&Runner{
-		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		detectDevice: func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 			return &sizedDevice{fakeDevice{path: "/dev/snap"}, 1024}, nil
 		},
 		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },

--- a/cmd/dump/remote_script_test.go
+++ b/cmd/dump/remote_script_test.go
@@ -51,7 +51,7 @@ func TestRemotePostScriptRunsOnError(t *testing.T) {
 			return io.ErrUnexpectedEOF
 		},
 		sumFile: func(string, string) ([32]byte, error) { return [32]byte{}, nil },
-		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		detectDevice: func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 			return &fakeDevice{path: "/dev/snap"}, nil
 		},
 		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
@@ -107,7 +107,7 @@ func TestRemotePostScriptNotRunIfPreScriptFails(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 
 	r := NewRunnerWithDeps(&Runner{
-		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		detectDevice: func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 			return &fakeDevice{path: "/dev/snap"}, nil
 		},
 		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },
@@ -168,7 +168,7 @@ func TestRemotePostScriptContextError(t *testing.T) {
 	cfg.LVMSyncPath = "lvmsync"
 
 	r := NewRunnerWithDeps(&Runner{
-		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		detectDevice: func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 			return &fakeDevice{path: "/dev/snap"}, nil
 		},
 		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },

--- a/cmd/dump/save_state_error_test.go
+++ b/cmd/dump/save_state_error_test.go
@@ -34,7 +34,7 @@ func TestRunLogsSaveStateError(t *testing.T) {
 		dumpDedup: func(_ context.Context, _ *transfer.Transfer, c *config.Config, snapshot, source string, out io.Writer, dedup transfer.DeduplicationStrategy) error {
 			return nil
 		},
-		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		detectDevice: func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 			return &fakeDevice{path: "/dev/snap"}, nil
 		},
 		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },

--- a/cmd/dump/stdout_test.go
+++ b/cmd/dump/stdout_test.go
@@ -31,7 +31,7 @@ func TestRunStdout(t *testing.T) {
 			_, writeErr := out.Write([]byte(expected))
 			return writeErr
 		},
-		detectDevice: func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
+		detectDevice: func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error) {
 			return &fakeDevice{path: "/dev/snap"}, nil
 		},
 		verifyIdentity: func(context.Context, *device.Info, string, string) error { return nil },

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -147,7 +147,7 @@ func (r *Runner) verifyDevices(ctx context.Context, cfg *config.Config, src, dst
 	esc := privilege.New(ctx, logger)
 	runner := device.NewRunner()
 
-	srcDev, err := device.Detect(ctx, src, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, esc, logger, runner)
+	srcDev, err := device.Detect(ctx, src, true, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, esc, logger, runner)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (r *Runner) verifyDevices(ctx context.Context, cfg *config.Config, src, dst
 		}
 	}()
 
-	dstDev, err := device.Detect(ctx, dst, cfg.Offline, cfg.DestType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, esc, logger, runner)
+	dstDev, err := device.Detect(ctx, dst, true, cfg.Offline, cfg.DestType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, esc, logger, runner)
 	if err != nil {
 		return err
 	}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -413,7 +413,7 @@ func TestVerifyDevicesContextCancelled(t *testing.T) {
 	r := newStubRunner()
 	ctx, cancel := context.WithCancel(context.Background())
 	called := make(chan struct{})
-	patch := monkey.Patch(device.Detect, func(ctx context.Context, _ string, _ bool, _ string, _ string, _ string, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *device.Runner) (device.Device, error) {
+	patch := monkey.Patch(device.Detect, func(ctx context.Context, _ string, _ bool, _ bool, _ string, _ string, _ string, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *device.Runner) (device.Device, error) {
 		close(called)
 		<-ctx.Done()
 		return nil, ctx.Err()

--- a/device/detect.go
+++ b/device/detect.go
@@ -42,8 +42,8 @@ func verifyPartition(ctx context.Context, dev Device, runner *Runner, logger *za
 }
 
 // detectFileDevice opens a regular file as a device.
-func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
-	dev, err := OpenFile(path, logger)
+func detectFileDevice(path string, readonly bool, logger *zap.Logger) (Device, error) {
+	dev, err := OpenFile(path, readonly, logger)
 	if err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeFile), zap.Error(err))
 		return nil, err
@@ -53,7 +53,7 @@ func detectFileDevice(path string, logger *zap.Logger) (Device, error) {
 }
 
 // detectLVMDevice opens an LVM logical volume.
-func detectLVMDevice(ctx context.Context, path string, offline bool, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
+func detectLVMDevice(ctx context.Context, path string, readonly bool, offline bool, lvmEscalation string, runner *Runner, logger *zap.Logger) (Device, error) {
 	if err := lvm.VerifyEscalationCommand(lvmEscalation); err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
@@ -63,7 +63,7 @@ func detectLVMDevice(ctx context.Context, path string, offline bool, lvmEscalati
 		return nil, err
 	}
 	defer cache.Close()
-	dev, err := runner.OpenLVM(ctx, path, cache, offline, lvmEscalation, logger)
+	dev, err := runner.OpenLVM(ctx, path, cache, readonly, offline, lvmEscalation, logger)
 	if err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeLVM), zap.Error(err))
 		return nil, err
@@ -81,6 +81,7 @@ func detectLVMDevice(ctx context.Context, path string, offline bool, lvmEscalati
 func detectRawDevice(
 	ctx context.Context,
 	path string,
+	readonly bool,
 	offline bool,
 	fsFreezeCmd, fsThawCmd string,
 	freezeTimeout, thawTimeout time.Duration,
@@ -114,7 +115,7 @@ func detectRawDevice(
 			thawArgs = parts[1:]
 		}
 	}
-	dev, err := runner.OpenRaw(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger)
+	dev, err := runner.OpenRaw(ctx, path, readonly, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger)
 	if err != nil {
 		logger.Error("detect_device_failed", zap.String("path", path), zap.String("device_type", TypeRaw), zap.Error(err))
 		return nil, err
@@ -137,6 +138,7 @@ func detectRawDevice(
 func Detect(
 	ctx context.Context,
 	path string,
+	readonly bool,
 	offline bool,
 	explicitType, fsFreezeCmd, fsThawCmd, lvmEscalation string,
 	freezeTimeout, thawTimeout time.Duration,
@@ -206,31 +208,31 @@ func Detect(
 			if !info.Mode().IsRegular() {
 				return nil, fmt.Errorf("expected regular file for type file: %s", resolved)
 			}
-			return detectFileDevice(resolved, logger)
+			return detectFileDevice(resolved, readonly, logger)
 		case TypeLVM:
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type lvm: %s", resolved)
 			}
-			return detectLVMDevice(ctx, resolved, offline, lvmEscalation, runner, logger)
+			return detectLVMDevice(ctx, resolved, readonly, offline, lvmEscalation, runner, logger)
 		case TypeRaw:
 			if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 				return nil, fmt.Errorf("expected block device for type raw: %s", resolved)
 			}
-			return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, esc, logger, runner)
+			return detectRawDevice(ctx, resolved, readonly, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, esc, logger, runner)
 		default:
 			return nil, fmt.Errorf("unknown device type %q", explicitType)
 		}
 	}
 	if info.Mode().IsRegular() {
-		return detectFileDevice(resolved, logger)
+		return detectFileDevice(resolved, readonly, logger)
 	}
 	if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
 		out, err := runner.command.CommandContext(ctx, "blkid", "-o", "value", "-s", "TYPE", resolved).Output()
 		fsType := strings.TrimSpace(string(out))
 		if err == nil && fsType == "LVM2_member" {
-			return detectLVMDevice(ctx, resolved, offline, lvmEscalation, runner, logger)
+			return detectLVMDevice(ctx, resolved, readonly, offline, lvmEscalation, runner, logger)
 		}
-		return detectRawDevice(ctx, resolved, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, esc, logger, runner)
+		return detectRawDevice(ctx, resolved, readonly, offline, fsFreezeCmd, fsThawCmd, freezeTimeout, thawTimeout, esc, logger, runner)
 	}
 	err = fmt.Errorf("unsupported path type: %s", resolved)
 	logger.Error("device_detect_failed", zap.String("path", resolved), zap.String("device_type", "unknown"), zap.Error(err))

--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -23,7 +23,7 @@ func TestDetectFileDeviceSuccess(t *testing.T) {
 	f.Close()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	dev, err := detectFileDevice(f.Name(), logger)
+	dev, err := detectFileDevice(f.Name(), true, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestDetectFileDeviceSuccess(t *testing.T) {
 
 func TestDetectFileDeviceError(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := detectFileDevice(dir, zap.NewNop()); err == nil {
+	if _, err := detectFileDevice(dir, true, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -56,10 +56,10 @@ func TestDetectLVMDeviceSuccess(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 	runner := NewRunner()
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
-	dev, err := detectLVMDevice(context.Background(), "/dev/test", false, "", runner, logger)
+	dev, err := detectLVMDevice(context.Background(), "/dev/test", true, false, "", runner, logger)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -83,10 +83,10 @@ func TestDetectLVMDeviceError(t *testing.T) {
 	restore := lvm.SetEscalationChecker(func(string) error { return nil })
 	defer restore()
 	runner := NewRunner()
-	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, bool, bool, string, *zap.Logger) (*LVMDevice, error) {
 		return nil, errors.New("fail")
 	}
-	if _, err := detectLVMDevice(context.Background(), "/dev/test", false, "", runner, zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice(context.Background(), "/dev/test", true, false, "", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -96,11 +96,11 @@ func TestDetectLVMDeviceEscalationError(t *testing.T) {
 	defer restore()
 	runner := NewRunner()
 	called := false
-	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, bool, bool, string, *zap.Logger) (*LVMDevice, error) {
 		called = true
 		return &LVMDevice{path: "/dev/test", logger: zap.NewNop(), runner: runner}, nil
 	}
-	if _, err := detectLVMDevice(context.Background(), "/dev/test", false, "sudo -n", runner, zap.NewNop()); err == nil {
+	if _, err := detectLVMDevice(context.Background(), "/dev/test", true, false, "sudo -n", runner, zap.NewNop()); err == nil {
 		t.Fatalf("expected error")
 	}
 	if called {
@@ -110,7 +110,7 @@ func TestDetectLVMDeviceEscalationError(t *testing.T) {
 
 func TestDetectRawDeviceSuccess(t *testing.T) {
 	runner := NewRunner()
-	runner.openRawOverride = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
+	runner.openRawOverride = func(ctx context.Context, path string, readonly bool, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
 		f, err := os.CreateTemp(t.TempDir(), "raw")
 		if err != nil {
 			return nil, err
@@ -122,7 +122,7 @@ func TestDetectRawDeviceSuccess(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := detectRawDevice(ctx, "/dev/test", true, "", "", 0, 0, fakeEsc{}, logger, runner)
+	dev, err := detectRawDevice(ctx, "/dev/test", true, true, "", "", 0, 0, fakeEsc{}, logger, runner)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestDetectRawDeviceError(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := detectRawDevice(ctx, "/dev/null", true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := detectRawDevice(ctx, "/dev/null", true, true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -154,7 +154,7 @@ func TestDetectRawDeviceError(t *testing.T) {
 func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 	runner := NewRunner()
 	called := false
-	runner.openRawOverride = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
+	runner.openRawOverride = func(ctx context.Context, path string, readonly bool, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
@@ -163,7 +163,7 @@ func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := detectRawDevice(ctx, "/dev/test", true, "/bin/echo \"unterminated", "", 0, 0, fakeEsc{}, logger, runner)
+	_, err := detectRawDevice(ctx, "/dev/test", true, true, "/bin/echo \"unterminated", "", 0, 0, fakeEsc{}, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "invalid freeze command") {
 		t.Fatalf("expected freeze parse error, got %v", err)
 	}
@@ -182,7 +182,7 @@ func TestDetectRawDeviceFreezeParseError(t *testing.T) {
 func TestDetectRawDeviceThawParseError(t *testing.T) {
 	runner := NewRunner()
 	called := false
-	runner.openRawOverride = func(ctx context.Context, path string, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
+	runner.openRawOverride = func(ctx context.Context, path string, readonly bool, offline bool, freezePath string, freezeArgs []string, thawPath string, thawArgs []string, freezeTimeout, thawTimeout time.Duration, esc privilege.Escalator, logger *zap.Logger) (*RawDevice, error) {
 		called = true
 		return nil, nil
 	}
@@ -191,7 +191,7 @@ func TestDetectRawDeviceThawParseError(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := detectRawDevice(ctx, "/dev/test", true, "", "/bin/echo \"unterminated", 0, 0, fakeEsc{}, logger, runner)
+	_, err := detectRawDevice(ctx, "/dev/test", true, true, "", "/bin/echo \"unterminated", 0, 0, fakeEsc{}, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "invalid thaw command") {
 		t.Fatalf("expected thaw parse error, got %v", err)
 	}

--- a/device/detect_test.go
+++ b/device/detect_test.go
@@ -49,7 +49,7 @@ func TestDetectFile(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := Detect(ctx, f.Name(), true, "", "", "", "", 0, 0, fakeEsc{}, logger, NewRunner())
+	dev, err := Detect(ctx, f.Name(), true, true, "", "", "", "", 0, 0, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestDetectFileSymlink(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := Detect(ctx, link, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+	dev, err := Detect(ctx, link, true, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestDetectPathValidation(t *testing.T) {
 			ctx := WithForce(context.Background(), true)
 			ctx = WithAllowOverwrite(ctx, true)
 			ctx = WithYesIKnow(ctx, true)
-			_, err := Detect(ctx, tc.path, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+			_, err := Detect(ctx, tc.path, true, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for path %s", tc.path)
@@ -151,7 +151,7 @@ func TestDetectRaw(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := Detect(ctx, loop, true, "", "", "", "", 0, 0, fakeEsc{}, logger, NewRunner())
+	dev, err := Detect(ctx, loop, true, true, "", "", "", "", 0, 0, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestDetectRawSymlink(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := Detect(ctx, link, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+	dev, err := Detect(ctx, link, true, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestDetectLVMSymlink(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := Detect(ctx, lvPath, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+	dev, err := Detect(ctx, lvPath, true, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -242,13 +242,13 @@ func TestDetectLVM(t *testing.T) {
 		return exec.CommandContext(ctx, name, args...)
 	})
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, logger: zap.NewNop(), runner: runner}, nil
 	}
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := Detect(ctx, loop, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), runner)
+	dev, err := Detect(ctx, loop, true, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), runner)
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestDetectRawCommandQuoting(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := Detect(ctx, loop, false, "raw", freeze, thaw, "", 0, 0, fakeEsc{}, zap.NewNop(), NewDeviceRunner(cmd))
+	dev, err := Detect(ctx, loop, false, false, "raw", freeze, thaw, "", 0, 0, fakeEsc{}, zap.NewNop(), NewDeviceRunner(cmd))
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
@@ -324,7 +324,7 @@ func TestDetectRawPartitionMismatch(t *testing.T) {
 	ctx = WithForce(ctx, true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := detectRawDevice(ctx, loop, true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, ErrPartitionMismatch) {
+	if _, err := detectRawDevice(ctx, loop, true, true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, ErrPartitionMismatch) {
 		t.Fatalf("expected partition mismatch error, got %v", err)
 	}
 }
@@ -354,7 +354,7 @@ func TestDetectRawPartitionMatch(t *testing.T) {
 	ctx = WithForce(ctx, true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := detectRawDevice(ctx, loop, true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+	dev, err := detectRawDevice(ctx, loop, true, true, "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("detectRawDevice: %v", err)
 	}
@@ -385,12 +385,12 @@ func TestDetectPartitionComparison(t *testing.T) {
 			ctx = WithForce(ctx, true)
 			ctx = WithAllowOverwrite(ctx, true)
 			ctx = WithYesIKnow(ctx, true)
-			dev, err := Detect(ctx, f1, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+			dev, err := Detect(ctx, f1, true, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 			if err != nil {
 				t.Fatalf("detect src: %v", err)
 			}
 			dev.Close()
-			_, err = Detect(ctx, f2, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+			_, err = Detect(ctx, f2, true, true, "", "", "", "", 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 			if tc.wantErr {
 				if err == nil || !errors.Is(err, ErrPartitionMismatch) {
 					t.Fatalf("expected partition mismatch error, got %v", err)

--- a/device/file.go
+++ b/device/file.go
@@ -18,8 +18,9 @@ type FileDevice struct {
 }
 
 // OpenFile opens a regular file and reports its size and filesystem block size.
-// logger must be non-nil.
-func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
+// When readonly is true the file is opened with os.O_RDONLY. logger must be
+// non-nil.
+func OpenFile(path string, readonly bool, logger *zap.Logger) (*FileDevice, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		logger.Error("file_device_open_failed", zap.String("path", path), zap.Error(err))
@@ -30,7 +31,12 @@ func OpenFile(path string, logger *zap.Logger) (*FileDevice, error) {
 		logger.Error("file_device_open_failed", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
-	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	var f *os.File
+	if readonly {
+		f, err = os.Open(path)
+	} else {
+		f, err = os.OpenFile(path, os.O_RDWR, 0)
+	}
 	if err != nil {
 		logger.Error("file_device_open_failed", zap.String("path", path), zap.Error(err))
 		return nil, err

--- a/device/file_test.go
+++ b/device/file_test.go
@@ -10,57 +10,74 @@ import (
 )
 
 func TestOpenFile(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "filedev")
-	if err != nil {
-		t.Fatalf("temp file: %v", err)
+	cases := []struct {
+		name     string
+		readonly bool
+	}{
+		{name: "read_write", readonly: false},
+		{name: "read_only", readonly: true},
 	}
-	if _, err := f.Write(make([]byte, 4096)); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	path := f.Name()
-	f.Close()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.CreateTemp(t.TempDir(), "filedev")
+			if err != nil {
+				t.Fatalf("temp file: %v", err)
+			}
+			if _, err := f.Write(make([]byte, 4096)); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			path := f.Name()
+			f.Close()
 
-	core, logs := observer.New(zap.InfoLevel)
-	logger := zap.New(core)
-	d, err := OpenFile(path, logger)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	ctx := context.Background()
-	_, _ = d.Snapshot(ctx, "")
-	_ = d.Cleanup(ctx)
-	d.Close()
+			core, logs := observer.New(zap.InfoLevel)
+			logger := zap.New(core)
+			d, err := OpenFile(path, tc.readonly, logger)
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			ctx := context.Background()
+			_, _ = d.Snapshot(ctx, "")
+			_ = d.Cleanup(ctx)
 
-	if d.SizeBytes() != 4096 {
-		t.Fatalf("expected size 4096, got %d", d.SizeBytes())
-	}
-	if d.BlockSize() == 0 {
-		t.Fatalf("expected non-zero block size")
-	}
+			if _, err := d.f.Write([]byte{1}); tc.readonly && err == nil {
+				t.Fatalf("expected write error in readonly mode")
+			} else if !tc.readonly && err != nil {
+				t.Fatalf("unexpected write error: %v", err)
+			}
+			d.Close()
 
-	if logs.FilterMessage("file_device_opened").Len() == 0 {
-		t.Fatalf("expected file_device_opened log")
-	}
-	entries := logs.FilterMessage("file_device_info").All()
-	found := false
-	for _, e := range entries {
-		if e.ContextMap()["path"] == path &&
-			e.ContextMap()["size_bytes"].(uint64) == d.SizeBytes() &&
-			e.ContextMap()["block_size_bytes"].(uint64) == d.BlockSize() {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("expected file_device_info log with fields, got %v", logs.All())
-	}
-	if logs.FilterMessage("file_device_closed").Len() == 0 {
-		t.Fatalf("expected file_device_closed log")
+			if d.SizeBytes() != 4096 {
+				t.Fatalf("expected size 4096, got %d", d.SizeBytes())
+			}
+			if d.BlockSize() == 0 {
+				t.Fatalf("expected non-zero block size")
+			}
+
+			if logs.FilterMessage("file_device_opened").Len() == 0 {
+				t.Fatalf("expected file_device_opened log")
+			}
+			entries := logs.FilterMessage("file_device_info").All()
+			found := false
+			for _, e := range entries {
+				if e.ContextMap()["path"] == path &&
+					e.ContextMap()["size_bytes"].(uint64) == d.SizeBytes() &&
+					e.ContextMap()["block_size_bytes"].(uint64) == d.BlockSize() {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("expected file_device_info log with fields, got %v", logs.All())
+			}
+			if logs.FilterMessage("file_device_closed").Len() == 0 {
+				t.Fatalf("expected file_device_closed log")
+			}
+		})
 	}
 }
 
 func TestOpenFileRejectsNonRegular(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := OpenFile(dir, zap.NewNop()); err == nil {
+	if _, err := OpenFile(dir, false, zap.NewNop()); err == nil {
 		t.Fatalf("expected error for directory")
 	}
 }
@@ -82,7 +99,7 @@ func TestFileSnapshotIdentityAndFDLeak(t *testing.T) {
 	path := f.Name()
 	f.Close()
 
-	d, err := OpenFile(path, zap.NewNop())
+	d, err := OpenFile(path, false, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -110,7 +127,7 @@ func TestFileSnapshotClosedDevice(t *testing.T) {
 	path := f.Name()
 	f.Close()
 
-	d, err := OpenFile(path, zap.NewNop())
+	d, err := OpenFile(path, false, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -130,7 +147,7 @@ func TestFileDevicePath(t *testing.T) {
 	}
 	path := f.Name()
 	f.Close()
-	d, err := OpenFile(path, zap.NewNop())
+	d, err := OpenFile(path, false, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/device/identity_mismatch_overwrite_test.go
+++ b/device/identity_mismatch_overwrite_test.go
@@ -21,15 +21,15 @@ func TestIdentityMismatchRequiresOverwriteFlags(t *testing.T) {
 	defer cleanupDst()
 
 	ctx := WithForce(context.Background(), true)
-	if _, err := OpenRaw(ctx, dstLoop, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "--allow-overwrite") {
+	if _, err := OpenRaw(ctx, dstLoop, true, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "--allow-overwrite") {
 		t.Fatalf("expected allow-overwrite error, got %v", err)
 	}
 	ctx = WithAllowOverwrite(ctx, true)
-	if _, err := OpenRaw(ctx, dstLoop, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "--yes-i-know") {
+	if _, err := OpenRaw(ctx, dstLoop, true, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "--yes-i-know") {
 		t.Fatalf("expected yes-i-know error, got %v", err)
 	}
 	ctx = WithYesIKnow(ctx, true)
-	dev, err := OpenRaw(ctx, dstLoop, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
+	dev, err := OpenRaw(ctx, dstLoop, true, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("OpenRaw: %v", err)
 	}

--- a/device/identity_preflight.go
+++ b/device/identity_preflight.go
@@ -37,7 +37,7 @@ func VerifyIdentity(ctx context.Context, info *Info, src, dest string) (err erro
 	if !match && !allow {
 		return fmt.Errorf("uuid mismatch: %w", exitcode.ErrPrecondition)
 	}
-	devA, err := info.detectFunc(ctx, src, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
+	devA, err := info.detectFunc(ctx, src, true, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func VerifyIdentity(ctx context.Context, info *Info, src, dest string) (err erro
 			err = fmt.Errorf("close block device: %w", closeErr)
 		}
 	}()
-	devB, err := info.detectFunc(ctx, dest, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
+	devB, err := info.detectFunc(ctx, dest, true, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
 	if err != nil {
 		return err
 	}

--- a/device/identity_test.go
+++ b/device/identity_test.go
@@ -39,7 +39,7 @@ func (s *identityStub) RecoverWAL(fn func(Range) error) error { return nil }
 
 func TestVerifyIdentityMatch(t *testing.T) {
 	info := NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
-	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return &identityStub{size: 1, epoch: 1}, nil
 	})
 	defer info.SetDetectFunc(prev)
@@ -50,7 +50,7 @@ func TestVerifyIdentityMatch(t *testing.T) {
 
 func TestIdentitySizeMismatchFailsEarly(t *testing.T) {
 	info := NewInfo()
-	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
 		if strings.Contains(path, "src") {
 			return &identityStub{size: 1, epoch: 1}, nil
 		}
@@ -73,7 +73,7 @@ func TestIdentityFSUUIDMismatch(t *testing.T) {
 		}
 		return "id2", nil
 	}, nil, nil, nil, nil)
-	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return &identityStub{size: 1, epoch: 1}, nil
 	})
 	defer info.SetDetectFunc(prev)
@@ -84,7 +84,7 @@ func TestIdentityFSUUIDMismatch(t *testing.T) {
 
 func TestIdentityGPTUUIDMismatch(t *testing.T) {
 	info := NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
-	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
 		if strings.Contains(path, "src") {
 			return &identityStub{size: 1, epoch: 1, gpt: "gpt1", mbr: "m"}, nil
 		}
@@ -98,7 +98,7 @@ func TestIdentityGPTUUIDMismatch(t *testing.T) {
 
 func TestIdentityMBRSignatureMismatch(t *testing.T) {
 	info := NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
-	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
 		if strings.Contains(path, "src") {
 			return &identityStub{size: 1, epoch: 1, gpt: "g", mbr: "m1"}, nil
 		}
@@ -112,7 +112,7 @@ func TestIdentityMBRSignatureMismatch(t *testing.T) {
 
 func TestIdentityPartitionHashMismatch(t *testing.T) {
 	info := NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
-	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
 		if strings.Contains(path, "src") {
 			return &identityStub{size: 1, epoch: 1, phash: hash.SumBLAKE3([]byte("a"))}, nil
 		}
@@ -126,7 +126,7 @@ func TestIdentityPartitionHashMismatch(t *testing.T) {
 
 func TestVerifyIdentityManifestEpochMismatch(t *testing.T) {
 	info := NewInfoWithDeps(func(context.Context, string) (string, error) { return "id", nil }, nil, nil, nil, nil)
-	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(_ context.Context, path string, _ bool, _ bool, _, _, _, _ string, _ time.Duration, _ time.Duration, _ privilege.Escalator, _ *zap.Logger, _ *Runner) (Device, error) {
 		if strings.Contains(path, "src") {
 			return &identityStub{size: 1, epoch: 1}, nil
 		}

--- a/device/info.go
+++ b/device/info.go
@@ -40,7 +40,7 @@ type Info struct {
 	lvmUUIDFunc func(context.Context, string) (string, error)
 	mountFunc   func(context.Context, string) (bool, error)
 	firstDigest func(context.Context, string, uint64) ([32]byte, error)
-	detectFunc  func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error)
+	detectFunc  func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error)
 }
 
 // NewInfo returns an Info using production dependencies.
@@ -61,7 +61,7 @@ func NewInfoWithDeps(
 	lvmUUID func(context.Context, string) (string, error),
 	mount func(context.Context, string) (bool, error),
 	digest func(context.Context, string, uint64) ([32]byte, error),
-	detect func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error),
+	detect func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error),
 ) *Info {
 	if uuid == nil {
 		uuid = defaultUUIDFunc
@@ -91,8 +91,8 @@ func (i *Info) SetMountFunc(f func(context.Context, string) (bool, error)) func(
 
 // SetDetectFunc allows tests to override the device detector. It returns the previous function for restoration.
 func (i *Info) SetDetectFunc(
-	f func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error),
-) func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
+	f func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error),
+) func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 	prev := i.detectFunc
 	i.detectFunc = f
 	return prev
@@ -187,7 +187,7 @@ func (i *Info) SizeBytes(ctx context.Context, path string) (size uint64, err err
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	dev, err := i.detectFunc(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
+	dev, err := i.detectFunc(ctx, path, true, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
 	if err != nil {
 		return 0, err
 	}

--- a/device/info_test.go
+++ b/device/info_test.go
@@ -869,7 +869,7 @@ func TestDefaultLVMUUIDFunc(t *testing.T) {
 func TestSizeBytes(t *testing.T) {
 	dev := &stubDevice{size: 123}
 	info := NewInfo()
-	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return dev, nil
 	})
 	defer info.SetDetectFunc(prev)
@@ -888,7 +888,7 @@ func TestSizeBytesCloseError(t *testing.T) {
 	want := errors.New("close boom")
 	dev := &stubDevice{size: 456, closeErr: want}
 	info := NewInfo()
-	prev := info.SetDetectFunc(func(context.Context, string, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
+	prev := info.SetDetectFunc(func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (Device, error) {
 		return dev, nil
 	})
 	defer info.SetDetectFunc(prev)

--- a/device/lvm.go
+++ b/device/lvm.go
@@ -39,9 +39,9 @@ type LVMDevice struct {
 // OpenLVM opens an LVM logical volume and queries its size and block size.
 // It fails unless the device is a snapshot or offline is true. Size
 // information is obtained through the lvm package helpers.
-func (r *Runner) OpenLVM(ctx context.Context, path string, cache *lvm.FDCache, offline bool, escalation string, logger *zap.Logger) (*LVMDevice, error) {
+func (r *Runner) OpenLVM(ctx context.Context, path string, cache *lvm.FDCache, readonly bool, offline bool, escalation string, logger *zap.Logger) (*LVMDevice, error) {
 	if r.openLVMOverride != nil {
-		return r.openLVMOverride(ctx, path, cache, offline, escalation, logger)
+		return r.openLVMOverride(ctx, path, cache, readonly, offline, escalation, logger)
 	}
 	exists, err := r.volumeExists(ctx, path)
 	if err != nil {
@@ -96,7 +96,12 @@ func (r *Runner) OpenLVM(ctx context.Context, path string, cache *lvm.FDCache, o
 	if err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	var f *os.File
+	if readonly {
+		f, err = os.Open(path)
+	} else {
+		f, err = os.OpenFile(path, os.O_RDWR, 0)
+	}
 	if err != nil {
 		_ = lk.Release()
 		return nil, err
@@ -295,7 +300,7 @@ func (d *LVMDevice) Snapshot(ctx context.Context, snapshotSize string) (Device, 
 		return nil, err
 	}
 	defer cache.Close()
-	snapDev, err := d.runner.OpenLVM(ctx, snapPath, cache, false, d.escalation, d.logger)
+	snapDev, err := d.runner.OpenLVM(ctx, snapPath, cache, true, false, d.escalation, d.logger)
 	if err != nil {
 		_ = d.runner.runLVM(ctx, d.escalation, "lvremove", "-f", snapPath)
 		return nil, err

--- a/device/lvm_nonlinux.go
+++ b/device/lvm_nonlinux.go
@@ -27,8 +27,8 @@ func NewRunnerWithDeps(func(context.Context, string) (bool, error), func(context
 type LVMDevice struct{}
 
 // OpenLVM returns an error on non-Linux systems.
-func (r *Runner) OpenLVM(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error) {
-	return nil, fmt.Errorf("LVM devices are only supported on Linux")
+func (r *Runner) OpenLVM(context.Context, string, *lvm.FDCache, bool, bool, string, *zap.Logger) (*LVMDevice, error) {
+        return nil, fmt.Errorf("LVM devices are only supported on Linux")
 }
 
 func (d *LVMDevice) Path() string      { return "" }

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -78,7 +78,7 @@ func TestOpenLVM(t *testing.T) {
 	}
 	defer cache.Close()
 	runner := NewRunner()
-	dev, err := runner.OpenLVM(context.Background(), loop, cache, false, "", zap.NewNop())
+	dev, err := runner.OpenLVM(context.Background(), loop, cache, true, false, "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestOpenLVMNonBlockDevice(t *testing.T) {
 	}
 	defer cache.Close()
 	runner := NewRunner()
-	if _, err := runner.OpenLVM(context.Background(), f.Name(), cache, false, "", zap.NewNop()); err == nil {
+	if _, err := runner.OpenLVM(context.Background(), f.Name(), cache, true, false, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error for non-block device")
 	}
 }
@@ -115,7 +115,7 @@ func TestOpenLVMChecks(t *testing.T) {
 	}
 	defer cache.Close()
 	runner := NewRunnerWithDeps(func(context.Context, string) (bool, error) { return false, nil }, lvm.AutoExtendEnabled, lvm.DiscardEnabled, defaultIsMountedRW, lock.Acquire, nil)
-	if _, err := runner.OpenLVM(context.Background(), "/dev/missing", cache, false, "", zap.NewNop()); err == nil {
+	if _, err := runner.OpenLVM(context.Background(), "/dev/missing", cache, true, false, "", zap.NewNop()); err == nil {
 		t.Fatalf("expected error when volume missing")
 	}
 }
@@ -149,10 +149,10 @@ func TestOpenLVMRequiresSnapshot(t *testing.T) {
 		func(string, string) (*lock.Lock, error) { return &lock.Lock{}, nil },
 		nil,
 	)
-	if _, err := runner.OpenLVM(context.Background(), loop, cache, false, "", zap.NewNop()); !errors.Is(err, exitcode.ErrPrecondition) {
+	if _, err := runner.OpenLVM(context.Background(), loop, cache, true, false, "", zap.NewNop()); !errors.Is(err, exitcode.ErrPrecondition) {
 		t.Fatalf("expected precondition error, got %v", err)
 	}
-	if _, err := runner.OpenLVM(context.Background(), loop, cache, true, "", zap.NewNop()); err != nil {
+	if _, err := runner.OpenLVM(context.Background(), loop, cache, true, true, "", zap.NewNop()); err != nil {
 		t.Fatalf("offline open: %v", err)
 	}
 }
@@ -186,7 +186,7 @@ func TestOpenLVMSnapshotAllowed(t *testing.T) {
 		func(string, string) (*lock.Lock, error) { return &lock.Lock{}, nil },
 		nil,
 	)
-	dev, err := runner.OpenLVM(context.Background(), loop, cache, false, "", zap.NewNop())
+	dev, err := runner.OpenLVM(context.Background(), loop, cache, true, false, "", zap.NewNop())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestSnapshotReadOnly(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop(), runner: runner}, nil
 	}
 

--- a/device/raw.go
+++ b/device/raw.go
@@ -86,7 +86,7 @@ func prepareFreeze(
 
 // openDevice ensures the path is a block device and opens it for reading and writing.
 // Callers must ensure the necessary privilege before invoking this function.
-func openDevice(path string) (*os.File, error) {
+func openDevice(path string, readonly bool) (*os.File, error) {
 	if !filepath.IsAbs(path) {
 		return nil, fmt.Errorf("precondition: path must be absolute: %s", path)
 	}
@@ -96,6 +96,9 @@ func openDevice(path string) (*os.File, error) {
 	}
 	if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
 		return nil, fmt.Errorf("%s is not a block device", path)
+	}
+	if readonly {
+		return os.Open(path)
 	}
 	return os.OpenFile(path, os.O_RDWR, 0)
 }
@@ -123,6 +126,7 @@ func queryDeviceInfo(f *os.File, path string, logger *zap.Logger) (uint64, uint6
 func OpenRaw(
 	ctx context.Context,
 	path string,
+	readonly bool,
 	offline bool,
 	fsFreezeCmdPath string,
 	fsFreezeCmdArgs []string,
@@ -159,7 +163,7 @@ func OpenRaw(
 			}
 		}()
 	}
-	f, err := openDevice(path)
+	f, err := openDevice(path, readonly)
 	if err != nil {
 		return nil, err
 	}

--- a/device/raw_helpers_test.go
+++ b/device/raw_helpers_test.go
@@ -50,7 +50,7 @@ func TestOpenDeviceSuccess(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	f, err := openDevice(loop)
+	f, err := openDevice(loop, true)
 	if err != nil {
 		t.Fatalf("openDevice: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestOpenDeviceFailure(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	if _, err := openDevice(f.Name()); err == nil {
+	if _, err := openDevice(f.Name(), true); err == nil {
 		t.Fatalf("expected error for non-block device")
 	}
 }
@@ -74,7 +74,7 @@ func TestQueryDeviceInfoSuccess(t *testing.T) {
 	}
 	loop, cleanup := setupLoop(t, 1<<20)
 	defer cleanup()
-	f, err := openDevice(loop)
+	f, err := openDevice(loop, true)
 	if err != nil {
 		t.Fatalf("openDevice: %v", err)
 	}

--- a/device/raw_nonlinux.go
+++ b/device/raw_nonlinux.go
@@ -16,7 +16,7 @@ import (
 type RawDevice struct{}
 
 // OpenRaw returns an error on non-Linux systems.
-func OpenRaw(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (*RawDevice, error) {
+func OpenRaw(context.Context, string, bool, bool, string, []string, string, []string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *Runner) (*RawDevice, error) {
 	return nil, fmt.Errorf("raw devices are only supported on Linux")
 }
 

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -42,7 +42,7 @@ func TestOpenRawLogsInfoAndClose(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	d, err := OpenRaw(ctx, loop, true, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, logger, NewRunner())
+	d, err := OpenRaw(ctx, loop, true, true, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestRawDeviceCloseErrorLogging(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	d, err := OpenRaw(ctx, loop, true, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, logger, NewRunner())
+	d, err := OpenRaw(ctx, loop, true, true, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, logger, NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestOpenRawRejectsRegularFile(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := OpenRaw(ctx, f.Name(), true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := OpenRaw(ctx, f.Name(), true, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error for regular file")
 	}
 }
@@ -111,7 +111,7 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 		ctx := WithForce(context.Background(), true)
 		ctx = WithAllowOverwrite(ctx, true)
 		ctx = WithYesIKnow(ctx, true)
-		if _, err := OpenRaw(ctx, "/dev/null", true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
+		if _, err := OpenRaw(ctx, "/dev/null", true, true, "", nil, "", nil, 0, 0, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 			t.Fatalf("expected error for char device")
 		}
 	} else if os.IsNotExist(err) {
@@ -120,7 +120,7 @@ func TestOpenRawRejectsCharDevice(t *testing.T) {
 }
 
 func TestOpenRawRequiresOfflineOrFreeze(t *testing.T) {
-	if _, err := OpenRaw(context.Background(), "/dev/null", false, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+	if _, err := OpenRaw(context.Background(), "/dev/null", true, false, "", nil, "", nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
 		t.Fatalf("expected precondition error, got %v", err)
 	}
 }
@@ -129,7 +129,7 @@ func TestOpenRawEscalatorError(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := OpenRaw(ctx, "/dev/null", true, "", nil, "", nil, 0, 0, fakeEsc{err: errors.New("boom")}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "boom") {
+	if _, err := OpenRaw(ctx, "/dev/null", true, true, "", nil, "", nil, 0, 0, fakeEsc{err: errors.New("boom")}, zap.NewNop(), NewRunner()); err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected escalator error, got %v", err)
 	}
 }
@@ -146,7 +146,7 @@ func TestOpenRawFreezeCommandFailure(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := OpenRaw(ctx, "/dev/null", false, falsePath, nil, truePath, nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := OpenRaw(ctx, "/dev/null", true, false, falsePath, nil, truePath, nil, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected freeze command failure")
 	}
 }
@@ -163,7 +163,7 @@ func TestOpenRawThawsOnFailure(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := OpenRaw(ctx, "/dev/null", false, touchPath, freezeArgs, touchPath, thawArgs, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
+	if _, err := OpenRaw(ctx, "/dev/null", true, false, touchPath, freezeArgs, touchPath, thawArgs, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner()); err == nil {
 		t.Fatalf("expected error for char device")
 	}
 	if _, err := os.Stat(freezeTmp); err != nil {
@@ -212,7 +212,7 @@ func TestOpenRawFreezeTimeout(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err = OpenRaw(ctx, "/dev/null", false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, fakeEsc{}, zap.NewNop(), NewRunner())
+	_, err = OpenRaw(ctx, "/dev/null", true, false, sleepPath, []string{"2"}, truePath, nil, 100*time.Millisecond, time.Second, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze command to be killed, got %v", err)
 	}
@@ -272,7 +272,7 @@ func TestOpenRawStoresThawConfig(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	d, err := OpenRaw(ctx, loop, false, truePath, nil, touchPath, []string{thawTmp}, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner())
+	d, err := OpenRaw(ctx, loop, true, false, truePath, nil, touchPath, []string{thawTmp}, time.Second, time.Second, fakeEsc{}, zap.NewNop(), NewRunner())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestOpenRawFreezeThawLogs(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := OpenRaw(ctx, "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-success"}, time.Second, time.Second, fakeEsc{}, logger, runner)
+	_, err := OpenRaw(ctx, "/dev/null", true, false, helper, []string{"freeze-success"}, helper, []string{"thaw-success"}, time.Second, time.Second, fakeEsc{}, logger, runner)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -316,7 +316,7 @@ func TestOpenRawFreezeTimeoutLogs(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := OpenRaw(ctx, "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, fakeEsc{}, logger, runner)
+	_, err := OpenRaw(ctx, "/dev/null", true, false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, fakeEsc{}, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze timeout, got %v", err)
 	}
@@ -339,7 +339,7 @@ func TestOpenRawFreezeTimeoutErrorLogs(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := OpenRaw(ctx, "/dev/null", false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, fakeEsc{}, logger, runner)
+	_, err := OpenRaw(ctx, "/dev/null", true, false, helper, []string{"freeze-timeout"}, helper, []string{"thaw-success"}, 50*time.Millisecond, time.Second, fakeEsc{}, logger, runner)
 	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
 		t.Fatalf("expected freeze timeout, got %v", err)
 	}
@@ -365,7 +365,7 @@ func TestOpenRawThawFailure(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	_, err := OpenRaw(ctx, "/dev/null", false, helper, []string{"freeze-success"}, helper, []string{"thaw-fail"}, time.Second, time.Second, fakeEsc{}, logger, runner)
+	_, err := OpenRaw(ctx, "/dev/null", true, false, helper, []string{"freeze-success"}, helper, []string{"thaw-fail"}, time.Second, time.Second, fakeEsc{}, logger, runner)
 	if err == nil {
 		t.Fatalf("expected error for char device")
 	}
@@ -395,7 +395,7 @@ func TestOpenRawFreezeCommandFailureIncludesOutput(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
 	ctx = WithYesIKnow(ctx, true)
-	if _, err := OpenRaw(ctx, "/dev/null", false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, fakeEsc{}, logger, runner); err == nil || !strings.Contains(err.Error(), "freeze output") {
+	if _, err := OpenRaw(ctx, "/dev/null", true, false, helper, []string{"freeze-fail-output"}, truePath, nil, time.Second, time.Second, fakeEsc{}, logger, runner); err == nil || !strings.Contains(err.Error(), "freeze output") {
 		t.Fatalf("expected freeze output in error, got %v", err)
 	}
 	entries := logs.FilterMessage("fs_freeze_failed").All()

--- a/device/runner.go
+++ b/device/runner.go
@@ -31,8 +31,8 @@ type Runner struct {
 	discardEnabled    func(context.Context, string) (bool, error)
 	isMountedRW       func(context.Context, string) (bool, error)
 	lockAcquire       func(string, string) (*lock.Lock, error)
-	openLVMOverride   func(context.Context, string, *lvm.FDCache, bool, string, *zap.Logger) (*LVMDevice, error)
-	openRawOverride   func(context.Context, string, bool, string, []string, string, []string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger) (*RawDevice, error)
+	openLVMOverride   func(context.Context, string, *lvm.FDCache, bool, bool, string, *zap.Logger) (*LVMDevice, error)
+	openRawOverride   func(context.Context, string, bool, bool, string, []string, string, []string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger) (*RawDevice, error)
 }
 
 // NewDeviceRunner returns a Runner using production dependencies and the provided Commander.
@@ -93,6 +93,7 @@ func defaultIsMountedRW(ctx context.Context, path string) (bool, error) {
 func (r *Runner) OpenRaw(
 	ctx context.Context,
 	path string,
+	readonly bool,
 	offline bool,
 	freezePath string,
 	freezeArgs []string,
@@ -104,7 +105,7 @@ func (r *Runner) OpenRaw(
 	logger *zap.Logger,
 ) (*RawDevice, error) {
 	if r.openRawOverride != nil {
-		return r.openRawOverride(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger)
+		return r.openRawOverride(ctx, path, readonly, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger)
 	}
-	return OpenRaw(ctx, path, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger, r)
+	return OpenRaw(ctx, path, readonly, offline, freezePath, freezeArgs, thawPath, thawArgs, freezeTimeout, thawTimeout, esc, logger, r)
 }

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -27,7 +27,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	f.Close()
-	fd, err := OpenFile(f.Name(), zap.NewNop())
+	fd, err := OpenFile(f.Name(), false, zap.NewNop())
 	if err != nil {
 		t.Fatalf("open file: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestSnapshotLifecycle(t *testing.T) {
 	defer func() { generateSnapshot = origName }()
 
 	runner := NewDeviceRunner(cmd)
-	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
+	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {
 		return &LVMDevice{path: p, cleanupPath: p, escalation: "doas -n", logger: zap.NewNop(), runner: runner}, nil
 	}
 

--- a/integration/freeze_helper_run_test.go
+++ b/integration/freeze_helper_run_test.go
@@ -50,7 +50,7 @@ func runOpenRaw(t *testing.T, freeze, thaw string, timeout time.Duration) (*obse
 	ctx = device.WithAllowOverwrite(ctx, true)
 	ctx = device.WithYesIKnow(ctx, true)
 	devPath := mockBlockDevice(t)
-	_, err := device.OpenRaw(ctx, devPath, false, freeze, nil, thaw, nil, timeout, time.Second, nil, logger, device.NewRunner())
+	_, err := device.OpenRaw(ctx, devPath, false, false, freeze, nil, thaw, nil, timeout, time.Second, nil, logger, device.NewRunner())
 	return logs, err
 }
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -91,7 +91,7 @@ func defaultIndexOptions() indexOptions {
 			ctx = device.WithForce(ctx, true)
 			ctx = device.WithAllowOverwrite(ctx, true)
 			ctx = device.WithYesIKnow(ctx, true)
-			return device.Detect(ctx, path, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+			return device.Detect(ctx, path, true, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
 		},
 		closeHook: func() error { return nil },
 		info:      device.NewInfo(),

--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -47,7 +47,7 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 	rw := writeOnlyReadWriter{out}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, rsyncMaxFrame))
 	// Send destination identity to allow early mismatch detection.
-	dev, err := device.Detect(ctx, origin, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
+	dev, err := device.Detect(ctx, origin, true, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
 	if err != nil {
 		return fmt.Errorf("detect origin: %w", err)
 	}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -289,7 +289,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 	if cfg.ResumeState != "" && strings.ToLower(cfg.VerifyLevel) != "none" {
 		cfg.ResumeVerify = true
 	}
-	dev, err := device.Detect(ctx, destPath, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
+	dev, err := device.Detect(ctx, destPath, true, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
 	if err != nil {
 		return 0, "", 0, err
 	}


### PR DESCRIPTION
## Summary
- allow files and devices to open in read-only mode
- propagate read-only flag through device detection
- test read-only and read-write device paths

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: many lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aabc8e61ec8323ac71863e525f6413