### PR TITLE
test: skip sudo agent tests without root

### DIFF
--- a/internal/lvm/agent_test.go
+++ b/internal/lvm/agent_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	privilege "lvmsync_go/internal/privilege"
 	lvmlib "lvmsync_go/lvm"
 )
 
@@ -245,8 +246,12 @@ func TestAgentIsMounted(t *testing.T) {
 	}
 }
 
+// TestNewSudoAgent requires root or appropriate capabilities.
 func TestNewSudoAgent(t *testing.T) {
 	ctx := context.Background()
+	if err := privilege.New(context.Background(), zap.NewNop()).Ensure(ctx); err != nil {
+		t.Skipf("requires root: %v", err)
+	}
 	mock := &mockLVM{exists: true}
 	a := NewSudoAgent("", mock, nil, zap.NewNop())
 	ok, err := a.VolumeExists(ctx, "vol")
@@ -255,8 +260,12 @@ func TestNewSudoAgent(t *testing.T) {
 	}
 }
 
+// TestNewSudoAgentNilAPI requires root or appropriate capabilities.
 func TestNewSudoAgentNilAPI(t *testing.T) {
 	ctx := context.Background()
+	if err := privilege.New(context.Background(), zap.NewNop()).Ensure(ctx); err != nil {
+		t.Skipf("requires root: %v", err)
+	}
 	a := NewSudoAgent("", nil, nil, zap.NewNop())
 	if err := a.Lock(ctx, "vol", "req"); err == nil {
 		t.Fatalf("expected error")


### PR DESCRIPTION
## Summary
- skip `NewSudoAgent` tests unless root/capabilities available

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 20`
- ⚠️ `golangci-lint run` *(unknown linters: 'deadcode,gosimple,stylecheck')*

------
https://chatgpt.com/codex/tasks/task_e_68aca1443308832383470406427aff02