### PR TITLE
remote: cancel-aware RecvAck

### DIFF
--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -109,15 +109,6 @@ func (c *PrivHelperClient) RecvAck(ctx context.Context) (bool, error) {
 		return false, errors.New("nil context")
 	}
 
-	if dl, ok := ctx.Deadline(); ok {
-		if conn, ok := c.stdout.(interface{ SetReadDeadline(time.Time) error }); ok {
-			if err := conn.SetReadDeadline(dl); err != nil {
-				return false, err
-			}
-			defer conn.SetReadDeadline(time.Time{}) //nolint:errcheck
-		}
-	}
-
 	type result struct {
 		b   byte
 		err error
@@ -125,6 +116,14 @@ func (c *PrivHelperClient) RecvAck(ctx context.Context) (bool, error) {
 	resCh := make(chan result, 1)
 	go func() {
 		var b [1]byte
+		if conn, ok := c.stdout.(interface{ SetReadDeadline(time.Time) error }); ok {
+			dl := time.Now().Add(100 * time.Millisecond)
+			if ctxDl, ok := ctx.Deadline(); ok && ctxDl.Before(dl) {
+				dl = ctxDl
+			}
+			_ = conn.SetReadDeadline(dl)
+			defer conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+		}
 		_, err := io.ReadFull(c.stdout, b[:])
 		resCh <- result{b: b[0], err: err}
 	}()
@@ -134,7 +133,13 @@ func (c *PrivHelperClient) RecvAck(ctx context.Context) (bool, error) {
 		if conn, ok := c.stdout.(interface{ SetReadDeadline(time.Time) error }); ok {
 			_ = conn.SetReadDeadline(time.Now())
 		}
-		<-resCh // drain goroutine to avoid leak
+		if closer, ok := c.stdout.(io.Closer); ok {
+			_ = closer.Close()
+		}
+		select {
+		case <-resCh:
+		default:
+		}
 		return false, ctx.Err()
 	case r := <-resCh:
 		if r.err != nil {

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -94,9 +95,98 @@ func TestRecvAckTimeout(t *testing.T) {
 	}
 }
 
+type blockingAckReader struct {
+	readStarted chan struct{}
+	closeCh     chan struct{}
+	closed      bool
+	readDone    chan struct{}
+}
+
+func newBlockingAckReader() *blockingAckReader {
+	return &blockingAckReader{
+		readStarted: make(chan struct{}),
+		closeCh:     make(chan struct{}),
+		readDone:    make(chan struct{}),
+	}
+}
+
+func (r *blockingAckReader) Read(_ []byte) (int, error) {
+	close(r.readStarted)
+	<-r.closeCh
+	close(r.readDone)
+	return 0, io.EOF
+}
+
+func (r *blockingAckReader) Close() error {
+	r.closed = true
+	close(r.closeCh)
+	return nil
+}
+
+type neverReader struct{}
+
+func (neverReader) Read(_ []byte) (int, error) { select {} }
+
+func TestRecvAckCancelClosesReader(t *testing.T) {
+	r := newBlockingAckReader()
+	c := &PrivHelperClient{stdout: r}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.RecvAck(ctx)
+		if err == nil || !errors.Is(err, context.Canceled) {
+			done <- fmt.Errorf("expected context canceled, got %v", err)
+			return
+		}
+		done <- nil
+	}()
+	<-r.readStarted
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("RecvAck did not return")
+	}
+	if !r.closed {
+		t.Fatalf("reader not closed")
+	}
+	select {
+	case <-r.readDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("read goroutine not cleaned up")
+	}
+}
+
+func TestRecvAckCancelUnclosable(t *testing.T) {
+	c := &PrivHelperClient{stdout: neverReader{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.RecvAck(ctx)
+		if err == nil || !errors.Is(err, context.Canceled) {
+			done <- fmt.Errorf("expected context canceled, got %v", err)
+			return
+		}
+		done <- nil
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("RecvAck blocked with unclosable reader")
+	}
+}
+
 type earlyTimeoutReader struct{ deadline time.Time }
 
-func (r *earlyTimeoutReader) Read(p []byte) (int, error) {
+func (r *earlyTimeoutReader) Read(_ []byte) (int, error) {
 	if !r.deadline.IsZero() {
 		if d := time.Until(r.deadline) - 50*time.Millisecond; d > 0 {
 			time.Sleep(d)


### PR DESCRIPTION
## Summary
- prevent RecvAck from blocking when context is canceled
- add tests for canceled and unclosable readers

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: existing issues across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68ab43cc57f88323ade816b1be971a6c