### PR TITLE
Persist full device identity in resume state and WAL

### DIFF
--- a/docs/wal.md
+++ b/docs/wal.md
@@ -6,20 +6,25 @@ LVMSync uses a write-ahead log (WAL) to record applied block ranges so interrupt
 
 The first 120 bytes contain fixed metadata:
 
-| Offset | Length | Field      | Description                          |
-|--------|--------|------------|--------------------------------------|
-| 0      | 8      | version    | WAL format version (currently `1`)   |
-| 8      | 8      | size       | Total device size in bytes           |
-| 16     | 8      | epoch      | Transfer epoch                       |
-| 24     | 64     | device_id  | UTF-8 identifier, zero padded        |
-| 88     | 32     | mac        | BLAKE3-256 of the previous fields    |
+| Offset | Length | Field         | Description                          |
+|--------|--------|---------------|--------------------------------------|
+| 0      | 8      | version       | WAL format version (currently `2`)   |
+| 8      | 8      | size          | Total device size in bytes           |
+| 16     | 8      | epoch         | Transfer epoch                       |
+| 24     | 64     | kernel_uuid   | Kernel-reported device UUID          |
+| 88     | 64     | gpt_uuid      | GPT partition UUID                   |
+| 152    | 8      | mbr_signature | MBR disk signature (hex)             |
+| 160    | 64     | fs_uuid       | Filesystem UUID                      |
+| 224    | 4      | major         | Device major number                  |
+| 228    | 4      | minor         | Device minor number                  |
+| 232    | 32     | mac           | BLAKE3-256 of the previous fields    |
 
 Each subsequent entry is 16 bytes and encodes a completed range as little-endian `start` and `end` offsets.
 
 ## Version Semantics
 
-New WALs default to version `1`. `OpenWAL` rejects headers with any other version.
-WALs written by earlier releases are automatically upgraded to version `1` on
+New WALs default to version `2`. `OpenWAL` rejects headers with any other version.
+WALs written by earlier releases are automatically upgraded to version `2` on
 open, rewriting the header and preserving existing entries.
 
 ## Fsync Requirements

--- a/transfer/apply.go
+++ b/transfer/apply.go
@@ -36,13 +36,9 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 
 	reader := bufio.NewReader(decReader)
 
