### PR TITLE
log progress encode errors

### DIFF
--- a/transfer/progress.go
+++ b/transfer/progress.go
@@ -21,7 +21,9 @@ func finalizeProgress(cfg *config.Config, logger *zap.Logger) {
 	if cfg.Progress {
 		logger.Info("progress complete")
 		if cfg.Output == "json" {
-			_ = json.NewEncoder(os.Stdout).Encode(progressEvent{Event: "complete", Progress: 100})
+			if err := json.NewEncoder(os.Stdout).Encode(progressEvent{Event: "complete", Progress: 100}); err != nil {
+				logger.Error("encode progress event", zap.Error(err))
+			}
 		}
 	}
 }
@@ -32,12 +34,14 @@ func reportProgress(cfg *config.Config, transferred, total int64, index int, sta
 
 		logger.Info("transfer progress", zap.Float64("progress_percent", progressPercent))
 		if cfg.Output == "json" {
-			_ = json.NewEncoder(os.Stdout).Encode(progressEvent{
+			if err := json.NewEncoder(os.Stdout).Encode(progressEvent{
 				Event:            "progress",
 				Progress:         progressPercent,
 				BytesTransferred: transferred,
 				BytesTotal:       total,
-			})
+			}); err != nil {
+				logger.Error("encode progress event", zap.Error(err))
+			}
 		}
 	}
 	if cfg.Verbose > 0 && index > 0 && index%100 == 0 {

--- a/transfer/progress_test.go
+++ b/transfer/progress_test.go
@@ -93,6 +93,38 @@ func TestFinalizeProgressJSON(t *testing.T) {
 	}
 }
 
+func TestReportProgressJSONEncodeError(t *testing.T) {
+	r, w, _ := os.Pipe()
+	w.Close()
+	old := os.Stdout
+	os.Stdout = w
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+	cfg := &config.Config{Progress: true, Output: "json"}
+	reportProgress(cfg, 50, 100, 1, time.Now(), logger)
+	os.Stdout = old
+	r.Close()
+	if logs.FilterMessage("encode progress event").Len() != 1 {
+		t.Fatalf("expected encode progress event error log, got %d", logs.FilterMessage("encode progress event").Len())
+	}
+}
+
+func TestFinalizeProgressJSONEncodeError(t *testing.T) {
+	r, w, _ := os.Pipe()
+	w.Close()
+	old := os.Stdout
+	os.Stdout = w
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+	cfg := &config.Config{Progress: true, Output: "json"}
+	finalizeProgress(cfg, logger)
+	os.Stdout = old
+	r.Close()
+	if logs.FilterMessage("encode progress event").Len() != 1 {
+		t.Fatalf("expected encode progress event error log, got %d", logs.FilterMessage("encode progress event").Len())
+	}
+}
+
 func TestLogSummaries(t *testing.T) {
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)


### PR DESCRIPTION
## Summary
- log JSON encoding failures when emitting progress updates
- test progress and finalize JSON encoding errors

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unknown linters: 'deadcode,gosimple,stylecheck')*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68aca5c13fb083238b2fc6cb669d8e68