### PR TITLE
remote: expire cached SSH sessions

### DIFF
--- a/remote/ssh_session.go
+++ b/remote/ssh_session.go
@@ -20,30 +20,45 @@ type SSHSession struct {
 	host    string
 }
 
+type sessionEntry struct {
+	session *SSHSession
+	timer   *time.Timer
+}
+
 type SSHMultiplexer struct {
 	mu       sync.Mutex
-	sessions map[string]*SSHSession
+	sessions map[string]*sessionEntry
+	ttl      time.Duration
 }
 
 var multiplexer = &SSHMultiplexer{
-	sessions: make(map[string]*SSHSession),
+	sessions: make(map[string]*sessionEntry),
+	ttl:      time.Minute,
 }
 
 func GetMultiplexedSession(client *SSHClient, host string) (*SSHSession, error) {
 	multiplexer.mu.Lock()
-	defer multiplexer.mu.Unlock()
-
-	if session, exists := multiplexer.sessions[host]; exists {
+	if entry, exists := multiplexer.sessions[host]; exists {
+		entry.timer.Reset(multiplexer.ttl)
+		session := entry.session
+		multiplexer.mu.Unlock()
 		return session, nil
 	}
+	multiplexer.mu.Unlock()
 
 	session, err := NewSSHSession(client)
 	if err != nil {
 		return nil, err
 	}
-
 	session.host = host
-	multiplexer.sessions[host] = session
+	timer := time.AfterFunc(multiplexer.ttl, func() {
+		session.Close()
+	})
+
+	multiplexer.mu.Lock()
+	multiplexer.sessions[host] = &sessionEntry{session: session, timer: timer}
+	multiplexer.mu.Unlock()
+
 	return session, nil
 }
 
@@ -78,8 +93,26 @@ func (s *SSHSession) Close() {
 // RemoveSession deletes the cached session for the given host.
 func RemoveSession(host string) {
 	multiplexer.mu.Lock()
-	defer multiplexer.mu.Unlock()
-	delete(multiplexer.sessions, host)
+	if entry, ok := multiplexer.sessions[host]; ok {
+		entry.timer.Stop()
+		delete(multiplexer.sessions, host)
+	}
+	multiplexer.mu.Unlock()
+}
+
+// CloseAllSessions closes and removes all cached sessions.
+func CloseAllSessions() {
+	multiplexer.mu.Lock()
+	sessions := make([]*SSHSession, 0, len(multiplexer.sessions))
+	for host, entry := range multiplexer.sessions {
+		entry.timer.Stop()
+		sessions = append(sessions, entry.session)
+		delete(multiplexer.sessions, host)
+	}
+	multiplexer.mu.Unlock()
+	for _, s := range sessions {
+		s.Close()
+	}
 }
 
 // RunSSHCommand executes a command on a remote host over SSH and logs using logger.

--- a/remote/ssh_session_cache_test.go
+++ b/remote/ssh_session_cache_test.go
@@ -2,13 +2,15 @@ package remote
 
 import (
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 )
 
 func TestSessionCloseRemovesFromCache(t *testing.T) {
 	multiplexer.mu.Lock()
-	multiplexer.sessions = make(map[string]*SSHSession)
+	multiplexer.sessions = make(map[string]*sessionEntry)
+	multiplexer.ttl = time.Minute
 	multiplexer.mu.Unlock()
 
 	_, rawClient := newSSHServerClient(t, func(string) int { return 0 })
@@ -46,4 +48,62 @@ func TestSessionCloseRemovesFromCache(t *testing.T) {
 		t.Fatalf("expected new session after close")
 	}
 	s3.Close()
+}
+
+func TestSessionExpiresFromCache(t *testing.T) {
+	multiplexer.mu.Lock()
+	multiplexer.sessions = make(map[string]*sessionEntry)
+	multiplexer.ttl = 50 * time.Millisecond
+	multiplexer.mu.Unlock()
+
+	_, rawClient := newSSHServerClient(t, func(string) int { return 0 })
+	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
+
+	const host = "expirehost"
+
+	s, err := GetMultiplexedSession(client, host)
+	if err != nil {
+		t.Fatalf("GetMultiplexedSession: %v", err)
+	}
+
+	time.Sleep(2 * multiplexer.ttl)
+
+	multiplexer.mu.Lock()
+	_, ok := multiplexer.sessions[host]
+	multiplexer.mu.Unlock()
+	if ok {
+		t.Fatalf("session did not expire")
+	}
+
+	// session should already be closed, but ensure no panic when calling Close
+	s.Close()
+}
+
+func TestCloseAllSessions(t *testing.T) {
+	multiplexer.mu.Lock()
+	multiplexer.sessions = make(map[string]*sessionEntry)
+	multiplexer.ttl = time.Minute
+	multiplexer.mu.Unlock()
+
+	_, rawClient := newSSHServerClient(t, func(string) int { return 0 })
+	client := &SSHClient{Client: rawClient, Logger: zap.NewNop()}
+
+	const host1 = "host1"
+	const host2 = "host2"
+
+	if _, err := GetMultiplexedSession(client, host1); err != nil {
+		t.Fatalf("GetMultiplexedSession host1: %v", err)
+	}
+	if _, err := GetMultiplexedSession(client, host2); err != nil {
+		t.Fatalf("GetMultiplexedSession host2: %v", err)
+	}
+
+	CloseAllSessions()
+
+	multiplexer.mu.Lock()
+	if len(multiplexer.sessions) != 0 {
+		multiplexer.mu.Unlock()
+		t.Fatalf("expected all sessions closed")
+	}
+	multiplexer.mu.Unlock()
 }


### PR DESCRIPTION
## Summary
- add timer-based expiration to SSHMultiplexer and reset on reuse
- expose CloseAllSessions to tear down cached SSH sessions
- test cache eviction on close, expiration, and shutdown

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unknown linters 'deadcode,gosimple,stylecheck')*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68ac9767b3408323b9dbfec901d0651f