-	size, id, epoch, err := t.verifyDestination(ctx, cfg, destPath)
-	if err != nil {
+	if _, _, _, err := t.verifyDestination(ctx, cfg, destPath); err != nil {
 		return err
 	}
-	t.Tracker.sizeBytes = size
-	t.Tracker.deviceID = id
-	t.Tracker.epoch = epoch
 
 	var destFile *os.File
 	if cfg.ODirect {
@@ -68,7 +64,7 @@ func (t *Transfer) processDumpDataCore(ctx context.Context, cfg *config.Config, 
 
 	var walRanges []Range
 	if cfg.ResumeState != "" {
-		t.wal, walRanges, err = OpenWAL(cfg.ResumeState+".wal", size, id, epoch, nil)
+		t.wal, walRanges, err = OpenWAL(cfg.ResumeState+".wal", t.Tracker.id, nil)
 		if err != nil {
 			return err
 		}

--- a/transfer/log_fields_test.go
+++ b/transfer/log_fields_test.go
@@ -56,7 +56,7 @@ func TestReadResumeDigestLogField(t *testing.T) {
 	digest := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{ResumeState: stateFile, Compress: "none", ChecksumAlgorithm: "blake3", DedupMode: "fixed"}
 	chk := resumeChunk{Chunk: digest, Offset: 1024, Length: 2048}
-	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: chk}, 0, "", 0, [32]byte{})
+	writeResumeState(cfg, logger, stateFile, resumeChunks{Fixed: chk}, device.DeviceIdentity{})
 
 	val := readResumeState(cfg, logger, device.DeviceIdentity{FSUUID: cfg.DeviceUUID}, [32]byte{}).Fixed
 	if val.Chunk != digest {

--- a/transfer/resume.go
+++ b/transfer/resume.go
@@ -1,6 +1,10 @@
 package transfer
 
-import "time"
+import (
+	"time"
+
+	"lvmsync_go/device"
+)
 
 // resumeChunk stores the boundaries and digest of the last processed chunk.
 type resumeChunk struct {
@@ -27,10 +31,7 @@ type resumeTracker struct {
 	bytes int64
 	last  time.Time
 	resumeChunks
-	sizeBytes     uint64
-	deviceID      string
-	epoch         uint64
-	partitionHash [32]byte
+	id device.DeviceIdentity
 }
 
 func (rt *resumeTracker) chunk(mode string) *resumeChunk {

--- a/transfer/resume_cdc_test.go
+++ b/transfer/resume_cdc_test.go
@@ -23,7 +23,7 @@ func TestResumeCDCOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0, [32]byte{})
+	writeResumeState(cfg, logger, state, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, device.DeviceIdentity{})
 
 	chk := readResumeState(cfg, logger, device.DeviceIdentity{FSUUID: cfg.DeviceUUID}, [32]byte{})
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -45,7 +45,7 @@ func TestResumeCDCSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "cdc"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, device.DeviceIdentity{})
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
@@ -70,7 +70,7 @@ func TestResumeCDCIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{CDC: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, device.DeviceIdentity{})
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_fixed_test.go
+++ b/transfer/resume_fixed_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 )
 
@@ -23,7 +24,7 @@ func TestResumeFixedIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, device.DeviceIdentity{})
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_hybrid_test.go
+++ b/transfer/resume_hybrid_test.go
@@ -23,7 +23,7 @@ func TestResumeHybridOffset(t *testing.T) {
 
 	cfg := &config.Config{ResumeState: state, Compress: "none", ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 	digest := blake3.Sum256([]byte("chunk"))
-	writeResumeState(cfg, logger, state, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, 0, "", 0, [32]byte{})
+	writeResumeState(cfg, logger, state, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: 80, Length: 40}}, device.DeviceIdentity{})
 
 	chk := readResumeState(cfg, logger, device.DeviceIdentity{FSUUID: cfg.DeviceUUID}, [32]byte{})
 	ranges := []Range{{Start: 0, End: 99}, {Start: 100, End: 199}}
@@ -45,7 +45,7 @@ func TestResumeHybridSequential(t *testing.T) {
 	cfg := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: "hybrid"}
 
 	digest := blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
-	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
+	writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, device.DeviceIdentity{})
 
 	var buf bytes.Buffer
 	if err := tr.DumpChangesParallel(context.Background(), cfg, snapshot, src, &buf); err != nil {
@@ -70,7 +70,7 @@ func TestResumeHybridIdempotent(t *testing.T) {
 	var first, second bytes.Buffer
 	for i := 0; i < 2; i++ {
 		tr.Tracker = &resumeTracker{}
-		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
+		writeResumeState(cfg, zap.NewNop(), resume, resumeChunks{Hybrid: resumeChunk{Chunk: digest, Offset: uint64(blockSize), Length: uint32(blockSize)}}, device.DeviceIdentity{})
 		buf := &first
 		if i == 1 {
 			buf = &second

--- a/transfer/resume_state.go
+++ b/transfer/resume_state.go
@@ -34,7 +34,12 @@ type resumeState struct {
 	CDC               resumeChunkState `json:"cdc"`
 	Hybrid            resumeChunkState `json:"hybrid"`
 	SizeBytes         uint64           `json:"size_bytes"`
-	DeviceID          string           `json:"device_id"`
+	KernelUUID        string           `json:"kernel_uuid"`
+	GPTUUID           string           `json:"gpt_uuid"`
+	MBRSignature      string           `json:"mbr_signature"`
+	FSUUID            string           `json:"fs_uuid"`
+	Major             uint32           `json:"major"`
+	Minor             uint32           `json:"minor"`
 	Epoch             uint64           `json:"epoch"`
 	PartitionHash     string           `json:"partition_hash"`
 	FirstBlockDigest  string           `json:"first_block_digest"`
@@ -43,7 +48,7 @@ type resumeState struct {
 // writeResumeState persists resume state using a WAL file. The state is written
 // to a temporary file, fsynced, and atomically renamed to `<path>.wal` to avoid
 // corruption on crashes. The logger must be non-nil.
-func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunks resumeChunks, size uint64, deviceID string, epoch uint64, partHash [32]byte) {
+func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunks resumeChunks, id device.DeviceIdentity) {
 	toState := func(ch resumeChunk) resumeChunkState {
 		return resumeChunkState{
 			Offset: ch.Offset,
@@ -60,10 +65,15 @@ func writeResumeState(cfg *config.Config, logger *zap.Logger, path string, chunk
 		Fixed:             toState(chunks.Fixed),
 		CDC:               toState(chunks.CDC),
 		Hybrid:            toState(chunks.Hybrid),
-		SizeBytes:         size,
-		DeviceID:          deviceID,
-		Epoch:             epoch,
-		PartitionHash:     hex.EncodeToString(partHash[:]),
+		SizeBytes:         id.SizeBytes,
+		KernelUUID:        id.KernelUUID,
+		GPTUUID:           id.GPTUUID,
+		MBRSignature:      id.MBRSignature,
+		FSUUID:            id.FSUUID,
+		Major:             id.Major,
+		Minor:             id.Minor,
+		Epoch:             id.ManifestEpoch,
+		PartitionHash:     hex.EncodeToString(id.PartitionHash[:]),
 		FirstBlockDigest:  cfg.FirstBlockDigest,
 	}
 	data, err := json.Marshal(rs)
@@ -120,7 +130,7 @@ func saveResumeState(cfg *config.Config, rt *resumeTracker, offset uint64, chunk
 	*rc = resumeChunk{Chunk: chunk, Offset: offset, Length: uint32(size)}
 	if (cfg.CheckpointBytes > 0 && rt.bytes >= int64(cfg.CheckpointBytes)) ||
 		(cfg.CheckpointInterval > 0 && time.Since(rt.last) >= cfg.CheckpointInterval) {
-		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunks{Fixed: rt.Fixed, CDC: rt.CDC, Hybrid: rt.Hybrid}, rt.sizeBytes, rt.deviceID, rt.epoch, rt.partitionHash)
+		writeResumeState(cfg, logger, cfg.ResumeState, resumeChunks{Fixed: rt.Fixed, CDC: rt.CDC, Hybrid: rt.Hybrid}, rt.id)
 		rt.bytes = 0
 		rt.last = time.Now()
 	}
@@ -142,10 +152,7 @@ func finalizeResumeState(cfg *config.Config, rt *resumeTracker, logger *zap.Logg
 	rt.bytes = 0
 	rt.last = time.Time{}
 	rt.resumeChunks = resumeChunks{}
-	rt.sizeBytes = 0
-	rt.deviceID = ""
-	rt.epoch = 0
-	rt.partitionHash = [32]byte{}
+	rt.id = device.DeviceIdentity{}
 }
 
 func readResumeState(cfg *config.Config, logger *zap.Logger, id device.DeviceIdentity, digest [32]byte) resumeCheckpoint {
@@ -191,23 +198,53 @@ func loadResumeState(path string, cfg *config.Config, id device.DeviceIdentity, 
 	if b, err := hex.DecodeString(rs.PartitionHash); err == nil && len(b) == 32 {
 		copy(part[:], b)
 	}
-	storedID := device.DeviceIdentity{SizeBytes: rs.SizeBytes, FSUUID: rs.DeviceID, ManifestEpoch: rs.Epoch, PartitionHash: part}
+	storedID := device.DeviceIdentity{
+		SizeBytes:     rs.SizeBytes,
+		KernelUUID:    rs.KernelUUID,
+		GPTUUID:       rs.GPTUUID,
+		MBRSignature:  rs.MBRSignature,
+		FSUUID:        rs.FSUUID,
+		PartitionHash: part,
+		Major:         rs.Major,
+		Minor:         rs.Minor,
+		ManifestEpoch: rs.Epoch,
+	}
 	actualID := id
 	if storedID.SizeBytes == 0 || actualID.SizeBytes == 0 {
 		storedID.SizeBytes = 0
 		actualID.SizeBytes = 0
 	}
+	if storedID.KernelUUID == "" || actualID.KernelUUID == "" {
+		storedID.KernelUUID = ""
+		actualID.KernelUUID = ""
+	}
+	if storedID.GPTUUID == "" || actualID.GPTUUID == "" {
+		storedID.GPTUUID = ""
+		actualID.GPTUUID = ""
+	}
+	if storedID.MBRSignature == "" || actualID.MBRSignature == "" {
+		storedID.MBRSignature = ""
+		actualID.MBRSignature = ""
+	}
 	if storedID.FSUUID == "" || actualID.FSUUID == "" {
 		storedID.FSUUID = ""
 		actualID.FSUUID = ""
 	}
-	if storedID.ManifestEpoch == 0 || actualID.ManifestEpoch == 0 {
-		storedID.ManifestEpoch = 0
-		actualID.ManifestEpoch = 0
-	}
 	if storedID.PartitionHash == ([32]byte{}) || actualID.PartitionHash == ([32]byte{}) {
 		storedID.PartitionHash = [32]byte{}
 		actualID.PartitionHash = [32]byte{}
+	}
+	if storedID.Major == 0 || actualID.Major == 0 {
+		storedID.Major = 0
+		actualID.Major = 0
+	}
+	if storedID.Minor == 0 || actualID.Minor == 0 {
+		storedID.Minor = 0
+		actualID.Minor = 0
+	}
+	if storedID.ManifestEpoch == 0 || actualID.ManifestEpoch == 0 {
+		storedID.ManifestEpoch = 0
+		actualID.ManifestEpoch = 0
 	}
 	if !device.SameIdentityStrict(storedID, actualID) {
 		return out, false

--- a/transfer/resume_state_test.go
+++ b/transfer/resume_state_test.go
@@ -26,7 +26,7 @@ func TestSaveAndReadResumeState(t *testing.T) {
 		CheckpointBytes:   4,
 		ResumeToken:       "tok",
 	}
-	rt := &resumeTracker{sizeBytes: 100, deviceID: "fsuuid", epoch: 1}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
 	digest := blake3.Sum256([]byte("data"))
 	cfg.FirstBlockDigest = hex.EncodeToString(digest[:])
 	saveResumeState(cfg, rt, 0, digest, 4, zap.NewNop())
@@ -34,7 +34,7 @@ func TestSaveAndReadResumeState(t *testing.T) {
 	if _, err := os.Stat(wal); err != nil {
 		t.Fatalf("expected resume wal file: %v", err)
 	}
-	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, FSUUID: "fsuuid", ManifestEpoch: 1}, digest)
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}, digest)
 	if cfg.ResumeToken != "tok" {
 		t.Fatalf("resume token not persisted: %s", cfg.ResumeToken)
 	}
@@ -120,10 +120,10 @@ func TestResumeStateWALRecovery(t *testing.T) {
 	}
 
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 1, FirstBlockDigest: hex.EncodeToString(digest[:])}
-	rt := &resumeTracker{sizeBytes: 100, deviceID: "fsuuid", epoch: 1}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
 	saveResumeState(cfg, rt, 0, digest, 4, zap.NewNop())
 
-	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, FSUUID: "fsuuid", ManifestEpoch: 1}, digest)
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}, digest)
 	rc := cp.chunk("fixed")
 	if rc.Offset != 0 {
 		t.Fatalf("expected wal offset 0, got %d", rc.Offset)
@@ -175,9 +175,9 @@ func TestReadResumeStateSizeMismatch(t *testing.T) {
 	path := filepath.Join(dir, "resume.json")
 	dig := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
-	rt := &resumeTracker{sizeBytes: 100, deviceID: "fsuuid", epoch: 1}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
 	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
-	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 200, FSUUID: "fsuuid", ManifestEpoch: 1}, dig)
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 200, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}, dig)
 	if cp != (resumeCheckpoint{}) {
 		t.Fatalf("expected empty checkpoint on size mismatch")
 	}
@@ -188,9 +188,9 @@ func TestReadResumeStateFSUUIDMismatch(t *testing.T) {
 	path := filepath.Join(dir, "resume.json")
 	dig := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
-	rt := &resumeTracker{sizeBytes: 100, deviceID: "fsuuid", epoch: 1}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
 	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
-	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, FSUUID: "other", ManifestEpoch: 1}, dig)
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "other", Major: 1, Minor: 2, ManifestEpoch: 1}, dig)
 	if cp != (resumeCheckpoint{}) {
 		t.Fatalf("expected empty checkpoint on fs uuid mismatch")
 	}
