### PR TITLE
Add direct device write confirmation tests

### DIFF
--- a/cmd/root/direct_device_confirm_test.go
+++ b/cmd/root/direct_device_confirm_test.go
@@ -1,0 +1,157 @@
+package root
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/creack/pty"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"lvmsync_go/internal/config"
+	"lvmsync_go/transport"
+)
+
+// createBlockDevice returns path to a temporary block device file.
+func createBlockDevice(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	devPath := filepath.Join(dir, "blkdev")
+	if err := unix.Mknod(devPath, unix.S_IFBLK|0600, int(unix.Mkdev(1, 5))); err != nil {
+		t.Skipf("mknod failed: %v", err)
+	}
+	return devPath
+}
+
+func newStubRunner(called *bool) *Runner {
+	return NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			*called = true
+			return "snap", make(chan error), func() {}, nil
+		},
+	})
+}
+
+func TestPrepareClientDirectDeviceTTYRequiresConfirmation(t *testing.T) {
+	devPath := createBlockDevice(t)
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.ForceOffline = true
+
+	master, slave, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty open error: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = slave
+	defer func() {
+		os.Stdin = origStdin
+		master.Close()
+		slave.Close()
+	}()
+	fmt.Fprintln(master, "no")
+
+	called := false
+	rnr := newStubRunner(&called)
+	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err == nil || err.Error() != "direct device write cancelled" {
+		t.Fatalf("expected cancellation error, got: %v", err)
+	}
+	if called {
+		t.Fatalf("prepareSnapshot should not be called")
+	}
+}
+
+func TestPrepareClientDirectDeviceTTYConfirmed(t *testing.T) {
+	devPath := createBlockDevice(t)
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.ForceOffline = true
+
+	master, slave, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty open error: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = slave
+	defer func() {
+		os.Stdin = origStdin
+		master.Close()
+		slave.Close()
+	}()
+	fmt.Fprintln(master, "double-confirm")
+
+	called := false
+	rnr := newStubRunner(&called)
+	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatalf("prepareSnapshot not called")
+	}
+}
+
+func TestPrepareClientDirectDeviceNonTTYRequiresYesIKnow(t *testing.T) {
+	devPath := createBlockDevice(t)
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.ForceOffline = true
+
+	origStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	defer func() {
+		os.Stdin = origStdin
+		r.Close()
+		w.Close()
+	}()
+
+	called := false
+	rnr := newStubRunner(&called)
+	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err == nil || err.Error() != "direct device writes require --yes-i-know flag when not run interactively" {
+		t.Fatalf("expected yes-i-know error, got: %v", err)
+	}
+	if called {
+		t.Fatalf("prepareSnapshot should not be called")
+	}
+}
+
+func TestPrepareClientDirectDeviceNonTTYConfirmed(t *testing.T) {
+	devPath := createBlockDevice(t)
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	cfg.ForceOffline = true
+	cfg.YesIKnow = true
+
+	origStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	defer func() {
+		os.Stdin = origStdin
+		r.Close()
+		w.Close()
+	}()
+
+	called := false
+	rnr := newStubRunner(&called)
+	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatalf("prepareSnapshot not called")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.0 // indirect
+	github.com/creack/pty v1.1.23 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.23 h1:4M6+isWdcStXEf15G/RbrMPOQj1dZ7HPZCGwE4kOeP0=
+github.com/creack/pty v1.1.23/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- test TTY direct device writes require "double-confirm" input before proceeding
- test non-TTY direct device writes require `--yes-i-know`
- ensure snapshot preparation executes after successful confirmation

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: existing revive, staticcheck, and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ac064d48323b0230e2af1a3e081