### PR TITLE
blockio: return errors from Size

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -277,8 +277,14 @@ func verifyInline(cfg *config.Config, src, dst string, logger *zap.Logger) error
 	}
 	defer fDst.Close()
 
-	sizeSrc := fSrc.Size()
-	sizeDst := fDst.Size()
+	sizeSrc, err := fSrc.Size()
+	if err != nil {
+		return fmt.Errorf("source size: %w", err)
+	}
+	sizeDst, err := fDst.Size()
+	if err != nil {
+		return fmt.Errorf("dest size: %w", err)
+	}
 	if sizeSrc != sizeDst {
 		logger.Error("size mismatch", zap.Int64("source_bytes", sizeSrc), zap.Int64("dest_bytes", sizeDst))
 		return fmt.Errorf("size mismatch")

--- a/internal/blockio/blockio.go
+++ b/internal/blockio/blockio.go
@@ -193,21 +193,28 @@ func (f *File) WriteAt(p []byte, off int64) (int, error) {
 }
 
 // Size returns the current size of the underlying file.
-func (f *File) Size() int64 {
+//
+// The file's current offset is preserved. Any error from Stat or Seek is
+// returned to the caller instead of treating the size as zero.
+func (f *File) Size() (int64, error) {
 	if fi, err := f.f.Stat(); err == nil {
-		return fi.Size()
+		return fi.Size(), nil
 	}
 	cur, err := f.f.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("seek current: %w", err)
 	}
 	end, err := f.f.Seek(0, io.SeekEnd)
 	if err != nil {
-		_, _ = f.f.Seek(cur, io.SeekStart)
-		return 0
+		if _, seekErr := f.f.Seek(cur, io.SeekStart); seekErr != nil {
+			return 0, fmt.Errorf("seek restore: %w", seekErr)
+		}
+		return 0, fmt.Errorf("seek end: %w", err)
 	}
-	_, _ = f.f.Seek(cur, io.SeekStart)
-	return end
+	if _, err := f.f.Seek(cur, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("seek restore: %w", err)
+	}
+	return end, nil
 }
 
 func (f *File) Sync() error {

--- a/internal/blockio/blockio_test.go
+++ b/internal/blockio/blockio_test.go
@@ -220,7 +220,11 @@ func TestReadWriteAtAndSize(t *testing.T) {
 	if !bytes.Equal(buf, data) {
 		t.Fatalf("ReadAt data mismatch")
 	}
-	if size := f.Size(); size != int64(len(data)) {
+	size, err := f.Size()
+	if err != nil {
+		t.Fatalf("Size: %v", err)
+	}
+	if size != int64(len(data)) {
 		t.Fatalf("size %d want %d", size, len(data))
 	}
 }


### PR DESCRIPTION
## Summary
- return errors from blockio.File.Size and preserve offset
- handle File.Size errors in verify
- update blockio tests for new signature

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unknown linters: 'deadcode,gosimple,stylecheck')*

------
https://chatgpt.com/codex/tasks/task_e_68ad04bb63b48323b0fd5b5bf7f95105