### PR TITLE
feat: define LVM API interface

### DIFF
--- a/internal/blockio/devicewriter_test.go
+++ b/internal/blockio/devicewriter_test.go
@@ -7,7 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"lvmsync_go/internal/lvm"
+	ilvm "lvmsync_go/internal/lvm"
+	lvmlib "lvmsync_go/lvm"
 )
 
 type mockAgent struct {
@@ -30,11 +31,11 @@ func (m *mockAgent) Unlock(ctx context.Context, volume, requester string) error 
 	return m.unlockErr
 }
 
-func (m *mockAgent) GetMetadata(ctx context.Context, volume string) (lvm.VolumeMetadata, error) {
-	return lvm.VolumeMetadata{}, nil
+func (m *mockAgent) GetMetadata(ctx context.Context, volume string) (lvmlib.VolumeMetadata, error) {
+	return lvmlib.VolumeMetadata{}, nil
 }
 
-func (m *mockAgent) SendMetadata(ctx context.Context, md lvm.VolumeMetadata) error { return nil }
+func (m *mockAgent) SendMetadata(ctx context.Context, md lvmlib.VolumeMetadata) error { return nil }
 
 func (m *mockAgent) StartTransferSession(ctx context.Context, volume, requester string) error {
 	return nil
@@ -76,7 +77,7 @@ func TestDeviceWriterOpenSuccess(t *testing.T) {
 	ftmp.Close()
 
 	agent := &mockAgent{volumeExists: true, autoExtend: true, discard: true}
-	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
+	dw := DeviceWriter{Checker: ilvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
 
 	f, closeFn, err := dw.Open(ctx, "testvg1", "testlv1", false)
 	if err != nil {
@@ -103,7 +104,7 @@ func TestDeviceWriterOpenPreOpenFailure(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	agent := &mockAgent{volumeExists: false}
-	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
+	dw := DeviceWriter{Checker: ilvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
 	f, closeFn, err := dw.Open(ctx, "vg", "lv", false)
 	if err == nil {
 		t.Fatalf("expected error")
@@ -130,7 +131,7 @@ func TestDeviceWriterOpenPostCommitFailure(t *testing.T) {
 	ftmp.Close()
 
 	agent := &mockAgent{volumeExists: true, autoExtend: true, discard: true, unlockErr: errors.New("unlock failed")}
-	dw := DeviceWriter{Checker: lvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
+	dw := DeviceWriter{Checker: ilvm.Checker{Agent: agent, Requester: "req", DevRoot: root}}
 
 	f, closeFn, err := dw.Open(ctx, "testvg2", "testlv2", false)
 	if err != nil {

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -11,19 +11,12 @@ import (
 	lvmlib "lvmsync_go/lvm"
 )
 
-// VolumeMetadata represents metadata about a logical volume.
-type VolumeMetadata struct {
-	VolumeName string
-	SizeBytes  uint64
-	ChunkSize  uint64
-}
-
 // Agent defines methods for performing privileged LVM operations.
 type Agent interface {
 	Lock(ctx context.Context, volume, requester string) error
 	Unlock(ctx context.Context, volume, requester string) error
-	GetMetadata(ctx context.Context, volume string) (VolumeMetadata, error)
-	SendMetadata(ctx context.Context, md VolumeMetadata) error
+	GetMetadata(ctx context.Context, volume string) (lvmlib.VolumeMetadata, error)
+	SendMetadata(ctx context.Context, md lvmlib.VolumeMetadata) error
 	StartTransferSession(ctx context.Context, volume, requester string) error
 	FinalizeSync(ctx context.Context, volume, requester string) error
 	GetStatus(ctx context.Context, volume, requester string) (string, error)
@@ -33,31 +26,16 @@ type Agent interface {
 	IsMounted(ctx context.Context, volume string) (bool, error)
 }
 
-// lvmAPI describes the subset of the LVM library used by the agent.
-type lvmAPI interface {
-	Lock(context.Context, string, string) error
-	Unlock(context.Context, string, string) error
-	GetMetadata(context.Context, string) (VolumeMetadata, error)
-	SendMetadata(context.Context, VolumeMetadata) error
-	StartTransferSession(context.Context, string, string) error
-	FinalizeSync(context.Context, string, string) error
-	GetStatus(context.Context, string, string) (string, error)
-	VolumeExists(context.Context, string) (bool, error)
-	AutoExtendEnabled(context.Context, string) (bool, error)
-	DiscardEnabled(context.Context, string) (bool, error)
-	IsMounted(context.Context, string) (bool, error)
-}
-
 // agent ensures privileges via an Escalator before delegating to the LVM API.
 type agent struct {
 	esc privilege.Escalator
-	lvm lvmAPI
+	lvm lvmlib.API
 }
 
 // NewAgent constructs an Agent that delegates LVM operations to the provided
-// lvmAPI and ensures privileges using the given Escalator. When esc is nil,
+// API and ensures privileges using the given Escalator. When esc is nil,
 // privilege.New(context.Background(), logger) supplies a default implementation.
-func NewAgent(lvm lvmAPI, esc privilege.Escalator, logger *zap.Logger) Agent {
+func NewAgent(lvm lvmlib.API, esc privilege.Escalator, logger *zap.Logger) Agent {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -73,8 +51,7 @@ func NewAgent(lvm lvmAPI, esc privilege.Escalator, logger *zap.Logger) Agent {
 func NewSudoAgent(sudoPath string, l lvmlib.API, ensureRoot func() error, logger *zap.Logger) Agent { //nolint:revive // sudoPath kept for future use
 	_ = sudoPath
 	_ = ensureRoot
-	api, _ := l.(lvmAPI)
-	return NewAgent(api, nil, logger)
+	return NewAgent(l, nil, logger)
 }
 
 func (a *agent) Lock(ctx context.Context, volume, requester string) error {
@@ -97,17 +74,17 @@ func (a *agent) Unlock(ctx context.Context, volume, requester string) error {
 	return a.lvm.Unlock(ctx, volume, requester)
 }
 
-func (a *agent) GetMetadata(ctx context.Context, volume string) (VolumeMetadata, error) {
+func (a *agent) GetMetadata(ctx context.Context, volume string) (lvmlib.VolumeMetadata, error) {
 	if err := a.esc.Ensure(ctx); err != nil {
-		return VolumeMetadata{}, err
+		return lvmlib.VolumeMetadata{}, err
 	}
 	if a.lvm == nil {
-		return VolumeMetadata{}, errors.New("lvm api not provided")
+		return lvmlib.VolumeMetadata{}, errors.New("lvm api not provided")
 	}
 	return a.lvm.GetMetadata(ctx, volume)
 }
 
-func (a *agent) SendMetadata(ctx context.Context, md VolumeMetadata) error {
+func (a *agent) SendMetadata(ctx context.Context, md lvmlib.VolumeMetadata) error {
 	if err := a.esc.Ensure(ctx); err != nil {
 		return err
 	}

--- a/internal/lvm/agent_test.go
+++ b/internal/lvm/agent_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+
+	lvmlib "lvmsync_go/lvm"
 )
 
 type fakeEsc struct{ err error }
@@ -19,7 +21,7 @@ func (fakeEsc) Command(ctx context.Context, name string, args ...string) *exec.C
 type mockLVM struct {
 	lockErr         error
 	unlockErr       error
-	md              VolumeMetadata
+	md              lvmlib.VolumeMetadata
 	getMetadataErr  error
 	sendMetadataErr error
 	startErr        error
@@ -44,11 +46,11 @@ func (m *mockLVM) Unlock(_ context.Context, _, _ string) error {
 	return m.unlockErr
 }
 
-func (m *mockLVM) GetMetadata(_ context.Context, _ string) (VolumeMetadata, error) {
+func (m *mockLVM) GetMetadata(_ context.Context, _ string) (lvmlib.VolumeMetadata, error) {
 	return m.md, m.getMetadataErr
 }
 
-func (m *mockLVM) SendMetadata(_ context.Context, md VolumeMetadata) error {
+func (m *mockLVM) SendMetadata(_ context.Context, md lvmlib.VolumeMetadata) error {
 	m.md = md
 	return m.sendMetadataErr
 }
@@ -81,6 +83,8 @@ func (m *mockLVM) IsMounted(_ context.Context, _ string) (bool, error) {
 	return m.mounted, m.mountedErr
 }
 
+var _ lvmlib.API = (*mockLVM)(nil)
+
 func TestAgentLock(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
@@ -109,7 +113,7 @@ func TestAgentUnlock(t *testing.T) {
 
 func TestAgentGetMetadata(t *testing.T) {
 	ctx := context.Background()
-	expected := VolumeMetadata{VolumeName: "vol", SizeBytes: 1, ChunkSize: 2}
+	expected := lvmlib.VolumeMetadata{VolumeName: "vol", SizeBytes: 1, ChunkSize: 2}
 	mock := &mockLVM{md: expected}
 	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
 	md, err := a.GetMetadata(ctx, "vol")
@@ -129,7 +133,7 @@ func TestAgentSendMetadata(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockLVM{}
 	a := NewAgent(mock, fakeEsc{}, zap.NewNop())
-	md := VolumeMetadata{VolumeName: "vol"}
+	md := lvmlib.VolumeMetadata{VolumeName: "vol"}
 	if err := a.SendMetadata(ctx, md); err != nil {
 		t.Fatalf("send metadata failed: %v", err)
 	}
@@ -237,6 +241,24 @@ func TestAgentIsMounted(t *testing.T) {
 	}
 	mock.mountedErr = errors.New("boom")
 	if _, err := a.IsMounted(ctx, "vol"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestNewSudoAgent(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockLVM{exists: true}
+	a := NewSudoAgent("", mock, nil, zap.NewNop())
+	ok, err := a.VolumeExists(ctx, "vol")
+	if err != nil || !ok {
+		t.Fatalf("VolumeExists failed: %v %v", ok, err)
+	}
+}
+
+func TestNewSudoAgentNilAPI(t *testing.T) {
+	ctx := context.Background()
+	a := NewSudoAgent("", nil, nil, zap.NewNop())
+	if err := a.Lock(ctx, "vol", "req"); err == nil {
 		t.Fatalf("expected error")
 	}
 }

--- a/lvm/api.go
+++ b/lvm/api.go
@@ -1,5 +1,25 @@
 package lvm
 
-// API defines the set of methods required by the server.
-// It currently acts as a placeholder for future expansion.
-type API any
+import "context"
+
+// VolumeMetadata represents metadata about a logical volume.
+type VolumeMetadata struct {
+	VolumeName string
+	SizeBytes  uint64
+	ChunkSize  uint64
+}
+
+// API defines the set of methods required by LVM operations.
+type API interface {
+	Lock(ctx context.Context, volume, requester string) error
+	Unlock(ctx context.Context, volume, requester string) error
+	GetMetadata(ctx context.Context, volume string) (VolumeMetadata, error)
+	SendMetadata(ctx context.Context, md VolumeMetadata) error
+	StartTransferSession(ctx context.Context, volume, requester string) error
+	FinalizeSync(ctx context.Context, volume, requester string) error
+	GetStatus(ctx context.Context, volume, requester string) (string, error)
+	VolumeExists(ctx context.Context, volume string) (bool, error)
+	AutoExtendEnabled(ctx context.Context, volume string) (bool, error)
+	DiscardEnabled(ctx context.Context, volume string) (bool, error)
+	IsMounted(ctx context.Context, volume string) (bool, error)
+}


### PR DESCRIPTION
## Summary
- replace placeholder API type with explicit interface and volume metadata
- wire internal LVM agent and tests to the new interface
- expand tests to cover privilege wrapper and interface usage

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unknown linters 'deadcode,gosimple,stylecheck')*


------
https://chatgpt.com/codex/tasks/task_e_68ac8f818da483239b1aece82dd6abab