### PR TITLE
docs: document required Go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing to lvmsync_go!
 
+Ensure Go 1.24.3 or later is installed. See the [development prerequisites](README.md#prerequisites) for how to verify your version with `go version`.
+
 ## Commit Message Policy
 
 This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification.

--- a/README.md
+++ b/README.md
@@ -1667,6 +1667,14 @@ Compression detection uses benchmark-driven selection between LZ4 and Zstd and n
 
 ## Development
 
+### Prerequisites
+
+LVMSync requires Go 1.24.3 or later. Verify your installation with:
+
+```sh
+go version
+```
+
 ### Development Setup
 
 The Super-Linter workflow validates the entire repository.


### PR DESCRIPTION
## Summary
- document Go 1.24.3 requirement and how to verify it
- reference Go version prerequisite from contributing guide

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: unknown linters 'deadcode,gosimple,stylecheck')*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68ad637004f08323a034f3e63d2ff2db