### PR TITLE
config: enforce freeze/thaw hooks for raw devices

### DIFF
--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -11,6 +11,7 @@ import (
 
 	"lvmsync_go/device"
 	digest "lvmsync_go/internal/digest"
+	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/lvm"
 )
 
@@ -61,6 +62,15 @@ func (c *Config) ValidateWith(geteuid func() int) error {
 		if err := device.ValidateCmd(thawParts[0], thawParts[1:]); err != nil {
 			return fmt.Errorf("invalid fs-thaw-command: %w", err)
 		}
+		if c.FreezeTimeout <= 0 {
+			return fmt.Errorf("freeze-timeout must be > 0")
+		}
+		if c.ThawTimeout <= 0 {
+			return fmt.Errorf("thaw-timeout must be > 0")
+		}
+	}
+	if (c.SourceType == "raw" || c.DestType == "raw") && !c.Offline && c.FSFreezeCommand == "" && c.FSThawCommand == "" {
+		return fmt.Errorf("raw sources require --offline or --fs-freeze-command/--fs-thaw-command: %w", fmt.Errorf("precondition: %w", exitcode.ErrPrecondition))
 	}
 	if c.SSHKeepAliveInterval <= 0 {
 		return fmt.Errorf("ssh keepalive interval must be > 0")

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -1,10 +1,14 @@
 package config
 
 import (
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"lvmsync_go/internal/exitcode"
 )
 
 func baseConfig(t *testing.T) *Config {
@@ -70,6 +74,42 @@ func TestValidateFSCommandsMismatchedPair(t *testing.T) {
 			err := cfg.ValidateWith(func() int { return 0 })
 			if err == nil || !strings.Contains(err.Error(), "must both be set") {
 				t.Fatalf("expected mismatch error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRawSourceRequiresFreezeOrOffline(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+	cfg.SourceType = "raw"
+	err = cfg.ValidateWith(func() int { return 0 })
+	if err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
+	}
+}
+
+func TestValidateFSCommandTimeouts(t *testing.T) {
+	cases := []struct {
+		name   string
+		freeze time.Duration
+		thaw   time.Duration
+	}{
+		{"zero freeze", 0, time.Second},
+		{"neg freeze", -time.Second, time.Second},
+		{"zero thaw", time.Second, 0},
+		{"neg thaw", time.Second, -time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseConfig(t)
+			cfg.FreezeTimeout = tc.freeze
+			cfg.ThawTimeout = tc.thaw
+			err := cfg.ValidateWith(func() int { return 0 })
+			if err == nil || !strings.Contains(err.Error(), "must be > 0") {
+				t.Fatalf("expected timeout error, got %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- ensure freeze/thaw commands include positive timeouts
- require freeze/thaw hooks or offline mode for raw devices
- add unit tests for raw precondition and timeout validation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab28a74e448323a10392c825b340df