### PR TITLE
remote: propagate deadline and close errors

### DIFF
--- a/remote/priv_helper.go
+++ b/remote/priv_helper.go
@@ -121,8 +121,18 @@ func (c *PrivHelperClient) RecvAck(ctx context.Context) (bool, error) {
 			if ctxDl, ok := ctx.Deadline(); ok && ctxDl.Before(dl) {
 				dl = ctxDl
 			}
-			_ = conn.SetReadDeadline(dl)
-			defer conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+			if err := conn.SetReadDeadline(dl); err != nil {
+				if c.logger != nil {
+					c.logger.Warn("set_read_deadline", zap.Error(err))
+				}
+			}
+			defer func() {
+				if err := conn.SetReadDeadline(time.Time{}); err != nil {
+					if c.logger != nil {
+						c.logger.Warn("clear_read_deadline", zap.Error(err))
+					}
+				}
+			}()
 		}
 		_, err := io.ReadFull(c.stdout, b[:])
 		resCh <- result{b: b[0], err: err}
@@ -130,17 +140,28 @@ func (c *PrivHelperClient) RecvAck(ctx context.Context) (bool, error) {
 
 	select {
 	case <-ctx.Done():
+		var err error
 		if conn, ok := c.stdout.(interface{ SetReadDeadline(time.Time) error }); ok {
-			_ = conn.SetReadDeadline(time.Now())
+			if e := conn.SetReadDeadline(time.Now()); e != nil {
+				if c.logger != nil {
+					c.logger.Warn("set_read_deadline", zap.Error(e))
+				}
+				err = errors.Join(err, e)
+			}
 		}
 		if closer, ok := c.stdout.(io.Closer); ok {
-			_ = closer.Close()
+			if e := closer.Close(); e != nil {
+				if c.logger != nil {
+					c.logger.Warn("close_stdout", zap.Error(e))
+				}
+				err = errors.Join(err, e)
+			}
 		}
 		select {
 		case <-resCh:
 		default:
 		}
-		return false, ctx.Err()
+		return false, errors.Join(ctx.Err(), err)
 	case r := <-resCh:
 		if r.err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {

--- a/remote/priv_helper_test.go
+++ b/remote/priv_helper_test.go
@@ -87,7 +87,7 @@ func TestRecvAckTimeout(t *testing.T) {
 	r, w := net.Pipe()
 	defer r.Close() //nolint:errcheck
 	defer w.Close() //nolint:errcheck
-	c := &PrivHelperClient{stdout: r}
+	c := &PrivHelperClient{stdout: r, logger: zap.NewNop()}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	if _, err := c.RecvAck(ctx); err == nil || !errors.Is(err, context.DeadlineExceeded) {
@@ -129,7 +129,7 @@ func (neverReader) Read(_ []byte) (int, error) { select {} }
 
 func TestRecvAckCancelClosesReader(t *testing.T) {
 	r := newBlockingAckReader()
-	c := &PrivHelperClient{stdout: r}
+	c := &PrivHelperClient{stdout: r, logger: zap.NewNop()}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
@@ -161,7 +161,7 @@ func TestRecvAckCancelClosesReader(t *testing.T) {
 }
 
 func TestRecvAckCancelUnclosable(t *testing.T) {
-	c := &PrivHelperClient{stdout: neverReader{}}
+	c := &PrivHelperClient{stdout: neverReader{}, logger: zap.NewNop()}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
@@ -181,6 +181,56 @@ func TestRecvAckCancelUnclosable(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatalf("RecvAck blocked with unclosable reader")
+	}
+}
+
+type errAckReader struct {
+	readStarted chan struct{}
+	closeCh     chan struct{}
+}
+
+func newErrAckReader() *errAckReader {
+	return &errAckReader{
+		readStarted: make(chan struct{}),
+		closeCh:     make(chan struct{}),
+	}
+}
+
+var (
+	errSetDeadline = errors.New("set deadline error")
+	errClose       = errors.New("close error")
+)
+
+func (r *errAckReader) Read(_ []byte) (int, error) {
+	close(r.readStarted)
+	<-r.closeCh
+	return 0, io.EOF
+}
+
+func (r *errAckReader) SetReadDeadline(time.Time) error { return errSetDeadline }
+
+func (r *errAckReader) Close() error {
+	close(r.closeCh)
+	return errClose
+}
+
+func TestRecvAckCancelJoinErrors(t *testing.T) {
+	r := newErrAckReader()
+	c := &PrivHelperClient{stdout: r, logger: zap.NewNop()}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.RecvAck(ctx)
+		done <- err
+	}()
+	<-r.readStarted
+	cancel()
+	err := <-done
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, errSetDeadline) || !errors.Is(err, errClose) {
+		t.Fatalf("expected joined errors, got %v", err)
 	}
 }
 
@@ -208,7 +258,7 @@ func (netTimeoutError) Temporary() bool { return true }
 
 func TestRecvAckNetTimeoutBeforeDeadline(t *testing.T) {
 	r := &earlyTimeoutReader{}
-	c := &PrivHelperClient{stdout: r}
+	c := &PrivHelperClient{stdout: r, logger: zap.NewNop()}
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	if _, err := c.RecvAck(ctx); err == nil || !errors.Is(err, context.DeadlineExceeded) {


### PR DESCRIPTION
## Summary
- log and propagate read deadline and close errors when receiving acks
- test cancel path to ensure errors are joined

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unknown linters 'deadcode,gosimple,stylecheck')*


------
https://chatgpt.com/codex/tasks/task_e_68ad555a13948323bde5caed765439c0