### PR TITLE
test: add rsync handshake deadline integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For snapshot cleanup, resuming transfers, and verify-only rollback procedures, s
  - **Planning**: `--plan` prints resolved configuration with secrets redacted, transport order, estimated bytes, and compression decisions as JSON without transferring data.
  - **Device Identity Tuple**: Each run records `(size_bytes, kernel_uuid, gpt_uuid, mbr_signature, fs_uuid, major, minor, manifest_epoch)` to prevent writing to the wrong destination.
 
-- **Handshake Timeouts**: Transport connections apply context deadlines during handshakes and clear them once negotiation succeeds.
+- **Handshake Timeouts**: All transports, including `rsync`, apply context deadlines during handshakes and clear them once negotiation succeeds.
 - **Sparse Destination Optimization**: Detects runs of zero bytes and punches holes when the filesystem supports it. Use `--sparse=never` to always write zeros instead.
 - **Aligned I/O Buffers and NUMA Pinning**: `--odirect` allocates block-size aligned slabs from a `sync.Pool` and can pin worker goroutines to a device's NUMA node (`--numa-pin`) or an explicit node (`--numa-node`).
 - **LVM Snapshot Management**:

--- a/transport/rsync_deadline_integration_test.go
+++ b/transport/rsync_deadline_integration_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package transport_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"lvmsync_go/common"
+	"lvmsync_go/transport"
+	"lvmsync_go/transport/testutil"
+
+	_ "lvmsync_go/transport/rsyncwire"
+)
+
+func TestRsyncHandshakeDeadline(t *testing.T) {
+	cfg := transport.Config{Logger: zap.NewNop(), AllowInsecure: true}
+	tr, err := transport.Get("rsync", cfg)
+	if err != nil {
+		t.Fatalf("get transport: %v", err)
+	}
+	hs := common.Handshake{ALPN: "lvmsync", TLSVersion: "1.3", BlockSize: 4096}
+	timeout := 100 * time.Millisecond
+	delay := 200 * time.Millisecond
+	_, cliRes := testutil.RunNegotiationWithDelay(t, tr, hs, hs, delay, timeout)
+	if cliRes.Err == nil || (!errors.Is(cliRes.Err, context.DeadlineExceeded) &&
+		!strings.Contains(cliRes.Err.Error(), "deadline") &&
+		!strings.Contains(cliRes.Err.Error(), "timeout")) {
+		t.Fatalf("client error = %v, want deadline exceeded", cliRes.Err)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test confirming rsync transport enforces handshake deadlines
- document handshake deadline enforcement for all transports in README

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 5`
- `go test -tags=integration ./transport -run TestRsyncHandshakeDeadline -count=1`
- `golangci-lint run` *(fails: errcheck, revive, staticcheck, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ada789fa6c832398744f5d96e14fa9