### PR TITLE
chore: enable deadcode gosimple stylecheck linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,9 @@ linters:
     - asciicheck
     - bodyclose
     - misspell
+    - deadcode
+    - gosimple
+    - stylecheck
 
 linters-settings:
   errcheck:


### PR DESCRIPTION
## Summary
- enable deadcode, gosimple, and stylecheck in golangci-lint config

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out`
- `/tmp/golangci/golangci-lint run --new-from-rev=$(git rev-parse HEAD)`

------
https://chatgpt.com/codex/tasks/task_e_68ab8efb2b308323854d641d4cd444d4