### PR TITLE
Fail gaps test when unresolved

### DIFF
--- a/reports/gaps_test.go
+++ b/reports/gaps_test.go
@@ -23,6 +23,6 @@ func TestNoUnresolvedGaps(t *testing.T) {
 		unresolved++
 	}
 	if unresolved > 0 {
-		t.Skipf("found %d unresolved gap(s); update reports/gaps.* after fixing", unresolved)
+		t.Fatalf("found %d unresolved gap(s); update reports/gaps.* after resolving gaps", unresolved)
 	}
 }


### PR DESCRIPTION
## Summary
- Fail `reports/gaps_test.go` when unresolved gaps remain
- Direct contributors to update `reports/gaps.*` once gaps are fixed

## Testing
- `go build ./... && echo build-succeeded`
- `go test ./reports` (fails with unresolved gaps)
- `echo "[]" > reports/gaps.json && go test ./reports && mv /tmp/gaps.json.bak reports/gaps.json` (passes with empty gaps)
- `golangci-lint run reports/... && echo lint-succeeded`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d597ea883238f41553b9d51f335