### PR TITLE
log identity mismatches in rsync server

### DIFF
--- a/internal/rsyncserver/server.go
+++ b/internal/rsyncserver/server.go
@@ -98,12 +98,23 @@ func (s *Server) Handle(ctx context.Context, stream *rsyncwire.Stream) error {
 				return err
 			}
 			if !device.SameIdentity(local, id) {
+				s.logger.Error("device_identity_mismatch",
+					zap.Any("expected_identity", identityMap(local)),
+					zap.Any("received_identity", identityMap(id)))
 				return fmt.Errorf("precondition: device identity mismatch")
 			}
 			idOK = true
 			continue
 		case 'D':
 			if !idOK {
+				local, err := s.dev.Identity(ctx)
+				if err != nil {
+					s.logger.Error("missing_identity", zap.Error(err))
+				} else {
+					s.logger.Error("missing_identity",
+						zap.Any("expected_identity", identityMap(local)),
+						zap.Any("received_identity", nil))
+				}
 				return fmt.Errorf("precondition: missing identity")
 			}
 			if len(frame) < 9 {
@@ -237,4 +248,21 @@ func (s *Server) verifyDigest() error {
 		}
 	}
 	return nil
+}
+
+func identityMap(id device.DeviceIdentity) map[string]any {
+	m := map[string]any{
+		"size_bytes":     id.SizeBytes,
+		"kernel_uuid":    id.KernelUUID,
+		"gpt_uuid":       id.GPTUUID,
+		"mbr_signature":  id.MBRSignature,
+		"fs_uuid":        id.FSUUID,
+		"major":          id.Major,
+		"minor":          id.Minor,
+		"manifest_epoch": id.ManifestEpoch,
+	}
+	if id.PartitionHash != [32]byte{} {
+		m["partition_hash"] = fmt.Sprintf("%x", id.PartitionHash[:])
+	}
+	return m
 }

--- a/internal/rsyncserver/server_test.go
+++ b/internal/rsyncserver/server_test.go
@@ -594,7 +594,8 @@ func TestHandleMissingIdentity(t *testing.T) {
 	defer c2.Close()
 
 	dev := &memDevice{buf: make([]byte, 1)}
-	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	core, logs := observer.New(zap.ErrorLevel)
+	srv, err := New(dev, zap.New(core), nil, "", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -608,6 +609,18 @@ func TestHandleMissingIdentity(t *testing.T) {
 	c1.Close()
 	if err := waitHandle(t, errCh); err == nil || !strings.Contains(err.Error(), "precondition") {
 		t.Fatalf("expected precondition error, got %v", err)
+	}
+	entries := logs.FilterMessage("missing_identity").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected missing_identity log, got %v", logs.All())
+	}
+	ctxMap := entries[0].ContextMap()
+	exp := ctxMap["expected_identity"].(map[string]any)
+	if v, ok := exp["size_bytes"].(uint64); !ok || v != 1 {
+		t.Fatalf("unexpected expected_identity size_bytes %v", exp["size_bytes"])
+	}
+	if v, ok := ctxMap["received_identity"]; ok && v != nil {
+		t.Fatalf("expected received_identity nil, got %v", v)
 	}
 	cancel()
 }
@@ -625,7 +638,8 @@ func TestHandleIdentityMismatch(t *testing.T) {
 		FSUUID:       "fs",
 	}
 	dev := &memDevice{buf: make([]byte, 1), id: id}
-	srv, err := New(dev, zap.NewNop(), nil, "", "")
+	core, logs := observer.New(zap.ErrorLevel)
+	srv, err := New(dev, zap.New(core), nil, "", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -642,6 +656,19 @@ func TestHandleIdentityMismatch(t *testing.T) {
 	c1.Close()
 	if err := waitHandle(t, errCh); err == nil || !strings.Contains(err.Error(), "precondition") {
 		t.Fatalf("expected precondition error, got %v", err)
+	}
+	entries := logs.FilterMessage("device_identity_mismatch").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected device_identity_mismatch log, got %v", logs.All())
+	}
+	ctxMap := entries[0].ContextMap()
+	exp := ctxMap["expected_identity"].(map[string]any)
+	if v, ok := exp["size_bytes"].(uint64); !ok || v != 1 {
+		t.Fatalf("unexpected expected_identity size_bytes %v", exp["size_bytes"])
+	}
+	recv := ctxMap["received_identity"].(map[string]any)
+	if v, ok := recv["size_bytes"].(uint64); !ok || v != 2 {
+		t.Fatalf("unexpected received_identity size_bytes %v", recv["size_bytes"])
 	}
 	cancel()
 }


### PR DESCRIPTION
## Summary
- log detailed expected and received device identities when mismatches or missing identity errors occur
- assert identity mismatch and missing identity logs in server tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 1284 issues)*


------
https://chatgpt.com/codex/tasks/task_e_68ab2ca9aca88323a342bc139b21c123