### PR TITLE
refactor: add EscalationChecker for lvm privilege verification

### DIFF
--- a/device/detect_helpers_test.go
+++ b/device/detect_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -51,7 +52,7 @@ func TestDetectFileDeviceError(t *testing.T) {
 }
 
 func TestDetectLVMDeviceSuccess(t *testing.T) {
-	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	restore := lvm.SetEscalationChecker(lvm.NewEscalationCheckerWithDeps(nil, func() int { return 0 }))
 	defer restore()
 	core, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
@@ -80,7 +81,7 @@ func TestDetectLVMDeviceSuccess(t *testing.T) {
 }
 
 func TestDetectLVMDeviceError(t *testing.T) {
-	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	restore := lvm.SetEscalationChecker(lvm.NewEscalationCheckerWithDeps(nil, func() int { return 0 }))
 	defer restore()
 	runner := NewRunner()
 	runner.openLVMOverride = func(context.Context, string, *lvm.FDCache, bool, bool, string, *zap.Logger) (*LVMDevice, error) {
@@ -92,7 +93,12 @@ func TestDetectLVMDeviceError(t *testing.T) {
 }
 
 func TestDetectLVMDeviceEscalationError(t *testing.T) {
-	restore := lvm.SetEscalationChecker(func(string) error { return errors.New("escalate fail") })
+	restore := lvm.SetEscalationChecker(
+		lvm.NewEscalationCheckerWithDeps(
+			func(string, ...string) *exec.Cmd { return exec.Command("false") },
+			func() int { return 1 },
+		),
+	)
 	defer restore()
 	runner := NewRunner()
 	called := false

--- a/device/lvm_test.go
+++ b/device/lvm_test.go
@@ -195,7 +195,7 @@ func TestOpenLVMSnapshotAllowed(t *testing.T) {
 
 func TestRunLVMPrivilegeEscalation(t *testing.T) {
 	ctx := context.Background()
-	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	restore := lvm.SetEscalationChecker(lvm.NewEscalationCheckerWithDeps(nil, func() int { return 0 }))
 	defer restore()
 	var gotName string
 	var gotArgs []string
@@ -218,7 +218,7 @@ func TestRunLVMPrivilegeEscalation(t *testing.T) {
 
 func TestRunLVMPrivilegeEscalationQuoted(t *testing.T) {
 	ctx := context.Background()
-	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	restore := lvm.SetEscalationChecker(lvm.NewEscalationCheckerWithDeps(nil, func() int { return 0 }))
 	defer restore()
 	var gotName string
 	var gotArgs []string

--- a/device/snapshot_test.go
+++ b/device/snapshot_test.go
@@ -144,7 +144,7 @@ func TestSnapshotCleanupLogsFailure(t *testing.T) {
 		}
 		return exec.CommandContext(ctx, "true")
 	})
-	restore := lvm.SetEscalationChecker(func(string) error { return nil })
+	restore := lvm.SetEscalationChecker(lvm.NewEscalationCheckerWithDeps(nil, func() int { return 0 }))
 	defer restore()
 	runner := NewDeviceRunner(cmd)
 	runner.openLVMOverride = func(ctx context.Context, p string, _ *lvm.FDCache, _ bool, _ bool, _ string, _ *zap.Logger) (*LVMDevice, error) {

--- a/lvm/escalation.go
+++ b/lvm/escalation.go
@@ -9,11 +9,27 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
-// execCommand is used for running external commands and can be overridden in tests.
-var execCommand = exec.Command
+// EscalationChecker validates that an escalation command is available.
+type EscalationChecker struct {
+	execCommand func(string, ...string) *exec.Cmd
+	geteuid     func() int
+}
 
-// geteuid returns the effective user ID; overridable for tests.
-var geteuid = os.Geteuid
+// NewEscalationChecker returns an EscalationChecker using real OS functions.
+func NewEscalationChecker() *EscalationChecker {
+	return NewEscalationCheckerWithDeps(exec.Command, os.Geteuid)
+}
+
+// NewEscalationCheckerWithDeps allows tests to inject dependencies.
+func NewEscalationCheckerWithDeps(execCommand func(string, ...string) *exec.Cmd, geteuid func() int) *EscalationChecker {
+	if execCommand == nil {
+		execCommand = exec.Command
+	}
+	if geteuid == nil {
+		geteuid = os.Geteuid
+	}
+	return &EscalationChecker{execCommand: execCommand, geteuid: geteuid}
+}
 
 // ParseEscalation splits the escalation command using shell-style quoting and
 // rejects unsafe characters. It returns an error if the command is empty or
@@ -36,15 +52,15 @@ func ParseEscalation(escalation string) ([]string, error) {
 }
 
 // verifyEscalation checks that the escalation command succeeds when not running as root.
-func verifyEscalation(escalation string) error {
-	if geteuid() == 0 {
+func (e *EscalationChecker) verifyEscalation(escalation string) error {
+	if e.geteuid() == 0 {
 		return nil
 	}
 	parts, err := ParseEscalation(escalation)
 	if err != nil {
 		return fmt.Errorf("insufficient privileges: %w", err)
 	}
-	cmd := execCommand(parts[0], append(parts[1:], "true")...)
+	cmd := e.execCommand(parts[0], append(parts[1:], "true")...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("escalation command failed: %s: %w", strings.TrimSpace(string(out)), err)
@@ -52,19 +68,27 @@ func verifyEscalation(escalation string) error {
 	return nil
 }
 
-var checkEscalation = verifyEscalation
-
 // VerifyEscalationCommand validates that the escalation command is available.
-func VerifyEscalationCommand(escalation string) error { return checkEscalation(escalation) }
+func (e *EscalationChecker) VerifyEscalationCommand(escalation string) error {
+	return e.verifyEscalation(escalation)
+}
 
-// SetEscalationChecker overrides the default escalation check function. It returns
-// a restore function to reset the original behavior.
-func SetEscalationChecker(fn func(string) error) func() {
-	orig := checkEscalation
-	if fn == nil {
-		checkEscalation = verifyEscalation
+var defaultEscalationChecker = NewEscalationChecker()
+
+// VerifyEscalationCommand validates that the escalation command is available using
+// the default EscalationChecker instance.
+func VerifyEscalationCommand(escalation string) error {
+	return defaultEscalationChecker.VerifyEscalationCommand(escalation)
+}
+
+// SetEscalationChecker overrides the default EscalationChecker. It returns a
+// restore function to reset the original behavior.
+func SetEscalationChecker(c *EscalationChecker) func() {
+	orig := defaultEscalationChecker
+	if c == nil {
+		defaultEscalationChecker = NewEscalationChecker()
 	} else {
-		checkEscalation = fn
+		defaultEscalationChecker = c
 	}
-	return func() { checkEscalation = orig }
+	return func() { defaultEscalationChecker = orig }
 }

--- a/lvm/escalation_test.go
+++ b/lvm/escalation_test.go
@@ -34,18 +34,16 @@ func TestParseEscalation(t *testing.T) {
 func TestVerifyEscalationCommandSplit(t *testing.T) {
 	var name string
 	var args []string
-	origExec := execCommand
-	execCommand = func(n string, a ...string) *exec.Cmd {
-		name = n
-		args = append([]string(nil), a...)
-		return exec.Command("true")
-	}
-	defer func() { execCommand = origExec }()
-	origUID := geteuid
-	geteuid = func() int { return 1 }
-	defer func() { geteuid = origUID }()
+	checker := NewEscalationCheckerWithDeps(
+		func(n string, a ...string) *exec.Cmd {
+			name = n
+			args = append([]string(nil), a...)
+			return exec.Command("true")
+		},
+		func() int { return 1 },
+	)
 	esc := "\"/usr/bin/sudo wrapper\" -p 'my prompt' -n"
-	if err := VerifyEscalationCommand(esc); err != nil {
+	if err := checker.VerifyEscalationCommand(esc); err != nil {
 		t.Fatalf("VerifyEscalationCommand: %v", err)
 	}
 	wantArgs := []string{"-p", "my prompt", "-n", "true"}


### PR DESCRIPTION
## Summary
- introduce EscalationChecker struct with injectable execCommand and geteuid
- rework VerifyEscalationCommand to use EscalationChecker and add constructors
- update tests to inject mock EscalationChecker

## Testing
- `go build -v ./...`
- `go test -cover ./lvm ./device`
- `go test -coverprofile=coverage.out ./lvm`
- `go tool cover -func=coverage.out`
- `golangci-lint run` *(fails: 496 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ac7df748323814533256063416b