### PR TITLE
privilege: require non-nil logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,11 @@ Override detection with `--source-type` and `--dest-type` when necessary.
 Internally, `device.Detect` delegates to dedicated helpers:
 
 ```go
-dev, err := device.Detect(ctx, "/dev/sdb", true, true, "auto", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+esc, err := privilege.New(ctx, logger)
+if err != nil {
+    // handle error
+}
+dev, err := device.Detect(ctx, "/dev/sdb", true, true, "auto", "", "", "", 0, 0, esc, logger, device.NewRunner())
 // detectFileDevice, detectLVMDevice, or detectRawDevice is selected based on the path.
 ```
 
@@ -1655,7 +1659,10 @@ can stub command execution:
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 defer cancel()
-esc := privilege.New(ctx, zap.NewNop())
+esc, err := privilege.New(ctx, zap.NewNop())
+if err != nil {
+    // handle error
+}
 if err := esc.Ensure(ctx); err != nil {
     // handle missing capabilities or sudo
 }

--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -289,6 +289,10 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 		fmt.Fprintf(os.Stdout, "%d %s %s %s %s %d %d %d\n", id.SizeBytes, id.KernelUUID, id.GPTUUID, id.MBRSignature, id.FSUUID, id.Major, id.Minor, id.ManifestEpoch)
 		return cfg.DestType, nil
 	}
