### PR TITLE
Default to zstd compression when supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For snapshot cleanup, resuming transfers, and verify-only rollback procedures, s
 - **Parallel Execution**: Configurable concurrency for optimal performance.
 - **Adaptive Transport Concurrency**: Maintains ~1–2×BDP of in-flight data and can be overridden with `--concurrency`.
 - **Rate-Limiting**: Control bandwidth usage during transfers.
-- **Compression**: Samples 8 KiB per chunk and skips compression when the ratio exceeds `--compress-threshold`. Auto mode selects LZ4 for chunks <256 KiB and Zstd for larger chunks on CPUs with AVX2 or NEON support. Compression levels are tuned via `--lz4-level` and `--zstd-level`. See [compression documentation](docs/compression.md) for pipeline details.
+- **Compression**: Samples 8 KiB per chunk and skips compression when the ratio exceeds `--compress-threshold`. Auto mode selects Zstd on CPUs with AVX2 or NEON support, falling back to LZ4 when those features are absent. Compression levels are tuned via `--lz4-level` and `--zstd-level`. See [compression documentation](docs/compression.md) for pipeline details.
 - **Checksum Verification**: Ensures data integrity using SHA-256 or BLAKE3, automatically selecting BLAKE3 on CPUs with AES-NI, AVX2/AVX-512, or NEON.
 - **Native LVM2 Integration**: Uses Go bindings to `liblvm2cmd` instead of shelling out.
 - **Generic Block Device Support**: Access raw `/dev/*` paths and regular files (including loopback images) through a unified device abstraction.
@@ -943,7 +943,7 @@ detects any mismatches so retries can resend the affected data. The mmap-backed
 index (`*.idx`) is truncated to zero on startup so each run begins with a clean
 bitset.
 
-Compression samples 8 KiB from each chunk and skips when the estimated ratio exceeds `--compress-threshold`. `--compress auto` selects LZ4 for chunks under 256 KiB and Zstd for larger chunks when AVX2 or NEON is available, falling back to LZ4 otherwise.
+Compression samples 8 KiB from each chunk and skips when the estimated ratio exceeds `--compress-threshold`. `--compress auto` selects Zstd when AVX2 or NEON is available, falling back to LZ4 otherwise.
 
 CLI:
 
@@ -1521,9 +1521,8 @@ When saving Bloom filter state, LVMSync logs `dedup_bloom_stats` with `entries`,
 
 LVMSync samples 8 KiB from each chunk to gauge compression efficiency. If the
 compressed sample ratio is greater than or equal to `--compress-threshold`, the
-chunk is sent uncompressed. In `auto` mode, chunks smaller than 256 KiB use LZ4,
-and larger ones select Zstd (levels 1–3) when AVX2 or NEON is available;
-otherwise LZ4.
+chunk is sent uncompressed. In `auto` mode, Zstd is used when AVX2 or NEON is
+available; otherwise LZ4 is selected.
 The compression threshold is tunable via `--compress-threshold` (`LVMSYNC_COMPRESSION_COMPRESS_THRESHOLD` or `compress_threshold`), where values near 1 favor compression and lower values skip high-entropy data.
 Levels can be tuned with `--zstd-level` (1-5) or `--lz4-level` (`fast` or `hc`).
 

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -37,12 +37,9 @@ var ErrRemoteCommand = errors.New("remote command error")
 
 const maxFrame = 1 << 20
 
