### PR TITLE
wal: validate range in Append

### DIFF
--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -79,6 +79,9 @@ func New(f File, deps *Deps) *WAL {
 
 // Append records r using a temporary file and atomic rename for crash safety.
 func (w *WAL) Append(r Range) error {
+	if r.Start > r.End {
+		return fmt.Errorf("wal: invalid range: start %d > end %d", r.Start, r.End)
+	}
 	name := w.f.Name()
 	tmpPath := name + ".tmp"
 	tf, err := w.deps.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -184,3 +184,36 @@ func TestAppendRenameError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestAppendValidRange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	w := New(f, nil)
+	if err := w.Append(Range{Start: 5, End: 5}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestAppendInvalidRange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	w := New(f, nil)
+	err = w.Append(Range{Start: 10, End: 5})
+	if err == nil || !strings.Contains(err.Error(), "invalid range") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cerr := w.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+}


### PR DESCRIPTION
## Summary
- guard WAL.Append with a range precondition
- return an error when start exceeds end
- test valid and invalid WAL ranges

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unknown linters deadcode, gosimple, stylecheck)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9314d4f883238ffcfc4d90ede7be