### PR TITLE
Move signature cache into testutil with rsync build tag

### DIFF
--- a/testutil/rsyncserver/server.go
+++ b/testutil/rsyncserver/server.go
@@ -17,7 +17,7 @@ import (
 	"lvmsync_go/device"
 	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncwire"
-	"lvmsync_go/internal/signaturecache"
+	"lvmsync_go/testutil/signaturecache"
 )
 
 // Device represents a writable block device supporting random writes and sync.

--- a/testutil/rsyncserver/server_test.go
+++ b/testutil/rsyncserver/server_test.go
@@ -22,7 +22,7 @@ import (
 	"lvmsync_go/device"
 	"lvmsync_go/internal/digest"
 	"lvmsync_go/internal/rsyncwire"
-	"lvmsync_go/internal/signaturecache"
+	"lvmsync_go/testutil/signaturecache"
 )
 
 const maxFrame = 1 << 20

--- a/testutil/signaturecache/cache.go
+++ b/testutil/signaturecache/cache.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package signaturecache
 
 import (

--- a/testutil/signaturecache/cache_test.go
+++ b/testutil/signaturecache/cache_test.go
@@ -1,3 +1,5 @@
+//go:build rsync
+
 package signaturecache
 
 import (


### PR DESCRIPTION
## Summary
- relocate signature cache helpers under testutil and gate them behind rsync build tag
- update rsyncserver imports to new testutil path

## Testing
- `go test ./testutil/... -tags rsync`


------
https://chatgpt.com/codex/tasks/task_e_68af5c45bf6883239779a90de14d9d43