### PR TITLE
privilege: respect context cancellation

### DIFF
--- a/internal/privilege/escalate.go
+++ b/internal/privilege/escalate.go
@@ -22,6 +22,7 @@ type Escalator interface {
 // sudoEscalator implements Escalator using Linux capabilities when present
 // and sudo -n as a fallback.
 type sudoEscalator struct {
+	ctx         context.Context
 	useSudo     bool
 	runner      *Runner
 	sanitizeEnv bool

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -213,6 +213,39 @@ func TestCommandContextCanceled(t *testing.T) {
 	}
 }
 
+func TestEnsureEscalatorContextCanceled(t *testing.T) {
+	HasCaps = func() bool { return false }
+	parent, cancel := context.WithCancel(context.Background())
+	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "10")
+	}), LookPath: fakeLookPath(nil)}
+	esc := NewWithRunner(parent, r, zap.NewNop())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	err := esc.Ensure(context.Background())
+	if err == nil || parent.Err() != context.Canceled {
+		t.Fatalf("expected context canceled, got err=%v ctxErr=%v", err, parent.Err())
+	}
+}
+
+func TestCommandEscalatorContextCanceled(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	esc := &sudoEscalator{useSudo: false, runner: &Runner{Cmd: cmdFunc(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "10")
+	}), Logger: zap.NewNop()}, ctx: parent}
+	cmd := esc.Command(context.Background(), "sleep", "10")
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	err := cmd.Run()
+	if err == nil || parent.Err() != context.Canceled {
+		t.Fatalf("expected context canceled, got err=%v ctxErr=%v", err, parent.Err())
+	}
+}
+
 func TestEnsureDefaultTimeout(t *testing.T) {
 	HasCaps = func() bool { return false }
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {

--- a/internal/privilege/runner.go
+++ b/internal/privilege/runner.go
@@ -27,8 +27,9 @@ type Runner struct {
 	Timeout  time.Duration
 }
 
-// New returns an Escalator with production dependencies.
-// ctx is currently unused but reserved for future use.
+// New returns an Escalator with production dependencies. The provided context
+// is stored on the Escalator and used when invoking external commands so
+// callers can cancel operations.
 func New(ctx context.Context, logger *zap.Logger) Escalator {
 	return NewWithRunner(ctx, nil, logger)
 }
@@ -59,7 +60,10 @@ func NewWithRunnerAndSanitize(ctx context.Context, r *Runner, sanitize bool) Esc
 	return newEscalator(ctx, r, sanitize)
 }
 
-func newEscalator(_ context.Context, r *Runner, sanitize bool) Escalator {
+func newEscalator(ctx context.Context, r *Runner, sanitize bool) Escalator {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	cmd := Commander(commanderFunc(exec.CommandContext))
 	lp := exec.LookPath
 	logger := zap.NewNop()
@@ -79,6 +83,7 @@ func newEscalator(_ context.Context, r *Runner, sanitize bool) Escalator {
 		}
 	}
 	return &sudoEscalator{
+		ctx:         ctx,
 		useSudo:     !HasCaps(),
 		runner:      &Runner{Cmd: cmd, LookPath: lp, Logger: logger},
 		sanitizeEnv: sanitize,

--- a/internal/privilege/sudo.go
+++ b/internal/privilege/sudo.go
@@ -17,7 +17,26 @@ import (
 // commands may run when the caller does not provide a deadline.
 const defaultEscalationTimeout = 5 * time.Second
 
+func (s *sudoEscalator) mergeContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s.ctx == nil {
+		return ctx
+	}
+	merged, cancel := context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-s.ctx.Done():
+			cancel()
+		case <-merged.Done():
+		}
+	}()
+	return merged
+}
+
 func (s *sudoEscalator) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	ctx = s.mergeContext(ctx)
 	if _, ok := ctx.Deadline(); ok {
 		return context.WithCancel(ctx)
 	}


### PR DESCRIPTION
## Summary
- track parent context in privilege escalator and propagate cancellation when executing commands
- merge parent and call contexts and honor deadlines before applying fallback timeouts
- test that canceled contexts abort Ensure and Command operations

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestRsyncDeltaCDCMutate)*
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aace0f4b248323b8354e6a2648ca3c