+	esc, err := privilege.New(ctx, logger)
+	if err != nil {
+		return cfg.DestType, err
+	}
 	dev, err := r.detectDevice(
 		ctx,
 		source,
@@ -300,7 +304,7 @@ func (r *Runner) Run(ctx context.Context, cfg *config.Config, source, dest strin
 		cfg.LVMEscalation,
 		cfg.FreezeTimeout,
 		cfg.ThawTimeout,
-		privilege.New(ctx, logger),
+		esc,
 		logger,
 		device.NewRunner(),
 	)
@@ -372,7 +376,11 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 		return destType, r.ExecuteDump(ctx, cfg, snapshotDevice, originDevice, io.Discard, logger)
 	}
 	if destType == "auto" {
-		dev, err := device.Detect(devCtx, dest, false, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(devCtx, logger), logger, devRunner)
+		esc, err := privilege.New(devCtx, logger)
+		if err != nil {
+			return destType, err
+		}
+		dev, err := device.Detect(devCtx, dest, false, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, esc, logger, devRunner)
 		if err != nil {
 			if cfg.CheckPartition && errors.Is(err, device.ErrPartitionMismatch) {
 				if !cfg.Force {
@@ -384,7 +392,10 @@ func (r *Runner) RunLocalDump(ctx context.Context, cfg *config.Config, snapshotD
 				tmpCtx := device.WithForce(context.Background(), cfg.Force)
 				tmpCtx = device.WithAllowOverwrite(tmpCtx, cfg.AllowOverwrite)
 				tmpCtx = device.WithYesIKnow(tmpCtx, cfg.YesIKnow)
-				dev, err = device.Detect(tmpCtx, dest, false, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, privilege.New(tmpCtx, logger), logger, devRunner)
+				tmpEsc, err := privilege.New(tmpCtx, logger)
+				if err == nil {
+					dev, err = device.Detect(tmpCtx, dest, false, true, destType, "", "", cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, tmpEsc, logger, devRunner)
+				}
 				if err != nil {
 					dev = nil
 				}
@@ -568,7 +579,12 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 
 	rw := writeOnlyReadWriter{remoteStdin}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, maxFrame))
-	dev, err := r.detectDevice(ctx, originDevice, true, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+	esc, err := privilege.New(ctx, logger)
+	if err != nil {
+		remoteStdin.Close()
+		return fmt.Errorf("detect origin: %w", err)
+	}
+	dev, err := r.detectDevice(ctx, originDevice, true, true, "", "", "", "", 0, 0, esc, logger, device.NewRunner())
 	if err != nil {
 		remoteStdin.Close()
 		return fmt.Errorf("detect origin: %w", err)

--- a/cmd/dump/probe.go
+++ b/cmd/dump/probe.go
@@ -22,7 +22,11 @@ const firstBlockDigestSize = 1 << 20
 
 func realProbeDestination(ctx context.Context, cfg *config.Config, dest string, logger *zap.Logger) (device.DeviceIdentity, error) {
 	info := device.NewInfo()
-	dev, err := device.Detect(ctx, dest, true, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+	esc, err := privilege.New(ctx, logger)
+	if err != nil {
+		return device.DeviceIdentity{}, err
+	}
+	dev, err := device.Detect(ctx, dest, true, true, "", "", "", "", 0, 0, esc, logger, device.NewRunner())
 	if err != nil {
 		return device.DeviceIdentity{}, err
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -144,7 +144,9 @@ func ConfigureWithEscalator(esc privilege.Escalator) (*config.Config, []string, 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.LVMTimeout)
 	defer cancel()
 	if esc == nil {
-		esc = privilege.New(ctx, zap.NewNop())
+		if esc, err = privilege.New(ctx, zap.NewNop()); err != nil {
+			return nil, nil, nil, fmt.Errorf("privilege init failed: %w", err)
+		}
 	}
 	if err = esc.Ensure(ctx); err != nil {
 		return nil, nil, nil, fmt.Errorf("privilege check failed: %w", err)

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -143,7 +143,10 @@ func (r *Runner) Run(args []string, logger *zap.Logger) error {
 }
 
 func (r *Runner) verifyDevices(ctx context.Context, cfg *config.Config, src, dst, manifestPath string, logger *zap.Logger) error {
-	esc := privilege.New(ctx, logger)
+	esc, err := privilege.New(ctx, logger)
+	if err != nil {
+		return err
+	}
 	runner := device.NewRunner()
 
 	srcDev, err := device.Detect(ctx, src, true, cfg.Offline, cfg.SourceType, cfg.FSFreezeCommand, cfg.FSThawCommand, cfg.LVMEscalation, cfg.FreezeTimeout, cfg.ThawTimeout, esc, logger, runner)

--- a/device/identity_preflight.go
+++ b/device/identity_preflight.go
@@ -37,7 +37,11 @@ func VerifyIdentity(ctx context.Context, info *Info, src, dest string) (err erro
 	if !match && !allow {
 		return fmt.Errorf("uuid mismatch: %w", exitcode.ErrPrecondition)
 	}
-	devA, err := info.detectFunc(ctx, src, true, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
+	escA, err := privilege.New(ctx, zap.NewNop())
+	if err != nil {
+		return err
+	}
+	devA, err := info.detectFunc(ctx, src, true, true, "", "", "", "", 0, 0, escA, zap.NewNop(), NewRunner())
 	if err != nil {
 		return err
 	}
@@ -46,7 +50,11 @@ func VerifyIdentity(ctx context.Context, info *Info, src, dest string) (err erro
 			err = fmt.Errorf("close block device: %w", closeErr)
 		}
 	}()
-	devB, err := info.detectFunc(ctx, dest, true, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
+	escB, err := privilege.New(ctx, zap.NewNop())
+	if err != nil {
+		return err
+	}
+	devB, err := info.detectFunc(ctx, dest, true, true, "", "", "", "", 0, 0, escB, zap.NewNop(), NewRunner())
 	if err != nil {
 		return err
 	}

--- a/device/info.go
+++ b/device/info.go
@@ -192,7 +192,11 @@ func (i *Info) SizeBytes(ctx context.Context, path string) (size uint64, err err
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	dev, err := i.detectFunc(ctx, path, true, true, "", "", "", "", 0, 0, privilege.New(ctx, zap.NewNop()), zap.NewNop(), NewRunner())
+	esc, err := privilege.New(ctx, zap.NewNop())
+	if err != nil {
+		return 0, err
+	}
+	dev, err := i.detectFunc(ctx, path, true, true, "", "", "", "", 0, 0, esc, zap.NewNop(), NewRunner())
 	if err != nil {
 		return 0, err
 	}

--- a/device/raw.go
+++ b/device/raw.go
@@ -139,7 +139,11 @@ func OpenRaw(
 	runner *Runner,
 ) (_ *RawDevice, err error) {
 	if esc == nil {
-		esc = privilege.New(ctx, logger)
+		var err error
+		esc, err = privilege.New(ctx, logger)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := esc.Ensure(ctx); err != nil {
 		return nil, err

--- a/internal/lvm/agent.go
+++ b/internal/lvm/agent.go
@@ -40,7 +40,11 @@ func NewAgent(lvm lvmlib.API, esc privilege.Escalator, logger *zap.Logger) Agent
 		logger = zap.NewNop()
 	}
 	if esc == nil {
-		esc = privilege.New(context.Background(), logger)
+		var err error
+		esc, err = privilege.New(context.Background(), logger)
+		if err != nil {
+			panic("privilege.New: " + err.Error())
+		}
 	}
 	return &agent{esc: esc, lvm: lvm}
 }

--- a/internal/lvm/agent_test.go
+++ b/internal/lvm/agent_test.go
@@ -249,7 +249,11 @@ func TestAgentIsMounted(t *testing.T) {
 // TestNewSudoAgent requires root or appropriate capabilities.
 func TestNewSudoAgent(t *testing.T) {
 	ctx := context.Background()
-	if err := privilege.New(context.Background(), zap.NewNop()).Ensure(ctx); err != nil {
+	esc, err := privilege.New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
+	if err := esc.Ensure(ctx); err != nil {
 		t.Skipf("requires root: %v", err)
 	}
 	mock := &mockLVM{exists: true}
@@ -263,7 +267,11 @@ func TestNewSudoAgent(t *testing.T) {
 // TestNewSudoAgentNilAPI requires root or appropriate capabilities.
 func TestNewSudoAgentNilAPI(t *testing.T) {
 	ctx := context.Background()
-	if err := privilege.New(context.Background(), zap.NewNop()).Ensure(ctx); err != nil {
+	esc, err := privilege.New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
+	if err := esc.Ensure(ctx); err != nil {
 		t.Skipf("requires root: %v", err)
 	}
 	a := NewSudoAgent("", nil, nil, zap.NewNop())

--- a/internal/privilege/ensure_root_test.go
+++ b/internal/privilege/ensure_root_test.go
@@ -22,7 +22,10 @@ func TestEnsureSudoTrue(t *testing.T) {
 	requireSudo(t)
 	privilege.HasCaps = func() bool { return false }
 	defer func() { privilege.HasCaps = privilege.RealHasCaps }()
-	esc := privilege.New(context.Background(), zap.NewNop())
+	esc, err := privilege.New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	if err := esc.Ensure(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,8 +53,11 @@ func TestEnsureSudoErrorsExitCode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			privilege.HasCaps = func() bool { return false }
 			defer func() { privilege.HasCaps = privilege.RealHasCaps }()
-			esc := privilege.NewWithRunner(context.Background(), tt.runner, zap.NewNop())
-			err := esc.Ensure(context.Background())
+			esc, err := privilege.NewWithRunner(context.Background(), tt.runner, zap.NewNop())
+			if err != nil {
+				t.Fatalf("privilege.NewWithRunner: %v", err)
+			}
+			err = esc.Ensure(context.Background())
 			if err == nil {
 				t.Fatalf("expected error")
 			}

--- a/internal/privilege/escalate_test.go
+++ b/internal/privilege/escalate_test.go
@@ -28,7 +28,11 @@ func fakeLookPath(err error) func(string) (string, error) {
 
 func TestEnsureWithCaps(t *testing.T) {
 	HasCaps = func() bool { return true }
-	esc := New(context.Background(), zap.NewNop()).(*sudoEscalator)
+	escInt, err := New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
+	esc := escInt.(*sudoEscalator)
 	if esc.useSudo {
 		t.Fatalf("expected capabilities to be used")
 	}
@@ -42,7 +46,11 @@ func TestEnsureWithSudo(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(context.Background(), r, zap.NewNop()).(*sudoEscalator)
+	escInt, err := NewWithRunner(context.Background(), r, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
+	esc := escInt.(*sudoEscalator)
 	if !esc.useSudo {
 		t.Fatalf("expected sudo usage")
 	}
@@ -53,7 +61,11 @@ func TestEnsureWithSudo(t *testing.T) {
 
 func TestEnsureNoSudo(t *testing.T) {
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(context.Background(), &Runner{LookPath: fakeLookPath(errors.New("missing"))}, zap.NewNop()).(*sudoEscalator)
+	escInt, err := NewWithRunner(context.Background(), &Runner{LookPath: fakeLookPath(errors.New("missing"))}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
+	esc := escInt.(*sudoEscalator)
 	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -61,13 +73,19 @@ func TestEnsureNoSudo(t *testing.T) {
 
 func TestCommand(t *testing.T) {
 	HasCaps = func() bool { return false }
-	esc := New(context.Background(), zap.NewNop())
+	esc, err := New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	cmd := esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] != "sudo" {
 		t.Fatalf("expected sudo prefix")
 	}
 	HasCaps = func() bool { return true }
-	esc = New(context.Background(), zap.NewNop())
+	esc, err = New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	cmd = esc.Command(context.Background(), "echo", "hi")
 	if cmd.Args[0] == "sudo" {
 		t.Fatalf("unexpected sudo prefix")
@@ -77,7 +95,10 @@ func TestCommand(t *testing.T) {
 func TestCommandLogs(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
-	esc := New(context.Background(), logger)
+	esc, err := New(context.Background(), logger)
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	esc.Command(context.Background(), "cmd", "--password=foo", "--token", "bar")
 	entries := logs.All()
 	if len(entries) != 1 {
@@ -100,7 +121,11 @@ func TestEnsureSudoFailure(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(context.Background(), r, zap.NewNop()).(*sudoEscalator)
+	escInt, err := NewWithRunner(context.Background(), r, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
+	esc := escInt.(*sudoEscalator)
 	if err := esc.Ensure(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -129,9 +154,13 @@ func requireSudo(t *testing.T) {
 func TestSudoSuccess(t *testing.T) {
 	requireSudo(t)
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
+	escInt, err := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(0)(name, args...)
 	})}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
+	esc := escInt
 	cmd := esc.Command(context.Background(), "echo")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -141,11 +170,15 @@ func TestSudoSuccess(t *testing.T) {
 func TestSudoPermissionDenied(t *testing.T) {
 	requireSudo(t)
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
+	escInt, err := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(1)(name, args...)
 	})}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
+	esc := escInt
 	cmd := esc.Command(context.Background(), "echo")
-	err := cmd.Run()
+	err = cmd.Run()
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -157,11 +190,15 @@ func TestSudoPermissionDenied(t *testing.T) {
 func TestSudoCommandNotFound(t *testing.T) {
 	requireSudo(t)
 	HasCaps = func() bool { return false }
-	esc := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
+	escInt, err := NewWithRunner(context.Background(), &Runner{Cmd: cmdFunc(func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return fakeSudo(127)(name, args...)
 	})}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
+	esc := escInt
 	cmd := esc.Command(context.Background(), "echo")
-	err := cmd.Run()
+	err = cmd.Run()
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -191,10 +228,13 @@ func TestEnsureContextCanceled(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(context.Background(), r, zap.NewNop())
+	esc, err := NewWithRunner(context.Background(), r, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	err := esc.Ensure(ctx)
+	err = esc.Ensure(ctx)
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
@@ -219,12 +259,15 @@ func TestEnsureEscalatorContextCanceled(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
 	}), LookPath: fakeLookPath(nil)}
-	esc := NewWithRunner(parent, r, zap.NewNop())
+	esc, err := NewWithRunner(parent, r, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
 	go func() {
 		time.Sleep(10 * time.Millisecond)
 		cancel()
 	}()
-	err := esc.Ensure(context.Background())
+	err = esc.Ensure(context.Background())
 	if err == nil || parent.Err() != context.Canceled {
 		t.Fatalf("expected context canceled, got err=%v ctxErr=%v", err, parent.Err())
 	}
@@ -251,8 +294,11 @@ func TestEnsureDefaultTimeout(t *testing.T) {
 	r := &Runner{Cmd: cmdFunc(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "sleep", "10")
 	}), LookPath: fakeLookPath(nil), Timeout: 10 * time.Millisecond}
-	esc := NewWithRunner(context.Background(), r, zap.NewNop())
-	err := esc.Ensure(context.Background())
+	esc, err := NewWithRunner(context.Background(), r, zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.NewWithRunner: %v", err)
+	}
+	err = esc.Ensure(context.Background())
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}

--- a/internal/privilege/runner.go
+++ b/internal/privilege/runner.go
@@ -2,6 +2,7 @@ package privilege
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"time"
 
@@ -30,22 +31,22 @@ type Runner struct {
 // New returns an Escalator with production dependencies. The provided context
 // is stored on the Escalator and used when invoking external commands so
 // callers can cancel operations.
-func New(ctx context.Context, logger *zap.Logger) Escalator {
+func New(ctx context.Context, logger *zap.Logger) (Escalator, error) {
 	return NewWithRunner(ctx, nil, logger)
 }
 
 // NewWithRunner constructs an Escalator with the provided Runner.
 // Nil fields default to exec.CommandContext and exec.LookPath.
-func NewWithRunner(ctx context.Context, r *Runner, logger *zap.Logger) Escalator {
+func NewWithRunner(ctx context.Context, r *Runner, logger *zap.Logger) (Escalator, error) {
 	if logger == nil {
-		logger = zap.NewNop()
+		return nil, errors.New("logger is nil")
 	}
 	if r == nil {
 		r = &Runner{Logger: logger}
 	} else if r.Logger == nil {
 		r.Logger = logger
 	}
-	return newEscalator(ctx, r, false)
+	return newEscalator(ctx, r, false), nil
 }
 
 // NewWithSanitize constructs an Escalator that optionally sanitizes the

--- a/internal/privilege/runner_test.go
+++ b/internal/privilege/runner_test.go
@@ -2,6 +2,7 @@ package privilege
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -35,5 +36,11 @@ func TestNewWithRunnerAndSanitize(t *testing.T) {
 	}
 	if esc.runner.Logger != r.Logger {
 		t.Fatalf("logger not propagated")
+	}
+}
+
+func TestNewNilLogger(t *testing.T) {
+	if _, err := New(context.Background(), nil); err == nil || !strings.Contains(err.Error(), "logger is nil") {
+		t.Fatalf("expected nil logger error, got %v", err)
 	}
 }

--- a/internal/privilege/sudo_integration_test.go
+++ b/internal/privilege/sudo_integration_test.go
@@ -12,7 +12,10 @@ import (
 func TestEnsureRealSudo(t *testing.T) {
 	requireSudo(t)
 	HasCaps = func() bool { return false }
-	esc := New(context.Background(), zap.NewNop())
+	esc, err := New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	if err := esc.Ensure(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -21,7 +24,10 @@ func TestEnsureRealSudo(t *testing.T) {
 func TestSudoCommandRealSuccess(t *testing.T) {
 	requireSudo(t)
 	HasCaps = func() bool { return false }
-	esc := New(context.Background(), zap.NewNop())
+	esc, err := New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	cmd := esc.Command(context.Background(), "true")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -31,9 +37,12 @@ func TestSudoCommandRealSuccess(t *testing.T) {
 func TestSudoCommandRealFailure(t *testing.T) {
 	requireSudo(t)
 	HasCaps = func() bool { return false }
-	esc := New(context.Background(), zap.NewNop())
+	esc, err := New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	cmd := esc.Command(context.Background(), "false")
-	err := cmd.Run()
+	err = cmd.Run()
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -45,7 +54,10 @@ func TestSudoCommandRealFailure(t *testing.T) {
 func TestSudoCommandNonInteractive(t *testing.T) {
 	requireSudo(t)
 	HasCaps = func() bool { return false }
-	esc := New(context.Background(), zap.NewNop())
+	esc, err := New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	cmd := esc.Command(context.Background(), "true")
 	if len(cmd.Args) < 2 || cmd.Args[1] != "-n" {
 		t.Fatalf("expected -n flag, got args %v", cmd.Args)
@@ -59,7 +71,10 @@ func TestEnsureMissingSudo(t *testing.T) {
 	requireSudo(t)
 	t.Setenv("PATH", "/nonexistent")
 	HasCaps = func() bool { return false }
-	esc := New(context.Background(), zap.NewNop())
+	esc, err := New(context.Background(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("privilege.New: %v", err)
+	}
 	if err := esc.Ensure(context.Background()); err == nil || !strings.Contains(err.Error(), "sudo not found") {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -95,7 +95,11 @@ func defaultIndexOptions() indexOptions {
 			ctx = device.WithForce(ctx, true)
 			ctx = device.WithAllowOverwrite(ctx, true)
 			ctx = device.WithYesIKnow(ctx, true)
-			return device.Detect(ctx, path, true, true, "", "", "", "", 0, 0, privilege.New(ctx, logger), logger, device.NewRunner())
+			esc, err := privilege.New(ctx, logger)
+			if err != nil {
+				return nil, err
+			}
+			return device.Detect(ctx, path, true, true, "", "", "", "", 0, 0, esc, logger, device.NewRunner())
 		},
 		closeHook: func() error { return nil },
 		info:      device.NewInfo(),

--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -58,7 +58,11 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 	stream = rsyncwire.NewStream(rw, rsyncMaxFrame)
 	cl := rsyncwire.NewClient(stream)
 	// Send destination identity to allow early mismatch detection.
-	dev, err := device.Detect(ctx, origin, true, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
+	esc, err := privilege.New(ctx, t.Logger)
+	if err != nil {
+		return fmt.Errorf("detect origin: %w", err)
+	}
+	dev, err := device.Detect(ctx, origin, true, true, "", "", "", "", 0, 0, esc, t.Logger, device.NewRunner())
 	if err != nil {
 		return fmt.Errorf("detect origin: %w", err)
 	}

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -293,7 +293,11 @@ func (t *Transfer) verifyDestination(ctx context.Context, cfg *config.Config, de
 	if cfg.ResumeState != "" && strings.ToLower(cfg.VerifyLevel) != "none" {
 		cfg.ResumeVerify = true
 	}
-	dev, err := device.Detect(ctx, destPath, true, true, "", "", "", "", 0, 0, privilege.New(ctx, t.Logger), t.Logger, device.NewRunner())
+	esc, err := privilege.New(ctx, t.Logger)
+	if err != nil {
+		return 0, "", 0, err
+	}
+	dev, err := device.Detect(ctx, destPath, true, true, "", "", "", "", 0, 0, esc, t.Logger, device.NewRunner())
 	if err != nil {
 		return 0, "", 0, err
 	}


### PR DESCRIPTION
## Summary
- require callers to provide a logger in privilege constructors and return errors when missing
- adjust callers to handle constructor errors and ensure non-nil loggers
- test nil-logger path in privilege runner

## Testing
- `go build -v ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: numerous errcheck and style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0d4c817483239c94150dc6f25130