-func chooseCompression(chunkLen int, compress string) string {
+func chooseCompression(_ int, compress string) string {
 	if compress != transfer.StrategyAuto && compress != "" {
 		return compress
-	}
-	if chunkLen > 0 && chunkLen < 256*1024 {
-		return "lz4"
 	}
 	if cpufeatures.HasAVX2() || cpufeatures.HasNEON() {
 		return "zstd"

--- a/cmd/dump/compression_test.go
+++ b/cmd/dump/compression_test.go
@@ -1,0 +1,45 @@
+package dump
+
+import (
+	"testing"
+
+	cpufeatures "lvmsync_go/internal/cpufeatures"
+	"lvmsync_go/transfer"
+)
+
+func TestChooseCompressionExplicit(t *testing.T) {
+	if got := chooseCompression(0, "lz4"); got != "lz4" {
+		t.Fatalf("chooseCompression explicit lz4 = %q, want lz4", got)
+	}
+	if got := chooseCompression(0, "zstd"); got != "zstd" {
+		t.Fatalf("chooseCompression explicit zstd = %q, want zstd", got)
+	}
+}
+
+func TestChooseCompressionAutoWithZstdSupport(t *testing.T) {
+	if !(cpufeatures.HasAVX2() || cpufeatures.HasNEON()) {
+		t.Skip("zstd not supported")
+	}
+	if got := chooseCompression(0, transfer.StrategyAuto); got != "zstd" {
+		t.Fatalf("chooseCompression auto with zstd support = %q, want zstd", got)
+	}
+}
+
+func TestChooseCompressionAutoWithoutZstdSupport(t *testing.T) {
+	if cpufeatures.HasAVX2() || cpufeatures.HasNEON() {
+		t.Skip("zstd supported")
+	}
+	if got := chooseCompression(0, transfer.StrategyAuto); got != "lz4" {
+		t.Fatalf("chooseCompression auto without zstd support = %q, want lz4", got)
+	}
+}
+
+func TestChooseCompressionSmallChunk(t *testing.T) {
+	want := "lz4"
+	if cpufeatures.HasAVX2() || cpufeatures.HasNEON() {
+		want = "zstd"
+	}
+	if got := chooseCompression(32*1024, transfer.StrategyAuto); got != want {
+		t.Fatalf("chooseCompression small chunk = %q, want %s", got, want)
+	}
+}

--- a/docs/compression.md
+++ b/docs/compression.md
@@ -15,18 +15,17 @@ LVMSync compresses data on a per‑chunk basis. Each chunk passes through a clas
 
 `--compress auto` chooses between LZ4 and Zstd for each chunk:
 
-- Chunks <256 KiB use LZ4.
-- Larger chunks use Zstd when the CPU reports AVX2 (amd64) or NEON (arm64) via [`x/sys/cpu`](https://pkg.go.dev/golang.org/x/sys/cpu); otherwise LZ4 is used.
+- Zstd is used when the CPU reports AVX2 (amd64) or NEON (arm64) via [`x/sys/cpu`](https://pkg.go.dev/golang.org/x/sys/cpu).
+- LZ4 is used otherwise.
 
 Compression levels are tuned with `--zstd-level 1..5` or `--lz4-level {fast|hc}`.
 
 ### Selection Matrix
 
-| Chunk size      | CPU features      | Algorithm | Level mapping                           |
-|-----------------|-------------------|-----------|-----------------------------------------|
-| `<256` KiB      | Any               | LZ4       | level1 when `--lz4-level` is `0`        |
-| `≥256` KiB      | AVX2 or NEON      | Zstd      | default `1`; values `>3` cap to `3`     |
-| `≥256` KiB      | Neither detected  | LZ4       | level1 when `--lz4-level` is `0`        |
+| CPU features      | Algorithm | Level mapping                           |
+|-------------------|-----------|-----------------------------------------|
+| AVX2 or NEON      | Zstd      | default `1`; values `>3` cap to `3`     |
+| Neither detected  | LZ4       | level1 when `--lz4-level` is `0`        |
 
 ## Dictionary Training
 


### PR DESCRIPTION
## Summary
- Default compression algorithm to zstd when AVX2 or NEON is present, otherwise fall back to lz4
- Add tests for explicit compression strategies, CPU feature detection, and small chunk sizes
- Document new zstd-first behavior in README and compression docs

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: revive, staticcheck, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab75f6f6c08323856987477cd31b1e