### PR TITLE
Simplify exit code mapping

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -50,7 +50,7 @@ lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target
 ```
 
 Reads both devices and reports mismatches without writing data. Exits with
-code `60` when blocks differ.
+code `3` when blocks differ.
 
 ## Skipping Snapshot Creation
 
@@ -100,14 +100,14 @@ effects. Estimates are expected to fall within ±5% of the final
    lvmsync run --resume=verify /dev/vg0/snap0 /dev/vg0/target
    ```
 
-Exit code `60` indicates a verification mismatch and leaves the destination untouched.
+Exit code `3` indicates a verification mismatch and leaves the destination untouched.
 
 ### Safe Overwrite Test
 
 The integration test `integration/safe_overwrite.sh` exercises this sequence:
 
 1. `lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target` exits `0` without writing.
-2. `lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target` exits `60` when blocks differ and leaves data unchanged.
+2. `lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target` exits `3` when blocks differ and leaves data unchanged.
 3. `lvmsync run /dev/vg0/snap0 /dev/vg0/target` performs the actual copy.
 
 The test confirms the probe and verify steps do not modify the destination logical volume.
@@ -123,17 +123,12 @@ committed ranges.
 
 | Constant | Code | Meaning | Recovery Step |
 |----------|------|---------|---------------|
-| [`exitcode.OK`](internal/exitcode/exitcode.go) | `0`  | Success | None |
-| [`exitcode.Capability`](internal/exitcode/exitcode.go) | `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
-| [`exitcode.Device`](internal/exitcode/exitcode.go) | `20` | Device error | Verify device paths and snapshot health. |
-| [`exitcode.SnapshotExhausted`](internal/exitcode/exitcode.go) | `25` | Snapshot space exhausted | Grow or recreate the snapshot before resuming. |
-| [`exitcode.Platform`](internal/exitcode/exitcode.go) | `30` | Unsupported platform | Run on a supported Linux platform. |
-| [`exitcode.Config`](internal/exitcode/exitcode.go) | `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
-| [`exitcode.Runtime`](internal/exitcode/exitcode.go) | `50` | Runtime failure | Inspect logs, fix the issue, and rerun using `--resume` when applicable. |
-| [`exitcode.Verify`](internal/exitcode/exitcode.go) | `60` | Verification mismatch | Investigate mismatched data before retrying. |
-| [`exitcode.Partial`](internal/exitcode/exitcode.go) | `70` | Partial transfer | Address the error and resume with `--resume`. |
-| [`exitcode.Precondition`](internal/exitcode/exitcode.go) | `80` | Precondition failed | Fix prerequisites and retry. |
-| [`exitcode.Resumable`](internal/exitcode/exitcode.go) | `90` | Resumable exit | Resume with `--resume` after resolving the issue. |
+| [`exitcode.OK`](internal/exitcode/exitcode.go) | `0` | Success | None |
+| [`exitcode.Precondition`](internal/exitcode/exitcode.go) | `2` | Precondition failed | Fix prerequisites and retry. |
+| [`exitcode.Verify`](internal/exitcode/exitcode.go) | `3` | Verification mismatch | Investigate mismatched data before retrying. |
+| [`exitcode.Resumable`](internal/exitcode/exitcode.go) | `4` | Resumable exit | Resume with `--resume` after resolving the issue. |
+| [`exitcode.Config`](internal/exitcode/exitcode.go) | `5` | Configuration error | Review flags, environment variables, and `config.yaml`. |
+| [`exitcode.Capability`](internal/exitcode/exitcode.go) | `6` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
 
 Definitions live in [internal/exitcode](internal/exitcode/exitcode.go).
 
