### PR TITLE
wal: add error path tests

### DIFF
--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -30,19 +30,37 @@ type File interface {
 
 // Deps bundles filesystem helpers for WAL operations.
 type Deps struct {
-	syncDir func(string) error
+	syncDir  func(string) error
+	openFile func(string, int, os.FileMode) (File, error)
+	rename   func(string, string) error
 }
 
 // NewDeps returns production dependencies.
 func NewDeps() *Deps {
-	return &Deps{syncDir: syncDir}
+	return &Deps{
+		syncDir:  syncDir,
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) { return os.OpenFile(name, flag, perm) },
+		rename:   os.Rename,
+	}
 }
 
 // SyncDir fsyncs the provided directory path.
 func (d *Deps) SyncDir(path string) error { return d.syncDir(path) }
 
+// OpenFile opens or creates a file.
+func (d *Deps) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	return d.openFile(name, flag, perm)
+}
+
+// Rename moves oldpath to newpath.
+func (d *Deps) Rename(oldpath, newpath string) error { return d.rename(oldpath, newpath) }
+
 // NewDepsWithSync returns dependencies using the provided syncDir implementation.
-func NewDepsWithSync(fn func(string) error) *Deps { return &Deps{syncDir: fn} }
+func NewDepsWithSync(fn func(string) error) *Deps {
+	d := NewDeps()
+	d.syncDir = fn
+	return d
+}
 
 // WAL manages a write-ahead log backed by a file.
 type WAL struct {
@@ -63,7 +81,7 @@ func New(f File, deps *Deps) *WAL {
 func (w *WAL) Append(r Range) error {
 	name := w.f.Name()
 	tmpPath := name + ".tmp"
-	tf, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	tf, err := w.deps.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -107,10 +125,10 @@ func (w *WAL) Append(r Range) error {
 	if err := w.f.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpPath, name); err != nil {
+	if err := w.deps.Rename(tmpPath, name); err != nil {
 		return err
 	}
-	nf, err := os.OpenFile(name, os.O_RDWR, 0)
+	nf, err := w.deps.OpenFile(name, os.O_RDWR, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -1,9 +1,11 @@
 package wal
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +36,151 @@ func TestAppendAndClose(t *testing.T) {
 	}
 	if len(data) != 32 { // header + one entry
 		t.Fatalf("unexpected size %d", len(data))
+	}
+}
+
+type stubFile struct {
+	*os.File
+	syncErr    error
+	syncCalled bool
+	closed     bool
+}
+
+func (s *stubFile) Sync() error {
+	s.syncCalled = true
+	if s.syncErr != nil {
+		return s.syncErr
+	}
+	return s.File.Sync()
+}
+
+func (s *stubFile) Close() error {
+	s.closed = true
+	return s.File.Close()
+}
+
+type shortWriteFile struct{ *stubFile }
+
+func (s *shortWriteFile) Write(p []byte) (int, error) {
+	return len(p) - 1, nil
+}
+
+func TestSyncError(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(dir, "wal"), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sf := &stubFile{File: f, syncErr: errors.New("sync fail")}
+	w := New(sf, nil)
+	if err := w.Sync(); err == nil || !strings.Contains(err.Error(), "sync fail") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sf.syncCalled {
+		t.Fatalf("sync not called")
+	}
+}
+
+func TestCloseDirSync(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(dir, "wal"), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sf := &stubFile{File: f}
+	var synced string
+	deps := NewDeps()
+	deps.syncDir = func(p string) error { synced = p; return nil }
+	w := New(sf, deps)
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if synced != dir {
+		t.Fatalf("syncDir not called with dir: %q", synced)
+	}
+	if w.f != nil {
+		t.Fatalf("file not nil after close")
+	}
+	if !sf.closed {
+		t.Fatalf("file not closed")
+	}
+}
+
+func TestCloseFileSyncError(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(dir, "wal"), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sf := &stubFile{File: f, syncErr: errors.New("sync fail")}
+	var called bool
+	deps := NewDeps()
+	deps.syncDir = func(string) error { called = true; return nil }
+	w := New(sf, deps)
+	if err := w.Close(); err == nil || !strings.Contains(err.Error(), "sync fail") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatalf("syncDir should not be called on sync error")
+	}
+	if !sf.closed {
+		t.Fatalf("file not closed")
+	}
+}
+
+func TestCloseDirSyncError(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(dir, "wal"), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sf := &stubFile{File: f}
+	deps := NewDeps()
+	deps.syncDir = func(string) error { return errors.New("dir sync fail") }
+	w := New(sf, deps)
+	if err := w.Close(); err == nil || !strings.Contains(err.Error(), "dir sync fail") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sf.closed {
+		t.Fatalf("file not closed")
+	}
+}
+
+func TestAppendShortWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	deps := NewDeps()
+	deps.openFile = func(name string, flag int, perm os.FileMode) (File, error) {
+		if strings.HasSuffix(name, ".tmp") {
+			tf, err := os.OpenFile(name, flag, perm)
+			if err != nil {
+				return nil, err
+			}
+			return &shortWriteFile{&stubFile{File: tf}}, nil
+		}
+		return os.OpenFile(name, flag, perm)
+	}
+	w := New(f, deps)
+	if err := w.Append(Range{Start: 1, End: 2}); err == nil || !strings.Contains(err.Error(), "short write") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAppendRenameError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	deps := NewDeps()
+	deps.rename = func(string, string) error { return errors.New("rename fail") }
+	w := New(f, deps)
+	if err := w.Append(Range{Start: 1, End: 2}); err == nil || !strings.Contains(err.Error(), "rename fail") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- extend WAL dependencies to allow faking file open and rename
- add tests for Sync and Close error paths and fsync behavior
- cover short write and rename failures in Append

## Testing
- `go build ./...`
- `go test ./...` (fails: TestNewSSHClient expected keepalive requests)
- `go test ./internal/wal -cover`
- `golangci-lint run` (fails: errcheck, revive, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68ab4de2b1d48323b859991ef5c92058