### PR TITLE
Add version flag and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,6 +1095,18 @@ make test    # run tests
 
 ## Usage
 
+### Show Version
+
+```sh
+lvmsync --version
+```
+
+Outputs `Version Commit BuildDate`, for example:
+
+```text
+v0.2.0 abcdef1 2024-01-02T15:04:05Z
+```
+
 ### Basic Syntax
 
 ```sh

--- a/cmd/lvmsync/cobra.go
+++ b/cmd/lvmsync/cobra.go
@@ -121,9 +121,15 @@ func NewRootCmd(logger *zap.Logger, r *Runner) *cobra.Command {
 		r = NewRunner()
 	}
 	rootCmd := &cobra.Command{
-		Use:   "lvmsync",
-		Short: "LVMSync command line tool",
+		Use:     "lvmsync",
+		Short:   "LVMSync command line tool",
+		Version: Version,
 	}
+	rootCmd.Annotations = map[string]string{
+		"commit": Commit,
+		"date":   Date,
+	}
+	rootCmd.SetVersionTemplate("{{.Version}} {{index .Annotations \"commit\"}} {{index .Annotations \"date\"}}\n")
 
 	runCmd := &cobra.Command{
 		Use:                "run [flags] <source> <dest>",

--- a/cmd/lvmsync/cobra_test.go
+++ b/cmd/lvmsync/cobra_test.go
@@ -1,6 +1,8 @@
 package lvmsync
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -352,4 +354,19 @@ func TestEstimateTransferNilLoggerPanics(t *testing.T) {
 	}
 	f.Close()
 	_ = estimateTransfer(f.Name(), &config.Config{}, nil)
+}
+
+func TestVersionFlag(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cmd := NewRootCmd(zap.NewNop(), nil)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"--version"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute version: %v", err)
+	}
+	expected := fmt.Sprintf("%s %s %s\n", cmd.Version, cmd.Annotations["commit"], cmd.Annotations["date"])
+	if buf.String() != expected {
+		t.Fatalf("unexpected version output: got %q want %q", buf.String(), expected)
+	}
 }

--- a/cmd/lvmsync/version.go
+++ b/cmd/lvmsync/version.go
@@ -1,0 +1,17 @@
+package lvmsync
+
+// Version information populated at build time via -ldflags.
+var (
+	// Version is the semantic version of the binary.
+	Version = "dev"
+	// Commit is the git commit hash for this build.
+	Commit = "unknown"
+	// Date is the build timestamp in RFC3339 format.
+	Date = "unknown"
+)
+
+func init() {
+	_ = Version
+	_ = Commit
+	_ = Date
+}

--- a/version.go
+++ b/version.go
@@ -1,6 +1,0 @@
-package main
-
-// version is populated at build time via -ldflags.
-var version = "v0.2.0"
-
-func init() { _ = version }


### PR DESCRIPTION
## Summary
- expose build metadata variables and wire them into Cobra's version handling
- add `lvmsync --version` flag and document sample output
- test new version reporting

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: unknown linters: 'deadcode,gosimple,stylecheck')*

------
https://chatgpt.com/codex/tasks/task_e_68ad6361bf608323a8ef62d41fb14216