### PR TITLE
Refactor prepareClient into discrete helpers

### DIFF
--- a/cmd/root/confirm_direct_device_test.go
+++ b/cmd/root/confirm_direct_device_test.go
@@ -1,18 +1,15 @@
 package root
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/creack/pty"
-	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
 	"lvmsync_go/internal/config"
-	"lvmsync_go/transport"
 )
 
 // createBlockDevice returns path to a temporary block device file.
@@ -26,20 +23,28 @@ func createBlockDevice(t *testing.T) string {
 	return devPath
 }
 
-func newStubRunner(called *bool) *Runner {
-	return NewRunnerWithDeps(&Runner{
-		selectTransportFn: func(*config.Config, *zap.Logger) (transport.Interface, error) { return nil, nil },
-		setupSignalHandleFn: func(context.Context, *config.Config, *string, *zap.Logger) (chan os.Signal, chan error) {
-			return make(chan os.Signal), make(chan error)
-		},
-		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
-			*called = true
-			return "snap", make(chan error), func() {}, nil
-		},
-	})
+func TestConfirmDirectDeviceNonBlock(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	if err := confirmDirectDevice(cfg, "/not-a-device"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
-func TestPrepareClientDirectDeviceTTYRequiresConfirmation(t *testing.T) {
+func TestConfirmDirectDeviceRequiresForceOffline(t *testing.T) {
+	devPath := createBlockDevice(t)
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	if err := confirmDirectDevice(cfg, devPath); err == nil || err.Error() != "direct device writes require --force-offline" {
+		t.Fatalf("expected force-offline error, got: %v", err)
+	}
+}
+
+func TestConfirmDirectDeviceTTYRequiresConfirmation(t *testing.T) {
 	devPath := createBlockDevice(t)
 	cfg, err := config.DefaultConfig()
 	if err != nil {
@@ -60,17 +65,12 @@ func TestPrepareClientDirectDeviceTTYRequiresConfirmation(t *testing.T) {
 	}()
 	fmt.Fprintln(master, "no")
 
-	called := false
-	rnr := newStubRunner(&called)
-	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err == nil || err.Error() != "direct device write cancelled" {
+	if err := confirmDirectDevice(cfg, devPath); err == nil || err.Error() != "direct device write cancelled" {
 		t.Fatalf("expected cancellation error, got: %v", err)
-	}
-	if called {
-		t.Fatalf("prepareSnapshot should not be called")
 	}
 }
 
-func TestPrepareClientDirectDeviceTTYConfirmed(t *testing.T) {
+func TestConfirmDirectDeviceTTYConfirmed(t *testing.T) {
 	devPath := createBlockDevice(t)
 	cfg, err := config.DefaultConfig()
 	if err != nil {
@@ -91,17 +91,12 @@ func TestPrepareClientDirectDeviceTTYConfirmed(t *testing.T) {
 	}()
 	fmt.Fprintln(master, "double-confirm")
 
-	called := false
-	rnr := newStubRunner(&called)
-	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err != nil {
+	if err := confirmDirectDevice(cfg, devPath); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if !called {
-		t.Fatalf("prepareSnapshot not called")
 	}
 }
 
-func TestPrepareClientDirectDeviceNonTTYRequiresYesIKnow(t *testing.T) {
+func TestConfirmDirectDeviceNonTTYRequiresYesIKnow(t *testing.T) {
 	devPath := createBlockDevice(t)
 	cfg, err := config.DefaultConfig()
 	if err != nil {
@@ -118,17 +113,12 @@ func TestPrepareClientDirectDeviceNonTTYRequiresYesIKnow(t *testing.T) {
 		w.Close()
 	}()
 
-	called := false
-	rnr := newStubRunner(&called)
-	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err == nil || err.Error() != "direct device writes require --yes-i-know flag when not run interactively" {
+	if err := confirmDirectDevice(cfg, devPath); err == nil || err.Error() != "direct device writes require --yes-i-know flag when not run interactively" {
 		t.Fatalf("expected yes-i-know error, got: %v", err)
-	}
-	if called {
-		t.Fatalf("prepareSnapshot should not be called")
 	}
 }
 
-func TestPrepareClientDirectDeviceNonTTYConfirmed(t *testing.T) {
+func TestConfirmDirectDeviceNonTTYConfirmed(t *testing.T) {
 	devPath := createBlockDevice(t)
 	cfg, err := config.DefaultConfig()
 	if err != nil {
@@ -146,12 +136,7 @@ func TestPrepareClientDirectDeviceNonTTYConfirmed(t *testing.T) {
 		w.Close()
 	}()
 
-	called := false
-	rnr := newStubRunner(&called)
-	if _, _, _, _, _, _, err := rnr.prepareClient(cfg, []string{"/src", devPath}, zap.NewNop()); err != nil {
+	if err := confirmDirectDevice(cfg, devPath); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if !called {
-		t.Fatalf("prepareSnapshot not called")
 	}
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -233,57 +233,55 @@ func (r *Runner) dispatchSubcommand(cfg *config.Config, args []string, logger *z
 	return false, nil
 }
 
-func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (context.Context, func(), string, string, chan error, chan error, error) {
-	if _, err := r.selectTransportFn(cfg, logger); err != nil {
-		return nil, nil, "", "", nil, nil, fmt.Errorf("select transport: %w", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	if cfg.CheckPartition {
-		ctx = device.WithPartitionSignatures(ctx, "", "")
-	}
-
-	var snapshotPath string
-	signals, sigErrCh := r.setupSignalHandleFn(ctx, cfg, &snapshotPath, logger)
-
+func validateArgs(cfg *config.Config, args []string) (string, string, error) {
 	if (cfg.StdoutMode && len(args) < 1) || (!cfg.StdoutMode && len(args) < 2) {
 		pflag.Usage()
-		cancel()
-		signal.Stop(signals)
-		return nil, nil, "", "", nil, nil, fmt.Errorf("invalid arguments")
+		return "", "", fmt.Errorf("invalid arguments")
 	}
-
 	originalVolume := args[0]
 	destPath := ""
 	if !cfg.StdoutMode {
 		destPath = args[1]
 	}
-	if destPath != "" && !cfg.StdoutMode && !strings.Contains(destPath, ":") {
-		resolved, err := filepath.EvalSymlinks(destPath)
-		if err == nil {
-			if info, err := os.Stat(resolved); err == nil && info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
-				if !cfg.ForceOffline {
-					cancel()
-					signal.Stop(signals)
-					return nil, nil, "", "", nil, nil, fmt.Errorf("direct device writes require --force-offline")
-				}
-				if term.IsTerminal(int(os.Stdin.Fd())) {
-					fmt.Fprint(os.Stderr, "Direct device writes may destroy data. Type 'double-confirm' to continue: ")
-					resp, _ := bufio.NewReader(os.Stdin).ReadString('\n')
-					if strings.TrimSpace(resp) != "double-confirm" {
-						cancel()
-						signal.Stop(signals)
-						return nil, nil, "", "", nil, nil, fmt.Errorf("direct device write cancelled")
-					}
-				} else if !cfg.YesIKnow {
-					cancel()
-					signal.Stop(signals)
-					return nil, nil, "", "", nil, nil, fmt.Errorf("direct device writes require --yes-i-know flag when not run interactively")
-				}
-			}
-		}
-	}
+	return originalVolume, destPath, nil
+}
 
+func confirmDirectDevice(cfg *config.Config, destPath string) error {
+	if destPath == "" || cfg.StdoutMode || strings.Contains(destPath, ":") {
+		return nil
+	}
+	resolved, err := filepath.EvalSymlinks(destPath)
+	if err != nil {
+		return nil
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
+		return nil
+	}
+	if !cfg.ForceOffline {
+		return fmt.Errorf("direct device writes require --force-offline")
+	}
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Fprint(os.Stderr, "Direct device writes may destroy data. Type 'double-confirm' to continue: ")
+		resp, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+		if strings.TrimSpace(resp) != "double-confirm" {
+			return fmt.Errorf("direct device write cancelled")
+		}
+		return nil
+	}
+	if !cfg.YesIKnow {
+		return fmt.Errorf("direct device writes require --yes-i-know flag when not run interactively")
+	}
+	return nil
+}
+
+func (r *Runner) setupSnapshotAndSignals(cfg *config.Config, originalVolume string, logger *zap.Logger) (context.Context, func(), string, chan error, chan error, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	if cfg.CheckPartition {
+		ctx = device.WithPartitionSignatures(ctx, "", "")
+	}
+	var snapshotPath string
+	signals, sigErrCh := r.setupSignalHandleFn(ctx, cfg, &snapshotPath, logger)
 	snapPath, monitorErrCh, snapCleanup, err := r.prepareSnapshotFn(ctx, cfg, originalVolume, logger)
 	if err != nil {
 		cancel()
@@ -291,16 +289,36 @@ func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Lo
 		if snapCleanup != nil {
 			snapCleanup()
 		}
-		return nil, nil, "", "", nil, nil, fmt.Errorf("prepare snapshot: %w", err)
+		return nil, nil, "", nil, nil, fmt.Errorf("prepare snapshot: %w", err)
 	}
 	snapshotPath = snapPath
-
 	cleanup := func() {
 		if snapCleanup != nil {
 			snapCleanup()
 		}
 		signal.Stop(signals)
 		cancel()
+	}
+	return ctx, cleanup, snapshotPath, sigErrCh, monitorErrCh, nil
+}
+
+func (r *Runner) prepareClient(cfg *config.Config, args []string, logger *zap.Logger) (context.Context, func(), string, string, chan error, chan error, error) {
+	if _, err := r.selectTransportFn(cfg, logger); err != nil {
+		return nil, nil, "", "", nil, nil, fmt.Errorf("select transport: %w", err)
+	}
+
+	originalVolume, destPath, err := validateArgs(cfg, args)
+	if err != nil {
+		return nil, nil, "", "", nil, nil, err
+	}
+
+	if err := confirmDirectDevice(cfg, destPath); err != nil {
+		return nil, nil, "", "", nil, nil, err
+	}
+
+	ctx, cleanup, snapshotPath, sigErrCh, monitorErrCh, err := r.setupSnapshotAndSignals(cfg, originalVolume, logger)
+	if err != nil {
+		return nil, nil, "", "", nil, nil, err
 	}
 	return ctx, cleanup, snapshotPath, destPath, sigErrCh, monitorErrCh, nil
 }

--- a/cmd/root/setup_snapshot_and_signals_test.go
+++ b/cmd/root/setup_snapshot_and_signals_test.go
@@ -1,0 +1,73 @@
+package root
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/internal/config"
+)
+
+func TestSetupSnapshotAndSignalsSuccess(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	snapCleanupCalled := false
+	var snapshotPtr *string
+	r := NewRunnerWithDeps(&Runner{
+		setupSignalHandleFn: func(ctx context.Context, cfg *config.Config, snap *string, _ *zap.Logger) (chan os.Signal, chan error) {
+			snapshotPtr = snap
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			return "snap-path", make(chan error), func() { snapCleanupCalled = true }, nil
+		},
+	})
+	ctx, cleanup, snapPath, sigCh, monitorCh, err := r.setupSnapshotAndSignals(cfg, "/dev/vg/orig", zap.NewNop())
+	if err != nil {
+		t.Fatalf("setupSnapshotAndSignals error: %v", err)
+	}
+	if ctx == nil || cleanup == nil || sigCh == nil || monitorCh == nil {
+		t.Fatalf("expected non-nil results")
+	}
+	if snapPath != "snap-path" {
+		t.Fatalf("unexpected snapshot path: %s", snapPath)
+	}
+	if snapshotPtr == nil || *snapshotPtr != snapPath {
+		t.Fatalf("snapshot pointer not updated")
+	}
+	cleanup()
+	if !snapCleanupCalled {
+		t.Fatalf("snapshot cleanup not called")
+	}
+	if ctx.Err() != context.Canceled {
+		t.Fatalf("context not canceled after cleanup")
+	}
+}
+
+func TestSetupSnapshotAndSignalsError(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	r := NewRunnerWithDeps(&Runner{
+		setupSignalHandleFn: func(ctx context.Context, cfg *config.Config, snap *string, _ *zap.Logger) (chan os.Signal, chan error) {
+			return make(chan os.Signal), make(chan error)
+		},
+		prepareSnapshotFn: func(context.Context, *config.Config, string, *zap.Logger) (string, chan error, func(), error) {
+			return "", nil, nil, errors.New("snap error")
+		},
+	})
+	ctx, cleanup, _, _, _, err := r.setupSnapshotAndSignals(cfg, "/dev/vg/orig", zap.NewNop())
+	if err == nil || !strings.Contains(err.Error(), "prepare snapshot") {
+		t.Fatalf("expected snapshot error, got: %v", err)
+	}
+	if ctx != nil || cleanup != nil {
+		t.Fatalf("expected nil ctx and cleanup on error")
+	}
+}

--- a/cmd/root/validate_args_test.go
+++ b/cmd/root/validate_args_test.go
@@ -1,0 +1,31 @@
+package root
+
+import (
+	"testing"
+
+	"lvmsync_go/internal/config"
+)
+
+func TestValidateArgsSuccess(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	orig, dest, err := validateArgs(cfg, []string{"/src", "/dst"})
+	if err != nil {
+		t.Fatalf("validateArgs error: %v", err)
+	}
+	if orig != "/src" || dest != "/dst" {
+		t.Fatalf("unexpected results: %s %s", orig, dest)
+	}
+}
+
+func TestValidateArgsFailure(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig error: %v", err)
+	}
+	if _, _, err := validateArgs(cfg, []string{"/src"}); err == nil || err.Error() != "invalid arguments" {
+		t.Fatalf("expected invalid arguments error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Extract argument validation, device confirmation, and snapshot/signal setup from `prepareClient` into dedicated helpers
- Simplify `prepareClient` to orchestrate the new helpers
- Add unit tests for `validateArgs`, `confirmDirectDevice`, and `setupSnapshotAndSignals`

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: can't unmarshal config by viper: 'Version' expected a map, got 'int')*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68ad5da7ef408323bc2d675119a4b483