### PR TITLE
Add lvmsyncd parseListen and TLS start tests

### DIFF
--- a/cmd/lvmsyncd/lvmsyncd_test.go
+++ b/cmd/lvmsyncd/lvmsyncd_test.go
@@ -55,6 +55,25 @@ func (d *dummyListener) Accept() (net.Conn, error) {
 func (d *dummyListener) Close() error   { return nil }
 func (d *dummyListener) Addr() net.Addr { return d.addr }
 
+func TestParseListenErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr string
+	}{
+		{"ParseError", "://bad", "parse listen URI"},
+		{"MissingScheme", "//:1234", "missing scheme"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseListen([]string{tt.uri})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestFlagParsing(t *testing.T) {
 	v := viper.New()
 	cmd := &cobra.Command{}
@@ -154,6 +173,26 @@ func TestStartMissingCerts(t *testing.T) {
 	err := start(context.Background(), options{}, zap.NewNop())
 	if err == nil || !strings.Contains(err.Error(), "server-cert, server-key, client-cert, client-key, and ca-cert are required") {
 		t.Fatalf("expected missing cert error, got %v", err)
+	}
+}
+
+func TestStartAllowsMissingCertsWithAllowInsecure(t *testing.T) {
+	if err := transport.Register("mocktls", func(cfg transport.Config) (transport.Interface, error) {
+		return &mockTransport{}, nil
+	}); err != nil && !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("register: %v", err)
+	}
+	opts := options{
+		listens:       []string{"mocktls://:1234"},
+		allowInsecure: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- start(ctx, opts, zap.NewNop()) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	if err := <-done; err != context.Canceled {
+		t.Fatalf("start returned %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- test parseListen failure scenarios for malformed URIs
- ensure start handles missing TLS files only when allow-insecure set

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...` *(fails: TestStreamToRemoteRsyncDelta context canceled)*
- `go tool cover -func=coverage.out | tail -n 1`
- `go test -cover ./cmd/lvmsyncd`
- `golangci-lint run` *(fails: unknown linters: 'deadcode,gosimple,stylecheck')*

------
https://chatgpt.com/codex/tasks/task_e_68ab97378d0483239207a9e92fc617c5