### PR TITLE
docs: document rsync build tag requirement and test in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -147,3 +147,23 @@ jobs:
 
       - name: Docs check
         run: make docs-check
+
+  rsync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24' }}"
+          cache: true
+
+      - name: Build with rsync tag
+        run: go build -tags rsync ./...
+
+      - name: Test with rsync tag
+        run: go test -tags rsync ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -183,3 +183,26 @@ jobs:
           name: reports-${{ matrix.os }}
           path: reports
           if-no-files-found: ignore
+
+  rsync:
+    runs-on: ubuntu-24.04
+    env:
+      GO111MODULE: "on"
+      CGO_ENABLED: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "${{ vars.GO_VERSION || '1.24.x' }}"
+          cache: true
+
+      - name: Build with rsync tag
+        run: go build -tags rsync ./...
+
+      - name: Test with rsync tag
+        run: go test -tags rsync ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,7 @@ lvmsync --compress auto --zstd-level 2 --compress-threshold 0.85
 
 - Tags follow `vX.Y.Z` semantic versioning.
 - Pushing a tag triggers `.github/workflows/release.yml` which builds and publishes artifacts.
+- Release binaries omit the `rsync` transport unless built with `GOFLAGS='-tags rsync'`.
 - Each release must include a `CHANGELOG.md` entry using the [Keep a Changelog](https://keepachangelog.com/) format:
 
   ```markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- docs: note rsync transport and tests require building with `-tags rsync`
+- ci: build and test rsync transport with the `rsync` tag in CI
 - docs: document snapshot cleanup, resume, and verify-only rollback procedures in docs/danger_rollback.md
 - device: split Detect into detectFileDevice, detectLVMDevice, and detectRawDevice helpers with dedicated tests
 - device: detect LVM, raw, or file devices using blkid metadata

--- a/README.md
+++ b/README.md
@@ -786,6 +786,10 @@ SSH transport negotiation also derives read and write deadlines from the caller'
   lvmsync run --delta=rsync --dedup-strategy bloom --compress lz4 --transport rsync --allow-insecure --dry-run /tmp/src /tmp/dst
   ```
 
+  The rsync transport is excluded from binaries by default. Compile with
+  `go build -tags rsync` (and run tests with `go test -tags rsync`) to enable
+  it.
+
 - **Throughput-optimized transfer**:
 
   ```sh

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -148,3 +148,6 @@ lvmsync run --transport h2 --concurrency 64 --tcp-parallel 4 --tcp-lowat 1048576
 - Security: traffic is unencrypted and unauthenticated. `--allow-insecure` must be set and connections should only run on trusted networks or within secure tunnels
 - Enabling the transport logs a warning noting the plaintext connection
 - Flags: `--transport rsync` selects this transport and requires `--allow-insecure`
+
+This transport is disabled unless the binary is built with `-tags rsync`.
+Run tests with the same tag to exercise rsync functionality.


### PR DESCRIPTION
## Summary
- document that rsync transport and tests require building with `-tags rsync`
- note in release workflow that rsync support needs `GOFLAGS='-tags rsync'`
- add CI jobs to build and test with the rsync tag

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `golangci-lint run` *(fails: 496 issues)*
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68af2e5972bc8323b890d73737bddb54