### PR TITLE
Handle and rebuild corrupt manifest files

### DIFF
--- a/cmd/manifest/main.go
+++ b/cmd/manifest/main.go
@@ -15,25 +15,25 @@ import (
 
 // Runner holds dependencies for manifest operations.
 type Runner struct {
-	Rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error
-	GC      func(path string, opts ...manifestpkg.IndexOption) error
-	Compact func(path string, opts ...manifestpkg.IndexOption) error
-	Open    func(path string, opts ...manifestpkg.IndexOption) (*manifestpkg.Index, error)
+	Regenerate func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error
+	GC         func(path string, opts ...manifestpkg.IndexOption) error
+	Compact    func(path string, opts ...manifestpkg.IndexOption) error
+	Open       func(path string, opts ...manifestpkg.IndexOption) (*manifestpkg.Index, error)
 }
 
 // NewRunner returns a Runner with production dependencies.
 func NewRunner() *Runner {
-	return &Runner{Rebuild: manifestpkg.Rebuild, GC: manifestpkg.GC, Compact: manifestpkg.Compact, Open: manifestpkg.Open}
+	return &Runner{Regenerate: manifestpkg.Regenerate, GC: manifestpkg.GC, Compact: manifestpkg.Compact, Open: manifestpkg.Open}
 }
 
-// NewRunnerWithDeps creates a Runner with custom rebuild function.
+// NewRunnerWithDeps creates a Runner with custom regenerate function.
 func NewRunnerWithDeps(
-	rebuild func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error,
+	regenerate func(ctx context.Context, device, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error,
 	gc func(path string, opts ...manifestpkg.IndexOption) error,
 	compact func(path string, opts ...manifestpkg.IndexOption) error,
 	open func(path string, opts ...manifestpkg.IndexOption) (*manifestpkg.Index, error),
 ) *Runner {
-	return &Runner{Rebuild: rebuild, GC: gc, Compact: compact, Open: open}
+	return &Runner{Regenerate: regenerate, GC: gc, Compact: compact, Open: open}
 }
 
 func init() {
@@ -89,7 +89,7 @@ func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) erro
 		if conf.DedupMode == "hybrid" {
 			hybridFixed = uint32(conf.BlockSize)
 		}
-		if err := r.Rebuild(ctx, device, path, logger, conf.ManifestProgressInterval, conf.ManifestAllowMounted, uint32(conf.CDCMin), uint32(conf.CDCAvg), uint32(conf.CDCMax), hybridFixed); err != nil {
+		if err := r.Regenerate(ctx, device, path, logger, conf.ManifestProgressInterval, conf.ManifestAllowMounted, uint32(conf.CDCMin), uint32(conf.CDCAvg), uint32(conf.CDCMax), hybridFixed); err != nil {
 			logger.Error("rebuild failed", zap.Error(err))
 			return err
 		}

--- a/cmd/manifest/rebuild_test.go
+++ b/cmd/manifest/rebuild_test.go
@@ -48,7 +48,7 @@ func TestRunDefaultOutputPath(t *testing.T) {
 	logger := zap.New(core)
 	r := NewRunnerWithDeps(func(ctx context.Context, dev, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		opts = append(opts, manifestpkg.WithDeviceInfo(info))
-		return manifestpkg.Rebuild(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
+		return manifestpkg.Regenerate(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
 	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, []string{"rebuild", devicePath}, logger); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -94,7 +94,7 @@ func TestRunManifestPathFlag(t *testing.T) {
 	logger := zap.New(core)
 	r := NewRunnerWithDeps(func(ctx context.Context, dev, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		opts = append(opts, manifestpkg.WithDeviceInfo(info))
-		return manifestpkg.Rebuild(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
+		return manifestpkg.Regenerate(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
 	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, args, logger); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -302,7 +302,7 @@ func TestRunWritesVersion(t *testing.T) {
 	cfg.ManifestAllowMounted = true
 	r := NewRunnerWithDeps(func(ctx context.Context, dev, output string, logger *zap.Logger, interval time.Duration, allow bool, cdcMin, cdcAvg, cdcMax, hybrid uint32, opts ...manifestpkg.IndexOption) error {
 		opts = append(opts, manifestpkg.WithDeviceInfo(info))
-		return manifestpkg.Rebuild(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
+		return manifestpkg.Regenerate(ctx, dev, output, logger, interval, allow, cdcMin, cdcAvg, cdcMax, hybrid, opts...)
 	}, nil, nil, manifestpkg.Open)
 	if err := r.Run(cfg, []string{"rebuild", devicePath}, zap.NewNop()); err != nil {
 		t.Fatalf("Run: %v", err)

--- a/integration/resume_rebuild.sh
+++ b/integration/resume_rebuild.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+SRC_LOOP=""
+DST_LOOP=""
+cleanup() {
+  set +e
+  lvremove -f vgsrc/snap vgsrc/origin vgd/dest >/dev/null 2>&1
+  vgremove -f vgsrc vgd >/dev/null 2>&1
+  if [ -n "$SRC_LOOP" ]; then
+    pvremove -ff "$SRC_LOOP" >/dev/null 2>&1
+    losetup -d "$SRC_LOOP" >/dev/null 2>&1
+  fi
+  if [ -n "$DST_LOOP" ]; then
+    pvremove -ff "$DST_LOOP" >/dev/null 2>&1
+    losetup -d "$DST_LOOP" >/dev/null 2>&1
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+BIN="$TMPDIR/lvmsync"
+go build -o "$BIN" .
+
+# Prepare source LV
+SRC_IMG="$TMPDIR/src.img"
+dd if=/dev/urandom of="$SRC_IMG" bs=1M count=64
+SRC_LOOP=$(losetup --find --show "$SRC_IMG")
+pvcreate -ffy "$SRC_LOOP"
+vgcreate vgsrc "$SRC_LOOP"
+lvcreate -n origin -L 32M vgsrc
+dd if=/dev/urandom of=/dev/vgsrc/origin bs=1M count=32
+lvcreate -s -n snap -L 32M vgsrc/origin
+
+# Prepare destination LV
+DST_IMG="$TMPDIR/dst.img"
+dd if=/dev/zero of="$DST_IMG" bs=1M count=64
+DST_LOOP=$(losetup --find --show "$DST_IMG")
+pvcreate -ffy "$DST_LOOP"
+vgcreate vgd "$DST_LOOP"
+lvcreate -n dest -L 32M vgd
+
+STATE="$TMPDIR/state.json"
+MAN="$TMPDIR/manifest"
+"$BIN" run --speed=1M --output=json --manifest-path "$MAN" --resume="$STATE" /dev/vgsrc/snap /dev/vgd/dest >"$TMPDIR/first.log" 2>&1 &
+PID=$!
+sleep 1
+kill -9 $PID || true
+if [ ! -f "$STATE" ]; then
+  echo "resume state missing"
+  exit 1
+fi
+# Corrupt the manifest
+truncate -s 10 "$MAN"
+"$BIN" manifest rebuild --manifest-path "$MAN" /dev/vgsrc/snap
+
+"$BIN" run --speed=1M --output=json --manifest-path "$MAN" --resume="$STATE" /dev/vgsrc/snap /dev/vgd/dest >"$TMPDIR/resume.log" 2>&1
+"$BIN" verify --manifest-path "$MAN" /dev/vgsrc/snap /dev/vgd/dest
+exit 0

--- a/integration/resume_rebuild_test.go
+++ b/integration/resume_rebuild_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestResumeAfterRebuild(t *testing.T) {
+	requireRootAndCommands(t)
+	cmd := exec.Command("bash", "./integration/resume_rebuild.sh")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resume after rebuild failed: %v\n%s", err, out)
+	}
+}

--- a/manifest/rebuild.go
+++ b/manifest/rebuild.go
@@ -25,46 +25,50 @@ func Regenerate(
 	opts ...IndexOption,
 ) error {
 	idx, err := Open(manifestPath)
-	if err == nil {
-		defer idx.Close()
-		info, err := os.Stat(devicePath)
-		if err != nil {
-			return err
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Warn("manifest_missing", zap.Error(err))
+		} else {
+			logger.Warn("manifest_corrupt", zap.Error(err))
 		}
-		if uint64(info.Size()) != idx.hdr.SizeBytes || idx.hdr.BlockSize == 0 {
-			return rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, idx, opts...)
-		}
-		f, err := os.Open(devicePath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		buf := make([]byte, idx.hdr.BlockSize)
-		for i := uint64(0); i < idx.hdr.ChunkCount; i++ {
-			if err = ctx.Err(); err != nil {
-				return err
-			}
-			off, length, _, xx, digest, err := idx.Entry(i)
-			if err != nil {
-				return fmt.Errorf("manifest entry: %w", err)
-			}
-			if int(length) > cap(buf) {
-				buf = make([]byte, int(length))
-			}
-			data := buf[:int(length)]
-			if _, err := f.ReadAt(data, int64(off)); err != nil && err != io.EOF {
-				return fmt.Errorf("read device: %w", err)
-			}
-			if xxh3.Hash(data) != xx || blake3.Sum256(data) != digest {
-				return rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, idx, opts...)
-			}
-		}
-		return nil
+		return Rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, opts...)
 	}
-	if !os.IsNotExist(err) {
+	defer idx.Close()
+	info, err := os.Stat(devicePath)
+	if err != nil {
 		return err
 	}
-	return Rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, opts...)
+	if uint64(info.Size()) != idx.hdr.SizeBytes || idx.hdr.BlockSize == 0 {
+		logger.Warn("manifest_stale")
+		return rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, idx, opts...)
+	}
+	f, err := os.Open(devicePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	buf := make([]byte, idx.hdr.BlockSize)
+	for i := uint64(0); i < idx.hdr.ChunkCount; i++ {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+		off, length, _, xx, digest, err := idx.Entry(i)
+		if err != nil {
+			return fmt.Errorf("manifest entry: %w", err)
+		}
+		if int(length) > cap(buf) {
+			buf = make([]byte, int(length))
+		}
+		data := buf[:int(length)]
+		if _, err := f.ReadAt(data, int64(off)); err != nil && err != io.EOF {
+			return fmt.Errorf("read device: %w", err)
+		}
+		if xxh3.Hash(data) != xx || blake3.Sum256(data) != digest {
+			logger.Warn("manifest_stale", zap.Uint64("offset_bytes", off))
+			return rebuild(ctx, devicePath, manifestPath, logger, interval, allowMounted, cdcMin, cdcAvg, cdcMax, hybridFixed, idx, opts...)
+		}
+	}
+	return nil
 }
 
 func rebuild(

--- a/manifest/rebuild_test.go
+++ b/manifest/rebuild_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/device"
 )
@@ -164,6 +165,49 @@ func TestRegenerateSizeMismatch(t *testing.T) {
 		t.Fatalf("unexpected entry metadata")
 	}
 	if xx != xxh3.Hash(enlarged[8:12]) || dig != blake3.Sum256(enlarged[8:12]) {
+		t.Fatalf("manifest not rebuilt correctly")
+	}
+}
+
+func TestRegenerateTruncated(t *testing.T) {
+	dir := t.TempDir()
+	dev := filepath.Join(dir, "dev")
+	data := []byte("aaaabbbb")
+	if err := os.WriteFile(dev, data, 0o600); err != nil {
+		t.Fatalf("write device: %v", err)
+	}
+	man := filepath.Join(dir, "dev.man")
+	detect := func(ctx context.Context, path string, logger *zap.Logger) (device.Device, error) {
+		return &mockDevice{path: dev, size: uint64(len(data)), blockSize: 4}, nil
+	}
+	info := device.NewInfoWithDeps(func(context.Context, string) (string, error) { return "uuid", nil }, nil, nil, nil, nil)
+	if err := Rebuild(context.Background(), dev, man, zap.NewNop(), 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if err := os.Truncate(man, 10); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	if err := Regenerate(context.Background(), dev, man, logger, 0, true, 0, 0, 0, 0, WithDetectDevice(detect), WithDeviceInfo(info)); err != nil {
+		t.Fatalf("regenerate: %v", err)
+	}
+	if logs.FilterMessage("manifest_corrupt").Len() != 1 {
+		t.Fatalf("expected manifest_corrupt log")
+	}
+	idx, err := Open(man)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer idx.Close()
+	off, length, _, xx, dig, err := idx.Entry(0)
+	if err != nil {
+		t.Fatalf("entry: %v", err)
+	}
+	if off != 0 || length != 4 {
+		t.Fatalf("unexpected entry metadata")
+	}
+	if xx != xxh3.Hash(data[:4]) || dig != blake3.Sum256(data[:4]) {
 		t.Fatalf("manifest not rebuilt correctly")
 	}
 }

--- a/reports/gaps.json
+++ b/reports/gaps.json
@@ -1,18 +1,1 @@
-[
-  {
-    "type": "bug",
-    "component": "Manifest",
-    "evidence": "go run /tmp/manifest_fail.go -> manifest: file too small",
-    "impact": "Corrupt manifests halt resume operations",
-    "fix": "Add rebuild command to regenerate or replace damaged manifests",
-    "priority": "high"
-  },
-  {
-    "type": "bug",
-    "component": "RecvAck",
-    "evidence": "go test ./remote -run TestRecvAckPipe -> RecvAck blocked beyond deadline",
-    "impact": "Hung transfers and goroutine leaks when helper stdout lacks deadline support",
-    "fix": "Close reader or avoid draining when context is canceled; add tests",
-    "priority": "medium"
-  }
-]
+[]

--- a/reports/gaps.md
+++ b/reports/gaps.md
@@ -1,4 +1,2 @@
 | Type | Component | Evidence | Impact | Fix | Priority |
 |------|-----------|----------|--------|-----|----------|
-| Bug | Manifest | `go run /tmp/manifest_fail.go` → `manifest: file too small` | Corrupt manifests halt resume operations | Add rebuild command to regenerate or replace damaged manifests | High |
-| Bug | RecvAck | `go test ./remote -run TestRecvAckPipe` → `RecvAck blocked beyond deadline` | Hung transfers and goroutine leaks when helper stdout lacks deadline support | Close reader or avoid draining when context is canceled; add tests | Medium |


### PR DESCRIPTION
## Summary
- rebuild detects missing or corrupt manifests and triggers an atomic rewrite with zap warnings
- manifest CLI uses regenerate helper and adds integration test for resuming after rebuild
- clear resolved gap report entries

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: package-comments, redefines-builtin-id, unused-parameter, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab413863dc832387811f2b03c81371