### PR TITLE
Drain rsync delta responses before closing client

### DIFF
--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -44,8 +44,19 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 
 	t.Logger.Warn("plaintext_connection", zap.String("transport", "rsync"), zap.String("docs", "docs/transports.md"))
 
-	rw := writeOnlyReadWriter{out}
-	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, rsyncMaxFrame))
+	// Prefer a read/write connection so we can drain server responses
+	// before closing the stream. Fall back to a write-only wrapper when the
+	// writer doesn't implement io.Reader.
+	var (
+		rw     io.ReadWriter
+		stream *rsyncwire.Stream
+		rwOK   bool
+	)
+	if rw, rwOK = out.(io.ReadWriter); !rwOK {
+		rw = writeOnlyReadWriter{out}
+	}
+	stream = rsyncwire.NewStream(rw, rsyncMaxFrame)
+	cl := rsyncwire.NewClient(stream)
 	// Send destination identity to allow early mismatch detection.
 	dev, err := device.Detect(ctx, origin, true, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
 	if err != nil {
@@ -171,6 +182,31 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 	}
 	if err := cl.SendDigest(ctx, cfg.ChecksumAlgorithm, sum); err != nil {
 		return fmt.Errorf("send digest: %w", err)
+	}
+
+	// When the underlying connection supports half-closing, close the
+	// write side, drain any server responses, then close the stream. This
+	// avoids the server encountering a closed pipe when sending its final
+	// frames (e.g. digest acknowledgments).
+	type closeWriter interface{ CloseWrite() error }
+	if cw, ok := out.(closeWriter); ok && rwOK {
+		if err := cw.CloseWrite(); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("close write: %w", err)
+		}
+		for {
+			if _, err := stream.Recv(ctx); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return fmt.Errorf("recv response: %w", err)
+			}
+		}
+		if closer, ok := out.(io.Closer); ok {
+			if err := closer.Close(); err != nil && !errors.Is(err, io.EOF) {
+				return fmt.Errorf("failed to close output: %w", err)
+			}
+		}
+		return nil
 	}
 
 	if closer, ok := out.(io.Closer); ok {

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -170,6 +170,9 @@ func TestDumpChangesRsyncDelta(t *testing.T) {
 		<-serverReady
 		clientErrCh <- tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
 		close(clientDone)
+		// Drain any server responses before closing our side of the pipe to
+		// ensure the server exits cleanly.
+		io.Copy(io.Discard, c1)
 		c1.Close()
 	}()
 
@@ -271,6 +274,9 @@ func TestRsyncDeltaCDCShift(t *testing.T) {
 		<-serverReady
 		clientErrCh <- tr.DumpChangesSequential(ctx, cfg, snapPath, origPath, cc)
 		close(clientDone)
+		// Drain any server responses before closing the client side to
+		// avoid triggering write errors on the server.
+		io.Copy(io.Discard, c1)
 		c1.Close()
 	}()
 


### PR DESCRIPTION
## Summary
- Avoid closing rsync delta client before the server responds
- Drain server frames in rsync delta tests to prevent closed pipe errors

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: multiple revive, staticcheck, errcheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aaed5817b08323893a62b3f64d977d