@@ -201,10 +201,66 @@ func TestReadResumeStateEpochMismatch(t *testing.T) {
 	path := filepath.Join(dir, "resume.json")
 	dig := blake3.Sum256([]byte("data"))
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
-	rt := &resumeTracker{sizeBytes: 100, deviceID: "fsuuid", epoch: 1}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
 	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
-	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, FSUUID: "fsuuid", ManifestEpoch: 2}, dig)
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 2}, dig)
 	if cp != (resumeCheckpoint{}) {
 		t.Fatalf("expected empty checkpoint on epoch mismatch")
+	}
+}
+
+func TestReadResumeStateKernelUUIDMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k2", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on kernel uuid mismatch")
+	}
+}
+
+func TestReadResumeStateGPTUUIDMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g2", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on gpt uuid mismatch")
+	}
+}
+
+func TestReadResumeStateMBRMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000002", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on mbr signature mismatch")
+	}
+}
+
+func TestReadResumeStateMajorMinorMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.json")
+	dig := blake3.Sum256([]byte("data"))
+	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3", ResumeState: path, DedupMode: "fixed", CheckpointBytes: 4, FirstBlockDigest: hex.EncodeToString(dig[:])}
+	rt := &resumeTracker{id: device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 2, ManifestEpoch: 1}}
+	saveResumeState(cfg, rt, 0, dig, 4, zap.NewNop())
+	cp := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 3, Minor: 2, ManifestEpoch: 1}, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on major mismatch")
+	}
+	cp = readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 100, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "fsuuid", Major: 1, Minor: 4, ManifestEpoch: 1}, dig)
+	if cp != (resumeCheckpoint{}) {
+		t.Fatalf("expected empty checkpoint on minor mismatch")
 	}
 }

--- a/transfer/resume_test.go
+++ b/transfer/resume_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zeebo/blake3"
 
 	"lvmsync_go/common"
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 
 	"go.uber.org/zap"
@@ -40,7 +41,7 @@ func createTestFiles(t *testing.T, blockSize int64, blockCount int, algo string)
 		digest = blake3.Sum256(bytes.Repeat([]byte{2}, int(blockSize)))
 	}
 	cfg := &config.Config{Transport: "ssh", Compress: "none", ChecksumAlgorithm: algo, DedupMode: "fixed"}
