### PR TITLE
Require double-confirm for destructive device operations

### DIFF
--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -363,7 +363,7 @@ func TestLVMDeviceCloseErrorLogging(t *testing.T) {
 
 func TestConfirmOverwriteTTYLVM(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
-	r := ttyLVMReader{strings.NewReader("yes\n")}
+	r := ttyLVMReader{strings.NewReader("double-confirm\n")}
 	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err != nil {
 		t.Fatalf("confirmOverwrite: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestConfirmOverwriteTTYLVM(t *testing.T) {
 
 func TestConfirmOverwriteNonTTYLVM(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
-	r := strings.NewReader("yes\n")
+	r := strings.NewReader("double-confirm\n")
 	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err == nil || !strings.Contains(err.Error(), "--allow-overwrite") {
 		t.Fatalf("expected allow-overwrite error, got %v", err)
 	}

--- a/device/overwrite.go
+++ b/device/overwrite.go
@@ -9,9 +9,10 @@ import (
 )
 
 // confirmOverwrite ensures destructive operations are allowed. It requires
-// --force and either an interactive confirmation on a TTY or the combination of
-// --allow-overwrite and --yes-i-know. stdin and stderr are used for prompting,
-// and isTerminal reports whether the stdin file descriptor is a TTY.
+// --force and either typing the literal text "double-confirm" on a TTY or the
+// combination of --allow-overwrite and --yes-i-know. stdin and stderr are used
+// for prompting, and isTerminal reports whether the stdin file descriptor is a
+// TTY.
 func confirmOverwrite(ctx context.Context, stdin io.Reader, stderr io.Writer, isTerminal func(int) bool) error {
 	if !forceFromContext(ctx) {
 		return fmt.Errorf("--force required for write operations")
@@ -23,13 +24,13 @@ func confirmOverwrite(ctx context.Context, stdin io.Reader, stderr io.Writer, is
 	}
 	type fdProvider interface{ Fd() uintptr }
 	if f, ok := stdin.(fdProvider); ok && isTerminal(int(f.Fd())) {
-		fmt.Fprint(stderr, "Device operations may overwrite data. Type 'yes' to continue: ")
+		fmt.Fprint(stderr, "Device operations may overwrite data. Type 'double-confirm' to continue: ")
 		reader := bufio.NewReader(stdin)
 		resp, err := reader.ReadString('\n')
 		if err != nil {
 			return fmt.Errorf("confirmation failed: %w", err)
 		}
-		if !strings.EqualFold(strings.TrimSpace(resp), "yes") {
+		if strings.TrimSpace(resp) != "double-confirm" {
 			return fmt.Errorf("operation cancelled")
 		}
 		return nil

--- a/device/overwrite_test.go
+++ b/device/overwrite_test.go
@@ -12,9 +12,9 @@ type overwriteTTYReader struct{ io.Reader }
 
 func (overwriteTTYReader) Fd() uintptr { return 0 }
 
-func TestConfirmOverwriteMixedCase(t *testing.T) {
+func TestConfirmOverwriteToken(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
-	r := overwriteTTYReader{strings.NewReader("YeS\n")}
+	r := overwriteTTYReader{strings.NewReader("double-confirm\n")}
 	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err != nil {
 		t.Fatalf("confirmOverwrite: %v", err)
 	}

--- a/device/raw_test.go
+++ b/device/raw_test.go
@@ -220,7 +220,7 @@ func TestOpenRawFreezeTimeout(t *testing.T) {
 
 func TestConfirmOverwriteTTYRaw(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
-	r := ttyReader{strings.NewReader("yes\n")}
+	r := ttyReader{strings.NewReader("double-confirm\n")}
 	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err != nil {
 		t.Fatalf("confirmOverwrite: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestConfirmOverwriteTTYRaw(t *testing.T) {
 
 func TestConfirmOverwriteNonTTYRaw(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
-	r := strings.NewReader("yes\n")
+	r := strings.NewReader("double-confirm\n")
 	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err == nil || !strings.Contains(err.Error(), "--allow-overwrite") {
 		t.Fatalf("expected allow-overwrite error, got %v", err)
 	}
@@ -237,7 +237,7 @@ func TestConfirmOverwriteNonTTYRaw(t *testing.T) {
 func TestConfirmOverwriteRequiresYesIKnowRaw(t *testing.T) {
 	ctx := WithForce(context.Background(), true)
 	ctx = WithAllowOverwrite(ctx, true)
-	r := strings.NewReader("yes\n")
+	r := strings.NewReader("double-confirm\n")
 	if err := confirmOverwrite(ctx, r, io.Discard, func(int) bool { return true }); err == nil || !strings.Contains(err.Error(), "--yes-i-know") {
 		t.Fatalf("expected yes-i-know error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- enforce literal `double-confirm` token for interactive device overwrites
- update raw and LVM overwrite tests to expect the new confirmation string

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: multiple unchecked return values and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab64c3d3d48323978b957337e0e195