### PR TITLE
Warn when O_DIRECT falls back

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -10,6 +10,11 @@ This guide outlines snapshot lifecycle management, resume workflows, verificatio
 
 Writing directly to block devices bypasses filesystem safeguards and can destroy data. These operations require `--force-offline`. When stdin is a TTY, `lvmsync` prompts for the literal text `double-confirm`; non-interactive sessions must also provide `--yes-i-know`.
 
+## O_DIRECT fallback
+
+Enabling `--odirect` requests direct device I/O. When the filesystem or kernel rejects `O_DIRECT`,
+LVMSync logs a warning and continues with buffered I/O.
+
 ## Dry-run and plan output
 
 `--dry-run` and `lvmsync plan` report the estimated transfer parameters without copying data. The JSON log entry includes `size_bytes`, `estimated_duration_ms`, `estimated_bandwidth_bps`, and `compression` showing the selected compression algorithm.

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -53,8 +53,13 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 		sector, err2 := DetectSectorSize(tmp)
 		_ = tmp.Close()
 		if err2 == nil && cfg.BlockSize%sector == 0 {
-			if f, direct, err2 := openFileODirect(destPath, os.O_RDWR); err2 == nil && direct {
-				destFile = f
+			var direct bool
+			destFile, direct, err2 = openFileODirect(destPath, os.O_RDWR)
+			if err2 != nil {
+				return fmt.Errorf("failed to open destination device %s: %w", destPath, err2)
+			}
+			if !direct {
+				t.Logger.Warn("odirect_requested_but_unused", zap.String("path", destPath))
 			}
 		}
 	}

--- a/transfer/block_generic.go
+++ b/transfer/block_generic.go
@@ -33,8 +33,11 @@ func punchHole(f *os.File, offset uint64, length int) error {
 
 func fdatasync(f *os.File) error { return f.Sync() }
 
-func openFileODirect(path string, flag int) (*os.File, bool, error) {
-	f, err := os.OpenFile(path, flag, 0)
+// openFileODirect opens path without O_DIRECT on non-Linux systems. The
+// returned boolean is always false to mirror the linux implementation when
+// O_DIRECT is unavailable.
+func openFileODirect(path string, flag int) (f *os.File, used bool, err error) {
+	f, err = os.OpenFile(path, flag, 0)
 	return f, false, err
 }
 

--- a/transfer/block_linux.go
+++ b/transfer/block_linux.go
@@ -92,13 +92,18 @@ func fdatasync(f *os.File) error {
 	return unix.Fdatasync(int(f.Fd()))
 }
 
-func openFileODirect(path string, flag int) (*os.File, bool, error) {
+// openFileODirect tries to open path with O_DIRECT. The returned boolean
+// reports whether O_DIRECT was actually enabled.
+func openFileODirect(path string, flag int) (f *os.File, used bool, err error) {
 	fd, err := unix.Open(path, flag|unix.O_DIRECT, 0)
-	if err != nil {
-		f, err2 := os.OpenFile(path, flag, 0)
-		return f, false, err2
+	if err == nil {
+		return os.NewFile(uintptr(fd), path), true, nil
 	}
-	return os.NewFile(uintptr(fd), path), true, nil
+	f, err = os.OpenFile(path, flag, 0)
+	if err != nil {
+		return nil, false, err
+	}
+	return f, false, nil
 }
 
 func seekHoleSupported(f *os.File) bool {

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -156,7 +156,7 @@ func (t *Transfer) dumpChangesCore(ctx context.Context, cfg *config.Config, snap
 	}
 	defer cleanupOutput(bufOut, compWriter, t.Logger)
 
-	srcFile, err := setupSourceFile(cfg, source)
+	srcFile, err := setupSourceFile(cfg, source, t.Logger)
 	if err != nil {
 		return err
 	}

--- a/transfer/worker.go
+++ b/transfer/worker.go
@@ -76,7 +76,7 @@ func prepareRanges(ctx context.Context, cfg *config.Config, snapshot, source str
 	return ranges, nil
 }
 
-func setupSourceFile(cfg *config.Config, source string) (*os.File, error) {
+func setupSourceFile(cfg *config.Config, source string, logger *zap.Logger) (*os.File, error) {
 	if cfg.ODirect {
 		tmp, err := os.Open(source)
 		if err != nil {
@@ -85,9 +85,14 @@ func setupSourceFile(cfg *config.Config, source string) (*os.File, error) {
 		sector, err := DetectSectorSize(tmp)
 		_ = tmp.Close()
 		if err == nil && cfg.BlockSize%sector == 0 {
-			if f, direct, err := openFileODirect(source, os.O_RDONLY); err == nil && direct {
-				return f, nil
+			f, direct, err := openFileODirect(source, os.O_RDONLY)
+			if err != nil {
+				return nil, err
 			}
+			if !direct {
+				logger.Warn("odirect_requested_but_unused", zap.String("path", source))
+			}
+			return f, nil
 		}
 	}
 	srcFile, err := os.Open(source)
@@ -176,7 +181,7 @@ func (t *Transfer) DumpChangesParallel(ctx context.Context, cfg *config.Config, 
 	}
 	defer cleanupOutput(bufOut, compWriter, t.Logger)
 
-	srcFile, err := setupSourceFile(cfg, source)
+	srcFile, err := setupSourceFile(cfg, source, t.Logger)
 	if err != nil {
 		return err
 	}

--- a/transfer/zero_test.go
+++ b/transfer/zero_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"lvmsync_go/internal/config"
 )
@@ -64,5 +65,32 @@ func TestWriteZeroBlockPunchesHole(t *testing.T) {
 	}
 	if !isAllZero(buf) {
 		t.Fatalf("expected zeros after punching hole")
+	}
+}
+
+func TestSetupSourceFileWarnsOnFallback(t *testing.T) {
+	cfg := &config.Config{BlockSize: 4096, ODirect: true}
+	tmp := t.TempDir()
+	path := tmp + "/src"
+	if err := os.WriteFile(path, make([]byte, cfg.BlockSize), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f, direct, err := openFileODirect(path, os.O_RDONLY)
+	if err != nil {
+		t.Fatalf("openFileODirect: %v", err)
+	}
+	_ = f.Close()
+	if direct {
+		t.Skip("O_DIRECT supported")
+	}
+	core, obs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	src, err := setupSourceFile(cfg, path, logger)
+	if err != nil {
+		t.Fatalf("setupSourceFile: %v", err)
+	}
+	_ = src.Close()
+	if obs.FilterMessage("odirect_requested_but_unused").Len() != 1 {
+		t.Fatalf("expected warning log when falling back")
 	}
 }


### PR DESCRIPTION
## Summary
- indicate when O_DIRECT is actually used when opening files
- warn and fall back to buffered I/O when O_DIRECT cannot be enabled
- document O_DIRECT fallback behavior

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: errcheck, gocritic, revive, staticcheck)*

------
https://chatgpt.com/codex/tasks/task_e_68adaa0aee1c83238e0dbe348f484f4b