### PR TITLE
test: expand cmd root coverage

### DIFF
--- a/cmd/root/configure_precedence_test.go
+++ b/cmd/root/configure_precedence_test.go
@@ -1,0 +1,41 @@
+package root
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigurePrecedence(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfgFile := filepath.Join(t.TempDir(), "cfg.yaml")
+	if err := os.WriteFile(cfgFile, []byte("tcp_port: 1111\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Run("flag_overrides_env_yaml", func(t *testing.T) {
+		t.Setenv("LVMSYNC_TCP_PORT", "2222")
+		orig := os.Args
+		os.Args = []string{"cmd", "--config", cfgFile, "--tcp-port", "3333", "/src", "/dst"}
+		defer func() { os.Args = orig }()
+		cfg, _, _, err := ConfigureWithEscalator(stubEscalator{})
+		if err != nil {
+			t.Fatalf("Configure error: %v", err)
+		}
+		if cfg.TCPPort != 3333 {
+			t.Fatalf("TCPPort=%d want 3333", cfg.TCPPort)
+		}
+	})
+	t.Run("env_overrides_yaml", func(t *testing.T) {
+		t.Setenv("LVMSYNC_TCP_PORT", "2222")
+		orig := os.Args
+		os.Args = []string{"cmd", "--config", cfgFile, "/src", "/dst"}
+		defer func() { os.Args = orig }()
+		cfg, _, _, err := ConfigureWithEscalator(stubEscalator{})
+		if err != nil {
+			t.Fatalf("Configure error: %v", err)
+		}
+		if cfg.TCPPort != 2222 {
+			t.Fatalf("TCPPort=%d want 2222", cfg.TCPPort)
+		}
+	})
+}

--- a/cmd/root/exitcode_test.go
+++ b/cmd/root/exitcode_test.go
@@ -1,0 +1,33 @@
+package root
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"lvmsync_go/internal/exitcode"
+)
+
+func TestExitCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"nil", nil, exitcode.OK},
+		{"capability", exitcode.ErrCapability, exitcode.Capability},
+		{"config", exitcode.ErrConfig, exitcode.Config},
+		{"precondition", exitcode.ErrPrecondition, exitcode.Precondition},
+		{"resumable", exitcode.ErrResumable, exitcode.Resumable},
+		{"canceled", context.Canceled, exitcode.Resumable},
+		{"verify", exitcode.ErrVerify, exitcode.Verify},
+		{"other", errors.New("boom"), 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if c := ExitCode(tc.err); c != tc.code {
+				t.Fatalf("ExitCode(%v)=%d want %d", tc.err, c, tc.code)
+			}
+		})
+	}
+}

--- a/cmd/root/plan_test.go
+++ b/cmd/root/plan_test.go
@@ -171,3 +171,9 @@ func TestEmitPlanRedactsAndOrdersTransports(t *testing.T) {
 		t.Fatalf("transport order %v != %v", po.TransportOrder, expected)
 	}
 }
+
+func TestEmitPlanMissingSource(t *testing.T) {
+	if err := emitPlan(&config.Config{}, nil, zap.NewNop()); err == nil || err.Error() != "missing source argument" {
+		t.Fatalf("expected missing source error, got: %v", err)
+	}
+}

--- a/cmd/root/prepare_client_error_test.go
+++ b/cmd/root/prepare_client_error_test.go
@@ -1,0 +1,62 @@
+package root
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/config"
+	"lvmsync_go/transport"
+)
+
+func TestPrepareClientSelectTransportError(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) {
+			return nil, errors.New("boom")
+		},
+	})
+	if _, _, _, _, _, _, err := r.prepareClient(cfg, []string{"/src", "/dst"}, zap.NewNop()); err == nil || !strings.Contains(err.Error(), "select transport") {
+		t.Fatalf("expected select transport error, got: %v", err)
+	}
+}
+
+func TestPrepareClientMissingArguments(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+	})
+	if _, _, _, _, _, _, err := r.prepareClient(cfg, []string{"/src"}, zap.NewNop()); err == nil || err.Error() != "invalid arguments" {
+		t.Fatalf("expected invalid arguments error, got: %v", err)
+	}
+}
+
+func TestPrepareClientDirectDeviceRequiresForceOffline(t *testing.T) {
+	devPath := createBlockDevice(t)
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
+		setupSignalHandleFn: func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+	})
+	if _, _, _, _, _, _, err := r.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err == nil || err.Error() != "direct device writes require --force-offline" {
+		t.Fatalf("expected force-offline error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add configuration precedence tests for root command
- exercise prepareClient and exit code error paths
- cover emitPlan missing source argument

## Testing
- `go build ./...`
- `go test ./...`
- `go test -cover ./cmd/root`
- `golangci-lint run` *(fails: 1299 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab815ed0ec8323982142d41f46fb02