### PR TITLE
Check full device identity during verification

### DIFF
--- a/cmd/dump/probe.go
+++ b/cmd/dump/probe.go
@@ -111,6 +111,10 @@ func manifestHeaderMAC(h *manifestpkg.Header) [32]byte {
 	binary.LittleEndian.PutUint32(buf[48:52], h.Major)
 	binary.LittleEndian.PutUint32(buf[52:56], h.Minor)
 	copy(buf[56:120], h.DeviceID[:])
-	copy(buf[120:152], h.FirstBlockDigest[:])
+	copy(buf[120:184], h.KernelUUID[:])
+	copy(buf[184:248], h.GPTUUID[:])
+	copy(buf[248:252], h.MBRSignature[:])
+	copy(buf[252:284], h.PartitionHash[:])
+	copy(buf[284:316], h.FirstBlockDigest[:])
 	return blake3.Sum256(buf[:])
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -26,8 +26,8 @@ const (
 	Version uint32 = 2
 
 	// HeaderSize is the binary size of Header.
-	HeaderSize = 4 + 4 + 8 + 8 + 4 + 4 + 4 + 4 + 8 + 4 + 4 + 64 + 32 + 32 // 184 bytes
-	entrySize  = 8 + 4 + 4 + 8 + 32                                       // 56 bytes
+	HeaderSize = 4 + 4 + 8 + 8 + 4 + 4 + 4 + 4 + 8 + 4 + 4 + 64 + 64 + 64 + 4 + 32 + 32 + 32 // 348 bytes
+	entrySize  = 8 + 4 + 4 + 8 + 32                                                          // 56 bytes
 
 	// FlagCDC marks chunks produced by content-defined chunking.
 	FlagCDC uint32 = 1 << 0
@@ -55,6 +55,10 @@ type Header struct {
 	Major            uint32
 	Minor            uint32
 	DeviceID         [64]byte
+	KernelUUID       [64]byte
+	GPTUUID          [64]byte
+	MBRSignature     [4]byte
+	PartitionHash    [32]byte
 	FirstBlockDigest [32]byte
 	MAC              [32]byte
 }
@@ -143,7 +147,11 @@ func headerMAC(h *Header) [32]byte {
 	binary.LittleEndian.PutUint32(buf[48:52], h.Major)
 	binary.LittleEndian.PutUint32(buf[52:56], h.Minor)
 	copy(buf[56:120], h.DeviceID[:])
-	copy(buf[120:152], h.FirstBlockDigest[:])
+	copy(buf[120:184], h.KernelUUID[:])
+	copy(buf[184:248], h.GPTUUID[:])
+	copy(buf[248:252], h.MBRSignature[:])
+	copy(buf[252:284], h.PartitionHash[:])
+	copy(buf[284:316], h.FirstBlockDigest[:])
 	sum := blake3.Sum256(buf[:])
 	return sum
 }
@@ -162,8 +170,12 @@ func (i *Index) writeHeader() {
 	binary.LittleEndian.PutUint32(buf[48:52], i.hdr.Major)
 	binary.LittleEndian.PutUint32(buf[52:56], i.hdr.Minor)
 	copy(buf[56:120], i.hdr.DeviceID[:])
-	copy(buf[120:152], i.hdr.FirstBlockDigest[:])
-	copy(buf[152:184], i.hdr.MAC[:])
+	copy(buf[120:184], i.hdr.KernelUUID[:])
+	copy(buf[184:248], i.hdr.GPTUUID[:])
+	copy(buf[248:252], i.hdr.MBRSignature[:])
+	copy(buf[252:284], i.hdr.PartitionHash[:])
+	copy(buf[284:316], i.hdr.FirstBlockDigest[:])
+	copy(buf[316:348], i.hdr.MAC[:])
 	copy(i.data[:HeaderSize], buf[:])
 }
 
@@ -184,8 +196,12 @@ func (i *Index) readHeader() error {
 	i.hdr.Major = binary.LittleEndian.Uint32(buf[48:52])
 	i.hdr.Minor = binary.LittleEndian.Uint32(buf[52:56])
 	copy(i.hdr.DeviceID[:], buf[56:120])
-	copy(i.hdr.FirstBlockDigest[:], buf[120:152])
-	copy(i.hdr.MAC[:], buf[152:184])
+	copy(i.hdr.KernelUUID[:], buf[120:184])
+	copy(i.hdr.GPTUUID[:], buf[184:248])
+	copy(i.hdr.MBRSignature[:], buf[248:252])
+	copy(i.hdr.PartitionHash[:], buf[252:284])
+	copy(i.hdr.FirstBlockDigest[:], buf[284:316])
+	copy(i.hdr.MAC[:], buf[316:348])
 	if mac := headerMAC(&i.hdr); !bytes.Equal(mac[:], i.hdr.MAC[:]) {
 		return fmt.Errorf("manifest: header MAC mismatch")
 	}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -251,7 +251,11 @@ func manifestHeaderMAC(h *manifestpkg.Header) [32]byte {
 	binary.LittleEndian.PutUint32(buf[48:52], h.Major)
 	binary.LittleEndian.PutUint32(buf[52:56], h.Minor)
 	copy(buf[56:120], h.DeviceID[:])
-	copy(buf[120:152], h.FirstBlockDigest[:])
+	copy(buf[120:184], h.KernelUUID[:])
+	copy(buf[184:248], h.GPTUUID[:])
+	copy(buf[248:252], h.MBRSignature[:])
+	copy(buf[252:284], h.PartitionHash[:])
+	copy(buf[284:316], h.FirstBlockDigest[:])
 	return blake3.Sum256(buf[:])
 }
 
@@ -324,11 +328,46 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 			t.Logger.Error("device_size_mismatch", zap.Uint64("expected_size_bytes", hdr.SizeBytes), zap.Uint64("size_bytes", size))
 			return 0, "", 0, fmt.Errorf("precondition: destination device size %d does not match manifest %d: %w", size, hdr.SizeBytes, exitcode.ErrPrecondition)
 		}
-		expectedID := device.DeviceIdentity{SizeBytes: hdr.SizeBytes, Major: hdr.Major, Minor: hdr.Minor}
-		actualID := device.DeviceIdentity{SizeBytes: size, Major: ident.Major, Minor: ident.Minor}
+		mbr := binary.LittleEndian.Uint32(hdr.MBRSignature[:])
+		mbrSig := ""
+		if mbr != 0 {
+			mbrSig = fmt.Sprintf("%08x", mbr)
+		}
+		expectedID := device.DeviceIdentity{
+			SizeBytes:     hdr.SizeBytes,
+			KernelUUID:    strings.TrimRight(string(hdr.KernelUUID[:]), "\x00"),
+			GPTUUID:       strings.TrimRight(string(hdr.GPTUUID[:]), "\x00"),
+			MBRSignature:  mbrSig,
+			FSUUID:        manID,
+			PartitionHash: hdr.PartitionHash,
+			Major:         hdr.Major,
+			Minor:         hdr.Minor,
+			ManifestEpoch: hdr.Epoch,
+		}
+		actualID := ident
+		actualID.SizeBytes = size
+		actualID.FSUUID = id
 		if !device.SameIdentityStrict(expectedID, actualID) {
-			t.Logger.Error("device_number_mismatch", zap.Uint32("expected_major", hdr.Major), zap.Uint32("expected_minor", hdr.Minor), zap.Uint32("major", ident.Major), zap.Uint32("minor", ident.Minor))
-			return 0, "", 0, fmt.Errorf("precondition: destination device number mismatch: %w", exitcode.ErrPrecondition)
+			t.Logger.Error(
+				"device_identity_mismatch",
+				zap.String("expected_kernel_uuid", expectedID.KernelUUID),
+				zap.String("kernel_uuid", actualID.KernelUUID),
+				zap.String("expected_gpt_uuid", expectedID.GPTUUID),
+				zap.String("gpt_uuid", actualID.GPTUUID),
+				zap.String("expected_mbr_signature", expectedID.MBRSignature),
+				zap.String("mbr_signature", actualID.MBRSignature),
+				zap.String("expected_fs_uuid", expectedID.FSUUID),
+				zap.String("fs_uuid", actualID.FSUUID),
+				zap.String("expected_partition_hash", hex.EncodeToString(expectedID.PartitionHash[:])),
+				zap.String("partition_hash", hex.EncodeToString(actualID.PartitionHash[:])),
+				zap.Uint32("expected_major", expectedID.Major),
+				zap.Uint32("expected_minor", expectedID.Minor),
+				zap.Uint32("major", actualID.Major),
+				zap.Uint32("minor", actualID.Minor),
+				zap.Uint64("expected_manifest_epoch", expectedID.ManifestEpoch),
+				zap.Uint64("manifest_epoch", actualID.ManifestEpoch),
+			)
+			return 0, "", 0, fmt.Errorf("precondition: destination device identity mismatch: %w", exitcode.ErrPrecondition)
 		}
 		dig, err := t.Info.FirstBlockDigest(ctx, destPath, firstBlockDigestSize)
 		if err != nil {

--- a/transfer/verify_destination_validation_test.go
+++ b/transfer/verify_destination_validation_test.go
@@ -119,3 +119,87 @@ func TestVerifyDestinationDeviceNumberMismatch(t *testing.T) {
 		t.Fatalf("expected precondition error, got %v", err)
 	}
 }
+
+func TestVerifyDestinationKernelUUIDMismatch(t *testing.T) {
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "id", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, make([]byte, 1024), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	man := filepath.Join(t.TempDir(), "man")
+	var hdr manifestpkg.Header
+	hdr.Version = manifestpkg.Version
+	hdr.BlockSize = 512
+	hdr.SizeBytes = 1024
+	hdr.ChunkCount = 2
+	var st unix.Stat_t
+	if err := unix.Stat(dest, &st); err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	hdr.Major = uint32(unix.Major(uint64(st.Rdev)))
+	hdr.Minor = uint32(unix.Minor(uint64(st.Rdev)))
+	copy(hdr.DeviceID[:], []byte("id"))
+	copy(hdr.KernelUUID[:], []byte("kernel"))
+	hdr.MAC = manifestHeaderMAC(&hdr)
+	f, err := os.Create(man)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	f.Close()
+	cfg := &config.Config{ManifestPath: man}
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
+	}
+}
+
+func TestVerifyDestinationPartitionHashMismatch(t *testing.T) {
+	info := device.NewInfoWithDeps(
+		func(context.Context, string) (string, error) { return "id", nil },
+		nil,
+		func(context.Context, string) (bool, error) { return false, nil },
+		nil,
+		nil,
+	)
+	tr := NewTransfer(zap.NewNop(), &sync.WaitGroup{}, info)
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.WriteFile(dest, make([]byte, 1024), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	man := filepath.Join(t.TempDir(), "man")
+	var hdr manifestpkg.Header
+	hdr.Version = manifestpkg.Version
+	hdr.BlockSize = 512
+	hdr.SizeBytes = 1024
+	hdr.ChunkCount = 2
+	var st unix.Stat_t
+	if err := unix.Stat(dest, &st); err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	hdr.Major = uint32(unix.Major(uint64(st.Rdev)))
+	hdr.Minor = uint32(unix.Minor(uint64(st.Rdev)))
+	copy(hdr.DeviceID[:], []byte("id"))
+	hdr.PartitionHash[0] = 1
+	hdr.MAC = manifestHeaderMAC(&hdr)
+	f, err := os.Create(man)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	f.Close()
+	cfg := &config.Config{ManifestPath: man}
+	if _, _, _, err := tr.verifyDestination(context.Background(), cfg, dest); err == nil || !errors.Is(err, exitcode.ErrPrecondition) {
+		t.Fatalf("expected precondition error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- persist full device identity in manifest headers
- verify destination identity using kernel, GPT, MBR, partition hash and epoch fields
- add tests for kernel UUID and partition hash mismatches

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: 1288 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4b446fa88323a10659e89b7fa1cd