### PR TITLE
Use structured logger in privdrop

### DIFF
--- a/cmd/privdrop/main.go
+++ b/cmd/privdrop/main.go
@@ -6,22 +6,57 @@ import (
 	"go.uber.org/zap"
 	rootcmd "lvmsync_go/cmd/root"
 	"lvmsync_go/escalate"
+	"lvmsync_go/internal/logging"
 )
 
 type runner struct {
 	ensureRootOrReexec  func(escalate.Options, *zap.Logger) (bool, error)
 	dropToInvokerIfSudo func(escalate.Options, *zap.Logger) error
+	syncLogger          func(*zap.Logger)
+	exit                func(int)
+	newLogger           func() *zap.Logger
 }
 
 func newRunner() *runner {
 	return &runner{
 		ensureRootOrReexec:  escalate.EnsureRootOrReexec,
 		dropToInvokerIfSudo: escalate.DropToInvokerIfSudo,
+		syncLogger:          rootcmd.SyncLogger,
+		exit:                os.Exit,
+		newLogger: func() *zap.Logger {
+			logger, err := logging.NewLogger(nil, "privdrop")
+			if err != nil {
+				return zap.NewNop()
+			}
+			return logger
+		},
 	}
 }
 
-func newRunnerWithDeps(ensure func(escalate.Options, *zap.Logger) (bool, error), drop func(escalate.Options, *zap.Logger) error) *runner {
-	return &runner{ensureRootOrReexec: ensure, dropToInvokerIfSudo: drop}
+func newRunnerWithDeps(
+	ensure func(escalate.Options, *zap.Logger) (bool, error),
+	drop func(escalate.Options, *zap.Logger) error,
+	syncFunc func(*zap.Logger),
+	exitFunc func(int),
+	loggerFunc func() *zap.Logger,
+) *runner {
+	r := newRunner()
+	if ensure != nil {
+		r.ensureRootOrReexec = ensure
+	}
+	if drop != nil {
+		r.dropToInvokerIfSudo = drop
+	}
+	if syncFunc != nil {
+		r.syncLogger = syncFunc
+	}
+	if exitFunc != nil {
+		r.exit = exitFunc
+	}
+	if loggerFunc != nil {
+		r.newLogger = loggerFunc
+	}
+	return r
 }
 
 func (r *runner) run(logger *zap.Logger) int {
@@ -43,10 +78,11 @@ func (r *runner) run(logger *zap.Logger) int {
 	return 0
 }
 
-func main() {
-	logger := zap.NewExample()
-	defer rootcmd.SyncLogger(logger)
-
-	r := newRunner()
-	os.Exit(r.run(logger))
+func (r *runner) Run() {
+	logger := r.newLogger()
+	defer r.syncLogger(logger)
+	code := r.run(logger)
+	r.exit(code)
 }
+
+func main() { newRunner().Run() }

--- a/cmd/privdrop/main_test.go
+++ b/cmd/privdrop/main_test.go
@@ -72,7 +72,7 @@ func TestRunnerRun(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			r := newRunnerWithDeps(tc.ensure, tc.drop)
+			r := newRunnerWithDeps(tc.ensure, tc.drop, nil, nil, nil)
 			core, logs := observer.New(zapcore.DebugLevel)
 			logger := zap.New(core)
 
@@ -98,5 +98,29 @@ func TestRunnerRun(t *testing.T) {
 				t.Fatalf("log level: got %v want %v", entries[0].Level, tc.logLevel)
 			}
 		})
+	}
+}
+
+func TestRunSyncsLogger(t *testing.T) {
+	syncCalled := false
+	exitCode := 0
+	core, logs := observer.New(zapcore.ErrorLevel)
+	r := newRunnerWithDeps(
+		func(escalate.Options, *zap.Logger) (bool, error) { return false, errors.New("boom") },
+		func(escalate.Options, *zap.Logger) error { t.Fatalf("drop should not be called"); return nil },
+		func(*zap.Logger) { syncCalled = true },
+		func(c int) { exitCode = c },
+		func() *zap.Logger { return zap.New(core) },
+	)
+	r.Run()
+	if exitCode != 1 {
+		t.Fatalf("exit code: got %d want 1", exitCode)
+	}
+	entries := logs.FilterMessage("ensure_root_or_reexec").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if !syncCalled {
+		t.Fatalf("expected SyncLogger to be called")
 	}
 }


### PR DESCRIPTION
## Summary
- initialize privdrop logger with `logging.NewLogger` and fall back to `zap.NewNop`
- inject logger creation and flushing into privdrop runner and add tests

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: cmd/verify TestVerifyWithManifestParallel)*
- `golangci-lint run` *(fails: 1288 issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68ab607b0af4832387e939fe1a690498