### PR TITLE
Ensure README example builds do not affect coverage

### DIFF
--- a/readme_examples_test.go
+++ b/readme_examples_test.go
@@ -47,6 +47,7 @@ func TestReadmeExamplesCompile(t *testing.T) {
 			t.Fatalf("example %d: %v", i+1, err)
 		}
 		cmd := exec.Command("go", "build", file)
+		cmd.Env = append(os.Environ(), "GOCOVERDIR=")
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("example %d: %v\n%s", i+1, err, out)
 		}


### PR DESCRIPTION
## Summary
- prevent README example builds from polluting `go test` coverage by clearing `GOCOVERDIR`

## Testing
- `go build ./...`
- `go test -cover ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 20`
- `golangci-lint run` *(fails: unknown linters deadcode, gosimple, stylecheck)*


------
https://chatgpt.com/codex/tasks/task_e_68abecbab74483238efd536ae079268b