### PR TITLE
cmd/root: refine allow_insecure warnings

### DIFF
--- a/cmd/root/plan.go
+++ b/cmd/root/plan.go
@@ -65,11 +65,12 @@ func emitPlan(cfg *config.Config, args []string, logger *zap.Logger) error {
 			break
 		}
 	}
-	if cfg.AllowInsecure || rsyncRequested {
+	if rsyncRequested && !cfg.AllowInsecure {
+		logger.Warn("rsync transport requires --allow-insecure", zap.String("reason", "allow_insecure_required"))
+		return fmt.Errorf("insecure configuration requires --allow-insecure")
+	}
+	if cfg.AllowInsecure {
 		logger.Warn("allow_insecure enabled; security checks disabled", zap.String("reason", "allow_insecure_enabled"))
-		if !cfg.AllowInsecure {
-			return fmt.Errorf("insecure configuration requires --allow-insecure")
-		}
 	}
 	_, est, err := estimateBytes(args[0], cfg)
 	if err != nil {

--- a/cmd/root/plan_test.go
+++ b/cmd/root/plan_test.go
@@ -53,6 +53,9 @@ func TestEmitPlanAllowInsecureWarns(t *testing.T) {
 	if logs.Len() == 0 {
 		t.Fatalf("missing warning")
 	}
+	if logs.All()[0].Message != "allow_insecure enabled; security checks disabled" {
+		t.Fatalf("unexpected warning: %v", logs.All()[0].Message)
+	}
 	if len(outBytes) == 0 {
 		t.Fatalf("expected plan output")
 	}
@@ -77,6 +80,9 @@ func TestEmitPlanRsyncRequiresAllowInsecure(t *testing.T) {
 	outBytes, _ := io.ReadAll(rOut)
 	if logs.Len() == 0 {
 		t.Fatalf("missing warning")
+	}
+	if logs.All()[0].Message != "rsync transport requires --allow-insecure" {
+		t.Fatalf("unexpected warning: %v", logs.All()[0].Message)
 	}
 	if len(outBytes) != 0 {
 		t.Fatalf("unexpected plan output: %q", outBytes)


### PR DESCRIPTION
## Summary
- warn only when `allow_insecure` is explicitly enabled
- clarify that `rsync` requires `--allow-insecure` when not set

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: 495 issues)*
- `go tool cover -func=coverage.out | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68adc398baf88323ba90f6b082f60d59