### PR TITLE
require allow insecure for rsync delta

### DIFF
--- a/cmd/dump/client.go
+++ b/cmd/dump/client.go
@@ -563,6 +563,13 @@ func (r *Runner) StreamToRemote(ctx context.Context, cfg *config.Config, remoteS
 }
 
 func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remoteStdin io.WriteCloser, snapshotDevice, originDevice, alg string, logger *zap.Logger) (err error) {
+	if !cfg.AllowInsecure {
+		remoteStdin.Close()
+		return fmt.Errorf("rsync delta requires AllowInsecure")
+	}
+
+	logger.Warn("plaintext_connection", zap.String("transport", "rsync"), zap.String("docs", "docs/transports.md"))
+
 	snap, err := r.openFile(snapshotDevice, os.O_RDONLY, 0)
 	if err != nil {
 		return fmt.Errorf("open snapshot: %w", err)
@@ -574,8 +581,6 @@ func (r *Runner) streamRsyncDelta(ctx context.Context, cfg *config.Config, remot
 		return fmt.Errorf("open origin: %w", err)
 	}
 	defer common.CloseWithErr(orig, &err, "close origin")
-
-	logger.Warn("plaintext_connection", zap.String("transport", "rsync"), zap.String("docs", "docs/transports.md"))
 
 	rw := writeOnlyReadWriter{remoteStdin}
 	cl := rsyncwire.NewClient(rsyncwire.NewStream(rw, maxFrame))

--- a/cmd/dump/rsync_delta_allow_insecure_test.go
+++ b/cmd/dump/rsync_delta_allow_insecure_test.go
@@ -1,0 +1,57 @@
+package dump
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/internal/config"
+	digestpkg "lvmsync_go/internal/digest"
+)
+
+type discardWriteCloser struct{ io.Writer }
+
+func (discardWriteCloser) Close() error { return nil }
+
+func TestRunnerStreamRsyncDeltaAllowInsecure(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Delta = "rsync"
+	cfg.ChecksumAlgorithm = digestpkg.SHA256
+
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "orig")
+	snap := filepath.Join(dir, "snap")
+	data := []byte("data")
+	if err := os.WriteFile(orig, data, 0o600); err != nil {
+		t.Fatalf("write origin: %v", err)
+	}
+	if err := os.WriteFile(snap, data, 0o600); err != nil {
+		t.Fatalf("write snap: %v", err)
+	}
+
+	core1, logs1 := observer.New(zap.WarnLevel)
+	r := NewRunner()
+	if err := r.streamRsyncDelta(context.Background(), cfg, discardWriteCloser{io.Discard}, snap, orig, cfg.ChecksumAlgorithm, zap.New(core1)); err == nil {
+		t.Fatalf("expected error without AllowInsecure")
+	}
+	if entries := logs1.FilterMessage("plaintext_connection").All(); len(entries) != 0 {
+		t.Fatalf("unexpected plaintext warning")
+	}
+
+	cfg.AllowInsecure = true
+	core2, logs2 := observer.New(zap.WarnLevel)
+	if err := r.streamRsyncDelta(context.Background(), cfg, discardWriteCloser{io.Discard}, snap, orig, cfg.ChecksumAlgorithm, zap.New(core2)); err != nil {
+		t.Fatalf("streamRsyncDelta: %v", err)
+	}
+	if entries := logs2.FilterMessage("plaintext_connection").All(); len(entries) == 0 {
+		t.Fatalf("expected plaintext warning")
+	}
+}

--- a/transfer/delta.go
+++ b/transfer/delta.go
@@ -30,6 +30,12 @@ func (w writeOnlyReadWriter) Read([]byte) (int, error) { return 0, io.EOF }
 // It streams signatures and deltas followed by a digest frame.
 // When out implements io.Closer, it is closed on completion.
 func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, snapshot, origin string, out io.Writer) (err error) {
+	if !cfg.AllowInsecure {
+		return fmt.Errorf("rsync delta requires AllowInsecure")
+	}
+
+	t.Logger.Warn("plaintext_connection", zap.String("transport", "rsync"), zap.String("docs", "docs/transports.md"))
+
 	snap, err := os.Open(snapshot)
 	if err != nil {
 		return fmt.Errorf("open snapshot: %w", err)
@@ -41,8 +47,6 @@ func (t *Transfer) streamRsyncDelta(ctx context.Context, cfg *config.Config, sna
 		return fmt.Errorf("open origin: %w", err)
 	}
 	defer common.CloseWithErr(orig, &err, "close origin")
-
-	t.Logger.Warn("plaintext_connection", zap.String("transport", "rsync"), zap.String("docs", "docs/transports.md"))
 
 	// Prefer a read/write connection so we can drain server responses
 	// before closing the stream. Fall back to a write-only wrapper when the

--- a/transfer/delta_allow_insecure_test.go
+++ b/transfer/delta_allow_insecure_test.go
@@ -1,0 +1,54 @@
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"lvmsync_go/internal/config"
+	digestpkg "lvmsync_go/internal/digest"
+)
+
+func TestStreamRsyncDeltaAllowInsecure(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Delta = "rsync"
+	cfg.ChecksumAlgorithm = digestpkg.SHA256
+
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "orig")
+	snap := filepath.Join(dir, "snap")
+	data := []byte("data")
+	if err := os.WriteFile(orig, data, 0o600); err != nil {
+		t.Fatalf("write origin: %v", err)
+	}
+	if err := os.WriteFile(snap, data, 0o600); err != nil {
+		t.Fatalf("write snap: %v", err)
+	}
+
+	core1, logs1 := observer.New(zap.WarnLevel)
+	tr := NewTransfer(zap.New(core1), nil, nil)
+	if err := tr.streamRsyncDelta(context.Background(), cfg, snap, orig, &bytes.Buffer{}); err == nil {
+		t.Fatalf("expected error without AllowInsecure")
+	}
+	if entries := logs1.FilterMessage("plaintext_connection").All(); len(entries) != 0 {
+		t.Fatalf("unexpected plaintext warning")
+	}
+
+	cfg.AllowInsecure = true
+	core2, logs2 := observer.New(zap.WarnLevel)
+	tr.Logger = zap.New(core2)
+	if err := tr.streamRsyncDelta(context.Background(), cfg, snap, orig, &bytes.Buffer{}); err != nil {
+		t.Fatalf("streamRsyncDelta: %v", err)
+	}
+	if entries := logs2.FilterMessage("plaintext_connection").All(); len(entries) == 0 {
+		t.Fatalf("expected plaintext warning")
+	}
+}


### PR DESCRIPTION
## Summary
- require --allow-insecure to run rsync delta operations
- log plaintext warning only when insecure mode is allowed
- add tests for rsync delta allow-insecure handling

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `golangci-lint run` *(fails: Error return value of `f.Close` is not checked, and more)*


------
https://chatgpt.com/codex/tasks/task_e_68af334faa6083238f2279c1d556aeb5