-	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: 0, Length: uint32(blockSize)}}, 0, "", 0, [32]byte{})
+	writeResumeState(cfg, zap.NewNop(), resumePath, resumeChunks{Fixed: resumeChunk{Chunk: digest, Offset: 0, Length: uint32(blockSize)}}, device.DeviceIdentity{})
 	return srcPath, snapshot, resumePath
 }
 
@@ -151,7 +152,7 @@ func TestResumeModeTransitions(t *testing.T) {
 			default:
 				chunks.Fixed = rc
 			}
-			writeResumeState(cfgStart, zap.NewNop(), resume, chunks, 0, "", 0, [32]byte{})
+			writeResumeState(cfgStart, zap.NewNop(), resume, chunks, device.DeviceIdentity{})
 
 			cfgResume := &config.Config{BlockSize: int(blockSize), Compress: "none", Parallel: 1, ResumeState: resume, MaxRetries: 1, ChecksumAlgorithm: "blake3", Transport: "ssh", DedupMode: trc.to}
 

--- a/transfer/resume_verify_integration_test.go
+++ b/transfer/resume_verify_integration_test.go
@@ -31,7 +31,8 @@ func TestResumeVerifyMismatch(t *testing.T) {
 	man := filepath.Join(dir, "dest.man")
 	buildManifest(t, dest, man, "uuid", uint64(len(data)))
 	resume := filepath.Join(dir, "resume.state")
-	w, _, err := OpenWAL(resume+".wal", uint64(len(data)), "uuid", 0, nil)
+	id := device.DeviceIdentity{SizeBytes: uint64(len(data)), KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000000", FSUUID: "uuid"}
+	w, _, err := OpenWAL(resume+".wal", id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/resume_verify_only_integration_test.go
+++ b/transfer/resume_verify_only_integration_test.go
@@ -168,7 +168,8 @@ func TestResumeVerifyAndVerifyOnly(t *testing.T) {
 	}
 
 	// Verify WAL ranges cover entire device without overlap.
-	w, ranges, err := OpenWAL(walPath, uint64(2*blockSize), "uuid", 0, nil)
+	id := device.DeviceIdentity{SizeBytes: uint64(2 * blockSize), KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000000", FSUUID: "uuid"}
+	w, ranges, err := OpenWAL(walPath, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/resume_wal_integration_test.go
+++ b/transfer/resume_wal_integration_test.go
@@ -148,7 +148,8 @@ func TestResumeMidTransfer(t *testing.T) {
 	}
 
 	// Ensure WAL contains two sequential entries.
-	w, ranges, err := OpenWAL(walPath, uint64(2*blockSize), "uuid", 0, nil)
+	id := device.DeviceIdentity{SizeBytes: uint64(2 * blockSize), KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000000", FSUUID: "uuid"}
+	w, ranges, err := OpenWAL(walPath, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -312,7 +312,7 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 		}
 	}
 	epoch := ident.ManifestEpoch
-	t.Tracker.partitionHash = ident.PartitionHash
+	t.Tracker.id = ident
 
 	if cfg.ManifestPath != "" {
 		hdr, err := readManifestHeader(ctx, cfg.ManifestPath, 0)

--- a/transfer/wal.go
+++ b/transfer/wal.go
@@ -6,30 +6,46 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/zeebo/blake3"
+	"lvmsync_go/device"
 	walpkg "lvmsync_go/internal/wal"
 )
 
 const (
-	walVersion      = 1
+	walVersion      = 2
 	walHeaderV0Size = 8 + 8 + 64 + 32
-	walHeaderSize   = 8 + walHeaderV0Size
+	walHeaderV1Size = 8 + walHeaderV0Size
+	walHeaderSize   = 8 + 8 + 8 + 64 + 64 + 8 + 64 + 4 + 4 + 32
 )
 
 type walHeader struct {
-	Version  uint64
-	Size     uint64
-	Epoch    uint64
-	DeviceID [64]byte
-	MAC      [32]byte
+	Version      uint64
+	Size         uint64
+	Epoch        uint64
+	KernelUUID   [64]byte
+	GPTUUID      [64]byte
+	MBRSignature [8]byte
+	FSUUID       [64]byte
+	Major        uint32
+	Minor        uint32
+	MAC          [32]byte
+}
+
+type walHeaderV1 struct {
+	Version uint64
+	Size    uint64
+	Epoch   uint64
+	FSUUID  [64]byte
+	MAC     [32]byte
 }
 
 type walHeaderV0 struct {
-	Size     uint64
-	Epoch    uint64
-	DeviceID [64]byte
-	MAC      [32]byte
+	Size   uint64
+	Epoch  uint64
+	FSUUID [64]byte
+	MAC    [32]byte
 }
 
 // WAL is a write-ahead log of device ranges. Each 16-byte entry records a
@@ -51,11 +67,25 @@ type WALDeps = walpkg.Deps
 func NewWALDeps() *WALDeps { return walpkg.NewDeps() }
 
 func walHeaderMAC(h *walHeader) [32]byte {
+	var buf [8 + 8 + 8 + 64 + 64 + 8 + 64 + 4 + 4]byte
+	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
+	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
+	binary.LittleEndian.PutUint64(buf[16:24], h.Epoch)
+	copy(buf[24:88], h.KernelUUID[:])
+	copy(buf[88:152], h.GPTUUID[:])
+	copy(buf[152:160], h.MBRSignature[:])
+	copy(buf[160:224], h.FSUUID[:])
+	binary.LittleEndian.PutUint32(buf[224:228], h.Major)
+	binary.LittleEndian.PutUint32(buf[228:232], h.Minor)
+	return blake3.Sum256(buf[:])
+}
+
+func walHeaderMACV1(h *walHeaderV1) [32]byte {
 	var buf [8 + 8 + 8 + 64]byte
 	binary.LittleEndian.PutUint64(buf[0:8], h.Version)
 	binary.LittleEndian.PutUint64(buf[8:16], h.Size)
 	binary.LittleEndian.PutUint64(buf[16:24], h.Epoch)
-	copy(buf[24:], h.DeviceID[:])
+	copy(buf[24:], h.FSUUID[:])
 	return blake3.Sum256(buf[:])
 }
 
@@ -63,7 +93,7 @@ func walHeaderMACV0(h *walHeaderV0) [32]byte {
 	var buf [8 + 8 + 64]byte
 	binary.LittleEndian.PutUint64(buf[0:8], h.Size)
 	binary.LittleEndian.PutUint64(buf[8:16], h.Epoch)
-	copy(buf[16:], h.DeviceID[:])
+	copy(buf[16:], h.FSUUID[:])
 	return blake3.Sum256(buf[:])
 }
 
@@ -71,7 +101,7 @@ func walHeaderMACV0(h *walHeaderV0) [32]byte {
 // returns any fully committed ranges. If a crash left a partially written
 // entry, the WAL is truncated to the last complete record and positioned for
 // further appends.
-func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALDeps) (*WAL, []Range, error) {
+func OpenWAL(path string, id device.DeviceIdentity, deps *WALDeps) (*WAL, []Range, error) {
 	if deps == nil {
 		deps = NewWALDeps()
 	}
@@ -87,16 +117,26 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 	w := &WAL{WAL: walpkg.New(f, deps)}
 	if st.Size() == 0 {
 		w.header.Version = walVersion
-		w.header.Size = size
-		w.header.Epoch = epoch
-		copy(w.header.DeviceID[:], []byte(deviceID))
+		w.header.Size = id.SizeBytes
+		w.header.Epoch = id.ManifestEpoch
+		copy(w.header.KernelUUID[:], []byte(id.KernelUUID))
+		copy(w.header.GPTUUID[:], []byte(id.GPTUUID))
+		copy(w.header.MBRSignature[:], []byte(id.MBRSignature))
+		copy(w.header.FSUUID[:], []byte(id.FSUUID))
+		w.header.Major = id.Major
+		w.header.Minor = id.Minor
 		w.header.MAC = walHeaderMAC(&w.header)
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], w.header.Version)
 		binary.LittleEndian.PutUint64(buf[8:16], w.header.Size)
 		binary.LittleEndian.PutUint64(buf[16:24], w.header.Epoch)
-		copy(buf[24:88], w.header.DeviceID[:])
-		copy(buf[88:120], w.header.MAC[:])
+		copy(buf[24:88], w.header.KernelUUID[:])
+		copy(buf[88:152], w.header.GPTUUID[:])
+		copy(buf[152:160], w.header.MBRSignature[:])
+		copy(buf[160:224], w.header.FSUUID[:])
+		binary.LittleEndian.PutUint32(buf[224:228], w.header.Major)
+		binary.LittleEndian.PutUint32(buf[228:232], w.header.Minor)
+		copy(buf[232:264], w.header.MAC[:])
 		if n, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, nil, err
@@ -135,13 +175,28 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 		hdr.Version = binary.LittleEndian.Uint64(buf[0:8])
 		hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
 		hdr.Epoch = binary.LittleEndian.Uint64(buf[16:24])
-		copy(hdr.DeviceID[:], buf[24:88])
-		copy(hdr.MAC[:], buf[88:120])
+		copy(hdr.KernelUUID[:], buf[24:88])
+		copy(hdr.GPTUUID[:], buf[88:152])
+		copy(hdr.MBRSignature[:], buf[152:160])
+		copy(hdr.FSUUID[:], buf[160:224])
+		hdr.Major = binary.LittleEndian.Uint32(buf[224:228])
+		hdr.Minor = binary.LittleEndian.Uint32(buf[228:232])
+		copy(hdr.MAC[:], buf[232:264])
 		if mac := walHeaderMAC(&hdr); mac != hdr.MAC {
 			f.Close()
 			return nil, nil, fmt.Errorf("wal: header mac mismatch")
 		}
-		if hdr.Size != size || hdr.Epoch != epoch || string(hdr.DeviceID[:len(deviceID)]) != deviceID {
+		hdrID := device.DeviceIdentity{
+			SizeBytes:     hdr.Size,
+			KernelUUID:    strings.TrimRight(string(hdr.KernelUUID[:]), "\x00"),
+			GPTUUID:       strings.TrimRight(string(hdr.GPTUUID[:]), "\x00"),
+			MBRSignature:  strings.TrimRight(string(hdr.MBRSignature[:]), "\x00"),
+			FSUUID:        strings.TrimRight(string(hdr.FSUUID[:]), "\x00"),
+			Major:         hdr.Major,
+			Minor:         hdr.Minor,
+			ManifestEpoch: hdr.Epoch,
+		}
+		if !device.SameIdentityStrict(hdrID, id) {
 			f.Close()
 			return nil, nil, fmt.Errorf("wal: metadata mismatch")
 		}
@@ -170,6 +225,91 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 		return w, ranges, nil
 	}
 
+	if ver == 1 && st.Size() >= walHeaderV1Size {
+		var buf1 [walHeaderV1Size]byte
+		if _, err := f.ReadAt(buf1[:], 0); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		var hdr1 walHeaderV1
+		hdr1.Version = binary.LittleEndian.Uint64(buf1[0:8])
+		hdr1.Size = binary.LittleEndian.Uint64(buf1[8:16])
+		hdr1.Epoch = binary.LittleEndian.Uint64(buf1[16:24])
+		copy(hdr1.FSUUID[:], buf1[24:88])
+		copy(hdr1.MAC[:], buf1[88:120])
+		if mac := walHeaderMACV1(&hdr1); mac != hdr1.MAC {
+			f.Close()
+			return nil, nil, fmt.Errorf("wal: header mac mismatch")
+		}
+		if hdr1.Size != id.SizeBytes || hdr1.Epoch != id.ManifestEpoch || strings.TrimRight(string(hdr1.FSUUID[:]), "\x00") != id.FSUUID {
+			f.Close()
+			return nil, nil, fmt.Errorf("wal: metadata mismatch")
+		}
+		data := make([]byte, st.Size()-walHeaderV1Size)
+		if _, err := f.ReadAt(data, walHeaderV1Size); err != nil && err != io.EOF {
+			f.Close()
+			return nil, nil, err
+		}
+		ranges := []Range{}
+		for off := 0; off+16 <= len(data); off += 16 {
+			start := binary.LittleEndian.Uint64(data[off : off+8])
+			end := binary.LittleEndian.Uint64(data[off+8 : off+16])
+			ranges = append(ranges, Range{Start: start, End: end})
+		}
+		var hdr walHeader
+		hdr.Version = walVersion
+		hdr.Size = hdr1.Size
+		hdr.Epoch = hdr1.Epoch
+		copy(hdr.KernelUUID[:], []byte(id.KernelUUID))
+		copy(hdr.GPTUUID[:], []byte(id.GPTUUID))
+		copy(hdr.MBRSignature[:], []byte(id.MBRSignature))
+		hdr.FSUUID = hdr1.FSUUID
+		hdr.Major = id.Major
+		hdr.Minor = id.Minor
+		hdr.MAC = walHeaderMAC(&hdr)
+		var buf [walHeaderSize]byte
+		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
+		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
+		binary.LittleEndian.PutUint64(buf[16:24], hdr.Epoch)
+		copy(buf[24:88], hdr.KernelUUID[:])
+		copy(buf[88:152], hdr.GPTUUID[:])
+		copy(buf[152:160], hdr.MBRSignature[:])
+		copy(buf[160:224], hdr.FSUUID[:])
+		binary.LittleEndian.PutUint32(buf[224:228], hdr.Major)
+		binary.LittleEndian.PutUint32(buf[228:232], hdr.Minor)
+		copy(buf[232:264], hdr.MAC[:])
+		if n, err := f.WriteAt(buf[:], 0); err != nil {
+			f.Close()
+			return nil, nil, err
+		} else if n != len(buf) {
+			f.Close()
+			return nil, nil, fmt.Errorf("wal: short write: wrote %d of %d bytes", n, len(buf))
+		}
+		if len(data) > 0 {
+			if n, err := f.WriteAt(data, walHeaderSize); err != nil {
+				f.Close()
+				return nil, nil, err
+			} else if n != len(data) {
+				f.Close()
+				return nil, nil, fmt.Errorf("wal: short write: wrote %d of %d bytes", n, len(data))
+			}
+		}
+		if err := f.Truncate(int64(walHeaderSize + len(data))); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		w.header = hdr
+		if _, err := f.Seek(int64(walHeaderSize+len(data)), 0); err != nil {
+			f.Close()
+			return nil, nil, err
+		}
+		return w, ranges, nil
+	}
+
 	if st.Size() >= walHeaderV0Size {
 		var buf0 [walHeaderV0Size]byte
 		if _, err := f.ReadAt(buf0[:], 0); err != nil {
@@ -179,13 +319,13 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 		var hdr0 walHeaderV0
 		hdr0.Size = binary.LittleEndian.Uint64(buf0[0:8])
 		hdr0.Epoch = binary.LittleEndian.Uint64(buf0[8:16])
-		copy(hdr0.DeviceID[:], buf0[16:80])
+		copy(hdr0.FSUUID[:], buf0[16:80])
 		copy(hdr0.MAC[:], buf0[80:112])
 		if mac := walHeaderMACV0(&hdr0); mac != hdr0.MAC {
 			f.Close()
 			return nil, nil, fmt.Errorf("wal: header mac mismatch")
 		}
-		if hdr0.Size != size || hdr0.Epoch != epoch || string(hdr0.DeviceID[:len(deviceID)]) != deviceID {
+		if hdr0.Size != id.SizeBytes || hdr0.Epoch != id.ManifestEpoch || strings.TrimRight(string(hdr0.FSUUID[:]), "\x00") != id.FSUUID {
 			f.Close()
 			return nil, nil, fmt.Errorf("wal: metadata mismatch")
 		}
@@ -204,14 +344,24 @@ func OpenWAL(path string, size uint64, deviceID string, epoch uint64, deps *WALD
 		hdr.Version = walVersion
 		hdr.Size = hdr0.Size
 		hdr.Epoch = hdr0.Epoch
-		hdr.DeviceID = hdr0.DeviceID
+		copy(hdr.KernelUUID[:], []byte(id.KernelUUID))
+		copy(hdr.GPTUUID[:], []byte(id.GPTUUID))
+		copy(hdr.MBRSignature[:], []byte(id.MBRSignature))
+		hdr.FSUUID = hdr0.FSUUID
+		hdr.Major = id.Major
+		hdr.Minor = id.Minor
 		hdr.MAC = walHeaderMAC(&hdr)
 		var buf [walHeaderSize]byte
 		binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
 		binary.LittleEndian.PutUint64(buf[8:16], hdr.Size)
 		binary.LittleEndian.PutUint64(buf[16:24], hdr.Epoch)
-		copy(buf[24:88], hdr.DeviceID[:])
-		copy(buf[88:120], hdr.MAC[:])
+		copy(buf[24:88], hdr.KernelUUID[:])
+		copy(buf[88:152], hdr.GPTUUID[:])
+		copy(buf[152:160], hdr.MBRSignature[:])
+		copy(buf[160:224], hdr.FSUUID[:])
+		binary.LittleEndian.PutUint32(buf[224:228], hdr.Major)
+		binary.LittleEndian.PutUint32(buf[228:232], hdr.Minor)
+		copy(buf[232:264], hdr.MAC[:])
 		if n, err := f.WriteAt(buf[:], 0); err != nil {
 			f.Close()
 			return nil, nil, err

--- a/transfer/wal_crash_test.go
+++ b/transfer/wal_crash_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"lvmsync_go/device"
 )
 
 // TestWALCrashRecovery simulates power loss scenarios and verifies WAL recovery.
@@ -12,7 +14,8 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("truncate_mid_entry", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, _, err := OpenWAL(path, 128, "dev", 1, nil)
+		id := device.DeviceIdentity{SizeBytes: 128, KernelUUID: "dev", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
+		w, _, err := OpenWAL(path, id, nil)
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -34,7 +37,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatalf("close file: %v", err)
 		}
-		w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
+		w2, ranges, err := OpenWAL(path, id, nil)
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}
@@ -47,7 +50,8 @@ func TestWALCrashRecovery(t *testing.T) {
 	t.Run("omit_fsync", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "wal")
-		w, _, err := OpenWAL(path, 128, "dev", 1, nil)
+		id := device.DeviceIdentity{SizeBytes: 128, KernelUUID: "dev", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
+		w, _, err := OpenWAL(path, id, nil)
 		if err != nil {
 			t.Fatalf("open wal: %v", err)
 		}
@@ -66,7 +70,7 @@ func TestWALCrashRecovery(t *testing.T) {
 		if err := os.Truncate(path, walHeaderSize+16); err != nil {
 			t.Fatalf("truncate: %v", err)
 		}
-		w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
+		w2, ranges, err := OpenWAL(path, id, nil)
 		if err != nil {
 			t.Fatalf("reopen wal: %v", err)
 		}

--- a/transfer/wal_resume_test.go
+++ b/transfer/wal_resume_test.go
@@ -17,7 +17,8 @@ import (
 func TestWALCommitFsync(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 128, KernelUUID: "dev", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -28,7 +29,7 @@ func TestWALCommitFsync(t *testing.T) {
 	if err := w.File().Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
+	w2, ranges, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -49,7 +50,12 @@ func TestResumeValidation(t *testing.T) {
 		ChecksumAlgorithm: "blake3",
 		DedupMode:         "fixed",
 		SizeBytes:         1,
-		DeviceID:          "src",
+		KernelUUID:        "k",
+		GPTUUID:           "g",
+		MBRSignature:      "00000001",
+		FSUUID:            "src",
+		Major:             1,
+		Minor:             2,
 		Epoch:             1,
 	}
 	data, err := json.Marshal(state)
@@ -60,7 +66,7 @@ func TestResumeValidation(t *testing.T) {
 		t.Fatalf("write resume: %v", err)
 	}
 	cfg := &config.Config{ResumeState: path, DedupMode: "fixed", Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3"}
-	chk := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 2, FSUUID: "dest", ManifestEpoch: 2}, [32]byte{})
+	chk := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 2, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "dest", Major: 1, Minor: 2, ManifestEpoch: 2}, [32]byte{})
 	if rc := chk.chunk("fixed"); rc != (resumeChunk{}) {
 		t.Fatalf("expected empty checkpoint, got %#v", rc)
 	}
@@ -76,7 +82,12 @@ func TestResumeDeviceIDMismatch(t *testing.T) {
 		ChecksumAlgorithm: "blake3",
 		DedupMode:         "fixed",
 		SizeBytes:         2,
-		DeviceID:          "src",
+		KernelUUID:        "k",
+		GPTUUID:           "g",
+		MBRSignature:      "00000001",
+		FSUUID:            "src",
+		Major:             1,
+		Minor:             2,
 		Epoch:             2,
 	}
 	data, err := json.Marshal(state)
@@ -87,7 +98,7 @@ func TestResumeDeviceIDMismatch(t *testing.T) {
 		t.Fatalf("write resume: %v", err)
 	}
 	cfg := &config.Config{ResumeState: path, DedupMode: "fixed", Transport: "ssh", Compress: "none", ChecksumAlgorithm: "blake3"}
-	chk := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 2, FSUUID: "dest", ManifestEpoch: 2}, [32]byte{})
+	chk := readResumeState(cfg, zap.NewNop(), device.DeviceIdentity{SizeBytes: 2, KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "dest", Major: 1, Minor: 2, ManifestEpoch: 2}, [32]byte{})
 	if rc := chk.chunk("fixed"); rc != (resumeChunk{}) {
 		t.Fatalf("expected empty checkpoint, got %#v", rc)
 	}
@@ -97,7 +108,8 @@ func TestResumeDeviceIDMismatch(t *testing.T) {
 func TestWALHeaderCorruption(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 128, KernelUUID: "dev", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -112,7 +124,7 @@ func TestWALHeaderCorruption(t *testing.T) {
 		t.Fatalf("corrupt header: %v", err)
 	}
 	f.Close()
-	if _, _, err := OpenWAL(path, 128, "dev", 1, nil); err == nil {
+	if _, _, err := OpenWAL(path, id, nil); err == nil {
 		t.Fatalf("expected header corruption error")
 	}
 }
@@ -121,7 +133,8 @@ func TestWALHeaderCorruption(t *testing.T) {
 func TestWALDeviceIDCorruption(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 128, KernelUUID: "dev", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -136,7 +149,7 @@ func TestWALDeviceIDCorruption(t *testing.T) {
 		t.Fatalf("corrupt device id: %v", err)
 	}
 	f.Close()
-	if _, _, err := OpenWAL(path, 128, "dev", 1, nil); err == nil {
+	if _, _, err := OpenWAL(path, id, nil); err == nil {
 		t.Fatalf("expected device id corruption error")
 	}
 }
@@ -145,7 +158,8 @@ func TestWALDeviceIDCorruption(t *testing.T) {
 func TestWALDetectsUnsyncedEntry(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 128, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 128, KernelUUID: "dev", GPTUUID: "g", MBRSignature: "00000001", FSUUID: "f", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -161,7 +175,7 @@ func TestWALDetectsUnsyncedEntry(t *testing.T) {
 	if err := w.File().Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	w2, ranges, err := OpenWAL(path, 128, "dev", 1, nil)
+	w2, ranges, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}

--- a/transfer/wal_test.go
+++ b/transfer/wal_test.go
@@ -7,32 +7,66 @@ import (
 	"path/filepath"
 	"testing"
 
+	"lvmsync_go/device"
 	walpkg "lvmsync_go/internal/wal"
 )
 
 func TestWALMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "00000001", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
 	w.Close()
-	if _, _, err := OpenWAL(path, 101, "dev", 1, nil); err == nil {
+	badID := id
+	badID.SizeBytes = 101
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
 		t.Fatalf("expected size mismatch error")
 	}
-	if _, _, err := OpenWAL(path, 100, "dev2", 1, nil); err == nil {
+	badID = id
+	badID.FSUUID = "fs2"
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
 		t.Fatalf("expected device mismatch error")
 	}
-	if _, _, err := OpenWAL(path, 100, "dev", 2, nil); err == nil {
+	badID = id
+	badID.ManifestEpoch = 2
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
 		t.Fatalf("expected epoch mismatch error")
+	}
+	badID = id
+	badID.KernelUUID = "dev2"
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
+		t.Fatalf("expected kernel uuid mismatch error")
+	}
+	badID = id
+	badID.GPTUUID = "gpt2"
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
+		t.Fatalf("expected gpt uuid mismatch error")
+	}
+	badID = id
+	badID.MBRSignature = "00000002"
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
+		t.Fatalf("expected mbr signature mismatch error")
+	}
+	badID = id
+	badID.Major = 3
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
+		t.Fatalf("expected major mismatch error")
+	}
+	badID = id
+	badID.Minor = 4
+	if _, _, err := OpenWAL(path, badID, nil); err == nil {
+		t.Fatalf("expected minor mismatch error")
 	}
 }
 
 func TestWALRecovery(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "00000001", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -40,7 +74,7 @@ func TestWALRecovery(t *testing.T) {
 		t.Fatalf("append: %v", err)
 	}
 	w.Close()
-	w, ranges, err := OpenWAL(path, 100, "dev", 1, nil)
+	w, ranges, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -56,7 +90,8 @@ func TestWALRecovery(t *testing.T) {
 func TestWALTruncatedHeader(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "00000001", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -66,7 +101,7 @@ func TestWALTruncatedHeader(t *testing.T) {
 	if err := os.Truncate(path, 10); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
-	if _, _, err := OpenWAL(path, 100, "dev", 1, nil); err == nil {
+	if _, _, err := OpenWAL(path, id, nil); err == nil {
 		t.Fatalf("expected truncated header error")
 	}
 }
@@ -74,7 +109,8 @@ func TestWALTruncatedHeader(t *testing.T) {
 func TestWALPartialWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "00000001", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -97,7 +133,7 @@ func TestWALPartialWrite(t *testing.T) {
 	if err := f.Close(); err != nil {
 		t.Fatalf("close file: %v", err)
 	}
-	w2, ranges, err := OpenWAL(path, 100, "dev", 1, nil)
+	w2, ranges, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("reopen wal: %v", err)
 	}
@@ -127,7 +163,8 @@ func TestWALSyncDirAppend(t *testing.T) {
 		}
 		return nil
 	})
-	w, _, err := OpenWAL(path, 100, "dev", 1, deps)
+	id := device.DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "00000001", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, deps)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/wal_verify_test.go
+++ b/transfer/wal_verify_test.go
@@ -52,7 +52,8 @@ func TestWALVerifySuccess(t *testing.T) {
 	man := filepath.Join(dir, "man")
 	buildManifest(t, dev, man, "uuid", uint64(len(data)))
 	walPath := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0, nil)
+	id := device.DeviceIdentity{SizeBytes: uint64(len(data)), KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000000", FSUUID: "uuid"}
+	w, _, err := OpenWAL(walPath, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -81,7 +82,8 @@ func TestWALVerifyMismatch(t *testing.T) {
 	man := filepath.Join(dir, "man")
 	buildManifest(t, dev, man, "uuid", uint64(len(data)))
 	walPath := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(walPath, uint64(len(data)), "uuid", 0, nil)
+	id := device.DeviceIdentity{SizeBytes: uint64(len(data)), KernelUUID: "k", GPTUUID: "g", MBRSignature: "00000000", FSUUID: "uuid"}
+	w, _, err := OpenWAL(walPath, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}

--- a/transfer/wal_version_test.go
+++ b/transfer/wal_version_test.go
@@ -5,12 +5,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"lvmsync_go/device"
 )
 
 func TestWALVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wal")
-	w, _, err := OpenWAL(path, 100, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "00000001", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, _, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}
@@ -29,15 +32,20 @@ func TestWALVersionMismatch(t *testing.T) {
 	hdr.Version = walVersion + 1
 	hdr.Size = binary.LittleEndian.Uint64(buf[8:16])
 	hdr.Epoch = binary.LittleEndian.Uint64(buf[16:24])
-	copy(hdr.DeviceID[:], buf[24:88])
+	copy(hdr.KernelUUID[:], buf[24:88])
+	copy(hdr.GPTUUID[:], buf[88:152])
+	copy(hdr.MBRSignature[:], buf[152:160])
+	copy(hdr.FSUUID[:], buf[160:224])
+	hdr.Major = binary.LittleEndian.Uint32(buf[224:228])
+	hdr.Minor = binary.LittleEndian.Uint32(buf[228:232])
 	hdr.MAC = walHeaderMAC(&hdr)
 	binary.LittleEndian.PutUint64(buf[0:8], hdr.Version)
-	copy(buf[88:120], hdr.MAC[:])
+	copy(buf[232:264], hdr.MAC[:])
 	if _, err := f.WriteAt(buf[:], 0); err != nil {
 		t.Fatalf("write header: %v", err)
 	}
 	f.Close()
-	if _, _, err := OpenWAL(path, 100, "dev", 1, nil); err == nil {
+	if _, _, err := OpenWAL(path, id, nil); err == nil {
 		t.Fatalf("expected version mismatch error")
 	}
 }
@@ -52,12 +60,12 @@ func TestWALUpgrade(t *testing.T) {
 	var hdr0 walHeaderV0
 	hdr0.Size = 100
 	hdr0.Epoch = 1
-	copy(hdr0.DeviceID[:], []byte("dev"))
+	copy(hdr0.FSUUID[:], []byte("fs"))
 	hdr0.MAC = walHeaderMACV0(&hdr0)
 	var buf0 [walHeaderV0Size]byte
 	binary.LittleEndian.PutUint64(buf0[0:8], hdr0.Size)
 	binary.LittleEndian.PutUint64(buf0[8:16], hdr0.Epoch)
-	copy(buf0[16:80], hdr0.DeviceID[:])
+	copy(buf0[16:80], hdr0.FSUUID[:])
 	copy(buf0[80:112], hdr0.MAC[:])
 	if _, err := f.Write(buf0[:]); err != nil {
 		t.Fatalf("write header: %v", err)
@@ -69,7 +77,8 @@ func TestWALUpgrade(t *testing.T) {
 		t.Fatalf("write entry: %v", err)
 	}
 	f.Close()
-	w, ranges, err := OpenWAL(path, 100, "dev", 1, nil)
+	id := device.DeviceIdentity{SizeBytes: 100, KernelUUID: "dev", GPTUUID: "gpt", MBRSignature: "00000001", FSUUID: "fs", Major: 1, Minor: 2, ManifestEpoch: 1}
+	w, ranges, err := OpenWAL(path, id, nil)
 	if err != nil {
 		t.Fatalf("open wal: %v", err)
 	}


### PR DESCRIPTION
## Summary
- persist kernel UUID, GPT UUID, MBR signature, and major/minor numbers in resume state and WAL headers
- validate full device identity on resume
- document expanded WAL header layout and add tests for identity mismatches

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68adaa0e732c83238b611e30312082ac