@@ -141,21 +136,21 @@ Verification mismatches exit with [`exitcode.Verify`](internal/exitcode/exitcode
 
 ```sh
 lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/bad_target || echo "verify failed with exit $?"
-# verify failed with exit 60
+# verify failed with exit 3
 ```
 
 Precondition failures exit with [`exitcode.Precondition`](internal/exitcode/exitcode.go):
 
 ```sh
 lvmsync run /dev/vg0/missing /dev/vg0/target || echo "precondition failed with exit $?"
-# precondition failed with exit 80
+# precondition failed with exit 2
 ```
 
 Partition-table changes between runs also trigger this error when GPT or MBR signatures differ.
 
 When using the `rsync` transport, the client sends the destination device identity
 before writing. If the server's identity differs, the transfer aborts with
-[`exitcode.Precondition`](internal/exitcode/exitcode.go) (`80`).
+[`exitcode.Precondition`](internal/exitcode/exitcode.go) (`2`).
 
 ## Troubleshooting
 
@@ -167,29 +162,29 @@ before writing. If the server's identity differs, the transfer aborts with
 ### Snapshot Overflow
 
 Snapshot volumes fill when copy-on-write blocks exceed the allocated snapshot size.
-LVMSync exits with [`exitcode.Device`](internal/exitcode/exitcode.go) (`20`).
+LVMSync exits with [`exitcode.Resumable`](internal/exitcode/exitcode.go) (`4`).
 Grow the snapshot or create a larger one, then rerun with the same `--resume` state:
 
 ```sh
 lvmsync run /dev/vg0/snap_full /dev/vg0/dst || echo "snapshot overflow exit $?"
-# snapshot overflow exit 20
+# snapshot overflow exit 4
 ```
 
 ### Verify Failure
 
 Verification mismatches stop the transfer with
-[`exitcode.Verify`](internal/exitcode/exitcode.go) (`60`). Inspect the logs to
+[`exitcode.Verify`](internal/exitcode/exitcode.go) (`3`). Inspect the logs to
 identify mismatched blocks before retrying:
 
 ```sh
 lvmsync run --verify-only /dev/vg0/snap0 /dev/vg0/target || echo "verify exit $?"
-# verify exit 60
+# verify exit 3
 ```
 
 ### Resume After Interruption
 
 Unexpected interruptions (signals, network loss) exit with
-[`exitcode.Resumable`](internal/exitcode/exitcode.go) (`90`). Fix the underlying
+[`exitcode.Resumable`](internal/exitcode/exitcode.go) (`4`). Fix the underlying
 issue and resume the transfer:
 
 ```sh
@@ -199,7 +194,7 @@ lvmsync run --resume state /dev/vg0/snap0 /dev/vg0/target
 ### Identity Tuple Mismatch
 
 If the source or destination no longer matches the resume state, LVMSync exits with
-[`exitcode.Precondition`](internal/exitcode/exitcode.go) (`80`) and refuses to resume. Recreate the
+[`exitcode.Precondition`](internal/exitcode/exitcode.go) (`2`) and refuses to resume. Recreate the
 destination or regenerate the resume state before restarting.
 
 ## Failure Drills
@@ -239,16 +234,16 @@ scenarios.
    ```sh
    lvmsync run --remote https://badhost /dev/vg0/snap0 user@host:/dev/vg0/dst
    ```
-2. The TLS handshake fails with `exitcode.Runtime`. Verify certificates and
+2. The TLS handshake fails with exit code `1`. Verify certificates and
    trust stores, then retry the transfer.
 
 ## Symptom Reference
 
 | Symptom/log excerpt | Exit code | Recommended operator action |
 |---------------------|-----------|------------------------------|
-| `privilege check failed` | [10](internal/exitcode/exitcode.go) | Run as root or adjust `--lvm-escalation`. |
-| `snapshot overflow exit 20` | [20](internal/exitcode/exitcode.go) | Grow or recreate the snapshot, then resume. |
-| `verify failed with exit 60` | [60](internal/exitcode/exitcode.go) | Investigate mismatched blocks before retrying. |
-| `precondition failed with exit 80` | [80](internal/exitcode/exitcode.go) | Ensure device identities match or regenerate the state file. |
-| `resumable exit 90` | [90](internal/exitcode/exitcode.go) | Retry with `--resume` after fixing the issue. |
+| `privilege check failed` | [6](internal/exitcode/exitcode.go) | Run as root or adjust `--lvm-escalation`. |
+| `snapshot overflow exit 4` | [4](internal/exitcode/exitcode.go) | Grow or recreate the snapshot, then resume. |
+| `verify failed with exit 3` | [3](internal/exitcode/exitcode.go) | Investigate mismatched blocks before retrying. |
+| `precondition failed with exit 2` | [2](internal/exitcode/exitcode.go) | Ensure device identities match or regenerate the state file. |
+| `resumable exit 4` | [4](internal/exitcode/exitcode.go) | Retry with `--resume` after fixing the issue. |
 

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ lvmsync run --dry-run --verify-only /dev/vg0/snap0 /dev/vg0/target
 lvmsync run --dry-run /dev/vg0/snap0 /dev/vg0/target
 ```
 
-Exit code `60` signals verification mismatches. See [operations guide](OPERATIONS.md) for detailed recovery steps.
+Exit code `3` signals verification mismatches. See [operations guide](OPERATIONS.md) for detailed recovery steps.
 
 ## Supported Platforms
 
 LVMSync supports Linux only. A runtime check in [`main.go`](main.go) aborts
-execution on other operating systems with exit code `30`. The project is
+execution on other operating systems with exit code `1`. The project is
 regularly tested on `amd64` and `arm64` architectures.
 
 To cross-compile for another Linux architecture, set `GOOS=linux` and the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Read-only operations can run without elevated privileges.
 `--probe-only` checks device metadata, validates privileges, and emits dry-run estimates. It prints `(size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` for confirmation.
 `--verify-only` reads source and destination devices and reports mismatches.
 
-Both commands exit `0` on success, return `60` for verification failures, and `10` when required capabilities are missing. See [exit code meanings](OPERATIONS.md#exit-codes-and-recovery) for all codes.
+Both commands exit `0` on success, return `3` for verification failures, and `6` when required capabilities are missing. See [exit code meanings](OPERATIONS.md#exit-codes-and-recovery) for all codes.
 
 Example `--probe-only` output:
 
@@ -26,7 +26,7 @@ When privileges are missing:
 ```sh
 lvmsync run --probe-only /dev/vg0/snap0 /dev/vg0/target || \
   echo "probe failed with exit $?; run as root or adjust --lvm-escalation"
-# probe failed with exit 10; run as root or adjust --lvm-escalation
+# probe failed with exit 6; run as root or adjust --lvm-escalation
 ```
 
 ## Device identity enforcement

--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -166,9 +166,8 @@ func TestExitCodeMapping(t *testing.T) {
 	}{
 		{"success", nil, exitcode.OK, nil},
 		{"config", fmt.Errorf("parse listen: %w", exitcode.ErrConfig), exitcode.Config, exitcode.ErrConfig},
-		{"runtime", fmt.Errorf("listen failed: %w", exitcode.ErrRuntime), exitcode.Runtime, exitcode.ErrRuntime},
+		{"runtime", fmt.Errorf("listen failed"), 1, nil},
 		{"verify", fmt.Errorf("digest mismatch: %w", exitcode.ErrVerify), exitcode.Verify, exitcode.ErrVerify},
-		{"partial", fmt.Errorf("received signal: %w", exitcode.ErrPartial), exitcode.Partial, exitcode.ErrPartial},
 		{"precondition", fmt.Errorf("precondition not met: %w", exitcode.ErrPrecondition), exitcode.Precondition, exitcode.ErrPrecondition},
 		{"resumable", fmt.Errorf("resumable: %w", exitcode.ErrResumable), exitcode.Resumable, exitcode.ErrResumable},
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -360,17 +360,11 @@ func ExitCode(err error) int {
 		return exitcode.Config
 	case errors.Is(err, exitcode.ErrPrecondition):
 		return exitcode.Precondition
-	case errors.Is(err, exitcode.ErrResumable):
+	case errors.Is(err, exitcode.ErrResumable) || errors.Is(err, context.Canceled):
 		return exitcode.Resumable
-	case errors.Is(err, exitcode.ErrSnapshotExhausted):
-		return exitcode.SnapshotExhausted
-	case errors.Is(err, exitcode.ErrDevice):
-		return exitcode.Device
 	case errors.Is(err, exitcode.ErrVerify):
 		return exitcode.Verify
-	case errors.Is(err, exitcode.ErrPartial) || errors.Is(err, context.Canceled):
-		return exitcode.Partial
 	default:
-		return exitcode.Runtime
+		return 1
 	}
 }

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -394,14 +394,6 @@ func TestSelectVolumeGroupNoMatchErrDevice(t *testing.T) {
 	r := lvm.NewRunnerWithDeps(nil, func() error { return nil }, nil, fb, "")
 	if _, err := r.SelectVolumeGroupForSize(context.Background(), []string{"vg1"}, 50); err == nil {
 		t.Fatalf("expected error")
-	} else {
-		code := exitcode.Runtime
-		if strings.Contains(err.Error(), "device") {
-			code = exitcode.Device
-		}
-		if code != exitcode.Device {
-			t.Fatalf("exit code = %d, want %d", code, exitcode.Device)
-		}
 	}
 }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -30,7 +30,7 @@ showing the selected compression algorithm.
 2. A snapshot of the source logical volume is created unless `--skip-snapshot-creation` is used.
 3. Snapshot usage is monitored while blocks are streamed to the destination.
 4. On completion or interruption, the snapshot is removed.
-5. If snapshot usage exceeds the threshold, the transfer aborts with exit code `25` and the snapshot is cleaned up.
+5. If snapshot usage exceeds the threshold, the transfer aborts with exit code `4` and the snapshot is cleaned up.
 
 ## Resume and Verification Sequences
 
@@ -74,13 +74,10 @@ The write-ahead log records completed block ranges so interrupted transfers can 
 
 | Code | Meaning | Recovery Step |
 |------|---------|---------------|
-| `0`  | Success | None |
-| `10` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
-| `20` | Device error | Verify device paths and snapshot health. |
-| `25` | Snapshot exhausted | Extend the snapshot or reduce source writes before resuming. |
-| `30` | Unsupported platform | Run on a supported Linux platform. |
-| `40` | Configuration error | Review flags, environment variables, and `config.yaml`. |
-| `50` | Runtime failure | Inspect logs and fix the issue. |
-| `60` | Verification mismatch | Investigate mismatched data before retrying. |
-| `70` | Partial transfer | Address the error and resume with `--resume`. |
+| `0` | Success | None |
+| `2` | Precondition failed | Fix prerequisites and retry. |
+| `3` | Verification mismatch | Investigate mismatched data before retrying. |
+| `4` | Resumable exit | Address the issue and resume with `--resume`. |
+| `5` | Configuration error | Review flags, environment variables, and `config.yaml`. |
+| `6` | Privilege or capability check failed | Run as root or adjust `--lvm-escalation`. |
 

--- a/integration/freeze_helper_validation_test.go
+++ b/integration/freeze_helper_validation_test.go
@@ -39,7 +39,7 @@ func TestFreezeHelperValidation(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type: %T\n%s", err, out)
 	}
-	if ee.ExitCode() != 80 {
-		t.Fatalf("expected exit code 80, got %d\n%s", ee.ExitCode(), out)
+	if ee.ExitCode() != 2 {
+		t.Fatalf("expected exit code 2, got %d\n%s", ee.ExitCode(), out)
 	}
 }

--- a/integration/offline_enforcement.sh
+++ b/integration/offline_enforcement.sh
@@ -54,8 +54,8 @@ run_fs() (
   "$BIN" --dry-run --transport=rsync "$LOOP" "$DEST" >/tmp/offline_${FS}_a.log 2>&1
   STATUS=$?
   set -e
-  if [ "$STATUS" -ne 80 ]; then
-    echo "expected exit code 80, got $STATUS for $FS"
+  if [ "$STATUS" -ne 2 ]; then
+    echo "expected exit code 2, got $STATUS for $FS"
     cat /tmp/offline_${FS}_a.log
     exit 1
   fi

--- a/integration/partition_signatures.sh
+++ b/integration/partition_signatures.sh
@@ -45,8 +45,8 @@ set +e
 "$BIN" run --offline --skip-snapshot-creation --force --verify inline --check-partition "$SRC_LOOP" "$DST_LOOP"
 status=$?
 set -e
-if [ "$status" -ne 80 ]; then
-  echo "expected exit code 80, got $status"
+if [ "$status" -ne 2 ]; then
+  echo "expected exit code 2, got $status"
   exit 1
 fi
 

--- a/integration/resume_dedup_mismatch.sh
+++ b/integration/resume_dedup_mismatch.sh
@@ -59,8 +59,8 @@ if [ $STATUS -eq 0 ]; then
   echo "expected resume to fail due to dedup mode mismatch"
   exit 1
 fi
-if [ $STATUS -ne 80 ]; then
-  echo "expected exit code 80, got $STATUS"
+if [ $STATUS -ne 2 ]; then
+  echo "expected exit code 2, got $STATUS"
   exit 1
 fi
 if ! grep -q precondition "$TMPDIR/mismatch.log"; then

--- a/integration/rsync_refusal_test.go
+++ b/integration/rsync_refusal_test.go
@@ -88,8 +88,8 @@ func TestRsyncRefusal(t *testing.T) {
 		if !ok {
 			t.Fatalf("unexpected error type: %T\n%s", err, out)
 		}
-		if ee.ExitCode() != 80 {
-			t.Fatalf("expected exit code 80, got %d\n%s", ee.ExitCode(), out)
+		if ee.ExitCode() != 2 {
+			t.Fatalf("expected exit code 2, got %d\n%s", ee.ExitCode(), out)
 		}
 		if !strings.Contains(string(out), "precondition") {
 			t.Fatalf("missing precondition message: %s", out)

--- a/integration/safe_overwrite.sh
+++ b/integration/safe_overwrite.sh
@@ -52,13 +52,13 @@ if [ "$HASH_AFTER_PROBE" != "$HASH_BEFORE" ]; then
   exit 1
 fi
 
-# Verify-only should exit 60 and not modify destination
+# Verify-only should exit 3 and not modify destination
 set +e
 "$BIN" run --verify-only /dev/vgsrc/snap /dev/vgd/dest
 STATUS=$?
 set -e
-if [ "$STATUS" -ne 60 ]; then
-  echo "expected exit code 60, got $STATUS"
+if [ "$STATUS" -ne 3 ]; then
+  echo "expected exit code 3, got $STATUS"
   exit 1
 fi
 HASH_AFTER_VERIFY=$(sha256sum /dev/vgd/dest | awk '{print $1}')

--- a/integration/snapshot_pressure_test.go
+++ b/integration/snapshot_pressure_test.go
@@ -66,7 +66,7 @@ func TestSnapshotPressure(t *testing.T) {
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("expected exit error, got %v", err)
 	}
-	if exitErr.ExitCode() != exitcode.Device {
-		t.Fatalf("expected exit code %d, got %d", exitcode.Device, exitErr.ExitCode())
+	if exitErr.ExitCode() != exitcode.Resumable {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Resumable, exitErr.ExitCode())
 	}
 }

--- a/integration/snapshot_usage_guard_test.go
+++ b/integration/snapshot_usage_guard_test.go
@@ -85,8 +85,8 @@ func TestSnapshotUsageGuard(t *testing.T) {
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("expected exit error, got %v", err)
 	}
-	if exitErr.ExitCode() != exitcode.SnapshotExhausted {
-		t.Fatalf("expected exit code %d, got %d", exitcode.SnapshotExhausted, exitErr.ExitCode())
+	if exitErr.ExitCode() != exitcode.Resumable {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Resumable, exitErr.ExitCode())
 	}
 
 	out := run(t, exec.Command("lvs", "--noheadings", "-o", "lv_name", "vgtest"))

--- a/integration/verify.sh
+++ b/integration/verify.sh
@@ -57,8 +57,8 @@ set +e
 "$BIN" run --verify-only /dev/vgsrc/snap /dev/vgd/dest
 STATUS=$?
 set -e
-if [ "$STATUS" -ne 60 ]; then
-  echo "expected exit code 60, got $STATUS"
+if [ "$STATUS" -ne 3 ]; then
+  echo "expected exit code 3, got $STATUS"
   exit 1
 fi
 

--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -5,38 +5,23 @@ import "errors"
 // Exit codes for lvmsync binaries.
 const (
 	OK = 0
-	// Capability indicates missing privileges or capabilities.
-	Capability = 10
-	// Device indicates a device-related failure.
-	Device = 20
-	// SnapshotExhausted indicates snapshot space was exhausted during transfer.
-	SnapshotExhausted = 25
-	// Platform is returned when the operating system is unsupported.
-	Platform = 30
-	// Config represents configuration or validation failures.
-	Config = 40
-	// Runtime represents errors during command execution.
-	Runtime = 50
-	// Verify indicates checksum or digest verification failures.
-	Verify = 60
-	// Partial indicates a resumable transfer was aborted before completion.
-	Partial = 70
 	// Precondition indicates a precondition failure before execution.
-	Precondition = 80
+	Precondition = 2
+	// Verify indicates checksum or digest verification failures.
+	Verify = 3
 	// Resumable indicates the process exited early but can be resumed.
-	Resumable = 90
+	Resumable = 4
+	// Config represents configuration or validation failures.
+	Config = 5
+	// Capability indicates missing privileges or capabilities.
+	Capability = 6
 )
 
 // Sentinel errors corresponding to exit codes.
 var (
-	ErrCapability        = errors.New("capability failure")
-	ErrDevice            = errors.New("device failure")
-	ErrSnapshotExhausted = errors.New("snapshot exhausted")
-	ErrPlatform          = errors.New("unsupported platform")
-	ErrConfig            = errors.New("configuration error")
-	ErrRuntime           = errors.New("runtime error")
-	ErrVerify            = errors.New("verification failure")
-	ErrPartial           = errors.New("partial transfer")
-	ErrPrecondition      = errors.New("precondition failure")
-	ErrResumable         = errors.New("resumable error")
+	ErrPrecondition = errors.New("precondition failure")
+	ErrVerify       = errors.New("verification failure")
+	ErrResumable    = errors.New("resumable error")
+	ErrConfig       = errors.New("configuration error")
+	ErrCapability   = errors.New("capability failure")
 )

--- a/internal/exitcode/exitcode_test.go
+++ b/internal/exitcode/exitcode_test.go
@@ -9,16 +9,11 @@ func TestExitCodeValues(t *testing.T) {
 		want int
 	}{
 		{"OK", OK, 0},
-		{"Capability", Capability, 10},
-		{"Device", Device, 20},
-		{"SnapshotExhausted", SnapshotExhausted, 25},
-		{"Platform", Platform, 30},
-		{"Config", Config, 40},
-		{"Runtime", Runtime, 50},
-		{"Verify", Verify, 60},
-		{"Partial", Partial, 70},
-		{"Precondition", Precondition, 80},
-		{"Resumable", Resumable, 90},
+		{"Precondition", Precondition, 2},
+		{"Verify", Verify, 3},
+		{"Resumable", Resumable, 4},
+		{"Config", Config, 5},
+		{"Capability", Capability, 6},
 	}
 	for _, c := range cases {
 		if c.code != c.want {

--- a/internal/privilege/ensure_root_test.go
+++ b/internal/privilege/ensure_root_test.go
@@ -55,8 +55,8 @@ func TestEnsureSudoErrorsExitCode(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error")
 			}
-			if code := rootcmd.ExitCode(fmt.Errorf("privilege check failed: %w", err)); code != exitcode.Runtime {
-				t.Fatalf("exit code = %d, want %d", code, exitcode.Runtime)
+			if code := rootcmd.ExitCode(fmt.Errorf("privilege check failed: %w", err)); code != 1 {
+				t.Fatalf("exit code = %d, want 1", code)
 			}
 		})
 	}

--- a/lvm/lvm.go
+++ b/lvm/lvm.go
@@ -165,7 +165,7 @@ func (r *Runner) MonitorSnapshot(ctx context.Context, snapshotPath string, thres
 					zap.String("snapshot", snapshotPath),
 					zap.Float64("usage_percent", usage),
 					zap.Float64("threshold_percent", threshold))
-				return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%: %w", usage, threshold, exitcode.ErrSnapshotExhausted)
+				return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%: %w", usage, threshold, exitcode.ErrResumable)
 			}
 		case <-ctx.Done():
 			logger.Info("snapshot monitoring stopped", zap.String("snapshot", snapshotPath))

--- a/lvm/snapshot_pressure_test.go
+++ b/lvm/snapshot_pressure_test.go
@@ -68,8 +68,8 @@ func TestSnapshotPressureAbortCleanup(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "snapshot exhausted") {
 		t.Fatalf("expected snapshot exhausted error, got %v", err)
 	}
-	if code := rootcmd.ExitCode(err); code != exitcode.SnapshotExhausted {
-		t.Fatalf("exit code = %d; want %d", code, exitcode.SnapshotExhausted)
+	if code := rootcmd.ExitCode(err); code != exitcode.Resumable {
+		t.Fatalf("exit code = %d; want %d", code, exitcode.Resumable)
 	}
 
 	cleanup()

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func (r *Runner) Run() {
 		tmpLogger := r.ExampleLogger()
 		tmpLogger.Error("unsupported platform", zap.String("goos", r.GOOS))
 		rootcmd.SyncLogger(tmpLogger)
-		r.Exit(exitcode.Platform)
+		r.Exit(1)
 		return
 	}
 

--- a/main_error_log_test.go
+++ b/main_error_log_test.go
@@ -38,7 +38,7 @@ func TestMainLogsStructuredError(t *testing.T) {
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
 		func(_ *config.Config, _ []string, _ *zap.Logger) error {
-			return fmt.Errorf("boom: %w", exitcode.ErrRuntime)
+			return fmt.Errorf("boom")
 		},
 		rootcmd.SyncLogger,
 		func(c int) { code = c },
@@ -47,8 +47,8 @@ func TestMainLogsStructuredError(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != exitcode.Runtime {
-		t.Fatalf("expected exit code %d, got %d", exitcode.Runtime, code)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
 	}
 
 	entries := logs.FilterMessage("run failed").All()
@@ -129,8 +129,8 @@ func TestMainErrorsOnNonLinux(t *testing.T) {
 	)
 	runner.Run()
 
-	if code != exitcode.Platform {
-		t.Fatalf("expected exit code %d, got %d", exitcode.Platform, code)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
 	}
 
 	entries := logs.FilterMessage("unsupported platform").All()
@@ -170,25 +170,6 @@ func TestMainCapabilityErrorExitCode(t *testing.T) {
 	}
 }
 
-func TestMainDeviceErrorExitCode(t *testing.T) {
-	var code int
-	logger := zap.NewNop()
-	runner := NewRunnerWithDeps(
-		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
-		func(_ *config.Config, _ []string, _ *zap.Logger) error {
-			return fmt.Errorf("device lost: %w", exitcode.ErrDevice)
-		},
-		rootcmd.SyncLogger,
-		func(c int) { code = c },
-		func() *zap.Logger { return zap.NewNop() },
-		"linux",
-	)
-	runner.Run()
-	if code != exitcode.Device {
-		t.Fatalf("expected exit code %d, got %d", exitcode.Device, code)
-	}
-}
-
 func TestMainVerifyExitCode(t *testing.T) {
 	var code int
 	logger := zap.NewNop()
@@ -208,13 +189,13 @@ func TestMainVerifyExitCode(t *testing.T) {
 	}
 }
 
-func TestMainPartialExitCode(t *testing.T) {
+func TestMainResumableExitCode(t *testing.T) {
 	var code int
 	logger := zap.NewNop()
 	runner := NewRunnerWithDeps(
 		func() (*config.Config, []string, *zap.Logger, error) { return &config.Config{}, nil, logger, nil },
 		func(_ *config.Config, _ []string, _ *zap.Logger) error {
-			return fmt.Errorf("received signal: %w", exitcode.ErrPartial)
+			return fmt.Errorf("received signal: %w", exitcode.ErrResumable)
 		},
 		rootcmd.SyncLogger,
 		func(c int) { code = c },
@@ -222,7 +203,7 @@ func TestMainPartialExitCode(t *testing.T) {
 		"linux",
 	)
 	runner.Run()
-	if code != exitcode.Partial {
-		t.Fatalf("expected exit code %d, got %d", exitcode.Partial, code)
+	if code != exitcode.Resumable {
+		t.Fatalf("expected exit code %d, got %d", exitcode.Resumable, code)
 	}
 }

--- a/main_exitcode_test.go
+++ b/main_exitcode_test.go
@@ -20,13 +20,11 @@ func TestRunnerExitCodes(t *testing.T) {
 		want   int
 	}{
 		{"success", "linux", nil, nil, exitcode.OK},
-		{"platform", "darwin", nil, nil, exitcode.Platform},
+		{"platform", "darwin", nil, nil, 1},
 		{"capability", "linux", fmt.Errorf("privilege: %w", exitcode.ErrCapability), nil, exitcode.Capability},
 		{"config", "linux", fmt.Errorf("config invalid: %w", exitcode.ErrConfig), nil, exitcode.Config},
-		{"device", "linux", nil, fmt.Errorf("device gone: %w", exitcode.ErrDevice), exitcode.Device},
-		{"runtime", "linux", nil, fmt.Errorf("boom: %w", exitcode.ErrRuntime), exitcode.Runtime},
+		{"runtime", "linux", nil, fmt.Errorf("boom"), 1},
 		{"verify", "linux", nil, fmt.Errorf("digest mismatch: %w", exitcode.ErrVerify), exitcode.Verify},
-		{"partial", "linux", nil, fmt.Errorf("interrupt: %w", exitcode.ErrPartial), exitcode.Partial},
 		{"precondition", "linux", nil, fmt.Errorf("precondition: %w", exitcode.ErrPrecondition), exitcode.Precondition},
 		{"resumable", "linux", nil, fmt.Errorf("resumable: %w", exitcode.ErrResumable), exitcode.Resumable},
 	}
@@ -61,15 +59,11 @@ func TestExitCodeValues(t *testing.T) {
 		want int
 	}{
 		{"OK", exitcode.OK, 0},
-		{"Capability", exitcode.Capability, 10},
-		{"Device", exitcode.Device, 20},
-		{"Platform", exitcode.Platform, 30},
-		{"Config", exitcode.Config, 40},
-		{"Runtime", exitcode.Runtime, 50},
-		{"Verify", exitcode.Verify, 60},
-		{"Partial", exitcode.Partial, 70},
-		{"Precondition", exitcode.Precondition, 80},
-		{"Resumable", exitcode.Resumable, 90},
+		{"Precondition", exitcode.Precondition, 2},
+		{"Verify", exitcode.Verify, 3},
+		{"Resumable", exitcode.Resumable, 4},
+		{"Config", exitcode.Config, 5},
+		{"Capability", exitcode.Capability, 6},
 	}
 	for _, tt := range cases {
 		if tt.code != tt.want {

--- a/perf.md
+++ b/perf.md
@@ -60,7 +60,7 @@ Common options:
 Benchmarks are executed with helper scripts that wrap the `lvmsync run` command and collect timing data.
 
 Ensure the privilege model is satisfied: run as root or configure `--lvm-escalation`.  
-Non-zero exit codes indicate problems (`10` for privilege failures, `60` for verification mismatches).
+Non-zero exit codes indicate problems (`6` for privilege failures, `3` for verification mismatches).
 
 ### LAN Flags
 

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -141,7 +141,7 @@ func (t *Transfer) dumpChangesCore(ctx context.Context, cfg *config.Config, snap
 			return err
 		}
 		if usage >= cfg.SnapshotMaxUsage {
-			return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%: %w", usage, cfg.SnapshotMaxUsage, exitcode.ErrSnapshotExhausted)
+			return fmt.Errorf("snapshot exhausted: usage %.2f%% >= threshold %.2f%%: %w", usage, cfg.SnapshotMaxUsage, exitcode.ErrResumable)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- streamline exit code constants and sentinels
- update exit-code references in logic, tests, and documentation

## Testing
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: revive, staticcheck, errcheck and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab576be7f883238718602951beb57d