### PR TITLE
Keep SSH agent connection open until authentication completes

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -53,9 +53,16 @@ func NewSSHClient(
 	logger *zap.Logger,
 ) (*SSHClient, error) {
 
-	authMethods, err := selectAuthMethods(ctx, logger, keyPath, timeout)
+	authMethods, cleanup, err := selectAuthMethods(ctx, logger, keyPath, timeout)
 	if err != nil {
 		return nil, err
+	}
+	if cleanup != nil {
+		defer func() {
+			if cerr := cleanup(); cerr != nil {
+				logger.Warn("ssh agent connection close error", zap.Error(cerr))
+			}
+		}()
 	}
 	hostKeyCallback, err := setupHostKeyCallback(verify, knownHostsPath)
 	if err != nil {
@@ -92,29 +99,29 @@ func keyFileAuth(keyPath string) (ssh.AuthMethod, error) {
 	return ssh.PublicKeys(signer), nil
 }
 
-func agentAuth(ctx context.Context, logger *zap.Logger, timeout time.Duration) (ssh.AuthMethod, error) {
+func agentAuth(ctx context.Context, logger *zap.Logger, timeout time.Duration) (ssh.AuthMethod, func() error, error) {
 	sshAgentSock := os.Getenv("SSH_AUTH_SOCK")
 	if sshAgentSock == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	dialer := net.Dialer{Timeout: timeout}
 	conn, err := dialer.DialContext(ctx, "unix", sshAgentSock)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr
+			return nil, nil, ctxErr
 		}
 		logger.Warn("ssh agent dial failed", zap.String("socket_path", sshAgentSock), zap.Error(err))
-		return nil, nil
+		return nil, nil, nil
 	}
 	agentClient := agent.NewClient(conn)
-	return ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {
-		defer func() {
-			if cerr := conn.Close(); cerr != nil {
-				logger.Warn("ssh agent connection close error", zap.Error(cerr))
-			}
-		}()
-		return agentClient.Signers()
-	}), nil
+	cleanup := func() error {
+		if cerr := conn.Close(); cerr != nil {
+			logger.Warn("ssh agent connection close error", zap.Error(cerr))
+			return cerr
+		}
+		return nil
+	}
+	return ssh.PublicKeysCallback(agentClient.Signers), cleanup, nil
 }
 
 func aggregateAuthMethods(methods ...ssh.AuthMethod) ([]ssh.AuthMethod, error) {
@@ -130,21 +137,48 @@ func aggregateAuthMethods(methods ...ssh.AuthMethod) ([]ssh.AuthMethod, error) {
 	return result, nil
 }
 
-func selectAuthMethods(ctx context.Context, logger *zap.Logger, keyPath string, timeout time.Duration) ([]ssh.AuthMethod, error) {
+func selectAuthMethods(ctx context.Context, logger *zap.Logger, keyPath string, timeout time.Duration) ([]ssh.AuthMethod, func() error, error) {
 	var methods []ssh.AuthMethod
+	var cleanups []func() error
+
 	if keyPath != "" {
 		keyMethod, err := keyFileAuth(keyPath)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		methods = append(methods, keyMethod)
 	}
-	agentMethod, err := agentAuth(ctx, logger, timeout)
+
+	agentMethod, cleanup, err := agentAuth(ctx, logger, timeout)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	methods = append(methods, agentMethod)
-	return aggregateAuthMethods(methods...)
+	if agentMethod != nil {
+		methods = append(methods, agentMethod)
+	}
+	if cleanup != nil {
+		cleanups = append(cleanups, cleanup)
+	}
+
+	aggregated, err := aggregateAuthMethods(methods...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var combined func() error
+	if len(cleanups) > 0 {
+		combined = func() error {
+			var firstErr error
+			for _, c := range cleanups {
+				if err := c(); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		}
+	}
+
+	return aggregated, combined, nil
 }
 
 func setupHostKeyCallback(verify bool, knownHostsPath string) (ssh.HostKeyCallback, error) {

--- a/remote/select_auth_methods_test.go
+++ b/remote/select_auth_methods_test.go
@@ -55,17 +55,23 @@ func TestKeyFileAuthMissing(t *testing.T) {
 }
 
 func TestAgentAuthSuccess(t *testing.T) {
-	sock, cleanup := startAgent(t)
-	defer cleanup()
+	sock, stop := startAgent(t)
+	defer stop()
 	t.Setenv("SSH_AUTH_SOCK", sock)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	method, err := agentAuth(ctx, zap.NewNop(), time.Second)
+	method, cleanup, err := agentAuth(ctx, zap.NewNop(), time.Second)
 	if err != nil {
 		t.Fatalf("agentAuth: %v", err)
 	}
 	if method == nil {
 		t.Fatal("expected auth method")
+	}
+	if cleanup == nil {
+		t.Fatal("expected cleanup function")
+	}
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup: %v", err)
 	}
 }
 
@@ -74,7 +80,7 @@ func TestAgentAuthContextError(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	defer cancel()
 	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "missing.sock"))
-	if _, err := agentAuth(ctx, zap.NewNop(), time.Second); !errors.Is(err, context.DeadlineExceeded) {
+	if _, _, err := agentAuth(ctx, zap.NewNop(), time.Second); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
 }
@@ -96,17 +102,22 @@ func TestAggregateAuthMethodsError(t *testing.T) {
 }
 
 func TestSelectAuthMethodsSuccess(t *testing.T) {
-	sock, cleanup := startAgent(t)
-	defer cleanup()
+	sock, stop := startAgent(t)
+	defer stop()
 	t.Setenv("SSH_AUTH_SOCK", sock)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	methods, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
+	methods, cleanup, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
 	if err != nil {
 		t.Fatalf("selectAuthMethods error: %v", err)
 	}
 	if len(methods) == 0 {
 		t.Fatal("expected auth methods")
+	}
+	if cleanup != nil {
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
 	}
 }
 
@@ -115,7 +126,7 @@ func TestSelectAuthMethodsTimeout(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	defer cancel()
 	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "missing.sock"))
-	_, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
+	_, _, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -128,7 +139,7 @@ func TestSelectAuthMethodsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "missing.sock"))
-	_, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
+	_, _, err := selectAuthMethods(ctx, zap.NewNop(), "", time.Second)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context canceled, got %v", err)
 	}
