### PR TITLE
ci: add jscpd check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -115,6 +115,22 @@ jobs:
       - name: Validate sudoers file
         run: visudo -cf docs/sudoers.d/lvmsync
 
+  jscpd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run jscpd
+        run: npx -y jscpd --config .jscpd.json
+
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- run jscpd in checks workflow to enforce duplication threshold

## Testing
- `npx -y jscpd --config .jscpd.json` *(fails: jscpd found too many duplicates (7.33%) over threshold (5%))*
- `go build ./...`
- `go test -cover ./...`
- `golangci-lint run` *(fails: 1299 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f0b4d9483239836c422e32cc08a