### PR TITLE
build: gate rsync transport behind build tag

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -27,7 +27,6 @@ import (
 	"lvmsync_go/transport"
 	_ "lvmsync_go/transport/h2"
 	_ "lvmsync_go/transport/quic"
-	_ "lvmsync_go/transport/rsyncwire"
 	_ "lvmsync_go/transport/ssh"
 	_ "lvmsync_go/transport/tcp_tls"
 )

--- a/cmd/dump/rsync_delta_integration_test.go
+++ b/cmd/dump/rsync_delta_integration_test.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package dump
 
 import (

--- a/cmd/dump/rsync_import.go
+++ b/cmd/dump/rsync_import.go
@@ -1,0 +1,5 @@
+//go:build rsync
+
+package dump
+
+import _ "lvmsync_go/transport/rsyncwire"

--- a/cmd/dump/select_transport_test.go
+++ b/cmd/dump/select_transport_test.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package dump
 
 import (

--- a/integration/rsync_refusal_test.go
+++ b/integration/rsync_refusal_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && rsync
 
 package integration
 

--- a/testutil/rsyncserver/server.go
+++ b/testutil/rsyncserver/server.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package rsyncserver
 
 import (

--- a/testutil/rsyncserver/server_test.go
+++ b/testutil/rsyncserver/server_test.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package rsyncserver
 
 import (

--- a/transfer/rsync_delta_test.go
+++ b/transfer/rsync_delta_test.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package transfer
 
 import (

--- a/transport/rsync_deadline_integration_test.go
+++ b/transport/rsync_deadline_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && rsync
 
 package transport_test
 

--- a/transport/rsyncwire/rsync_integration_test.go
+++ b/transport/rsyncwire/rsync_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration && rsync
+
 package rsyncwire
 
 import (

--- a/transport/rsyncwire/rsyncwire.go
+++ b/transport/rsyncwire/rsyncwire.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package rsyncwire
 
 import (

--- a/transport/rsyncwire/rsyncwire_test.go
+++ b/transport/rsyncwire/rsyncwire_test.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package rsyncwire
 
 import (


### PR DESCRIPTION
## Summary
- gate rsync transport and related tests behind an `rsync` build tag
- add conditional import for rsync transport registration

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: errcheck, gocritic, revive, staticcheck: 495 issues)*
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_68adbb9f45ac8323a22c9d76a0c564cb