@@ -143,7 +154,7 @@ func TestSelectAuthMethodsLogsAgentFailure(t *testing.T) {
 	core, obs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 
-	_, err := selectAuthMethods(ctx, logger, "", 50*time.Millisecond)
+	_, _, err := selectAuthMethods(ctx, logger, "", 50*time.Millisecond)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/remote/ssh_agent_auth_test.go
+++ b/remote/ssh_agent_auth_test.go
@@ -1,0 +1,114 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// startAgentWithKey starts an SSH agent with a single RSA key and returns the
+// socket path, the public key, and a cleanup function.
+func startAgentWithKey(t *testing.T) (string, ssh.PublicKey, func()) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "agent.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	keyring := agent.NewKeyring()
+	if err := keyring.Add(agent.AddedKey{PrivateKey: priv}); err != nil {
+		t.Fatalf("add key: %v", err)
+	}
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		agent.ServeAgent(keyring, conn)
+	}()
+	cleanup := func() { ln.Close() }
+	return sock, signer.PublicKey(), cleanup
+}
+
+// startAuthServer starts a minimal SSH server that accepts the provided public
+// key for authentication.
+func startAuthServer(t *testing.T, allowed ssh.PublicKey) (string, func()) {
+	t.Helper()
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("host key: %v", err)
+	}
+	hostSigner, err := ssh.NewSignerFromKey(hostKey)
+	if err != nil {
+		t.Fatalf("host signer: %v", err)
+	}
+	config := &ssh.ServerConfig{PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+		if bytes.Equal(key.Marshal(), allowed.Marshal()) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unauthorized key")
+	}}
+	config.AddHostKey(hostSigner)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				_, _, _, _ = ssh.NewServerConn(c, config)
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { ln.Close() }
+}
+
+func TestNewSSHClientAgentAuthSuccess(t *testing.T) {
+	sock, pubKey, stopAgent := startAgentWithKey(t)
+	defer stopAgent()
+	t.Setenv("SSH_AUTH_SOCK", sock)
+
+	addr, stopServer := startAuthServer(t, pubKey)
+	defer stopServer()
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+	client, err := NewSSHClient(ctx, host, "test", "", port, "", false, time.Second, time.Second, 0, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewSSHClient: %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client close: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure `agentAuth` keeps SSH agent connection alive and returns a cleanup closure
- close agent connection after SSH dial completes
- add tests covering agent-based authentication flow

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unknown linters: 'deadcode,gosimple,stylecheck')*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68ac94eb8c008323b3076ebe5cbf5032