### PR TITLE
transport/rsyncwire: warn once

### DIFF
--- a/transport/rsyncwire/rsyncwire.go
+++ b/transport/rsyncwire/rsyncwire.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gokrazy/rsync"
@@ -16,6 +17,8 @@ import (
 )
 
 const defaultDialTimeout = 5 * time.Second
+
+var plaintextWarnOnce sync.Once
 
 // Transport implements the rsync daemon handshake over plain TCP.
 type Transport struct {
@@ -30,11 +33,13 @@ func New(cfg transport.Config) (transport.Interface, error) {
 	if !cfg.AllowInsecure {
 		return nil, fmt.Errorf("rsync transport requires AllowInsecure")
 	}
-	cfg.Logger.Warn(
-		"plaintext_connection",
-		zap.String("transport", "rsync"),
-		zap.String("docs", "docs/transports.md"),
-	)
+	plaintextWarnOnce.Do(func() {
+		cfg.Logger.Warn(
+			"plaintext_connection",
+			zap.String("transport", "rsync"),
+			zap.String("docs", "docs/transports.md"),
+		)
+	})
 	return &Transport{logger: cfg.Logger}, nil
 }
 

--- a/transport/rsyncwire/rsyncwire_test.go
+++ b/transport/rsyncwire/rsyncwire_test.go
@@ -1,6 +1,7 @@
 package rsyncwire
 
 import (
+	"sync"
 	"testing"
 
 	"go.uber.org/zap"
@@ -22,6 +23,7 @@ func TestRequiresLogger(t *testing.T) {
 }
 
 func TestLogsPlaintextWarning(t *testing.T) {
+	plaintextWarnOnce = sync.Once{}
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 	if _, err := New(transport.Config{Logger: logger, AllowInsecure: true}); err != nil {
@@ -36,5 +38,25 @@ func TestLogsPlaintextWarning(t *testing.T) {
 	}
 	if entries[0].ContextMap()["docs"] != "docs/transports.md" {
 		t.Fatalf("missing docs field: %v", entries[0].ContextMap()["docs"])
+	}
+}
+
+func TestPlaintextWarningOnce(t *testing.T) {
+	plaintextWarnOnce = sync.Once{}
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	cfg := transport.Config{Logger: logger, AllowInsecure: true}
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 warning log, got %d", len(entries))
+	}
+	if entries[0].Message != "plaintext_connection" {
+		t.Fatalf("unexpected message: %s", entries[0].Message)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure plaintext warning logs only once in rsync transport
- test that multiple constructors log a single warning

## Testing
- `go test ./transport/rsyncwire -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ad98e6a6448323a452d96ef49496cb