### PR TITLE
Refactor snapshot registry to struct-based API

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -48,20 +48,21 @@ func chooseCompression(_ int, compress string) string {
 
 // Runner manages external interactions for dump operations.
 type Runner struct {
-	dumpSeq        func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error
-	dumpPar        func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error
-	dumpDedup      func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer, transfer.DeduplicationStrategy) error
-	newSSHClient   func(context.Context, string, string, string, int, string, bool, time.Duration, time.Duration, int, *zap.Logger) (*remote.SSHClient, error)
-	openFile       func(string, int, os.FileMode) (*os.File, error)
-	detectDevice   func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error)
-	sumFile        func(string, string) ([32]byte, error)
-	streamToRemote func(context.Context, *config.Config, io.WriteCloser, string, string, string, *zap.Logger) error
-	probeDest      func(context.Context, *config.Config, string, *zap.Logger) (device.DeviceIdentity, error)
-	createLV       func(context.Context, string, string, uint64, *zap.Logger) error
-	parseLVPath    func(string) (string, string, error)
-	getVolumeSize  func(string, *lvm.FDCache, *zap.Logger) (uint64, error)
-	newFDC         func(*zap.Logger) (*lvm.FDCache, error)
-	verifyIdentity func(context.Context, *device.Info, string, string) error
+	dumpSeq          func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error
+	dumpPar          func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer) error
+	dumpDedup        func(context.Context, *transfer.Transfer, *config.Config, string, string, io.Writer, transfer.DeduplicationStrategy) error
+	newSSHClient     func(context.Context, string, string, string, int, string, bool, time.Duration, time.Duration, int, *zap.Logger) (*remote.SSHClient, error)
+	openFile         func(string, int, os.FileMode) (*os.File, error)
+	detectDevice     func(context.Context, string, bool, bool, string, string, string, string, time.Duration, time.Duration, privilege.Escalator, *zap.Logger, *device.Runner) (device.Device, error)
+	sumFile          func(string, string) ([32]byte, error)
+	streamToRemote   func(context.Context, *config.Config, io.WriteCloser, string, string, string, *zap.Logger) error
+	probeDest        func(context.Context, *config.Config, string, *zap.Logger) (device.DeviceIdentity, error)
+	createLV         func(context.Context, string, string, uint64, *zap.Logger) error
+	parseLVPath      func(string) (string, string, error)
+	getVolumeSize    func(string, *lvm.FDCache, *zap.Logger) (uint64, error)
+	newFDC           func(*zap.Logger) (*lvm.FDCache, error)
+	verifyIdentity   func(context.Context, *device.Info, string, string) error
+	snapshotRegistry *lvm.SnapshotRegistry
 }
 
 var (
@@ -82,19 +83,20 @@ var (
 // NewRunner constructs a Runner with production dependencies.
 func NewRunner() *Runner {
 	r := &Runner{
-		dumpSeq:        dumpChangesSequential,
-		dumpPar:        dumpChangesParallel,
-		dumpDedup:      dumpChangesWithDeduplication,
-		newSSHClient:   remote.NewSSHClient,
-		openFile:       os.OpenFile,
-		detectDevice:   device.Detect,
-		sumFile:        digestpkg.SumFile,
-		probeDest:      probeDestination,
-		createLV:       lvm.CreateLogicalVolume,
-		parseLVPath:    lvm.ParseLVPath,
-		getVolumeSize:  lvm.GetVolumeSize,
-		newFDC:         lvm.NewDeviceFDCache,
-		verifyIdentity: device.VerifyIdentity,
+		dumpSeq:          dumpChangesSequential,
+		dumpPar:          dumpChangesParallel,
+		dumpDedup:        dumpChangesWithDeduplication,
+		newSSHClient:     remote.NewSSHClient,
+		openFile:         os.OpenFile,
+		detectDevice:     device.Detect,
+		sumFile:          digestpkg.SumFile,
+		probeDest:        probeDestination,
+		createLV:         lvm.CreateLogicalVolume,
+		parseLVPath:      lvm.ParseLVPath,
+		getVolumeSize:    lvm.GetVolumeSize,
+		newFDC:           lvm.NewDeviceFDCache,
+		verifyIdentity:   device.VerifyIdentity,
+		snapshotRegistry: lvm.NewSnapshotRegistry(nil),
 	}
 	r.streamToRemote = r.StreamToRemote
 	return r
@@ -152,6 +154,9 @@ func NewRunnerWithDeps(deps *Runner) *Runner {
 	}
 	if deps.verifyIdentity != nil {
 		r.verifyIdentity = deps.verifyIdentity
+	}
+	if deps.snapshotRegistry != nil {
+		r.snapshotRegistry = deps.snapshotRegistry
 	}
 	return r
 }
@@ -337,8 +342,8 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 	}
 	snapshotDevice := snapDev.Path()
 	originDevice := dev.Path()
-	lvm.RegisterSnapshot(snapshotDevice, logger)
-	defer lvm.CleanupSnapshot(ctx, snapshotDevice, logger)
+	r.snapshotRegistry.RegisterSnapshot(snapshotDevice, logger)
+	defer r.snapshotRegistry.CleanupSnapshot(ctx, snapshotDevice, logger)
 	defer func() {
 		snapDev.Close()
 		if snapDev != dev {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -21,7 +21,6 @@ import (
 	"lvmsync_go/internal/exitcode"
 	"lvmsync_go/internal/logging"
 	"lvmsync_go/internal/privilege"
-	"lvmsync_go/lvm"
 	"lvmsync_go/transport"
 )
 
@@ -328,7 +327,6 @@ func (r *Runner) executeSync(ctx context.Context, cfg *config.Config, snapshotPa
 }
 
 func (r *Runner) Run(cfg *config.Config, args []string, logger *zap.Logger) error {
-	defer lvm.CleanupRegistered(context.Background())
 	handled, err := r.dispatchSubcommand(cfg, args, logger)
 	if handled || err != nil {
 		return err

--- a/internal/client/snapshot.go
+++ b/internal/client/snapshot.go
@@ -22,13 +22,13 @@ type Runner struct {
 	createSnapshot           func(context.Context, string, string, string, *zap.Logger) error
 	getSnapshotDevicePath    func(string, string, *zap.Logger) string
 	monitorSnapshot          func(context.Context, string, float64, time.Duration, *zap.Logger) error
-	removeSnapshot           func(context.Context, string, *zap.Logger) error
 	snapshotName             func() string
+	snapshotRegistry         *lvm.SnapshotRegistry
 }
 
 // NewRunner constructs a Runner with production dependencies.
 func NewRunner() *Runner {
-	return &Runner{
+	r := &Runner{
 		parseSnapshotSize:        lvm.ParseSnapshotSize,
 		getVolumeGroupName:       lvm.GetVolumeGroupName,
 		getVolumeSize:            lvm.GetVolumeSize,
@@ -37,9 +37,10 @@ func NewRunner() *Runner {
 		createSnapshot:           lvm.CreateSnapshot,
 		getSnapshotDevicePath:    lvm.GetSnapshotDevicePath,
 		monitorSnapshot:          lvm.MonitorSnapshot,
-		removeSnapshot:           lvm.RemoveSnapshot,
 		snapshotName:             func() string { return fmt.Sprintf("snap-%d", time.Now().Unix()) },
 	}
+	r.snapshotRegistry = lvm.NewSnapshotRegistry(lvm.RemoveSnapshot)
+	return r
 }
 
 // NewRunnerWithDeps constructs a Runner overriding dependencies. Nil functions use defaults.
@@ -81,7 +82,7 @@ func NewRunnerWithDeps(
 		r.monitorSnapshot = monitor
 	}
 	if remove != nil {
-		r.removeSnapshot = remove
+		r.snapshotRegistry = lvm.NewSnapshotRegistry(remove)
 	}
 	if snapName != nil {
 		r.snapshotName = snapName
@@ -155,7 +156,7 @@ func (r *Runner) createSnapshotIfNeeded(ctx context.Context, cfg *config.Config,
 		return "", nil, nil, fmt.Errorf("snapshot creation failed: %w", err)
 	}
 	snapshotPath = r.getSnapshotDevicePath(snapshotName, cfg.VolumeGroup, logger)
-	lvm.RegisterSnapshot(snapshotPath, logger)
+	r.snapshotRegistry.RegisterSnapshot(snapshotPath, logger)
 	logger.Info("Snapshot created", zap.String("snapshot", snapshotPath))
 
 	monitorCtx, cancel := context.WithCancel(ctx)
@@ -173,14 +174,7 @@ func (r *Runner) createSnapshotIfNeeded(ctx context.Context, cfg *config.Config,
 
 	cleanup = func() {
 		cancel()
-		lvm.UnregisterSnapshot(snapshotPath)
-		removeCtx, removeCancel := context.WithTimeout(ctx, 10*time.Second)
-		defer removeCancel()
-		if err := r.removeSnapshot(removeCtx, snapshotPath, logger); err != nil {
-			logger.Warn("Failed to remove snapshot", zap.Error(err))
-		} else {
-			logger.Info("Snapshot removed", zap.String("snapshot", snapshotPath))
-		}
+		r.snapshotRegistry.CleanupSnapshot(ctx, snapshotPath, logger)
 	}
 
 	return snapshotPath, monitorErrCh, cleanup, nil

--- a/lvm/snapshot_registry.go
+++ b/lvm/snapshot_registry.go
@@ -11,61 +11,71 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	registryMu  sync.Mutex
-	registry    = make(map[string]*zap.Logger)
+// SnapshotRegistry tracks LVM snapshots for cleanup on process exit.
+type SnapshotRegistry struct {
+	mu          sync.Mutex
+	registry    map[string]*zap.Logger
 	handlerOnce sync.Once
-	removeSnap  = RemoveSnapshot
-)
+	remove      func(context.Context, string, *zap.Logger) error
+}
+
+// NewSnapshotRegistry constructs a SnapshotRegistry. If remove is nil,
+// RemoveSnapshot is used.
+func NewSnapshotRegistry(remove func(context.Context, string, *zap.Logger) error) *SnapshotRegistry {
+	if remove == nil {
+		remove = RemoveSnapshot
+	}
+	return &SnapshotRegistry{
+		registry: make(map[string]*zap.Logger),
+		remove:   remove,
+	}
+}
 
 // RegisterSnapshot adds the snapshot path to the cleanup registry and installs
-// a signal handler on first use. If logger is nil, zap.NewNop() is used.
-func RegisterSnapshot(path string, logger *zap.Logger) {
+// a signal handler on first use.
+func (r *SnapshotRegistry) RegisterSnapshot(path string, logger *zap.Logger) {
 	if path == "" {
 		return
 	}
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-	registryMu.Lock()
-	registry[path] = logger
-	registryMu.Unlock()
-	handlerOnce.Do(func() {
+	r.mu.Lock()
+	r.registry[path] = logger
+	r.mu.Unlock()
+	r.handlerOnce.Do(func() {
 		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 		go func() {
 			<-ch
-			CleanupRegistered(context.Background())
+			r.CleanupRegistered(context.Background())
 			signal.Stop(ch)
 		}()
 	})
 }
 
 // UnregisterSnapshot removes the snapshot from the cleanup registry.
-func UnregisterSnapshot(path string) {
-	registryMu.Lock()
-	delete(registry, path)
-	registryMu.Unlock()
+func (r *SnapshotRegistry) UnregisterSnapshot(path string) {
+	r.mu.Lock()
+	delete(r.registry, path)
+	r.mu.Unlock()
 }
 
 // CleanupRegistered removes all registered snapshots. It is safe to call from a
 // deferred function to ensure cleanup on panic or normal exit.
-func CleanupRegistered(ctx context.Context) {
-	registryMu.Lock()
-	paths := make([]string, 0, len(registry))
-	loggers := make([]*zap.Logger, 0, len(registry))
-	for p, l := range registry {
+func (r *SnapshotRegistry) CleanupRegistered(ctx context.Context) {
+	r.mu.Lock()
+	paths := make([]string, 0, len(r.registry))
+	loggers := make([]*zap.Logger, 0, len(r.registry))
+	for p, l := range r.registry {
 		paths = append(paths, p)
 		loggers = append(loggers, l)
 	}
-	registry = make(map[string]*zap.Logger)
-	registryMu.Unlock()
+	r.registry = make(map[string]*zap.Logger)
+	r.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	for i, p := range paths {
 		rmCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		if err := removeSnap(rmCtx, p, loggers[i]); err != nil {
+		if err := r.remove(rmCtx, p, loggers[i]); err != nil {
 			loggers[i].Warn("failed to remove snapshot", zap.String("snapshot", p), zap.Error(err))
 		} else {
 			loggers[i].Info("snapshot removed", zap.String("snapshot", p))
@@ -74,23 +84,19 @@ func CleanupRegistered(ctx context.Context) {
 	}
 }
 
-// CleanupSnapshot removes a single snapshot, unregistering it first. If logger
-// is nil, zap.NewNop() is used. It logs success or failure and ignores empty
-// paths.
-func CleanupSnapshot(ctx context.Context, path string, logger *zap.Logger) {
+// CleanupSnapshot removes a single snapshot, unregistering it first. It logs
+// success or failure and ignores empty paths.
+func (r *SnapshotRegistry) CleanupSnapshot(ctx context.Context, path string, logger *zap.Logger) {
 	if path == "" {
 		return
 	}
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-	UnregisterSnapshot(path)
+	r.UnregisterSnapshot(path)
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	rmCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	if err := removeSnap(rmCtx, path, logger); err != nil {
+	if err := r.remove(rmCtx, path, logger); err != nil {
 		logger.Warn("failed to remove snapshot", zap.String("snapshot", path), zap.Error(err))
 	} else {
 		logger.Info("snapshot removed", zap.String("snapshot", path))

--- a/lvm/snapshot_registry_test.go
+++ b/lvm/snapshot_registry_test.go
@@ -10,38 +10,30 @@ import (
 )
 
 func TestCleanupSnapshotSuccess(t *testing.T) {
-	original := removeSnap
-	defer func() { removeSnap = original }()
-
 	var called bool
-	removeSnap = func(ctx context.Context, path string, logger *zap.Logger) error {
+	sr := NewSnapshotRegistry(func(ctx context.Context, path string, logger *zap.Logger) error {
 		called = true
 		if path != "/dev/vg/test" {
-			t.Fatalf("removeSnap called with %s", path)
+			t.Fatalf("remove called with %s", path)
 		}
 		return nil
-	}
-
-	registryMu.Lock()
-	registry = map[string]*zap.Logger{"/dev/vg/test": zap.NewNop()}
-	registryMu.Unlock()
+	})
+	sr.RegisterSnapshot("/dev/vg/test", zap.NewNop())
 
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
 
-	CleanupSnapshot(context.Background(), "/dev/vg/test", logger)
+	sr.CleanupSnapshot(context.Background(), "/dev/vg/test", logger)
 
 	if !called {
-		t.Fatal("removeSnap was not called")
+		t.Fatal("remove not called")
 	}
-
-	registryMu.Lock()
-	if _, ok := registry["/dev/vg/test"]; ok {
-		registryMu.Unlock()
-		t.Fatal("snapshot still registered after cleanup")
+	sr.mu.Lock()
+	if _, ok := sr.registry["/dev/vg/test"]; ok {
+		sr.mu.Unlock()
+		t.Fatal("snapshot still registered")
 	}
-	registryMu.Unlock()
-
+	sr.mu.Unlock()
 	entries := logs.FilterMessage("snapshot removed").All()
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 log entry, got %d", len(entries))
@@ -52,29 +44,22 @@ func TestCleanupSnapshotSuccess(t *testing.T) {
 }
 
 func TestCleanupSnapshotError(t *testing.T) {
-	original := removeSnap
-	defer func() { removeSnap = original }()
-
-	removeSnap = func(ctx context.Context, path string, logger *zap.Logger) error {
+	sr := NewSnapshotRegistry(func(ctx context.Context, path string, logger *zap.Logger) error {
 		return errors.New("boom")
-	}
-
-	registryMu.Lock()
-	registry = map[string]*zap.Logger{"/dev/vg/test": zap.NewNop()}
-	registryMu.Unlock()
+	})
+	sr.RegisterSnapshot("/dev/vg/test", zap.NewNop())
 
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 
-	CleanupSnapshot(context.Background(), "/dev/vg/test", logger)
+	sr.CleanupSnapshot(context.Background(), "/dev/vg/test", logger)
 
-	registryMu.Lock()
-	if _, ok := registry["/dev/vg/test"]; ok {
-		registryMu.Unlock()
-		t.Fatal("snapshot still registered after cleanup")
+	sr.mu.Lock()
+	if _, ok := sr.registry["/dev/vg/test"]; ok {
+		sr.mu.Unlock()
+		t.Fatal("snapshot still registered")
 	}
-	registryMu.Unlock()
-
+	sr.mu.Unlock()
 	entries := logs.FilterMessage("failed to remove snapshot").All()
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 log entry, got %d", len(entries))
@@ -85,120 +70,52 @@ func TestCleanupSnapshotError(t *testing.T) {
 }
 
 func TestCleanupRegisteredMultiple(t *testing.T) {
-	original := removeSnap
-	defer func() { removeSnap = original }()
-
 	var calls []string
-	removeSnap = func(ctx context.Context, path string, logger *zap.Logger) error {
+	sr := NewSnapshotRegistry(func(ctx context.Context, path string, logger *zap.Logger) error {
 		calls = append(calls, path)
 		return nil
-	}
-
+	})
 	core1, logs1 := observer.New(zap.InfoLevel)
 	logger1 := zap.New(core1)
 	core2, logs2 := observer.New(zap.InfoLevel)
 	logger2 := zap.New(core2)
+	sr.RegisterSnapshot("/snap/1", logger1)
+	sr.RegisterSnapshot("/snap/2", logger2)
 
-	registryMu.Lock()
-	registry = map[string]*zap.Logger{
-		"/snap/1": logger1,
-		"/snap/2": logger2,
-	}
-	registryMu.Unlock()
-
-	CleanupRegistered(context.Background())
+	sr.CleanupRegistered(context.Background())
 
 	if len(calls) != 2 {
-		t.Fatalf("expected 2 removeSnap calls, got %d", len(calls))
+		t.Fatalf("expected 2 remove calls, got %d", len(calls))
 	}
 	got := map[string]bool{}
 	for _, c := range calls {
 		got[c] = true
 	}
 	if !got["/snap/1"] || !got["/snap/2"] {
-		t.Fatalf("expected calls for both snapshots, got %v", calls)
+		t.Fatalf("unexpected calls %v", calls)
 	}
-
 	if len(logs1.FilterMessage("snapshot removed").All()) != 1 {
 		t.Fatalf("logger1 expected 1 log entry")
 	}
 	if len(logs2.FilterMessage("snapshot removed").All()) != 1 {
 		t.Fatalf("logger2 expected 1 log entry")
 	}
-
-	registryMu.Lock()
-	if len(registry) != 0 {
-		registryMu.Unlock()
-		t.Fatalf("registry not cleared: %v", registry)
+	sr.mu.Lock()
+	if len(sr.registry) != 0 {
+		sr.mu.Unlock()
+		t.Fatalf("registry not cleared: %v", sr.registry)
 	}
-	registryMu.Unlock()
-}
-
-func TestRegisterSnapshotNilLoggerDefaults(t *testing.T) {
-	registryMu.Lock()
-	registry = make(map[string]*zap.Logger)
-	registryMu.Unlock()
-
-	RegisterSnapshot("/dev/test", nil)
-
-	registryMu.Lock()
-	l, ok := registry["/dev/test"]
-	registry = make(map[string]*zap.Logger)
-	registryMu.Unlock()
-
-	if !ok {
-		t.Fatalf("snapshot not registered")
-	}
-	if l == nil {
-		t.Fatalf("logger not defaulted")
-	}
+	sr.mu.Unlock()
 }
 
 func TestRegisterSnapshotAddsSnapshot(t *testing.T) {
-	registryMu.Lock()
-	registry = make(map[string]*zap.Logger)
-	registryMu.Unlock()
-
-	RegisterSnapshot("/dev/test", zap.NewNop())
-
-	registryMu.Lock()
-	_, ok := registry["/dev/test"]
-	registry = make(map[string]*zap.Logger)
-	registryMu.Unlock()
-
+	sr := NewSnapshotRegistry(nil)
+	sr.RegisterSnapshot("/dev/test", zap.NewNop())
+	sr.mu.Lock()
+	_, ok := sr.registry["/dev/test"]
+	sr.registry = make(map[string]*zap.Logger)
+	sr.mu.Unlock()
 	if !ok {
 		t.Fatalf("snapshot not registered")
-	}
-}
-
-func TestCleanupSnapshotNilLoggerDefaults(t *testing.T) {
-	var got *zap.Logger
-	old := removeSnap
-	removeSnap = func(ctx context.Context, path string, logger *zap.Logger) error {
-		got = logger
-		return nil
-	}
-	defer func() { removeSnap = old }()
-
-	CleanupSnapshot(context.Background(), "/dev/test", nil)
-
-	if got == nil {
-		t.Fatalf("logger not defaulted")
-	}
-}
-
-func TestCleanupSnapshotCallsRemove(t *testing.T) {
-	var called bool
-	old := removeSnap
-	removeSnap = func(ctx context.Context, path string, logger *zap.Logger) error {
-		called = true
-		return nil
-	}
-	defer func() { removeSnap = old }()
-
-	CleanupSnapshot(context.Background(), "/dev/test", zap.NewNop())
-
-	if !called {
-		t.Fatalf("removeSnap not called")
 	}
 }

--- a/lvm/snapshot_signal_test.go
+++ b/lvm/snapshot_signal_test.go
@@ -62,7 +62,8 @@ func TestSnapshotRemovedOnSignal(t *testing.T) {
 		t.Skipf("CreateSnapshot: %v", err)
 	}
 	snapPath := "/dev/vgsig/snap"
-	RegisterSnapshot(snapPath, zap.NewNop())
+	sr := NewSnapshotRegistry(nil)
+	sr.RegisterSnapshot(snapPath, zap.NewNop())
 
 	if err := syscall.Kill(os.Getpid(), syscall.SIGINT); err != nil {
 		t.Fatalf("send signal: %v", err)


### PR DESCRIPTION
## Summary
- introduce `SnapshotRegistry` struct with non-nil logger requirement
- update snapshot lifecycle code and callers to use registry instance
- adjust tests for new snapshot registry API

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68adc78609a083239cbae092856a4d24