### PR TITLE
ci: report rsync test coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -164,6 +164,17 @@ jobs:
 
       - name: Build with rsync tag
         run: go build -tags rsync ./...
-
       - name: Test with rsync tag
-        run: go test -tags rsync ./...
+        run: go test -race -tags rsync -coverprofile=coverage-rsync.out ./...
+
+      - name: Show rsync coverage
+        if: always() && hashFiles('coverage-rsync.out') != ''
+        run: go tool cover -func=coverage-rsync.out | tail -n 1
+
+      - name: Upload rsync coverage
+        if: always() && hashFiles('coverage-rsync.out') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-rsync
+          path: coverage-rsync.out
+          if-no-files-found: error

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -203,6 +203,18 @@ jobs:
 
       - name: Build with rsync tag
         run: go build -tags rsync ./...
-
       - name: Test with rsync tag
-        run: go test -tags rsync ./...
+        run: go test -race -tags rsync -coverprofile=coverage-rsync.out ./...
+
+      - name: Show rsync coverage (summary)
+        if: always() && hashFiles('coverage-rsync.out') != ''
+        run: |
+          go tool cover -func=coverage-rsync.out | tail -n 1 | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload rsync coverage
+        if: always() && hashFiles('coverage-rsync.out') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-rsync
+          path: coverage-rsync.out
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,21 @@ make coverage
 
 This command writes `coverage.out` and prints function coverage details.
 
+## Rsync-tagged tests
+
+Some packages require the `rsync` build tag. Run their tests locally with the tag enabled:
+
+```sh
+go test -tags rsync ./...
+```
+
+To include coverage for these tests:
+
+```sh
+go test -tags rsync -coverprofile=coverage-rsync.out ./...
+go tool cover -func=coverage-rsync.out
+```
+
 ## Sudoers file validation
 
 CI also checks the syntax of the sample sudoers rules:


### PR DESCRIPTION
## Summary
- run rsync-tagged tests with coverage
- upload rsync coverage artifacts
- document running rsync-tag tests locally

## Testing
- `go build ./...`
- `go test -coverprofile=coverage.out ./...`
- `go test -tags rsync -coverprofile=coverage-rsync.out ./...`
- `go tool cover -func=coverage.out | tail -n 1`
- `go tool cover -func=coverage-rsync.out | tail -n 1`
- `golangci-lint run` *(fails: 495 issues)*


------
https://chatgpt.com/codex/tasks/task_e_68af493e5c608323b2b753f8ebc3524e