### PR TITLE
refactor: add Discarder struct

### DIFF
--- a/device/discard_linux.go
+++ b/device/discard_linux.go
@@ -30,23 +30,31 @@ func blkdiscard(f *os.File, offset, length uint64, sanitize, noNewPrivs bool, lo
 	return nil
 }
 
-var discardImpl = blkdiscard
+// Discarder issues block discard operations using a configurable implementation.
+type Discarder struct {
+	fn func(*os.File, uint64, uint64, bool, bool, *zap.Logger) error
+}
 
-// SetDiscardFunc overrides the discard implementation. It returns a restore function.
-func SetDiscardFunc(fn func(*os.File, uint64, uint64, bool, bool, *zap.Logger) error) func() {
-	orig := discardImpl
+// NewDiscarder returns a Discarder that uses the real blkdiscard implementation.
+func NewDiscarder() *Discarder {
+	return &Discarder{fn: blkdiscard}
+}
+
+// NewDiscarderWithFunc returns a Discarder that uses fn. If fn is nil, blkdiscard is used.
+func NewDiscarderWithFunc(fn func(*os.File, uint64, uint64, bool, bool, *zap.Logger) error) *Discarder {
 	if fn == nil {
-		discardImpl = blkdiscard
-	} else {
-		discardImpl = fn
+		fn = blkdiscard
 	}
-	return func() { discardImpl = orig }
+	return &Discarder{fn: fn}
 }
 
 // DiscardRange issues BLKDISCARD for the specified range on f. logger must be non-nil.
-func DiscardRange(f *os.File, offset, length uint64, sanitize, noNewPrivs bool, logger *zap.Logger) error {
+func (d *Discarder) DiscardRange(f *os.File, offset, length uint64, sanitize, noNewPrivs bool, logger *zap.Logger) error {
+	if d == nil {
+		return fmt.Errorf("discarder is nil")
+	}
 	if logger == nil {
 		return fmt.Errorf("logger is nil")
 	}
-	return discardImpl(f, offset, length, sanitize, noNewPrivs, logger)
+	return d.fn(f, offset, length, sanitize, noNewPrivs, logger)
 }

--- a/device/discard_linux_test.go
+++ b/device/discard_linux_test.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestDiscardRangeStubAndRestore(t *testing.T) {
+func TestDiscardRangeCustomFunc(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "discard")
 	if err != nil {
 		t.Fatalf("temp file: %v", err)
@@ -19,7 +19,7 @@ func TestDiscardRangeStubAndRestore(t *testing.T) {
 
 	stubErr := errors.New("stub discard error")
 	calls := 0
-	restore := SetDiscardFunc(func(got *os.File, off, length uint64, sanitize, noNewPrivs bool, _ *zap.Logger) error {
+	d := NewDiscarderWithFunc(func(got *os.File, off, length uint64, sanitize, noNewPrivs bool, _ *zap.Logger) error {
 		calls++
 		if got != f || off != 123 || length != 456 || sanitize || noNewPrivs {
 			t.Errorf("unexpected args: %v %d %d %v %v", got.Name(), off, length, sanitize, noNewPrivs)
@@ -27,7 +27,7 @@ func TestDiscardRangeStubAndRestore(t *testing.T) {
 		return stubErr
 	})
 
-	err = DiscardRange(f, 123, 456, false, false, zap.NewNop())
+	err = d.DiscardRange(f, 123, 456, false, false, zap.NewNop())
 	if !errors.Is(err, stubErr) {
 		t.Fatalf("expected stub error, got %v", err)
 	}
@@ -35,14 +35,12 @@ func TestDiscardRangeStubAndRestore(t *testing.T) {
 		t.Fatalf("expected stub to be called once, got %d", calls)
 	}
 
-	restore()
-
-	err = DiscardRange(f, 123, 456, false, false, zap.NewNop())
+	err = NewDiscarder().DiscardRange(f, 123, 456, false, false, zap.NewNop())
 	if err == nil || errors.Is(err, stubErr) {
-		t.Fatalf("expected non-stub error after restore, got %v", err)
+		t.Fatalf("expected non-stub error, got %v", err)
 	}
 	if calls != 1 {
-		t.Fatalf("stub called after restore: %d", calls)
+		t.Fatalf("stub called unexpectedly: %d", calls)
 	}
 }
 
@@ -52,7 +50,8 @@ func TestDiscardRangeNilLogger(t *testing.T) {
 		t.Fatalf("temp file: %v", err)
 	}
 	defer func() { _ = f.Close() }()
-	if err := DiscardRange(f, 0, 0, false, false, nil); err == nil {
+	d := NewDiscarder()
+	if err := d.DiscardRange(f, 0, 0, false, false, nil); err == nil {
 		t.Fatalf("expected error when logger is nil")
 	}
 }

--- a/device/discard_loop_test.go
+++ b/device/discard_loop_test.go
@@ -35,7 +35,8 @@ func TestDiscardLoopDevice(t *testing.T) {
 	}
 
 	hadCaps := privilege.RealHasCaps()
-	if err := DiscardRange(f, 0, uint64(len(data)), true, false, zap.NewNop()); err != nil {
+	d := NewDiscarder()
+	if err := d.DiscardRange(f, 0, uint64(len(data)), true, false, zap.NewNop()); err != nil {
 		t.Fatalf("discard: %v", err)
 	}
 

--- a/transfer/block_writer.go
+++ b/transfer/block_writer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 	"lvmsync_go/internal/sizeparse"
 )
@@ -29,6 +30,7 @@ type blockWriter struct {
 	deps      *Deps
 	wal       *WAL
 	applied   []Range
+	discarder *device.Discarder
 }
 
 // newBlockWriter constructs a blockWriter, detecting the destination's physical
@@ -62,15 +64,16 @@ func newBlockWriterWithDeps(cfg *config.Config, dest *os.File, dedup Deduplicati
 		cfg.SyncIntervalBytes = int(val)
 	}
 	bw := &blockWriter{
-		cfg:      cfg,
-		dest:     dest,
-		dedup:    dedup,
-		verify:   verify,
-		checksum: checksum,
-		logger:   logger,
-		deps:     deps,
-		wal:      wal,
-		applied:  applied,
+		cfg:       cfg,
+		dest:      dest,
+		dedup:     dedup,
+		verify:    verify,
+		checksum:  checksum,
+		logger:    logger,
+		deps:      deps,
+		wal:       wal,
+		applied:   applied,
+		discarder: device.NewDiscarder(),
 	}
 	if cfg.IntraDedup {
 		bw.intra = newChunkCache(intraCacheCapacity)
@@ -135,7 +138,7 @@ func (bw *blockWriter) write(reader *bufio.Reader) (int64, error) {
 		} else {
 			chunkID = zeroHash(int(chunkSize))
 		}
-		written, zlen, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.intra, bw.verify, bw.checksum, offset, crc, transmitted, data, chunkSize, bw.logger, bw.wal)
+		written, zlen, err := processBlock(bw.cfg, bw.dest, bw.dedup, bw.intra, bw.verify, bw.checksum, offset, crc, transmitted, data, chunkSize, bw.logger, bw.wal, bw.discarder)
 		if bw.cfg.ODirect {
 			if data != nil {
 				putAlignedBlockBuffer(data)

--- a/transfer/discard_test.go
+++ b/transfer/discard_test.go
@@ -18,17 +18,16 @@ func TestProcessBlockDiscard(t *testing.T) {
 	}
 	defer f.Close()
 	called := false
-	restore := device.SetDiscardFunc(func(_ *os.File, off, length uint64, sanitize, noNewPrivs bool, _ *zap.Logger) error {
+	d := device.NewDiscarderWithFunc(func(_ *os.File, off, length uint64, sanitize, noNewPrivs bool, _ *zap.Logger) error {
 		called = true
 		if off != 0 || length != 4 || sanitize || noNewPrivs {
 			t.Errorf("unexpected params: off=%d len=%d sanitize=%v noNewPrivs=%v", off, length, sanitize, noNewPrivs)
 		}
 		return nil
 	})
-	defer restore()
 	data := []byte("abcd")
 	crc := crc32c(data)
-	if written, _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil || !written {
+	if written, _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil, d); err != nil || !written {
 		t.Fatalf("processBlock: %v written=%v", err, written)
 	}
 	if !called {
@@ -44,14 +43,13 @@ func TestProcessBlockDiscardDisabled(t *testing.T) {
 	}
 	defer f.Close()
 	called := false
-	restore := device.SetDiscardFunc(func(_ *os.File, off, length uint64, sanitize, noNewPrivs bool, _ *zap.Logger) error {
+	d := device.NewDiscarderWithFunc(func(_ *os.File, off, length uint64, sanitize, noNewPrivs bool, _ *zap.Logger) error {
 		called = true
 		return nil
 	})
-	defer restore()
 	data := []byte("abcd")
 	crc := crc32c(data)
-	if _, _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil); err != nil {
+	if _, _, err := processBlock(cfg, f, nil, nil, false, nil, 0, crc, nil, data, 4, zap.NewNop(), nil, d); err != nil {
 		t.Fatalf("processBlock: %v", err)
 	}
 	if called {

--- a/transfer/intra_dedup_test.go
+++ b/transfer/intra_dedup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"lvmsync_go/device"
 	"lvmsync_go/internal/config"
 )
 
@@ -43,11 +44,12 @@ func TestProcessBlockIntraDedup(t *testing.T) {
 	defer os.Remove(f.Name())
 	data := []byte("data")
 	crc := crc32c(data)
-	written, _, err := processBlock(cfg, f, nil, cache, false, nil, 0, crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
+	d := device.NewDiscarderWithFunc(func(*os.File, uint64, uint64, bool, bool, *zap.Logger) error { return nil })
+	written, _, err := processBlock(cfg, f, nil, cache, false, nil, 0, crc, nil, data, uint32(len(data)), zap.NewNop(), nil, d)
 	if err != nil || !written {
 		t.Fatalf("first write %v %v", written, err)
 	}
-	written, _, err = processBlock(cfg, f, nil, cache, false, nil, uint64(len(data)), crc, nil, data, uint32(len(data)), zap.NewNop(), nil)
+	written, _, err = processBlock(cfg, f, nil, cache, false, nil, uint64(len(data)), crc, nil, data, uint32(len(data)), zap.NewNop(), nil, d)
 	if err != nil {
 		t.Fatalf("second write err %v", err)
 	}

--- a/transfer/writer.go
+++ b/transfer/writer.go
@@ -137,6 +137,7 @@ func processBlock(
 	chunkSize uint32,
 	logger *zap.Logger,
 	wal *WAL,
+	discarder *device.Discarder,
 ) (bool, uint64, error) {
 	if offset > math.MaxInt64 {
 		return false, 0, fmt.Errorf("offset %d overflows int64", offset)
@@ -169,7 +170,10 @@ func processBlock(
 		}
 	}
 	if cfg.Discard {
-		if err := device.DiscardRange(destFile, offset, uint64(chunkSize), cfg.SanitizeEnv, cfg.NoNewPrivs, logger); err != nil {
+		if discarder == nil {
+			return false, 0, fmt.Errorf("discarder is nil")
+		}
+		if err := discarder.DiscardRange(destFile, offset, uint64(chunkSize), cfg.SanitizeEnv, cfg.NoNewPrivs, logger); err != nil {
 			logger.Debug("discard failed", zap.Error(err))
 		}
 	}


### PR DESCRIPTION
## Summary
- encapsulate blkdiscard with a new Discarder type and constructors for production and tests
- require a Discarder in transfer processing and update blockWriter to hold one
- update tests to inject mock discarders

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: 496 issues; errcheck, revive, gocritic, staticcheck)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ac9c64c83238ad7d788ee0f30da